### PR TITLE
MDBook download + cache speedup

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -47,14 +47,11 @@ jobs:
           tar -xzf mdbook.tar.gz -C mdbook-bin --strip-components=1
           rm mdbook.tar.gz
 
-      - name: Add mdBook to PATH
-        run: echo "${{ github.workspace }}/mdbook-bin" >> $GITHUB_PATH
-
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
       - name: Build with mdBook
-        run: mdbook build docs
+        run: ${{ github.workspace }}/mdbook-bin/mdbook build docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Context & Requests for Reviewers
Fixes #3

This Action changes from building mdbook to downloading the release and caching it. Should speed up the process of our action by looking from cache or downloading the release over building from source. 