### PR TITLE
fix wording in CS API documentation

### DIFF
--- a/docs/SIGNALS.md
+++ b/docs/SIGNALS.md
@@ -135,7 +135,7 @@ The response contains 1 of 5 priorities:
 | HIGH          |
 | VERY_HIGH     |
 
-The higher the priority, the more likely the video may be abusive content. However, this is an indication and not a confirmation of it. You must always do a manual review to confirm and avoid false positives. This signal is only available for manual routing rules and not automated action rules.
+The higher the priority, the more likely the image may be abusive content. However, this is an indication and not a confirmation of it. You must always do a manual review to confirm and avoid false positives. This signal is only available for manual routing rules and not automated action rules.
 
 #### Best practice
 * It is recommended for the image resolution to be around 640x480 pixels (about 300k pixels) for best performance.


### PR DESCRIPTION
## Context & Requests for Reviewers

The documentation for the Content Safety API mistakenly says "video" when it should say "image". Fixes #19 

## Tests
<img width="558" height="393" alt="Screenshot 2026-02-09 at 4 27 40 PM" src="https://github.com/user-attachments/assets/1516b46f-2ac4-491c-8f0e-0a10c8bd4f42" />
