### PR TITLE
Reduce actions workflows for mdbook

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -1,9 +1,12 @@
 name: Deploy mdBook site to Pages
 
 on:
-  # Runs on pushes targeting the default branch
+  # Runs on pushes targeting the default branch, only when docs or this workflow change
   push:
     branches: ["main"]
+    paths:
+      - "docs/**"
+      - ".github/workflows/mdbook.yml"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
## Context & Requests for Reviewers

We should only be building mdbook and publishing when the docs folder or the workflow itself has been modified as to avoid paying for actions running and not doing anything.