### PR TITLE
NCMEC <-> Queue Improvements and default NCMEC queue

### DIFF
--- a/.devops/migrator/src/scripts/api-server-pg/2026.02.10T00.00.00.add_default_ncmec_queue_to_ncmec_org_settings.sql
+++ b/.devops/migrator/src/scripts/api-server-pg/2026.02.10T00.00.00.add_default_ncmec_queue_to_ncmec_org_settings.sql
@@ -1,0 +1,12 @@
+-- Add default NCMEC queue to ncmec_org_settings so Enqueue to NCMEC can target a specific queue.
+ALTER TABLE ncmec_reporting.ncmec_org_settings
+  ADD COLUMN IF NOT EXISTS default_ncmec_queue_id character varying(255) NULL;
+
+ALTER TABLE ncmec_reporting.ncmec_org_settings
+  ADD CONSTRAINT ncmec_org_settings_default_ncmec_queue_fkey
+  FOREIGN KEY (default_ncmec_queue_id)
+  REFERENCES manual_review_tool.manual_review_queues(id)
+  ON DELETE SET NULL;
+
+COMMENT ON COLUMN ncmec_reporting.ncmec_org_settings.default_ncmec_queue_id IS
+  'When set, Enqueue to NCMEC sends jobs to this queue instead of the org default.';

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ and then follow the steps below:
 3. Make sure the `.env` files for `/server` and `.devops/migrator` are populated (including ClickHouse credentials). Run database migrations:
    ```bash
    npm run db:update -- --env staging --db api-server-pg
+   npm run db:update -- --env staging --db scylla
    npm run db:update -- --env staging --db clickhouse
    ```
 ### Alternative: Single Command for Steps 2-3

