### PR TITLE
Add Google Content Safety API library

### DIFF
--- a/server/services/signalsService/signals/third_party_signals/google/content_safety/fetchUtils.ts
+++ b/server/services/signalsService/signals/third_party_signals/google/content_safety/fetchUtils.ts
@@ -1,0 +1,40 @@
+export async function fetchWithTimeout(
+  resource: string,
+  options: RequestInit,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(resource, {
+      ...options,
+      signal: controller.signal,
+    });
+    return response;
+  } finally {
+    clearTimeout(id);
+  }
+}
+
+export async function fetchImage(
+  url: string,
+  timeoutMs: number,
+): Promise<Buffer> {
+  try {
+    const response = await fetchWithTimeout(url, {method: 'GET'}, timeoutMs);
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch image: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    return Buffer.from(arrayBuffer);
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to download image for classification: ${msg}`);
+  }
+}
+

--- a/server/services/signalsService/signals/third_party_signals/google/content_safety/googleContentSafetyLib.ts
+++ b/server/services/signalsService/signals/third_party_signals/google/content_safety/googleContentSafetyLib.ts
@@ -1,0 +1,104 @@
+import {type ReadonlyDeep} from 'type-fest';
+import {fetchWithTimeout} from './fetch_utils';
+
+export const GOOGLE_CONTENT_SAFETY_PRIORITIES = [
+  'VERY_LOW',
+  'LOW',
+  'MEDIUM',
+  'HIGH',
+  'VERY_HIGH',
+] as const;
+
+export type GoogleContentSafetyPriority =
+  (typeof GOOGLE_CONTENT_SAFETY_PRIORITIES)[number];
+
+export interface GoogleContentSafetyOptions {
+  apiKey: string;
+  /** Timeout for requests to the API in milliseconds. */
+  timeoutMs?: number;
+}
+
+export interface ClassificationResult {
+  reviewPriorities: GoogleContentSafetyPriority[];
+  modelVersion?: string;
+}
+
+export class GoogleContentSafetyClient {
+  private readonly apiKey: string;
+  private readonly timeoutMs: number;
+  private readonly baseUrl =
+    'https://contentsafety.googleapis.com/v1beta1/images:classify';
+
+  constructor(options: GoogleContentSafetyOptions) {
+    if (!options.apiKey) {
+      throw new Error('Google Content Safety API key is required.');
+    }
+    this.apiKey = options.apiKey;
+    this.timeoutMs = options.timeoutMs ?? 10_000;
+  }
+
+  /**
+   * Classifies a single raw image (Buffer or Uint8Array).
+   *
+   * Prefer `classifyImages` when classifying multiple images.
+   */
+  public async classifyImage(
+    image: Buffer | Uint8Array,
+  ): Promise<GoogleContentSafetyPriority | undefined> {
+    const priorities = await this.classifyImages([image]);
+    return priorities[0];
+  }
+
+  /**
+   * Classifies a list of raw images (Buffer or Uint8Array).
+   *
+   * This method is preferred over calling `classifyImage` multiple times, as it
+   * batches the images into a single API request.
+   */
+  public async classifyImages(
+    images: (Buffer | Uint8Array)[],
+  ): Promise<ReadonlyDeep<GoogleContentSafetyPriority[]>> {
+    const url = `${this.baseUrl}?key=${this.apiKey}`;
+
+    const reqBody = {
+      images: images.map((image) => {
+        if (Buffer.isBuffer(image)) {
+          return image.toString('base64');
+        }
+        return Buffer.from(image).toString('base64');
+      }),
+    };
+
+    try {
+      const response = await fetchWithTimeout(
+        url,
+        {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify(reqBody),
+        },
+        this.timeoutMs,
+      );
+
+      if (!response.ok) {
+        throw new Error(
+          `Google Content Safety API request failed with status ${response.status}: ${response.statusText}`,
+        );
+      }
+
+      const responseJson = (await response.json()) as {
+        reviewPriorities: GoogleContentSafetyPriority[];
+        model_version: string;
+      };
+
+      return responseJson.reviewPriorities;
+    } catch (error: unknown) {
+      // Map known errors or rethrow
+      if (error instanceof Error) {
+        throw new Error(`Google Content Safety API Error: ${error.message}`);
+      }
+      throw error;
+    }
+  }
+}
+


### PR DESCRIPTION
Hi everyone, I've added a library to query Google's Content Safety API. At the moment it's not using any of coop's internals such as NetworkingService (FetchHTTP) so it may still require some additional modifications. I'm happy to remove the fetchUtils I added. Let me know how you prefer to move forward!

Here's an example usage of the library:
```typescript
import {GoogleContentSafetyClient} from './googleContentSafetyLib';
import {fetchImage} from './fetchUtils';

async function main() {
  const apiKey = process.env['CONTENT_SAFETY_API_KEY'];
  if (!apiKey) {
    console.error('CONTENT_SAFETY_API_KEY environment variable not set.');
    process.exit(1);
  }

  const client = new GoogleContentSafetyClient({apiKey});

  try {
    // Example image URL for testing
    const imageUrl =
      'https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png';
    console.log(`Classifying image URL: ${imageUrl}`);
    const image = await fetchImage(imageUrl, 10000);
    const priority = await client.classifyImage(image);
    console.log('Classification Result:', priority);
  } catch (error) {
    console.error('Error during classification:', error);
  }
}

main();
```

The corresponding issue is https://github.com/roostorg/coop/issues/11