### PR TITLE
Upgrade to newest migrator package

### DIFF
--- a/.devops/migrator/package-lock.json
+++ b/.devops/migrator/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-rds": "^3.49.0",
         "@clickhouse/client": "^1.13.0",
-        "@roostorg/db-migrator": "^1.0.7",
+        "@roostorg/db-migrator": "^1.0.8",
         "@types/umzug": "^2.3.3",
         "cassandra-driver": "^4.8.0",
         "csv-parse": "^5.0.4",
@@ -1695,17 +1695,15 @@
       }
     },
     "node_modules/@roostorg/db-migrator": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@roostorg/db-migrator/-/db-migrator-1.0.7.tgz",
-      "integrity": "sha512-3en0WhSHu1r8pxZrHfKAs1ZNlGVq1na7D3yp45ocYxRYG30/ssj8PXzr8tvOeG374mshDI/LvWGb+ehY0vJaoQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@roostorg/db-migrator/-/db-migrator-1.0.8.tgz",
+      "integrity": "sha512-JtFdbAN0ezmBhMqEZ6FK5+GIQNJIiB8/5klSgp3+xifyzXfFKmGIJL9zN7j8cVcBdfNPatw+Qavah/jnFFHlHA==",
       "license": "ISC",
       "dependencies": {
         "@total-typescript/ts-reset": "^0.5.1",
-        "@types/glob": "^7.2.0",
         "@types/umzug": "^2.3.3",
         "@types/yargs": "^17.0.24",
-        "cassandra-driver": "^4.6.4",
-        "glob": "^7.2.0",
+        "cassandra-driver": "^4.8.0",
         "sequelize": "^6.32.1",
         "umzug": "^3.0.0",
         "yargs": "^16.2.0"
@@ -2530,24 +2528,10 @@
         "@types/ms": "*"
       }
     },
-    "node_modules/@types/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
-      "dependencies": {
-        "@types/minimatch": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/lodash": {
       "version": "4.14.178",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz",
       "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw=="
-    },
-    "node_modules/@types/minimatch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
     },
     "node_modules/@types/ms": {
       "version": "0.7.31",
@@ -6946,16 +6930,14 @@
       "optional": true
     },
     "@roostorg/db-migrator": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@roostorg/db-migrator/-/db-migrator-1.0.7.tgz",
-      "integrity": "sha512-3en0WhSHu1r8pxZrHfKAs1ZNlGVq1na7D3yp45ocYxRYG30/ssj8PXzr8tvOeG374mshDI/LvWGb+ehY0vJaoQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@roostorg/db-migrator/-/db-migrator-1.0.8.tgz",
+      "integrity": "sha512-JtFdbAN0ezmBhMqEZ6FK5+GIQNJIiB8/5klSgp3+xifyzXfFKmGIJL9zN7j8cVcBdfNPatw+Qavah/jnFFHlHA==",
       "requires": {
         "@total-typescript/ts-reset": "^0.5.1",
-        "@types/glob": "^7.2.0",
         "@types/umzug": "^2.3.3",
         "@types/yargs": "^17.0.24",
-        "cassandra-driver": "^4.6.4",
-        "glob": "^7.2.0",
+        "cassandra-driver": "^4.8.0",
         "sequelize": "^6.32.1",
         "umzug": "^3.0.0",
         "yargs": "^16.2.0"
@@ -7573,24 +7555,10 @@
         "@types/ms": "*"
       }
     },
-    "@types/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
-      "requires": {
-        "@types/minimatch": "*",
-        "@types/node": "*"
-      }
-    },
     "@types/lodash": {
       "version": "4.14.178",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz",
       "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw=="
-    },
-    "@types/minimatch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
     },
     "@types/ms": {
       "version": "0.7.31",

--- a/.devops/migrator/package.json
+++ b/.devops/migrator/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@aws-sdk/client-rds": "^3.49.0",
     "@clickhouse/client": "^1.13.0",
-    "@roostorg/db-migrator": "^1.0.7",
+    "@roostorg/db-migrator": "^1.0.8",
     "@types/umzug": "^2.3.3",
     "cassandra-driver": "^4.8.0",
     "csv-parse": "^5.0.4",


### PR DESCRIPTION
## Context & Requests for Reviewers
We recently upgraded our repo to Node24 as such some of our dependencies were also upgraded and we published a new db-migrator. 

we need to now upgrade the package on the repo itself. 