### PR TITLE
docs: Correct edit URL template

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -8,7 +8,7 @@ src = "."
 build-dir = "./book"
 
 [output.html]
-edit-url-template = "https://github.com/roostorg/coop/edit/OSS/docs/{path}"
+edit-url-template = "https://github.com/roostorg/coop/edit/main/docs/{path}"
 git-repository-url = "https://github.com/roostorg/coop"
 
 [output.html.print]


### PR DESCRIPTION
This was still pointing to the `OSS` branch, but docs are served from `main` now.
