### PR TITLE
Split publishing of packages in repo

### DIFF
--- a/.github/workflows/publish-db-migrator.yaml
+++ b/.github/workflows/publish-db-migrator.yaml
@@ -5,16 +5,15 @@ on:
     branches: [main]
     paths:
       - 'migrator/**'
-      - 'types/**'
   workflow_dispatch:
+
+permissions:
+  id-token: write  # Required for OIDC i.e. publish package
+  contents: read
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -41,22 +40,3 @@ jobs:
             npm run build
             npm publish
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Check and publish types
-        run: |
-          cd types
-          VERSION=$(node -p "require('./package.json').version")
-          echo "Checking @roostorg/types@$VERSION..."
-          
-          if npm view "@roostorg/types@$VERSION" version >/dev/null 2>&1; then
-            echo "⚠️  Version $VERSION of @roostorg/types already exists on npm - skipping"
-          else
-            echo "✅ Publishing @roostorg/types@$VERSION..."
-            npm ci
-            npm run build
-            npm publish
-          fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-types.yaml
+++ b/.github/workflows/publish-types.yaml
@@ -1,0 +1,42 @@
+name: Publish Packages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'types/**'
+  workflow_dispatch:
+
+permissions:
+  id-token: write  # Required for OIDC i.e. publish package
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          check-latest: true
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Check and publish types
+        run: |
+          cd types
+          VERSION=$(node -p "require('./package.json').version")
+          echo "Checking @roostorg/types@$VERSION..."
+          
+          if npm view "@roostorg/types@$VERSION" version >/dev/null 2>&1; then
+            echo "⚠️  Version $VERSION of @roostorg/types already exists on npm - skipping"
+          else
+            echo "✅ Publishing @roostorg/types@$VERSION..."
+            npm ci
+            npm run build
+            npm publish
+          fi


### PR DESCRIPTION
## Context & Requests for Reviewers

This PR splits the publish workflows for each package to simplify and reduce the checks to only run when each package has actually changed.

This also adds the `id-token: write` as explained [here](https://docs.npmjs.com/trusted-publishers#supported-cicd-providers) removing the need to use NPM tokens for publishing packages and just native integration with GitHub.

This will prevent us having to rotate tokens and secures our pipeline for publishing.