--- a/client/src/graphql/generated.ts
+++ b/client/src/graphql/generated.ts
@@ -2714,6 +2714,7 @@ export type GQLNcmecOrgSettings = {
   readonly __typename: 'NcmecOrgSettings';
   readonly companyTemplate?: Maybe<Scalars['String']>;
   readonly contactEmail?: Maybe<Scalars['String']>;
+  readonly defaultNcmecQueueId?: Maybe<Scalars['String']>;
   readonly legalUrl?: Maybe<Scalars['String']>;
   readonly moreInfoUrl?: Maybe<Scalars['String']>;
   readonly ncmecAdditionalInfoEndpoint?: Maybe<Scalars['String']>;
@@ -2725,6 +2726,7 @@ export type GQLNcmecOrgSettings = {
 export type GQLNcmecOrgSettingsInput = {
   readonly companyTemplate?: InputMaybe<Scalars['String']>;
   readonly contactEmail?: InputMaybe<Scalars['String']>;
+  readonly defaultNcmecQueueId?: InputMaybe<Scalars['String']>;
   readonly legalUrl?: InputMaybe<Scalars['String']>;
   readonly moreInfoUrl?: InputMaybe<Scalars['String']>;
   readonly ncmecAdditionalInfoEndpoint?: InputMaybe<Scalars['String']>;
@@ -23585,10 +23587,16 @@ export type GQLNcmecOrgSettingsQuery = {
     readonly legalUrl?: string | null;
     readonly ncmecPreservationEndpoint?: string | null;
     readonly ncmecAdditionalInfoEndpoint?: string | null;
+    readonly defaultNcmecQueueId?: string | null;
   } | null;
   readonly myOrg?: {
     readonly __typename: 'Org';
     readonly hasNCMECReportingEnabled: boolean;
+    readonly mrtQueues: ReadonlyArray<{
+      readonly __typename: 'ManualReviewQueue';
+      readonly id: string;
+      readonly name: string;
+    }>;
   } | null;
 };
 
@@ -36506,9 +36514,14 @@ export const GQLNcmecOrgSettingsDocument = gql`
       legalUrl
       ncmecPreservationEndpoint
       ncmecAdditionalInfoEndpoint
+      defaultNcmecQueueId
     }
     myOrg {
       hasNCMECReportingEnabled
+      mrtQueues {
+        id
+        name
+      }
     }
   }
 `;

--- a/client/src/webpages/settings/NCMECSettings.tsx
+++ b/client/src/webpages/settings/NCMECSettings.tsx
@@ -1,6 +1,13 @@
 import { Button } from '@/coop-ui/Button';
 import { Input } from '@/coop-ui/Input';
 import { Label } from '@/coop-ui/Label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/coop-ui/Select';
 import { toast } from '@/coop-ui/Toast';
 import { Heading, Text } from '@/coop-ui/Typography';
 import {
@@ -24,9 +31,14 @@ gql`
       legalUrl
       ncmecPreservationEndpoint
       ncmecAdditionalInfoEndpoint
+      defaultNcmecQueueId
     }
     myOrg {
       hasNCMECReportingEnabled
+      mrtQueues {
+        id
+        name
+      }
     }
   }
 
@@ -46,6 +58,7 @@ type NcmecSettings = {
   legalUrl: string;
   ncmecPreservationEndpoint: string;
   ncmecAdditionalInfoEndpoint: string;
+  defaultNcmecQueueId: string;
 };
 
 export default function NCMECSettings() {
@@ -58,6 +71,7 @@ export default function NCMECSettings() {
     legalUrl: '',
     ncmecPreservationEndpoint: '',
     ncmecAdditionalInfoEndpoint: '',
+    defaultNcmecQueueId: '',
   });
 
   const { loading, error, data } = useGQLNcmecOrgSettingsQuery();
@@ -87,6 +101,8 @@ export default function NCMECSettings() {
           data.ncmecOrgSettings.ncmecPreservationEndpoint ?? '',
         ncmecAdditionalInfoEndpoint:
           data.ncmecOrgSettings.ncmecAdditionalInfoEndpoint ?? '',
+        defaultNcmecQueueId:
+          data.ncmecOrgSettings.defaultNcmecQueueId ?? '',
       });
     }
   }, [data?.ncmecOrgSettings]);
@@ -126,6 +142,7 @@ export default function NCMECSettings() {
             settings.ncmecPreservationEndpoint || null,
           ncmecAdditionalInfoEndpoint:
             settings.ncmecAdditionalInfoEndpoint || null,
+          defaultNcmecQueueId: settings.defaultNcmecQueueId || null,
         },
       },
     });
@@ -265,6 +282,44 @@ export default function NCMECSettings() {
               }
               placeholder="https://yourcompany.com/ncmec-info"
             />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label
+              htmlFor="defaultNcmecQueueId"
+              className="text-sm font-medium"
+            >
+              Default NCMEC queue
+            </Label>
+            <Select
+              value={settings.defaultNcmecQueueId || '__default__'}
+              onValueChange={(value) =>
+                setSettings({
+                  ...settings,
+                  defaultNcmecQueueId:
+                    value === '__default__' ? '' : value,
+                })
+              }
+            >
+              <SelectTrigger id="defaultNcmecQueueId">
+                <SelectValue placeholder="Use org default queue" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__default__">
+                  Use org default queue
+                </SelectItem>
+                {(data?.myOrg?.mrtQueues ?? []).map((queue) => (
+                  <SelectItem key={queue.id} value={queue.id}>
+                    {queue.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Text size="XS" className="text-gray-500">
+              When reviewers choose &quot;Enqueue to NCMEC&quot;, jobs will be
+              sent to this queue. Leave as &quot;Use org default queue&quot; to
+              use the organization&apos;s default manual review queue.
+            </Text>
           </div>
 
           <div className="flex flex-col gap-2">

--- a/server/graphql/generated.ts
+++ b/server/graphql/generated.ts
@@ -2783,6 +2783,7 @@ export type GQLNcmecOrgSettings = {
   readonly __typename?: 'NcmecOrgSettings';
   readonly companyTemplate?: Maybe<Scalars['String']>;
   readonly contactEmail?: Maybe<Scalars['String']>;
+  readonly defaultNcmecQueueId?: Maybe<Scalars['String']>;
   readonly legalUrl?: Maybe<Scalars['String']>;
   readonly moreInfoUrl?: Maybe<Scalars['String']>;
   readonly ncmecAdditionalInfoEndpoint?: Maybe<Scalars['String']>;
@@ -2794,6 +2795,7 @@ export type GQLNcmecOrgSettings = {
 export type GQLNcmecOrgSettingsInput = {
   readonly companyTemplate?: InputMaybe<Scalars['String']>;
   readonly contactEmail?: InputMaybe<Scalars['String']>;
+  readonly defaultNcmecQueueId?: InputMaybe<Scalars['String']>;
   readonly legalUrl?: InputMaybe<Scalars['String']>;
   readonly moreInfoUrl?: InputMaybe<Scalars['String']>;
   readonly ncmecAdditionalInfoEndpoint?: InputMaybe<Scalars['String']>;
@@ -10504,6 +10506,11 @@ export type GQLNcmecOrgSettingsResolvers<
     ContextType
   >;
   contactEmail?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  defaultNcmecQueueId?: Resolver<
     Maybe<GQLResolversTypes['String']>,
     ParentType,
     ContextType

--- a/server/graphql/modules/manualReviewTool.ts
+++ b/server/graphql/modules/manualReviewTool.ts
@@ -980,9 +980,11 @@ const ManualReviewJobPayload: GQLManualReviewJobPayloadResolvers = {
       case 'USER': {
         return 'appealId' in it
           ? 'UserAppealManualReviewJobPayload'
-          : 'allMediaItems' in it
-          ? 'NcmecManualReviewJobPayload'
-          : 'UserManualReviewJobPayload';
+          : it.kind === 'DEFAULT'
+            ? 'UserManualReviewJobPayload'
+            : 'allMediaItems' in it
+              ? 'NcmecManualReviewJobPayload'
+              : 'UserManualReviewJobPayload';
       }
       case 'THREAD': {
         return 'appealId' in it

--- a/server/graphql/modules/ncmec.ts
+++ b/server/graphql/modules/ncmec.ts
@@ -28,6 +28,7 @@ const typeDefs = /* GraphQL */ `
     legalUrl: String
     ncmecPreservationEndpoint: String
     ncmecAdditionalInfoEndpoint: String
+    defaultNcmecQueueId: String
   }
 
   input NcmecOrgSettingsInput {
@@ -39,6 +40,7 @@ const typeDefs = /* GraphQL */ `
     legalUrl: String
     ncmecPreservationEndpoint: String
     ncmecAdditionalInfoEndpoint: String
+    defaultNcmecQueueId: String
   }
 
   type UpdateNcmecOrgSettingsResponse {
@@ -233,6 +235,7 @@ const Mutation: GQLMutationResolvers = {
       legalUrl: input.legalUrl ?? null,
       ncmecPreservationEndpoint: input.ncmecPreservationEndpoint ?? null,
       ncmecAdditionalInfoEndpoint: input.ncmecAdditionalInfoEndpoint ?? null,
+      defaultNcmecQueueId: input.defaultNcmecQueueId ?? null,
     });
 
     return { success: true };

--- a/server/services/ncmecService/dbTypes.ts
+++ b/server/services/ncmecService/dbTypes.ts
@@ -18,6 +18,7 @@ export type NcmecReportingServicePg = {
     legal_url?: string;
     ncmec_preservation_endpoint?: string;
     ncmec_additional_info_endpoint?: string;
+    default_ncmec_queue_id?: string | null;
     created_at: GeneratedAlways<Date>;
     updated_at: GeneratedAlways<Date>;
   } & (

--- a/server/services/ncmecService/ncmecService.ts
+++ b/server/services/ncmecService/ncmecService.ts
@@ -123,7 +123,12 @@ export class NcmecService {
         }
     ),
   ) {
-    return this.ncmecEnqueueToMrt.enqueueForHumanReviewIfApplicable(input);
+    const settings = await this.getNcmecOrgSettings(input.orgId);
+    const targetQueueId = settings?.defaultNcmecQueueId ?? undefined;
+    return this.ncmecEnqueueToMrt.enqueueForHumanReviewIfApplicable({
+      ...input,
+      targetQueueId,
+    });
   }
 
   async getNCMECActionsToRunAndPolicies(orgId: string) {
@@ -182,6 +187,7 @@ export class NcmecService {
         'legal_url as legalUrl',
         'ncmec_preservation_endpoint as ncmecPreservationEndpoint',
         'ncmec_additional_info_endpoint as ncmecAdditionalInfoEndpoint',
+        'default_ncmec_queue_id as defaultNcmecQueueId',
       ])
       .where('org_id', '=', orgId)
       .executeTakeFirst();
@@ -199,6 +205,7 @@ export class NcmecService {
     legalUrl: string | null;
     ncmecPreservationEndpoint: string | null;
     ncmecAdditionalInfoEndpoint: string | null;
+    defaultNcmecQueueId: string | null;
   }) {
     await this.pgQuery
       .insertInto('ncmec_reporting.ncmec_org_settings')
@@ -214,6 +221,7 @@ export class NcmecService {
           params.ncmecPreservationEndpoint ?? undefined,
         ncmec_additional_info_endpoint:
           params.ncmecAdditionalInfoEndpoint ?? undefined,
+        default_ncmec_queue_id: params.defaultNcmecQueueId ?? undefined,
         actions_to_run_upon_report_creation: null,
         policies_applied_to_actions_run_on_report_creation: null,
       })
@@ -229,6 +237,7 @@ export class NcmecService {
             params.ncmecPreservationEndpoint ?? undefined,
           ncmec_additional_info_endpoint:
             params.ncmecAdditionalInfoEndpoint ?? undefined,
+          default_ncmec_queue_id: params.defaultNcmecQueueId ?? undefined,
         }),
       )
       .execute();

--- a/server/services/ncmecService/ncmecService.ts
+++ b/server/services/ncmecService/ncmecService.ts
@@ -221,7 +221,7 @@ export class NcmecService {
           params.ncmecPreservationEndpoint ?? undefined,
         ncmec_additional_info_endpoint:
           params.ncmecAdditionalInfoEndpoint ?? undefined,
-        default_ncmec_queue_id: params.defaultNcmecQueueId ?? undefined,
+        default_ncmec_queue_id: params.defaultNcmecQueueId ?? null,
         actions_to_run_upon_report_creation: null,
         policies_applied_to_actions_run_on_report_creation: null,
       })
@@ -237,7 +237,7 @@ export class NcmecService {
             params.ncmecPreservationEndpoint ?? undefined,
           ncmec_additional_info_endpoint:
             params.ncmecAdditionalInfoEndpoint ?? undefined,
-          default_ncmec_queue_id: params.defaultNcmecQueueId ?? undefined,
+          default_ncmec_queue_id: params.defaultNcmecQueueId ?? null,
         }),
       )
       .execute();


### PR DESCRIPTION
## Context & Requests for Reviewers

Adds a configurable Default NCMEC queue in NCMEC settings. When reviewers (or rules) use Enqueue to NCMEC, jobs are sent to this queue when set; otherwise they continue to use the org’s default manual review queue.

NCMEC Settings (/dashboard/settings/ncmec): New “Default NCMEC queue” dropdown. When set, “Enqueue to NCMEC” sends jobs to that queue instead of the org default.

## Tests:

JobRouting test that enqueue with an explicit queueId adds the job to that queue and skips routing.

<img width="801" height="250" alt="Screenshot 2026-02-16 at 5 03 25 PM" src="https://github.com/user-attachments/assets/b0504c98-1f08-45be-abda-cc3608d2f028" />
