### PR TITLE
#7 Fix datetime format on generated mock items

### DIFF
--- a/client/src/webpages/dashboard/item_types/itemTypeUtils.ts
+++ b/client/src/webpages/dashboard/item_types/itemTypeUtils.ts
@@ -184,7 +184,7 @@ export function generateFakeScalarFieldValue(fieldType: ScalarType) {
     case 'BOOLEAN':
       return Math.random() < 0.5;
     case 'DATETIME':
-      return new Date().toLocaleTimeString();
+      return new Date().toISOString();
     case 'GEOHASH':
       // Geohashes are always 6 characters long, so we just hardcode this one
       // for example purposes. NB: not all 6 character strings are valid geohashes.


### PR DESCRIPTION
## Context & Requests for Reviewers

Fixes #7 

Issue was bad date format on item type utils providing the wrong date format.

Before:
<img width="1408" height="799" alt="Screenshot 2026-02-07 at 6 51 29 PM" src="https://github.com/user-attachments/assets/a8bc8fd7-75e3-447d-92bd-f9c02f2164a6" />

After:
<img width="1348" height="821" alt="Screenshot 2026-02-07 at 6 50 49 PM" src="https://github.com/user-attachments/assets/830754b0-b3ca-43cb-92b9-92f06c1b9341" />
