### PR TITLE
docker-compose: Use fixed Docker image tag for Jaeger and Redis

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   redis:
-    image: redis
+    image: redis:8.6.1-trixie
     volumes:
       - redis_data:/data
     ports:


### PR DESCRIPTION
## Context & Requests for Reviewers

Fixes: #77

## Tests

Setting up an instance with `npm run up` should work as usual. This change is intended to lock remaining Docker image versions in `docker-compose` so that breaking changes in images tagged as `:latest` don't affect Coop.

## (Optional) Rollout Plan

Up-to-date dev/evaluation environments might not be affected at all; others will get updated to the locked versions.