### PR TITLE
docs: Correct score thresholds table formatting

### DIFF
--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -144,7 +144,7 @@ You can create an Appeal in Coop when a user on your platform requests that a mo
 
 The User Score is calculated based on the ratio of penalties to submissions:
 
- `weightedPenaltyRate \= sum(penalties) / numSubmissions`
+ `weightedPenaltyRate = sum(penalties) / numSubmissions`
 
 #### Score Thresholds
 


### PR DESCRIPTION
Escape the `>` so it doesn't cause a blockquote