### PR TITLE
fix: remove always-auth=true

### DIFF
--- a/.devops/migrator/.npmrc
+++ b/.devops/migrator/.npmrc
@@ -1,2 +1,1 @@
 //registry.npmjs.org/:_authToken=${NPM_TOKEN}
-always-auth=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 //registry.npmjs.org/:_authToken=${NPM_TOKEN}
-always-auth=true

--- a/client/.npmrc
+++ b/client/.npmrc
@@ -1,2 +1,1 @@
 //registry.npmjs.org/:_authToken=${NPM_TOKEN}
-always-auth=true


### PR DESCRIPTION
## Context & Requests for Reviewers

Remove below warning during npm run start
`npm warn Unknown project config "always-auth". This will stop working in the next major version of npm.`

Ref: https://github.com/actions/setup-node/issues/1305
## Tests

<!-- Describe how you tested your changes, including any manual steps or automated tests performed. -->
<!-- Provide screenshots if available -->

## (Optional) Rollout Plan
<!--
Are there any special things that have to be done before this can be deployed
to prod (e.g., other blocking PRs; manual load testing/validation that needs to
be done on staging; etc.)? If so, please note them here.
 -->