### PR TITLE
ci: Correct mdbook extraction command

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -44,7 +44,7 @@ jobs:
           URL="https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/${ARCHIVE}"
           mkdir -p mdbook-bin
           curl -sSL -o mdbook.tar.gz "$URL"
-          tar -xzf mdbook.tar.gz -C mdbook-bin --strip-components=1
+          tar -xzf mdbook.tar.gz -C mdbook-bin
           rm mdbook.tar.gz
 
       - name: Setup Pages


### PR DESCRIPTION
Testing locally on my Linux environment, anyway, the `--strip-components` flag is causing the unpacking to fail because the binary is already at the root of the archive. I believe this is causing #26.
