### PR TITLE
Integration Plugin Backend: migration, GraphQL API, and plugin signals

### DIFF
--- a/.devops/migrator/src/scripts/api-server-pg/2026.02.23T00.00.00.add_generic_integration_configs.sql
+++ b/.devops/migrator/src/scripts/api-server-pg/2026.02.23T00.00.00.add_generic_integration_configs.sql
@@ -1,0 +1,22 @@
+-- Generic integration configs table: one row per (org_id, integration_id).
+-- Config is stored as JSONB so each integration can define its own credential/config
+-- shape without new tables or migrations. The app serializes/deserializes using
+-- the integration's manifest (e.g. credentialFields).
+
+CREATE TABLE signal_auth_service.integration_configs (
+    org_id character varying(255) NOT NULL,
+    integration_id character varying(255) NOT NULL,
+    config JSONB NOT NULL DEFAULT '{}',
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+ALTER TABLE signal_auth_service.integration_configs OWNER TO postgres;
+
+ALTER TABLE ONLY signal_auth_service.integration_configs
+    ADD CONSTRAINT integration_configs_pkey PRIMARY KEY (org_id, integration_id);
+
+ALTER TABLE ONLY signal_auth_service.integration_configs
+    ADD CONSTRAINT integration_configs_org_id_fkey FOREIGN KEY (org_id) REFERENCES public.orgs(id) ON DELETE CASCADE;
+
+COMMENT ON TABLE signal_auth_service.integration_configs IS 'Extensible per-org integration credentials/config. config is JSON; shape is defined by each integration (e.g. via CoopIntegrationPlugin manifest.credentialFields).';

--- a/client/src/graphql/generated.ts
+++ b/client/src/graphql/generated.ts
@@ -401,7 +401,7 @@ export type GQLConditionInputSignalInput = {
   readonly id: Scalars['ID'];
   readonly name?: InputMaybe<Scalars['String']>;
   readonly subcategory?: InputMaybe<Scalars['String']>;
-  readonly type: GQLSignalType;
+  readonly type: Scalars['String'];
 };
 
 export type GQLConditionMatchingValuesInput = {
@@ -1259,6 +1259,7 @@ export type GQLIntegration =
 export type GQLIntegrationApiCredential =
   | GQLGoogleContentSafetyApiIntegrationApiCredential
   | GQLOpenAiIntegrationApiCredential
+  | GQLPluginIntegrationApiCredential
   | GQLZentropiIntegrationApiCredential;
 
 export type GQLIntegrationApiCredentialInput = {
@@ -1270,7 +1271,14 @@ export type GQLIntegrationApiCredentialInput = {
 export type GQLIntegrationConfig = {
   readonly __typename: 'IntegrationConfig';
   readonly apiCredential: GQLIntegrationApiCredential;
-  readonly name: GQLIntegration;
+  readonly docsUrl: Scalars['String'];
+  readonly logoUrl?: Maybe<Scalars['String']>;
+  readonly logoWithBackgroundUrl?: Maybe<Scalars['String']>;
+  readonly modelCard: GQLModelCard;
+  readonly modelCardLearnMoreUrl?: Maybe<Scalars['String']>;
+  readonly name: Scalars['String'];
+  readonly requiresConfig: Scalars['Boolean'];
+  readonly title: Scalars['String'];
 };
 
 export type GQLIntegrationConfigQueryResponse =
@@ -1310,6 +1318,16 @@ export type GQLIntegrationEmptyInputCredentialsError = GQLError & {
   readonly status: Scalars['Int'];
   readonly title: Scalars['String'];
   readonly type: ReadonlyArray<Scalars['String']>;
+};
+
+export type GQLIntegrationMetadata = {
+  readonly __typename: 'IntegrationMetadata';
+  readonly docsUrl: Scalars['String'];
+  readonly logoUrl?: Maybe<Scalars['String']>;
+  readonly logoWithBackgroundUrl?: Maybe<Scalars['String']>;
+  readonly name: Scalars['String'];
+  readonly requiresConfig: Scalars['Boolean'];
+  readonly title: Scalars['String'];
 };
 
 export type GQLIntegrationNoInputCredentialsError = GQLError & {
@@ -2094,6 +2112,34 @@ export const GQLMetricsTimeDivisionOptions = {
 
 export type GQLMetricsTimeDivisionOptions =
   (typeof GQLMetricsTimeDivisionOptions)[keyof typeof GQLMetricsTimeDivisionOptions];
+export type GQLModelCard = {
+  readonly __typename: 'ModelCard';
+  readonly modelName: Scalars['String'];
+  readonly releaseDate?: Maybe<Scalars['String']>;
+  readonly sections?: Maybe<ReadonlyArray<GQLModelCardSection>>;
+  readonly version: Scalars['String'];
+};
+
+export type GQLModelCardField = {
+  readonly __typename: 'ModelCardField';
+  readonly label: Scalars['String'];
+  readonly value: Scalars['String'];
+};
+
+export type GQLModelCardSection = {
+  readonly __typename: 'ModelCardSection';
+  readonly fields?: Maybe<ReadonlyArray<GQLModelCardField>>;
+  readonly id: Scalars['String'];
+  readonly subsections?: Maybe<ReadonlyArray<GQLModelCardSubsection>>;
+  readonly title: Scalars['String'];
+};
+
+export type GQLModelCardSubsection = {
+  readonly __typename: 'ModelCardSubsection';
+  readonly fields: ReadonlyArray<GQLModelCardField>;
+  readonly title: Scalars['String'];
+};
+
 export type GQLModeratorSafetySettingsInput = {
   readonly moderatorSafetyBlurLevel: Scalars['Int'];
   readonly moderatorSafetyGrayscale: Scalars['Boolean'];
@@ -2267,6 +2313,7 @@ export type GQLMutation = {
   readonly setModeratorSafetySettings?: Maybe<GQLSetModeratorSafetySettingsSuccessResponse>;
   readonly setMrtChartConfigurationSettings?: Maybe<GQLSetMrtChartConfigurationSettingsSuccessResponse>;
   readonly setOrgDefaultSafetySettings?: Maybe<GQLSetModeratorSafetySettingsSuccessResponse>;
+  readonly setPluginIntegrationConfig: GQLSetIntegrationConfigResponse;
   readonly signUp: GQLSignUpResponse;
   readonly submitManualReviewDecision: GQLSubmitDecisionResponse;
   readonly updateAccountInfo?: Maybe<Scalars['Boolean']>;
@@ -2517,6 +2564,10 @@ export type GQLMutationSetMrtChartConfigurationSettingsArgs = {
 
 export type GQLMutationSetOrgDefaultSafetySettingsArgs = {
   orgDefaultSafetySettings: GQLModeratorSafetySettingsInput;
+};
+
+export type GQLMutationSetPluginIntegrationConfigArgs = {
+  input: GQLSetPluginIntegrationConfigInput;
 };
 
 export type GQLMutationSignUpArgs = {
@@ -2968,6 +3019,11 @@ export type GQLPlaceBoundsInput = {
   readonly southwestCorner: GQLLatLngInput;
 };
 
+export type GQLPluginIntegrationApiCredential = {
+  readonly __typename: 'PluginIntegrationApiCredential';
+  readonly credential: Scalars['JSONObject'];
+};
+
 export type GQLPolicy = {
   readonly __typename: 'Policy';
   readonly applyUserStrikeCountConfigToChildren?: Maybe<Scalars['Boolean']>;
@@ -3036,6 +3092,7 @@ export type GQLQuery = {
   readonly allRuleInsights: GQLAllRuleInsights;
   readonly apiKey: Scalars['String'];
   readonly appealSettings?: Maybe<GQLAppealSettings>;
+  readonly availableIntegrations: ReadonlyArray<GQLIntegrationMetadata>;
   readonly getCommentsForJob: ReadonlyArray<GQLManualReviewJobComment>;
   readonly getDecidedJob?: Maybe<GQLManualReviewJob>;
   readonly getDecidedJobFromJobId?: Maybe<GQLManualReviewJobWithDecisions>;
@@ -3178,7 +3235,7 @@ export type GQLQueryHashBankByIdArgs = {
 };
 
 export type GQLQueryIntegrationConfigArgs = {
-  name: GQLIntegration;
+  name: Scalars['String'];
 };
 
 export type GQLQueryInviteUserTokenArgs = {
@@ -3853,6 +3910,11 @@ export type GQLSetMrtChartConfigurationSettingsSuccessResponse = {
   readonly _?: Maybe<Scalars['Boolean']>;
 };
 
+export type GQLSetPluginIntegrationConfigInput = {
+  readonly credential: Scalars['JSONObject'];
+  readonly integrationId: Scalars['String'];
+};
+
 export type GQLSetUserStrikeThresholdInput = {
   readonly actions: ReadonlyArray<Scalars['String']>;
   readonly threshold: Scalars['Int'];
@@ -3901,7 +3963,13 @@ export type GQLSignal = {
   readonly eligibleInputs: ReadonlyArray<GQLSignalInputType>;
   readonly eligibleSubcategories: ReadonlyArray<GQLSignalSubcategory>;
   readonly id: Scalars['ID'];
-  readonly integration?: Maybe<GQLIntegration>;
+  readonly integration?: Maybe<Scalars['String']>;
+  /** Logo URL for the integration. Null if not set or when signal has no integration. */
+  readonly integrationLogoUrl?: Maybe<Scalars['String']>;
+  /** Logo-with-background URL for the integration. Null if not set or when signal has no integration. */
+  readonly integrationLogoWithBackgroundUrl?: Maybe<Scalars['String']>;
+  /** Display name for the signal’s integration (from registry manifest). Null when signal has no integration. */
+  readonly integrationTitle?: Maybe<Scalars['String']>;
   readonly name: Scalars['String'];
   readonly outputType: GQLSignalOutputType;
   readonly pricingStructure: GQLSignalPricingStructure;
@@ -3909,7 +3977,7 @@ export type GQLSignal = {
   readonly shouldPromptForMatchingValues: Scalars['Boolean'];
   readonly subcategory?: Maybe<Scalars['String']>;
   readonly supportedLanguages: GQLSupportedLanguages;
-  readonly type: GQLSignalType;
+  readonly type: Scalars['String'];
 };
 
 export type GQLSignalArgs = GQLAggregationSignalArgs;
@@ -4005,7 +4073,7 @@ export const GQLSignalType = {
 export type GQLSignalType = (typeof GQLSignalType)[keyof typeof GQLSignalType];
 export type GQLSignalWithScore = {
   readonly __typename: 'SignalWithScore';
-  readonly integration?: Maybe<GQLIntegration>;
+  readonly integration?: Maybe<Scalars['String']>;
   readonly score: Scalars['String'];
   readonly signalName: Scalars['String'];
   readonly subcategory?: Maybe<Scalars['String']>;
@@ -5653,13 +5721,41 @@ export type GQLSetIntegrationConfigMutation = {
         readonly __typename: 'SetIntegrationConfigSuccessResponse';
         readonly config: {
           readonly __typename: 'IntegrationConfig';
-          readonly name: GQLIntegration;
+          readonly name: string;
+        };
+      };
+};
+
+export type GQLSetPluginIntegrationConfigMutationVariables = Exact<{
+  input: GQLSetPluginIntegrationConfigInput;
+}>;
+
+export type GQLSetPluginIntegrationConfigMutation = {
+  readonly __typename: 'Mutation';
+  readonly setPluginIntegrationConfig:
+    | {
+        readonly __typename: 'IntegrationConfigTooManyCredentialsError';
+        readonly title: string;
+      }
+    | {
+        readonly __typename: 'IntegrationEmptyInputCredentialsError';
+        readonly title: string;
+      }
+    | {
+        readonly __typename: 'IntegrationNoInputCredentialsError';
+        readonly title: string;
+      }
+    | {
+        readonly __typename: 'SetIntegrationConfigSuccessResponse';
+        readonly config: {
+          readonly __typename: 'IntegrationConfig';
+          readonly name: string;
         };
       };
 };
 
 export type GQLIntegrationConfigQueryVariables = Exact<{
-  name: GQLIntegration;
+  name: Scalars['String'];
 }>;
 
 export type GQLIntegrationConfigQuery = {
@@ -5669,7 +5765,38 @@ export type GQLIntegrationConfigQuery = {
         readonly __typename: 'IntegrationConfigSuccessResult';
         readonly config?: {
           readonly __typename: 'IntegrationConfig';
-          readonly name: GQLIntegration;
+          readonly name: string;
+          readonly title: string;
+          readonly docsUrl: string;
+          readonly requiresConfig: boolean;
+          readonly logoUrl?: string | null;
+          readonly logoWithBackgroundUrl?: string | null;
+          readonly modelCardLearnMoreUrl?: string | null;
+          readonly modelCard: {
+            readonly __typename: 'ModelCard';
+            readonly modelName: string;
+            readonly version: string;
+            readonly releaseDate?: string | null;
+            readonly sections?: ReadonlyArray<{
+              readonly __typename: 'ModelCardSection';
+              readonly id: string;
+              readonly title: string;
+              readonly subsections?: ReadonlyArray<{
+                readonly __typename: 'ModelCardSubsection';
+                readonly title: string;
+                readonly fields: ReadonlyArray<{
+                  readonly __typename: 'ModelCardField';
+                  readonly label: string;
+                  readonly value: string;
+                }>;
+              }> | null;
+              readonly fields?: ReadonlyArray<{
+                readonly __typename: 'ModelCardField';
+                readonly label: string;
+                readonly value: string;
+              }> | null;
+            }> | null;
+          };
           readonly apiCredential:
             | {
                 readonly __typename: 'GoogleContentSafetyApiIntegrationApiCredential';
@@ -5678,6 +5805,10 @@ export type GQLIntegrationConfigQuery = {
             | {
                 readonly __typename: 'OpenAiIntegrationApiCredential';
                 readonly apiKey: string;
+              }
+            | {
+                readonly __typename: 'PluginIntegrationApiCredential';
+                readonly credential: JsonObject;
               }
             | {
                 readonly __typename: 'ZentropiIntegrationApiCredential';
@@ -5704,9 +5835,26 @@ export type GQLMyIntegrationsQuery = {
     readonly __typename: 'Org';
     readonly integrationConfigs: ReadonlyArray<{
       readonly __typename: 'IntegrationConfig';
-      readonly name: GQLIntegration;
+      readonly name: string;
     }>;
   } | null;
+};
+
+export type GQLAvailableIntegrationsQueryVariables = Exact<{
+  [key: string]: never;
+}>;
+
+export type GQLAvailableIntegrationsQuery = {
+  readonly __typename: 'Query';
+  readonly availableIntegrations: ReadonlyArray<{
+    readonly __typename: 'IntegrationMetadata';
+    readonly name: string;
+    readonly title: string;
+    readonly docsUrl: string;
+    readonly requiresConfig: boolean;
+    readonly logoUrl?: string | null;
+    readonly logoWithBackgroundUrl?: string | null;
+  }>;
 };
 
 export type GQLInvestigationItemTypesQueryVariables = Exact<{
@@ -6429,7 +6577,7 @@ export type GQLInvestigationItemsQuery = {
                         readonly signal?: {
                           readonly __typename: 'Signal';
                           readonly id: string;
-                          readonly type: GQLSignalType;
+                          readonly type: string;
                           readonly name: string;
                           readonly subcategory?: string | null;
                           readonly args?: {
@@ -6506,7 +6654,7 @@ export type GQLInvestigationItemsQuery = {
                   readonly signal?: {
                     readonly __typename: 'Signal';
                     readonly id: string;
-                    readonly type: GQLSignalType;
+                    readonly type: string;
                     readonly name: string;
                     readonly subcategory?: string | null;
                     readonly args?: {
@@ -16934,7 +17082,7 @@ export type GQLManualReviewQueueRoutingRulesQuery = {
                     readonly signal?: {
                       readonly __typename: 'Signal';
                       readonly id: string;
-                      readonly type: GQLSignalType;
+                      readonly type: string;
                       readonly name: string;
                       readonly subcategory?: string | null;
                       readonly args?: {
@@ -17010,7 +17158,7 @@ export type GQLManualReviewQueueRoutingRulesQuery = {
               readonly signal?: {
                 readonly __typename: 'Signal';
                 readonly id: string;
-                readonly type: GQLSignalType;
+                readonly type: string;
                 readonly name: string;
                 readonly subcategory?: string | null;
                 readonly args?: {
@@ -17282,7 +17430,7 @@ export type GQLManualReviewQueueRoutingRulesQuery = {
                     readonly signal?: {
                       readonly __typename: 'Signal';
                       readonly id: string;
-                      readonly type: GQLSignalType;
+                      readonly type: string;
                       readonly name: string;
                       readonly subcategory?: string | null;
                       readonly args?: {
@@ -17358,7 +17506,7 @@ export type GQLManualReviewQueueRoutingRulesQuery = {
               readonly signal?: {
                 readonly __typename: 'Signal';
                 readonly id: string;
-                readonly type: GQLSignalType;
+                readonly type: string;
                 readonly name: string;
                 readonly subcategory?: string | null;
                 readonly args?: {
@@ -17411,9 +17559,12 @@ export type GQLManualReviewQueueRoutingRulesQuery = {
     readonly signals: ReadonlyArray<{
       readonly __typename: 'Signal';
       readonly id: string;
-      readonly type: GQLSignalType;
+      readonly type: string;
       readonly name: string;
-      readonly integration?: GQLIntegration | null;
+      readonly integration?: string | null;
+      readonly integrationTitle?: string | null;
+      readonly integrationLogoUrl?: string | null;
+      readonly integrationLogoWithBackgroundUrl?: string | null;
       readonly docsUrl?: string | null;
       readonly description: string;
       readonly eligibleInputs: ReadonlyArray<GQLSignalInputType>;
@@ -18408,7 +18559,7 @@ export type GQLRulesQuery = {
                         readonly signal?: {
                           readonly __typename: 'Signal';
                           readonly id: string;
-                          readonly type: GQLSignalType;
+                          readonly type: string;
                           readonly name: string;
                           readonly subcategory?: string | null;
                           readonly args?: {
@@ -18484,7 +18635,7 @@ export type GQLRulesQuery = {
                   readonly signal?: {
                     readonly __typename: 'Signal';
                     readonly id: string;
-                    readonly type: GQLSignalType;
+                    readonly type: string;
                     readonly name: string;
                     readonly subcategory?: string | null;
                     readonly args?: {
@@ -18608,7 +18759,7 @@ export type GQLRulesQuery = {
                         readonly signal?: {
                           readonly __typename: 'Signal';
                           readonly id: string;
-                          readonly type: GQLSignalType;
+                          readonly type: string;
                           readonly name: string;
                           readonly subcategory?: string | null;
                           readonly args?: {
@@ -18684,7 +18835,7 @@ export type GQLRulesQuery = {
                   readonly signal?: {
                     readonly __typename: 'Signal';
                     readonly id: string;
-                    readonly type: GQLSignalType;
+                    readonly type: string;
                     readonly name: string;
                     readonly subcategory?: string | null;
                     readonly args?: {
@@ -18956,7 +19107,7 @@ export type GQLSpotTestRuleQuery = {
                   readonly signal?: {
                     readonly __typename: 'Signal';
                     readonly id: string;
-                    readonly type: GQLSignalType;
+                    readonly type: string;
                     readonly name: string;
                     readonly subcategory?: string | null;
                     readonly args?: {
@@ -19033,7 +19184,7 @@ export type GQLSpotTestRuleQuery = {
             readonly signal?: {
               readonly __typename: 'Signal';
               readonly id: string;
-              readonly type: GQLSignalType;
+              readonly type: string;
               readonly name: string;
               readonly subcategory?: string | null;
               readonly args?: {
@@ -19096,7 +19247,7 @@ export type GQLSpotTestRuleQuery = {
     readonly signalResults?: ReadonlyArray<{
       readonly __typename: 'SignalWithScore';
       readonly signalName: string;
-      readonly integration?: GQLIntegration | null;
+      readonly integration?: string | null;
       readonly subcategory?: string | null;
       readonly score: string;
     }> | null;
@@ -19150,7 +19301,7 @@ export type GQLSampleReportingRuleExecutionResultFieldsFragment = {
   readonly signalResults?: ReadonlyArray<{
     readonly __typename: 'SignalWithScore';
     readonly signalName: string;
-    readonly integration?: GQLIntegration | null;
+    readonly integration?: string | null;
     readonly subcategory?: string | null;
     readonly score: string;
   }> | null;
@@ -19229,7 +19380,7 @@ export type GQLReportingRuleInsightsCurrentVersionSamplesQuery = {
         readonly signalResults?: ReadonlyArray<{
           readonly __typename: 'SignalWithScore';
           readonly signalName: string;
-          readonly integration?: GQLIntegration | null;
+          readonly integration?: string | null;
           readonly subcategory?: string | null;
           readonly score: string;
         }> | null;
@@ -19309,7 +19460,7 @@ export type GQLReportingRuleInsightsPriorVersionSamplesQuery = {
         readonly signalResults?: ReadonlyArray<{
           readonly __typename: 'SignalWithScore';
           readonly signalName: string;
-          readonly integration?: GQLIntegration | null;
+          readonly integration?: string | null;
           readonly subcategory?: string | null;
           readonly score: string;
         }> | null;
@@ -19377,7 +19528,7 @@ export type GQLLeafConditionWithResultFieldsFragment = {
   readonly signal?: {
     readonly __typename: 'Signal';
     readonly id: string;
-    readonly type: GQLSignalType;
+    readonly type: string;
     readonly name: string;
     readonly subcategory?: string | null;
     readonly args?: { readonly __typename: 'AggregationSignalArgs' } | null;
@@ -19441,7 +19592,7 @@ export type GQLSampleRuleExecutionResultFieldsFragment = {
   readonly signalResults?: ReadonlyArray<{
     readonly __typename: 'SignalWithScore';
     readonly signalName: string;
-    readonly integration?: GQLIntegration | null;
+    readonly integration?: string | null;
     readonly subcategory?: string | null;
     readonly score: string;
   }> | null;
@@ -19473,7 +19624,7 @@ export type GQLSampleRuleExecutionResultConditionResultFieldsFragment = {
               readonly signal?: {
                 readonly __typename: 'Signal';
                 readonly id: string;
-                readonly type: GQLSignalType;
+                readonly type: string;
                 readonly name: string;
                 readonly subcategory?: string | null;
                 readonly args?: {
@@ -19550,7 +19701,7 @@ export type GQLSampleRuleExecutionResultConditionResultFieldsFragment = {
         readonly signal?: {
           readonly __typename: 'Signal';
           readonly id: string;
-          readonly type: GQLSignalType;
+          readonly type: string;
           readonly name: string;
           readonly subcategory?: string | null;
           readonly args?: {
@@ -19622,7 +19773,7 @@ export type GQLRuleInsightsTableAllSignalsQuery = {
     readonly signals: ReadonlyArray<{
       readonly __typename: 'Signal';
       readonly id: string;
-      readonly integration?: GQLIntegration | null;
+      readonly integration?: string | null;
       readonly eligibleSubcategories: ReadonlyArray<{
         readonly __typename: 'SignalSubcategory';
         readonly id: string;
@@ -19657,7 +19808,7 @@ export type GQLRuleInsightsCurrentVersionSamplesQuery = {
             readonly signalResults?: ReadonlyArray<{
               readonly __typename: 'SignalWithScore';
               readonly signalName: string;
-              readonly integration?: GQLIntegration | null;
+              readonly integration?: string | null;
               readonly subcategory?: string | null;
               readonly score: string;
             }> | null;
@@ -19729,7 +19880,7 @@ export type GQLRuleInsightsCurrentVersionSamplesQuery = {
             readonly signalResults?: ReadonlyArray<{
               readonly __typename: 'SignalWithScore';
               readonly signalName: string;
-              readonly integration?: GQLIntegration | null;
+              readonly integration?: string | null;
               readonly subcategory?: string | null;
               readonly score: string;
             }> | null;
@@ -19764,7 +19915,7 @@ export type GQLRuleInsightsPriorVersionSamplesQuery = {
             readonly signalResults?: ReadonlyArray<{
               readonly __typename: 'SignalWithScore';
               readonly signalName: string;
-              readonly integration?: GQLIntegration | null;
+              readonly integration?: string | null;
               readonly subcategory?: string | null;
               readonly score: string;
             }> | null;
@@ -19866,7 +20017,7 @@ export type GQLRuleInsightsPriorVersionSamplesQuery = {
             readonly signalResults?: ReadonlyArray<{
               readonly __typename: 'SignalWithScore';
               readonly signalName: string;
-              readonly integration?: GQLIntegration | null;
+              readonly integration?: string | null;
               readonly subcategory?: string | null;
               readonly score: string;
             }> | null;
@@ -19920,7 +20071,7 @@ export type GQLGetFullResultForRuleQuery = {
                       readonly signal?: {
                         readonly __typename: 'Signal';
                         readonly id: string;
-                        readonly type: GQLSignalType;
+                        readonly type: string;
                         readonly name: string;
                         readonly subcategory?: string | null;
                         readonly args?: {
@@ -19997,7 +20148,7 @@ export type GQLGetFullResultForRuleQuery = {
                 readonly signal?: {
                   readonly __typename: 'Signal';
                   readonly id: string;
-                  readonly type: GQLSignalType;
+                  readonly type: string;
                   readonly name: string;
                   readonly subcategory?: string | null;
                   readonly args?: {
@@ -20060,7 +20211,7 @@ export type GQLGetFullResultForRuleQuery = {
         readonly signalResults?: ReadonlyArray<{
           readonly __typename: 'SignalWithScore';
           readonly signalName: string;
-          readonly integration?: GQLIntegration | null;
+          readonly integration?: string | null;
           readonly subcategory?: string | null;
           readonly score: string;
         }> | null;
@@ -20147,7 +20298,7 @@ export type GQLReportingRuleFormRuleFieldsFragmentFragment = {
                 readonly signal?: {
                   readonly __typename: 'Signal';
                   readonly id: string;
-                  readonly type: GQLSignalType;
+                  readonly type: string;
                   readonly name: string;
                   readonly subcategory?: string | null;
                   readonly args?: {
@@ -20223,7 +20374,7 @@ export type GQLReportingRuleFormRuleFieldsFragmentFragment = {
           readonly signal?: {
             readonly __typename: 'Signal';
             readonly id: string;
-            readonly type: GQLSignalType;
+            readonly type: string;
             readonly name: string;
             readonly subcategory?: string | null;
             readonly args?: {
@@ -20596,7 +20747,7 @@ export type GQLReportingRuleQuery = {
                   readonly signal?: {
                     readonly __typename: 'Signal';
                     readonly id: string;
-                    readonly type: GQLSignalType;
+                    readonly type: string;
                     readonly name: string;
                     readonly subcategory?: string | null;
                     readonly args?: {
@@ -20672,7 +20823,7 @@ export type GQLReportingRuleQuery = {
             readonly signal?: {
               readonly __typename: 'Signal';
               readonly id: string;
-              readonly type: GQLSignalType;
+              readonly type: string;
               readonly name: string;
               readonly subcategory?: string | null;
               readonly args?: {
@@ -21006,9 +21157,12 @@ export type GQLReportingRuleFormOrgDataQuery = {
     readonly signals: ReadonlyArray<{
       readonly __typename: 'Signal';
       readonly id: string;
-      readonly type: GQLSignalType;
+      readonly type: string;
       readonly name: string;
-      readonly integration?: GQLIntegration | null;
+      readonly integration?: string | null;
+      readonly integrationTitle?: string | null;
+      readonly integrationLogoUrl?: string | null;
+      readonly integrationLogoWithBackgroundUrl?: string | null;
       readonly docsUrl?: string | null;
       readonly description: string;
       readonly eligibleInputs: ReadonlyArray<GQLSignalInputType>;
@@ -21369,9 +21523,12 @@ export type GQLItemTypeFragmentFragment =
 export type GQLSignalsFragmentFragment = {
   readonly __typename: 'Signal';
   readonly id: string;
-  readonly type: GQLSignalType;
+  readonly type: string;
   readonly name: string;
-  readonly integration?: GQLIntegration | null;
+  readonly integration?: string | null;
+  readonly integrationTitle?: string | null;
+  readonly integrationLogoUrl?: string | null;
+  readonly integrationLogoWithBackgroundUrl?: string | null;
   readonly docsUrl?: string | null;
   readonly description: string;
   readonly eligibleInputs: ReadonlyArray<GQLSignalInputType>;
@@ -21449,7 +21606,7 @@ export type GQLLeafConditionFieldsFragment = {
   readonly signal?: {
     readonly __typename: 'Signal';
     readonly id: string;
-    readonly type: GQLSignalType;
+    readonly type: string;
     readonly name: string;
     readonly subcategory?: string | null;
     readonly args?: { readonly __typename: 'AggregationSignalArgs' } | null;
@@ -21531,7 +21688,7 @@ export type GQLConditionSetFieldsFragment = {
               readonly signal?: {
                 readonly __typename: 'Signal';
                 readonly id: string;
-                readonly type: GQLSignalType;
+                readonly type: string;
                 readonly name: string;
                 readonly subcategory?: string | null;
                 readonly args?: {
@@ -21607,7 +21764,7 @@ export type GQLConditionSetFieldsFragment = {
         readonly signal?: {
           readonly __typename: 'Signal';
           readonly id: string;
-          readonly type: GQLSignalType;
+          readonly type: string;
           readonly name: string;
           readonly subcategory?: string | null;
           readonly args?: {
@@ -21706,7 +21863,7 @@ type GQLRuleFormRuleFieldsFragmentContentRuleFragment = {
                 readonly signal?: {
                   readonly __typename: 'Signal';
                   readonly id: string;
-                  readonly type: GQLSignalType;
+                  readonly type: string;
                   readonly name: string;
                   readonly subcategory?: string | null;
                   readonly args?: {
@@ -21782,7 +21939,7 @@ type GQLRuleFormRuleFieldsFragmentContentRuleFragment = {
           readonly signal?: {
             readonly __typename: 'Signal';
             readonly id: string;
-            readonly type: GQLSignalType;
+            readonly type: string;
             readonly name: string;
             readonly subcategory?: string | null;
             readonly args?: {
@@ -21976,7 +22133,7 @@ type GQLRuleFormRuleFieldsFragmentUserRuleFragment = {
                 readonly signal?: {
                   readonly __typename: 'Signal';
                   readonly id: string;
-                  readonly type: GQLSignalType;
+                  readonly type: string;
                   readonly name: string;
                   readonly subcategory?: string | null;
                   readonly args?: {
@@ -22052,7 +22209,7 @@ type GQLRuleFormRuleFieldsFragmentUserRuleFragment = {
           readonly signal?: {
             readonly __typename: 'Signal';
             readonly id: string;
-            readonly type: GQLSignalType;
+            readonly type: string;
             readonly name: string;
             readonly subcategory?: string | null;
             readonly args?: {
@@ -22433,7 +22590,7 @@ export type GQLRuleQuery = {
                       readonly signal?: {
                         readonly __typename: 'Signal';
                         readonly id: string;
-                        readonly type: GQLSignalType;
+                        readonly type: string;
                         readonly name: string;
                         readonly subcategory?: string | null;
                         readonly args?: {
@@ -22509,7 +22666,7 @@ export type GQLRuleQuery = {
                 readonly signal?: {
                   readonly __typename: 'Signal';
                   readonly id: string;
-                  readonly type: GQLSignalType;
+                  readonly type: string;
                   readonly name: string;
                   readonly subcategory?: string | null;
                   readonly args?: {
@@ -22702,7 +22859,7 @@ export type GQLRuleQuery = {
                       readonly signal?: {
                         readonly __typename: 'Signal';
                         readonly id: string;
-                        readonly type: GQLSignalType;
+                        readonly type: string;
                         readonly name: string;
                         readonly subcategory?: string | null;
                         readonly args?: {
@@ -22778,7 +22935,7 @@ export type GQLRuleQuery = {
                 readonly signal?: {
                   readonly __typename: 'Signal';
                   readonly id: string;
-                  readonly type: GQLSignalType;
+                  readonly type: string;
                   readonly name: string;
                   readonly subcategory?: string | null;
                   readonly args?: {
@@ -23309,9 +23466,12 @@ export type GQLContentRuleFormConfigQuery = {
     readonly signals: ReadonlyArray<{
       readonly __typename: 'Signal';
       readonly id: string;
-      readonly type: GQLSignalType;
+      readonly type: string;
       readonly name: string;
-      readonly integration?: GQLIntegration | null;
+      readonly integration?: string | null;
+      readonly integrationTitle?: string | null;
+      readonly integrationLogoUrl?: string | null;
+      readonly integrationLogoWithBackgroundUrl?: string | null;
       readonly docsUrl?: string | null;
       readonly description: string;
       readonly eligibleInputs: ReadonlyArray<GQLSignalInputType>;
@@ -24612,6 +24772,9 @@ export const GQLSignalsFragmentFragmentDoc = gql`
     type
     name
     integration
+    integrationTitle
+    integrationLogoUrl
+    integrationLogoWithBackgroundUrl
     docsUrl
     recommendedThresholds {
       highPrecisionThreshold
@@ -27362,12 +27525,104 @@ export type GQLSetIntegrationConfigMutationOptions = Apollo.BaseMutationOptions<
   GQLSetIntegrationConfigMutation,
   GQLSetIntegrationConfigMutationVariables
 >;
+export const GQLSetPluginIntegrationConfigDocument = gql`
+  mutation SetPluginIntegrationConfig(
+    $input: SetPluginIntegrationConfigInput!
+  ) {
+    setPluginIntegrationConfig(input: $input) {
+      ... on SetIntegrationConfigSuccessResponse {
+        config {
+          name
+        }
+      }
+      ... on IntegrationConfigTooManyCredentialsError {
+        title
+      }
+      ... on IntegrationNoInputCredentialsError {
+        title
+      }
+      ... on IntegrationEmptyInputCredentialsError {
+        title
+      }
+    }
+  }
+`;
+export type GQLSetPluginIntegrationConfigMutationFn = Apollo.MutationFunction<
+  GQLSetPluginIntegrationConfigMutation,
+  GQLSetPluginIntegrationConfigMutationVariables
+>;
+
+/**
+ * __useGQLSetPluginIntegrationConfigMutation__
+ *
+ * To run a mutation, you first call `useGQLSetPluginIntegrationConfigMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useGQLSetPluginIntegrationConfigMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [gqlSetPluginIntegrationConfigMutation, { data, loading, error }] = useGQLSetPluginIntegrationConfigMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useGQLSetPluginIntegrationConfigMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    GQLSetPluginIntegrationConfigMutation,
+    GQLSetPluginIntegrationConfigMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    GQLSetPluginIntegrationConfigMutation,
+    GQLSetPluginIntegrationConfigMutationVariables
+  >(GQLSetPluginIntegrationConfigDocument, options);
+}
+export type GQLSetPluginIntegrationConfigMutationHookResult = ReturnType<
+  typeof useGQLSetPluginIntegrationConfigMutation
+>;
+export type GQLSetPluginIntegrationConfigMutationResult =
+  Apollo.MutationResult<GQLSetPluginIntegrationConfigMutation>;
+export type GQLSetPluginIntegrationConfigMutationOptions =
+  Apollo.BaseMutationOptions<
+    GQLSetPluginIntegrationConfigMutation,
+    GQLSetPluginIntegrationConfigMutationVariables
+  >;
 export const GQLIntegrationConfigDocument = gql`
-  query IntegrationConfig($name: Integration!) {
+  query IntegrationConfig($name: String!) {
     integrationConfig(name: $name) {
       ... on IntegrationConfigSuccessResult {
         config {
           name
+          title
+          docsUrl
+          requiresConfig
+          logoUrl
+          logoWithBackgroundUrl
+          modelCard {
+            modelName
+            version
+            releaseDate
+            sections {
+              id
+              title
+              subsections {
+                title
+                fields {
+                  label
+                  value
+                }
+              }
+              fields {
+                label
+                value
+              }
+            }
+          }
+          modelCardLearnMoreUrl
           apiCredential {
             ... on GoogleContentSafetyApiIntegrationApiCredential {
               apiKey
@@ -27381,6 +27636,9 @@ export const GQLIntegrationConfigDocument = gql`
                 id
                 label
               }
+            }
+            ... on PluginIntegrationApiCredential {
+              credential
             }
           }
         }
@@ -27503,6 +27761,68 @@ export type GQLMyIntegrationsLazyQueryHookResult = ReturnType<
 export type GQLMyIntegrationsQueryResult = Apollo.QueryResult<
   GQLMyIntegrationsQuery,
   GQLMyIntegrationsQueryVariables
+>;
+export const GQLAvailableIntegrationsDocument = gql`
+  query AvailableIntegrations {
+    availableIntegrations {
+      name
+      title
+      docsUrl
+      requiresConfig
+      logoUrl
+      logoWithBackgroundUrl
+    }
+  }
+`;
+
+/**
+ * __useGQLAvailableIntegrationsQuery__
+ *
+ * To run a query within a React component, call `useGQLAvailableIntegrationsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGQLAvailableIntegrationsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGQLAvailableIntegrationsQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGQLAvailableIntegrationsQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    GQLAvailableIntegrationsQuery,
+    GQLAvailableIntegrationsQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GQLAvailableIntegrationsQuery,
+    GQLAvailableIntegrationsQueryVariables
+  >(GQLAvailableIntegrationsDocument, options);
+}
+export function useGQLAvailableIntegrationsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GQLAvailableIntegrationsQuery,
+    GQLAvailableIntegrationsQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GQLAvailableIntegrationsQuery,
+    GQLAvailableIntegrationsQueryVariables
+  >(GQLAvailableIntegrationsDocument, options);
+}
+export type GQLAvailableIntegrationsQueryHookResult = ReturnType<
+  typeof useGQLAvailableIntegrationsQuery
+>;
+export type GQLAvailableIntegrationsLazyQueryHookResult = ReturnType<
+  typeof useGQLAvailableIntegrationsLazyQuery
+>;
+export type GQLAvailableIntegrationsQueryResult = Apollo.QueryResult<
+  GQLAvailableIntegrationsQuery,
+  GQLAvailableIntegrationsQueryVariables
 >;
 export const GQLInvestigationItemTypesDocument = gql`
   query InvestigationItemTypes {
@@ -37176,6 +37496,7 @@ export const namedOperations = {
     MatchingBankIds: 'MatchingBankIds',
     IntegrationConfig: 'IntegrationConfig',
     MyIntegrations: 'MyIntegrations',
+    AvailableIntegrations: 'AvailableIntegrations',
     InvestigationItemTypes: 'InvestigationItemTypes',
     GetOrgData: 'GetOrgData',
     GetItemsWithId: 'GetItemsWithId',
@@ -37297,6 +37618,7 @@ export const namedOperations = {
     DeleteTextBank: 'DeleteTextBank',
     BulkActionExecution: 'BulkActionExecution',
     SetIntegrationConfig: 'SetIntegrationConfig',
+    SetPluginIntegrationConfig: 'SetPluginIntegrationConfig',
     DeleteItemType: 'DeleteItemType',
     CreateContentType: 'CreateContentType',
     UpdateContentType: 'UpdateContentType',

--- a/client/src/models/signal.ts
+++ b/client/src/models/signal.ts
@@ -26,6 +26,9 @@ export type CoreSignal = Pick<
   | 'eligibleInputs'
   | 'subcategory'
   | 'integration'
+  | 'integrationTitle'
+  | 'integrationLogoUrl'
+  | 'integrationLogoWithBackgroundUrl'
   | 'pricingStructure'
   | 'docsUrl'
   | 'recommendedThresholds'
@@ -34,7 +37,8 @@ export type CoreSignal = Pick<
   | 'allowedInAutomatedRules'
 >;
 
-export function receivesRegexInput(type: GQLSignalType) {
+/** Signal type is string to support plugin signal types (e.g. RANDOM_SIGNAL_SELECTION). */
+export function receivesRegexInput(type: string) {
   return (
     type === GQLSignalType.TextMatchingContainsRegex ||
     type === GQLSignalType.TextMatchingNotContainsRegex
@@ -42,12 +46,11 @@ export function receivesRegexInput(type: GQLSignalType) {
 }
 
 /**
- * This function returns the integration type for a given signal type
- * @param type Signal type to find the integration for
- * @returns a GQLIntegration enum value, or null in the case of signals that are
- * not integrations
+ * Returns the integration type for a given signal type.
+ * @param type Signal type (built-in or plugin)
+ * @returns a GQLIntegration enum value, or null for non-integration signals or plugin signals
  */
-export function integrationForSignalType(type: GQLSignalType) {
+export function integrationForSignalType(type: string) {
   switch (type) {
     case 'GOOGLE_CONTENT_SAFETY_API_IMAGE':
       return GQLIntegration.GoogleContentSafetyApi;
@@ -80,7 +83,8 @@ export function integrationForSignalType(type: GQLSignalType) {
     case 'BENIGN_MODEL':
       return null;
     default:
-      assertUnreachable(type);
+      // Plugin signal types (e.g. RANDOM_SIGNAL_SELECTION) or unknown: no built-in integration
+      return null;
   }
 }
 

--- a/client/src/utils/signalUtils.ts
+++ b/client/src/utils/signalUtils.ts
@@ -1,7 +1,7 @@
 import { SignalSubcategory } from '@roostorg/types';
 import transform from 'lodash/transform';
 
-import { GQLIntegration, GQLSignalSubcategory } from '../graphql/generated';
+import { GQLSignalSubcategory } from '../graphql/generated';
 import { safePick } from './misc';
 
 /**
@@ -39,7 +39,7 @@ export function rebuildSubcategoryTreeFromGraphQLResponse(
 
 export function createSubcategoryIdToLabelMapping(
   signals: readonly {
-    integration?: GQLIntegration | null;
+    integration?: string | null;
     eligibleSubcategories: readonly { id: string; label: string }[];
   }[],
 ) {

--- a/client/src/webpages/dashboard/integrations/IntegrationCard.tsx
+++ b/client/src/webpages/dashboard/integrations/IntegrationCard.tsx
@@ -1,16 +1,27 @@
 import { ReactNode, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
+import type { GQLIntegrationMetadata } from '../../../graphql/generated';
 import CoopModal from '../components/CoopModal';
 
-import { IntegrationConfig } from './IntegrationsDashboard';
+import { INTEGRATION_LOGO_FALLBACKS } from './integrationLogos';
 
 export default function IntegrationCard(props: {
-  integration: IntegrationConfig;
+  integration: GQLIntegrationMetadata;
   useExternalURL?: boolean;
 }) {
   const { integration, useExternalURL } = props;
-  const { name, title, logo, requiresInfo, url } = integration;
+  const { name, title, docsUrl } = integration;
+  // Integrations page uses only the plain logo (logoUrl from logoPath). Do not fall back to logoWithBackgroundUrl.
+  const rawLogo =
+    integration.logoUrl ??
+    INTEGRATION_LOGO_FALLBACKS[name]?.logo ??
+    '';
+  // Resolve relative API paths to absolute URL so img loads correctly (e.g. /api/v1/integration-logos/ID).
+  const logo =
+    typeof rawLogo === 'string' && rawLogo.startsWith('/')
+      ? `${window.location.origin}${rawLogo}`
+      : rawLogo;
   const navigate = useNavigate();
 
   const [modalVisible, setModalVisible] = useState(false);
@@ -31,8 +42,10 @@ export default function IntegrationCard(props: {
       ]}
     >
       <div className="flex flex-col items-center max-w-md">
-        <div className="p-6 mb-6 rounded-full bg-slate-200 w-fit h-fit">
-          <img src={logo} alt="Logo" className="w-16 h-16" />
+        <div className="p-6 mb-6 rounded-full bg-slate-200 w-fit h-fit flex items-center justify-center">
+          {logo ? (
+            <img src={logo} alt="" className="w-16 h-16 object-contain" />
+          ) : null}
         </div>
         <div>
           <span className="font-medium">{title}</span> doesn't require any
@@ -56,12 +69,12 @@ export default function IntegrationCard(props: {
   }) => {
     if (Boolean(useExternalURL)) {
       return (
-        <a href={url} {...rest}>
+        <a href={docsUrl} {...rest}>
           {children}
         </a>
       );
     }
-    if (!requiresInfo) {
+    if (!integration.requiresConfig) {
       return (
         <div onClick={() => setModalVisible(true)} {...rest}>
           {children}
@@ -81,8 +94,10 @@ export default function IntegrationCard(props: {
   return (
     <>
       <Wrapper className="relative flex flex-col items-center justify-center w-full h-full p-6 pt-12 pb-12 bg-white border border-solid rounded-3xl border-slate-300 transition-all duration-200 ease-out box-border hover:transform hover:-translate-y-1 hover:transition-all hover:duration-200 hover:ease-in hover:dashboard-border-primary/70 hover:cursor-pointer">
-        <div className="w-16 h-16 p-4 mb-6 rounded-full bg-slate-200">
-          <img src={logo} alt="Logo" className="w-full h-full" />
+        <div className="w-16 h-16 p-4 mb-6 rounded-full bg-slate-200 flex items-center justify-center overflow-hidden">
+          {logo ? (
+            <img src={logo} alt="" className="w-full h-full object-contain" />
+          ) : null}
         </div>
         <div className="flex flex-col justify-start text-lg font-bold text-center text-slate-700">
           {title}

--- a/client/src/webpages/dashboard/integrations/IntegrationConfigApiCredentialsSection.tsx
+++ b/client/src/webpages/dashboard/integrations/IntegrationConfigApiCredentialsSection.tsx
@@ -3,14 +3,13 @@ import { Plus, Trash2 } from 'lucide-react';
 
 import {
   GQLGoogleContentSafetyApiIntegrationApiCredential,
-  GQLIntegration,
   GQLIntegrationApiCredential,
   GQLOpenAiIntegrationApiCredential,
   GQLZentropiIntegrationApiCredential,
 } from '../../../graphql/generated';
 
 export default function IntegrationConfigApiCredentialsSection(props: {
-  name: GQLIntegration;
+  name: string;
   setApiCredential: (cred: GQLIntegrationApiCredential) => void;
   apiCredential: GQLIntegrationApiCredential;
 }) {
@@ -142,6 +141,44 @@ export default function IntegrationConfigApiCredentialsSection(props: {
     );
   };
 
+  const PLUGIN_FIELD_LABELS: Record<string, string> = {
+    truePercentage: 'True percentage (0–100)',
+  };
+
+  const renderPluginCredential = (
+    pluginCredential: { __typename: 'PluginIntegrationApiCredential'; credential: Record<string, unknown> },
+  ) => {
+    const credential = pluginCredential.credential ?? {};
+    const entries = Object.entries(credential).filter(
+      ([key]) => key !== 'name',
+    );
+    const fieldsToShow =
+      entries.length > 0
+        ? entries
+        : [['truePercentage', ''] as [string, unknown]];
+    return (
+      <div className="flex flex-col gap-4">
+        {fieldsToShow.map(([key, value]) => (
+          <div key={key} className="flex flex-col w-1/2">
+            <div className="mb-1">
+              {PLUGIN_FIELD_LABELS[key] ?? key}
+            </div>
+            <Input
+              value={String(value ?? '')}
+              onChange={(event) => {
+                const next = { ...credential, [key]: event.target.value };
+                setApiCredential({
+                  __typename: 'PluginIntegrationApiCredential',
+                  credential: next as import('../../../graphql/generated').Scalars['JSONObject'],
+                });
+              }}
+            />
+          </div>
+        ))}
+      </div>
+    );
+  };
+
   const projectKeysInput = () => {
     switch (apiCredential.__typename) {
       case 'GoogleContentSafetyApiIntegrationApiCredential':
@@ -150,6 +187,8 @@ export default function IntegrationConfigApiCredentialsSection(props: {
         return renderOpenAiCredential(apiCredential);
       case 'ZentropiIntegrationApiCredential':
         return renderZentropiCredential(apiCredential);
+      case 'PluginIntegrationApiCredential':
+        return renderPluginCredential(apiCredential);
       default:
         throw new Error('Integration not implemented yet');
     }

--- a/client/src/webpages/dashboard/integrations/IntegrationConfigForm.tsx
+++ b/client/src/webpages/dashboard/integrations/IntegrationConfigForm.tsx
@@ -1,5 +1,5 @@
 import { gql } from '@apollo/client';
-import { useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useNavigate, useParams } from 'react-router-dom';
 
@@ -8,7 +8,6 @@ import CoopButton from '../components/CoopButton';
 import CoopModal from '../components/CoopModal';
 
 import {
-  GQLIntegration,
   GQLIntegrationApiCredential,
   GQLIntegrationConfigDocument,
   GQLUserPermission,
@@ -16,6 +15,7 @@ import {
   useGQLIntegrationConfigQuery,
   useGQLPermissionGatedRouteLoggedInUserQuery,
   useGQLSetIntegrationConfigMutation,
+  useGQLSetPluginIntegrationConfigMutation,
   type GQLGoogleContentSafetyApiIntegrationApiCredential,
   type GQLOpenAiIntegrationApiCredential,
   type GQLZentropiIntegrationApiCredential,
@@ -26,7 +26,8 @@ import {
 } from '../../../graphql/inputHelpers';
 import { userHasPermissions } from '../../../routing/permissions';
 import IntegrationConfigApiCredentialsSection from './IntegrationConfigApiCredentialsSection';
-import { INTEGRATION_CONFIGS } from './integrationConfigs';
+import { INTEGRATION_LOGO_FALLBACKS } from './integrationLogos';
+import ModelCardView from './ModelCardView';
 
 gql`
   mutation SetIntegrationConfig($input: SetIntegrationConfigInput!) {
@@ -48,11 +49,56 @@ gql`
     }
   }
 
-  query IntegrationConfig($name: Integration!) {
+  mutation SetPluginIntegrationConfig($input: SetPluginIntegrationConfigInput!) {
+    setPluginIntegrationConfig(input: $input) {
+      ... on SetIntegrationConfigSuccessResponse {
+        config {
+          name
+        }
+      }
+      ... on IntegrationConfigTooManyCredentialsError {
+        title
+      }
+      ... on IntegrationNoInputCredentialsError {
+        title
+      }
+      ... on IntegrationEmptyInputCredentialsError {
+        title
+      }
+    }
+  }
+
+  query IntegrationConfig($name: String!) {
     integrationConfig(name: $name) {
       ... on IntegrationConfigSuccessResult {
         config {
           name
+          title
+          docsUrl
+          requiresConfig
+          logoUrl
+          logoWithBackgroundUrl
+          modelCard {
+            modelName
+            version
+            releaseDate
+            sections {
+              id
+              title
+              subsections {
+                title
+                fields {
+                  label
+                  value
+                }
+              }
+              fields {
+                label
+                value
+              }
+            }
+          }
+          modelCardLearnMoreUrl
           apiCredential {
             ... on GoogleContentSafetyApiIntegrationApiCredential {
               apiKey
@@ -66,6 +112,9 @@ gql`
                 id
                 label
               }
+            }
+            ... on PluginIntegrationApiCredential {
+              credential
             }
           }
         }
@@ -88,7 +137,7 @@ gql`
  * IntegrationConfigApiCredential), so the UI can display the proper empty inputs.
  */
 export function getNewEmptyApiKey(
-  name: GQLIntegration,
+  name: string,
 ): GQLIntegrationApiCredential {
   switch (name) {
     case 'GOOGLE_CONTENT_SAFETY_API': {
@@ -108,7 +157,10 @@ export function getNewEmptyApiKey(
       };
     }
     default: {
-      throw new Error(`${name} integration not implemented.`);
+      return {
+        __typename: 'PluginIntegrationApiCredential',
+        credential: {},
+      };
     }
   }
 }
@@ -119,12 +171,7 @@ export default function IntegrationConfigForm() {
     throw Error('Integration name not provided');
   }
   // Cast back to upper case (see lowercase cast in IntegrationCard.tsx)
-  const integrationName = name.toUpperCase() as GQLIntegration;
-  const config = INTEGRATION_CONFIGS.find((i) => i.name === integrationName);
-  if (config == null) {
-    throw Error(`Integration with name ${name} not found`);
-  }
-  const formattedName = config.title;
+  const integrationName = name.toUpperCase();
   const navigate = useNavigate();
 
   const [modalVisible, setModalVisible] = useState(false);
@@ -142,8 +189,17 @@ export default function IntegrationConfigForm() {
       },
       onCompleted: () => showModal(),
     });
-  const mutationError = setConfigMutationParams.error;
-  const mutationLoading = setConfigMutationParams.loading;
+  const [setPluginConfig, setPluginConfigMutationParams] =
+    useGQLSetPluginIntegrationConfigMutation({
+      onError: () => {
+        showModal();
+      },
+      onCompleted: () => showModal(),
+    });
+  const mutationError =
+    setConfigMutationParams.error ?? setPluginConfigMutationParams.error;
+  const mutationLoading =
+    setConfigMutationParams.loading || setPluginConfigMutationParams.loading;
 
   const {
     loading,
@@ -177,9 +233,17 @@ export default function IntegrationConfigForm() {
    * If editing an existing config and the INTEGRATION_CONFIG_QUERY
    * has finished, reset the state values to whatever the query returned
    */
-  useMemo(() => {
+  useEffect(() => {
     if (response?.config != null) {
-      setApiCredential(response.config.apiCredential);
+      const cred = response.config.apiCredential;
+      if (cred.__typename === 'PluginIntegrationApiCredential') {
+        setApiCredential({
+          __typename: 'PluginIntegrationApiCredential',
+          credential: cred.credential ?? {},
+        });
+      } else {
+        setApiCredential(cred);
+      }
     }
   }, [response]);
 
@@ -189,6 +253,19 @@ export default function IntegrationConfigForm() {
   if (loading || userQueryLoading) {
     return <FullScreenLoading />;
   }
+
+  const apiConfig =
+    response?.__typename === 'IntegrationConfigSuccessResult'
+      ? response.config
+      : undefined;
+  const formattedName =
+    apiConfig?.title ?? integrationName.replace(/_/g, ' ');
+  const logo = apiConfig
+    ? (apiConfig.logoUrl ??
+      INTEGRATION_LOGO_FALLBACKS[apiConfig.name]?.logo ??
+      '')
+    : '';
+
   const canEditConfig = userHasPermissions(permissions, [
     GQLUserPermission.ManageOrg,
   ]);
@@ -197,9 +274,18 @@ export default function IntegrationConfigForm() {
     GoogleContentSafetyApiIntegrationApiCredential: 'googleContentSafetyApi',
     OpenAiIntegrationApiCredential: 'openAi',
     ZentropiIntegrationApiCredential: 'zentropi',
+    PluginIntegrationApiCredential: 'pluginCredential',
   });
 
+  const isPluginIntegration = ![
+    'GOOGLE_CONTENT_SAFETY_API',
+    'OPEN_AI',
+    'ZENTROPI',
+  ].includes(integrationName);
   const validationMessage = (() => {
+    if (isPluginIntegration) {
+      return undefined;
+    }
     if (
       'googleContentSafetyApi' in mappedApiCredential &&
       !(
@@ -237,22 +323,36 @@ export default function IntegrationConfigForm() {
     <CoopButton
       title="Save"
       loading={mutationLoading}
-      onClick={async () =>
-        setConfig({
-          variables: {
-            input: {
-              apiCredential: stripTypename(mappedApiCredential),
-            },
+      onClick={async () => {
+        const refetchQueries = [
+          namedOperations.Query.MyIntegrations,
+          {
+            query: GQLIntegrationConfigDocument,
+            variables: { name: integrationName },
           },
-          refetchQueries: [
-            namedOperations.Query.MyIntegrations,
-            {
-              query: GQLIntegrationConfigDocument,
-              variables: { name: integrationName },
+        ];
+        if (isPluginIntegration) {
+          const cred =
+            apiCredential.__typename === 'PluginIntegrationApiCredential'
+              ? apiCredential.credential ?? {}
+              : {};
+          await setPluginConfig({
+            variables: {
+              input: { integrationId: integrationName, credential: cred },
             },
-          ],
-        })
-      }
+            refetchQueries,
+          });
+        } else {
+          await setConfig({
+            variables: {
+              input: {
+                apiCredential: stripTypename(mappedApiCredential),
+              },
+            },
+            refetchQueries,
+          });
+        }
+      }}
       disabled={!canEditConfig || validationMessage != null}
       disabledTooltipTitle={validationMessage}
     />
@@ -296,11 +396,11 @@ export default function IntegrationConfigForm() {
   );
 
   const headerSubtitle = (
-    integration: GQLIntegration,
+    integrationName: string,
     formattedName: string,
   ): React.ReactNode | string | undefined => {
-    switch (integration) {
-      case GQLIntegration.GoogleContentSafetyApi:
+    switch (integrationName) {
+      case 'GOOGLE_CONTENT_SAFETY_API':
         return (
           <>
             The Content Safety API is an AI classifier which issues a Child 
@@ -322,12 +422,16 @@ export default function IntegrationConfigForm() {
             back in touch shortly to take the application forward if you qualify.
           </>
         );
-      case GQLIntegration.OpenAi:
+      case 'OPEN_AI':
         return `The ${formattedName} integration requires one API Key.`;
       default:
         return undefined;
     }
   };
+
+  const apiModelCard = response?.config?.modelCard;
+  const apiModelCardLearnMoreUrl = response?.config?.modelCardLearnMoreUrl;
+  const hasModelCard = apiModelCard != null;
 
   return (
     <div className="flex flex-col text-start">
@@ -335,19 +439,66 @@ export default function IntegrationConfigForm() {
         <title>{formattedName} Integration</title>
       </Helmet>
       <div className="flex flex-col justify-between w-4/5 mb-4">
-        <div className="mb-1 text-2xl font-bold">{`${formattedName} Integration`}</div>
-        <div className="mb-4 text-base text-zinc-900">
-          {headerSubtitle(integrationName, formattedName)}
+        <div className="flex items-center gap-3 mb-1">
+          <div className="w-12 h-12 rounded-full bg-slate-200 flex items-center justify-center shrink-0 overflow-hidden">
+            <img
+              src={logo}
+              alt=""
+              className="w-full h-full object-contain"
+            />
+          </div>
+          <div className="text-2xl font-bold">{`${formattedName} Integration`}</div>
         </div>
+        {!hasModelCard && (
+          <div className="mb-4 text-base text-zinc-900">
+            {headerSubtitle(integrationName, formattedName)}
+          </div>
+        )}
       </div>
-      <IntegrationConfigApiCredentialsSection
-        name={integrationName}
-        apiCredential={apiCredential}
-        setApiCredential={(cred: GQLIntegrationApiCredential) =>
-          setApiCredential(cred)
-        }
-      />
-      {saveButton}
+
+      {hasModelCard && apiModelCard ? (
+        <div className="flex flex-col lg:flex-row gap-8 w-full max-w-5xl">
+          <div className="flex-1 min-w-0">
+            <ModelCardView card={apiModelCard} />
+          </div>
+          <div className="flex flex-col lg:w-80 shrink-0">
+            {apiModelCardLearnMoreUrl != null && (
+              <a
+                href={apiModelCardLearnMoreUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm text-blue-600 hover:underline mb-4 inline-flex items-center gap-1"
+              >
+                <span className="align-middle">ⓘ</span>
+                <span>Learn more about how to read model cards</span>
+              </a>
+            )}
+            <div className="font-semibold text-zinc-800 mb-2">Credentials</div>
+            <div className="text-sm text-zinc-600 mb-3">
+              Configure your credentials below.
+            </div>
+            <IntegrationConfigApiCredentialsSection
+              name={integrationName}
+              apiCredential={apiCredential}
+              setApiCredential={(cred: GQLIntegrationApiCredential) =>
+                setApiCredential(cred)
+              }
+            />
+            {saveButton}
+          </div>
+        </div>
+      ) : (
+        <>
+          <IntegrationConfigApiCredentialsSection
+            name={integrationName}
+            apiCredential={apiCredential}
+            setApiCredential={(cred: GQLIntegrationApiCredential) =>
+              setApiCredential(cred)
+            }
+          />
+          {saveButton}
+        </>
+      )}
       {modal}
     </div>
   );

--- a/client/src/webpages/dashboard/integrations/IntegrationsDashboard.tsx
+++ b/client/src/webpages/dashboard/integrations/IntegrationsDashboard.tsx
@@ -5,20 +5,10 @@ import FullScreenLoading from '../../../components/common/FullScreenLoading';
 import DashboardHeader from '../components/DashboardHeader';
 
 import {
-  GQLIntegration,
+  useGQLAvailableIntegrationsQuery,
   useGQLMyIntegrationsQuery,
 } from '../../../graphql/generated';
 import IntegrationCard from './IntegrationCard';
-import { INTEGRATION_CONFIGS } from './integrationConfigs';
-
-export type IntegrationConfig = {
-  name: GQLIntegration;
-  title: string;
-  logo: string;
-  logoWithBackground: string;
-  url: string;
-  requiresInfo: boolean;
-};
 
 export default function IntegrationsDashboard() {
   gql`
@@ -31,7 +21,27 @@ export default function IntegrationsDashboard() {
     }
   `;
 
-  const { loading, error, data } = useGQLMyIntegrationsQuery();
+  gql`
+    query AvailableIntegrations {
+      availableIntegrations {
+        name
+        title
+        docsUrl
+        requiresConfig
+        logoUrl
+        logoWithBackgroundUrl
+      }
+    }
+  `;
+
+  const { loading: loadingCatalog, data: catalogData } =
+    useGQLAvailableIntegrationsQuery({
+      fetchPolicy: 'network-only',
+    });
+  const { loading: loadingMy, error, data: myData } =
+    useGQLMyIntegrationsQuery();
+
+  const loading = loadingCatalog || loadingMy;
 
   if (loading) {
     return <FullScreenLoading />;
@@ -41,15 +51,15 @@ export default function IntegrationsDashboard() {
     throw error;
   }
 
-  const integrationNames =
-    data?.myOrg?.integrationConfigs?.map((config) => config.name) ?? [];
+  const allIntegrations = catalogData?.availableIntegrations ?? [];
+  const myIntegrationNames =
+    myData?.myOrg?.integrationConfigs?.map((config) => config.name) ?? [];
 
-  const myIntegrations = INTEGRATION_CONFIGS.filter((it) =>
-    integrationNames.includes(it.name),
+  const myIntegrations = allIntegrations.filter((it) =>
+    myIntegrationNames.includes(it.name),
   );
-
-  const otherIntegrations = INTEGRATION_CONFIGS.filter(
-    (it) => !myIntegrations.includes(it),
+  const otherIntegrations = allIntegrations.filter(
+    (it) => !myIntegrationNames.includes(it.name),
   ).sort((a, b) => a.name.localeCompare(b.name));
 
   return (

--- a/client/src/webpages/dashboard/integrations/ModelCardView.tsx
+++ b/client/src/webpages/dashboard/integrations/ModelCardView.tsx
@@ -1,0 +1,127 @@
+import { useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+
+import type {
+  GQLModelCard,
+  GQLModelCardField,
+  GQLModelCardSection,
+  GQLModelCardSubsection,
+} from '../../../graphql/generated';
+
+type ModelCardViewProps = { card: GQLModelCard };
+
+/**
+ * Renders a single label-value row. Linkifies URLs in value.
+ */
+function ModelCardFieldRow({ field }: { field: GQLModelCardField }) {
+  const isUrl =
+    field.value.startsWith('http://') || field.value.startsWith('https://');
+  return (
+    <div className="flex flex-col gap-0.5 py-1 text-sm">
+      <span className="font-medium text-zinc-600">{field.label}</span>
+      {isUrl ? (
+        <a
+          href={field.value}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-600 hover:underline break-all"
+        >
+          {field.value}
+        </a>
+      ) : (
+        <span className="text-zinc-900">{field.value}</span>
+      )}
+    </div>
+  );
+}
+
+function SubsectionBlock({
+  subsection,
+}: {
+  subsection: GQLModelCardSubsection;
+}) {
+  return (
+    <div className="mb-4 last:mb-0">
+      <div className="mb-2 font-semibold text-zinc-800">{subsection.title}</div>
+      <div className="flex flex-col gap-0">
+        {subsection.fields.map((field, i) => (
+          <ModelCardFieldRow key={i} field={field} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ModelCardSectionBlock({
+  section,
+  defaultOpen = true,
+}: {
+  section: GQLModelCardSection;
+  defaultOpen?: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  const hasSubsections = section.subsections && section.subsections.length > 0;
+  const hasFields = section.fields && section.fields.length > 0;
+  const hasContent = hasSubsections ?? hasFields;
+
+  return (
+    <div className="border-b border-zinc-200 last:border-b-0">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center justify-between py-3 text-left font-semibold text-zinc-900 hover:bg-zinc-50 rounded"
+        aria-expanded={open}
+      >
+        {section.title}
+        {hasContent ? (
+          open ? (
+            <ChevronDown className="shrink-0 text-zinc-500" size={18} />
+          ) : (
+            <ChevronRight className="shrink-0 text-zinc-500" size={18} />
+          )
+        ) : null}
+      </button>
+      {open && hasContent && (
+        <div className="pb-4 pl-0">
+          {hasSubsections &&
+            section.subsections?.map((sub) => (
+              <SubsectionBlock key={sub.title} subsection={sub} />
+            ))}
+          {hasFields && !hasSubsections && (
+            <div className="flex flex-col gap-0">
+              {section.fields?.map((field, i) => (
+                <ModelCardFieldRow key={i} field={field} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function ModelCardView({ card }: ModelCardViewProps) {
+  const sections = card.sections ?? [];
+  return (
+    <div className="flex flex-col">
+      <div className="mb-3 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+        <span className="text-lg font-semibold text-zinc-900">
+          {card.modelName}
+        </span>
+        <span className="text-sm text-zinc-600">{card.version}</span>
+        {card.releaseDate != null && (
+          <span className="text-sm text-zinc-500">{card.releaseDate}</span>
+        )}
+      </div>
+      <div className="flex flex-col">
+        {sections.map((section) => (
+          <ModelCardSectionBlock
+            key={section.id}
+            section={section}
+            defaultOpen={sections.length <= 3}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/client/src/webpages/dashboard/integrations/integrationConfigs.ts
+++ b/client/src/webpages/dashboard/integrations/integrationConfigs.ts
@@ -1,14 +1,27 @@
-import { GQLIntegration } from '../../../graphql/generated';
+/**
+ * Client-side integration list for contexts that do not yet use the API
+ * (e.g. rule form signal modals). Prefer backend-driven data (availableIntegrations,
+ * integrationConfig) for the integrations dashboard and detail page.
+ */
+import type { GQLIntegration } from '../../../graphql/generated';
 import GoogleLogo from '../../../images/GoogleLogo.png';
 import GoogleLogoWithBackground from '../../../images/GoogleLogoWithBackground.png';
 import OpenAILogo from '../../../images/OpenAILogo.png';
 import OpenAILogoWithBackground from '../../../images/OpenAILogoWithBackground.png';
 import ZentropiLogo from '../../../images/ZentropiLogo.png';
-import { IntegrationConfig } from './IntegrationsDashboard';
+
+export type IntegrationConfig = {
+  name: GQLIntegration;
+  title: string;
+  logo: string;
+  logoWithBackground: string;
+  url: string;
+  requiresInfo: boolean;
+};
 
 export const INTEGRATION_CONFIGS: IntegrationConfig[] = [
   {
-    name: GQLIntegration.GoogleContentSafetyApi,
+    name: 'GOOGLE_CONTENT_SAFETY_API' as GQLIntegration,
     title: 'Google Content Safety API',
     logo: GoogleLogo,
     logoWithBackground: GoogleLogoWithBackground,
@@ -16,7 +29,7 @@ export const INTEGRATION_CONFIGS: IntegrationConfig[] = [
     requiresInfo: true,
   },
   {
-    name: GQLIntegration.OpenAi,
+    name: 'OPEN_AI' as GQLIntegration,
     title: 'OpenAI',
     logo: OpenAILogo,
     logoWithBackground: OpenAILogoWithBackground,
@@ -24,7 +37,7 @@ export const INTEGRATION_CONFIGS: IntegrationConfig[] = [
     requiresInfo: true,
   },
   {
-    name: GQLIntegration.Zentropi,
+    name: 'ZENTROPI' as GQLIntegration,
     title: 'Zentropi',
     logo: ZentropiLogo,
     logoWithBackground: ZentropiLogo,

--- a/client/src/webpages/dashboard/integrations/integrationLogos.ts
+++ b/client/src/webpages/dashboard/integrations/integrationLogos.ts
@@ -1,0 +1,27 @@
+/**
+ * Fallback logo assets when the backend does not provide logoUrl.
+ * Integrations are backend-driven; logos can come from API (logoUrl) or this map.
+ * Keys are integration names (built-in enum or plugin id string).
+ */
+import GoogleLogo from '../../../images/GoogleLogo.png';
+import GoogleLogoWithBackground from '../../../images/GoogleLogoWithBackground.png';
+import OpenAILogo from '../../../images/OpenAILogo.png';
+import OpenAILogoWithBackground from '../../../images/OpenAILogoWithBackground.png';
+import ZentropiLogo from '../../../images/ZentropiLogo.png';
+
+export const INTEGRATION_LOGO_FALLBACKS: Partial<
+  Record<string, { logo: string; logoWithBackground: string }>
+> = {
+  GOOGLE_CONTENT_SAFETY_API: {
+    logo: GoogleLogo,
+    logoWithBackground: GoogleLogoWithBackground,
+  },
+  OPEN_AI: {
+    logo: OpenAILogo,
+    logoWithBackground: OpenAILogoWithBackground,
+  },
+  ZENTROPI: {
+    logo: ZentropiLogo,
+    logoWithBackground: ZentropiLogo,
+  },
+};

--- a/client/src/webpages/dashboard/rules/info/insights/RuleInsightsSamplesTable.tsx
+++ b/client/src/webpages/dashboard/rules/info/insights/RuleInsightsSamplesTable.tsx
@@ -29,7 +29,6 @@ import Table from '../../../components/table/Table';
 import {
   GQLField,
   GQLFieldType,
-  GQLIntegration,
   GQLRuleStatus,
   useGQLRuleInsightsCurrentVersionSamplesQuery,
   useGQLRuleInsightsPriorVersionSamplesLazyQuery,
@@ -62,7 +61,7 @@ export enum RuleEnvironment {
 export type SignalWithResult = {
   subcategory?: string | null;
   signalName: string;
-  integration?: GQLIntegration | null | undefined;
+  integration?: string | null | undefined;
   score?: string;
 };
 

--- a/client/src/webpages/dashboard/rules/info/insights/sample_details/RuleInsightsSampleDetailMatchingValues.tsx
+++ b/client/src/webpages/dashboard/rules/info/insights/sample_details/RuleInsightsSampleDetailMatchingValues.tsx
@@ -100,8 +100,9 @@ export default function RuleInsightsSampleDetailMatchingValues(props: {
         matchingValues.strings!,
         result?.outcome,
         result?.matchedValue ?? undefined,
-        (condition.signal?.type && receivesRegexInput(condition.signal.type)) ??
-          false,
+        Boolean(
+          condition.signal?.type && receivesRegexInput(condition.signal.type),
+        ),
       );
     case MatchingValueType.LOCATION:
       return renderMatchingValuesStringsInput(

--- a/client/src/webpages/dashboard/rules/rule_form/RuleForm.tsx
+++ b/client/src/webpages/dashboard/rules/rule_form/RuleForm.tsx
@@ -201,6 +201,9 @@ export const SIGNALS_FRAGMENT = gql`
     type
     name
     integration
+    integrationTitle
+    integrationLogoUrl
+    integrationLogoWithBackgroundUrl
     docsUrl
     recommendedThresholds {
       highPrecisionThreshold

--- a/client/src/webpages/dashboard/rules/rule_form/signal_modal/RuleFormSignalModal.tsx
+++ b/client/src/webpages/dashboard/rules/rule_form/signal_modal/RuleFormSignalModal.tsx
@@ -14,10 +14,7 @@ export default function RuleFormSignalModal(props: {
   allSignals: CoreSignal[];
   onSelectSignal: (signal: CoreSignal, subcategoryOption?: string) => void;
   onClose: () => void;
-  // If the user has already selected a signal, the modal needs to know
-  // which signal it is.
   selectedSignal?: CoreSignal;
-  // Whether this is the automated rule form ( proactive/autoenforcements )
   isAutomatedRule?: boolean;
 }) {
   const { visible, allSignals, onSelectSignal, onClose, selectedSignal, isAutomatedRule } =

--- a/client/src/webpages/dashboard/rules/rule_form/signal_modal/RuleFormSignalModalMenuItem.tsx
+++ b/client/src/webpages/dashboard/rules/rule_form/signal_modal/RuleFormSignalModalMenuItem.tsx
@@ -8,17 +8,31 @@ import {
 } from '../../../../../graphql/generated';
 import LogoWhiteWithBackground from '../../../../../images/LogoWhiteWithBackground.png';
 import { CoreSignal } from '../../../../../models/signal';
-import { INTEGRATION_CONFIGS } from '../../../integrations/integrationConfigs';
+import {
+  type IntegrationConfig,
+  INTEGRATION_CONFIGS,
+} from '../../../integrations/integrationConfigs';
 
+/** Vendor/company name for display. Uses signal.integrationTitle (from API) when set, else static config, else formatted id. */
 export function vendorName(signal: CoreSignal) {
   if (signal.type === GQLSignalType.Custom) {
     return 'Custom';
-  } else if (!signal.integration) {
-    return 'Coop';
-  } else {
-    return INTEGRATION_CONFIGS.find((it) => it.name === signal.integration)!
-      .title;
   }
+  if (!signal.integration) {
+    return 'Coop';
+  }
+  if (signal.integrationTitle) {
+    return signal.integrationTitle;
+  }
+  const staticConfig = INTEGRATION_CONFIGS.find(
+    (it: IntegrationConfig) => it.name === signal.integration,
+  );
+  if (staticConfig) {
+    return staticConfig.title;
+  }
+  return typeof signal.integration === 'string'
+    ? signal.integration.replace(/_/g, ' ')
+    : 'Plugin';
 }
 
 export function signalDisplayName(signal: CoreSignal, hideVendor = true) {
@@ -28,7 +42,7 @@ export function signalDisplayName(signal: CoreSignal, hideVendor = true) {
   }
 
   const integrationConfig = INTEGRATION_CONFIGS.find(
-    (it) => it.name === integration,
+    (it: IntegrationConfig) => it.name === integration,
   );
   if (!integrationConfig) {
     return name;

--- a/client/src/webpages/dashboard/rules/rule_form/signal_modal/RuleFormSignalModalSignalDetailView.tsx
+++ b/client/src/webpages/dashboard/rules/rule_form/signal_modal/RuleFormSignalModalSignalDetailView.tsx
@@ -9,7 +9,10 @@ import {
 } from '../../../../../graphql/generated';
 import LogoWhiteWithBackground from '../../../../../images/LogoWhiteWithBackground.png';
 import { CoreSignal } from '../../../../../models/signal';
-import { INTEGRATION_CONFIGS } from '../../../integrations/integrationConfigs';
+import {
+  type IntegrationConfig,
+  INTEGRATION_CONFIGS,
+} from '../../../integrations/integrationConfigs';
 import { signalDisplayName } from './RuleFormSignalModalMenuItem';
 
 export default function RuleFormSignalModalSignalDetailView(props: {
@@ -21,9 +24,27 @@ export default function RuleFormSignalModalSignalDetailView(props: {
   ) => void;
 }) {
   const { signal, subcategories, onSelectSignal } = props;
-  const integration = INTEGRATION_CONFIGS.find(
-    (it) => it.name === signal.integration,
+  const staticConfig = INTEGRATION_CONFIGS.find(
+    (it: IntegrationConfig) => it.name === signal.integration,
   );
+  const integrationTitle =
+    signal.integrationTitle ??
+    staticConfig?.title ??
+    (typeof signal.integration === 'string'
+      ? signal.integration
+          .replace(/_/g, ' ')
+          .toLowerCase()
+          .replace(/^([a-z])|\s+([a-z])/g, (m) => m.toUpperCase())
+      : 'Coop');
+  // Signals use the logo-with-background variant.
+  const rawLogoSrc =
+    signal.integrationLogoWithBackgroundUrl ??
+    staticConfig?.logoWithBackground ??
+    LogoWhiteWithBackground;
+  const logoSrc =
+    typeof rawLogoSrc === 'string' && rawLogoSrc.startsWith('/')
+      ? `${window.location.origin}${rawLogoSrc}`
+      : rawLogoSrc;
 
   const infoSectionData = [
     {
@@ -33,9 +54,9 @@ export default function RuleFormSignalModalSignalDetailView(props: {
           <img
             alt="logo"
             className="w-8 h-8 mr-2 rounded-full"
-            src={integration?.logoWithBackground ?? LogoWhiteWithBackground}
+            src={logoSrc}
           />{' '}
-          {integration?.title ?? 'Coop'}
+          {integrationTitle}
         </div>
       ),
     },

--- a/integrations.config.example.json
+++ b/integrations.config.example.json
@@ -1,0 +1,24 @@
+{
+  "integrations": [
+    {
+      "package": "@roostorg/coop-integration-example",
+      "enabled": true
+    },
+    {
+      "package": "../coop-integration-example",
+      "enabled": false
+    },
+    {
+      "package": "@acme/coop-integration-acme",
+      "enabled": false
+    },
+    {
+      "package": "./local-integrations/my-custom-integration",
+      "enabled": false,
+      "config": {
+        "endpoint": "https://api.example.com",
+        "timeoutMs": 5000
+      }
+    }
+  ]
+}

--- a/server/condition_evaluator/conditionSet.ts
+++ b/server/condition_evaluator/conditionSet.ts
@@ -261,11 +261,13 @@ export function tryGetOutcomeFromPartialOutcomes(
 export function getAllAggregationsInConditionSet(
   conditionSet: ReadonlyDeep<ConditionSet>,
 ): ReadonlyDeep<AggregationClause>[] {
-  return conditionSet.conditions.flatMap((condition) =>
-    isConditionSet(condition)
-      ? getAllAggregationsInConditionSet(condition)
-      : condition.signal?.type === 'AGGREGATION'
-      ? [condition.signal.args.aggregationClause]
-      : [],
-  );
+  return conditionSet.conditions.flatMap((condition) => {
+    if (isConditionSet(condition)) {
+      return getAllAggregationsInConditionSet(condition);
+    }
+    const sig = condition.signal;
+    const args =
+      sig?.type === 'AGGREGATION' ? sig.args : undefined;
+    return args != null ? [args.aggregationClause] : [];
+  });
 }

--- a/server/condition_evaluator/leafCondition.ts
+++ b/server/condition_evaluator/leafCondition.ts
@@ -560,11 +560,14 @@ async function getSignalRuntimeArgs(
   conditionSignalInfo: ReadonlyDeep<ConditionSignalInfo>,
 ) {
   if (conditionSignalInfo.type === 'AGGREGATION') {
-    return evaluateAggregationRuntimeArgsForItem(
-      evaluationContext,
-      itemSubmission,
-      conditionSignalInfo.args.aggregationClause,
-    );
+    const args = conditionSignalInfo.args;
+    if (args != null) {
+      return evaluateAggregationRuntimeArgsForItem(
+        evaluationContext,
+        itemSubmission,
+        args.aggregationClause,
+      );
+    }
   }
   return undefined;
 }

--- a/server/graphql/datasources/IntegrationApi.ts
+++ b/server/graphql/datasources/IntegrationApi.ts
@@ -1,29 +1,63 @@
 import { DataSource } from 'apollo-datasource';
 
 import { inject, type Dependencies } from '../../iocContainer/index.js';
-import {
-  configurableIntegrations,
-  type ConfigurableIntegration,
-  type CredentialTypes,
-} from '../../services/signalAuthService/index.js';
-import { filterNullOrUndefined } from '../../utils/collections.js';
+import '../../services/signalAuthService/index.js';
+import { Integration } from '../../services/signalsService/index.js';
 import {
   CoopError,
   ErrorType,
   type ErrorInstanceData,
 } from '../../utils/errors.js';
+import { getIntegrationRegistry } from '../../services/integrationRegistry/index.js';
+import type {
+  IntegrationManifestEntry,
+  ModelCard,
+} from './integrationManifests.js';
 import { type GQLSetIntegrationConfigInput } from '../generated.js';
 
-export type TIntegrationConfig = {
-  [K in keyof CredentialTypes]: {
-    name: K;
-    apiCredential: {
-      name: K;
-    } & CredentialTypes[K];
-  };
-}[ConfigurableIntegration];
+export type TIntegrationConfigWithMetadata = Readonly<{
+  name: string;
+  apiCredential: Readonly<Record<string, unknown>>;
+  modelCard: ModelCard;
+  modelCardLearnMoreUrl?: string;
+  title: string;
+  docsUrl: string;
+  requiresConfig: boolean;
+  logoUrl?: string;
+  logoWithBackgroundUrl?: string;
+}>;
 
-export type TIntegrationCredential = TIntegrationConfig['apiCredential'];
+function defaultCredentialForIntegrationId(
+  integrationId: string,
+): Record<string, unknown> {
+  switch (integrationId) {
+    case Integration.GOOGLE_CONTENT_SAFETY_API:
+    case Integration.OPEN_AI:
+      return { apiKey: '' };
+    case Integration.ZENTROPI:
+      return { apiKey: '', labelerVersions: [] };
+    default:
+      return {};
+  }
+}
+
+function mergeManifest(
+  integrationId: string,
+  apiCredential: Record<string, unknown>,
+  manifest: IntegrationManifestEntry,
+): TIntegrationConfigWithMetadata {
+  return {
+    name: integrationId,
+    apiCredential,
+    modelCard: manifest.modelCard,
+    modelCardLearnMoreUrl: manifest.modelCardLearnMoreUrl,
+    title: manifest.title,
+    docsUrl: manifest.docsUrl,
+    requiresConfig: manifest.requiresConfig,
+    logoUrl: manifest.logoUrl,
+    logoWithBackgroundUrl: manifest.logoWithBackgroundUrl,
+  };
+}
 
 /**
  * TODO: this whole class should probably be merged into the signal auth service.
@@ -38,27 +72,25 @@ class IntegrationAPI extends DataSource {
   async setConfig(
     params: GQLSetIntegrationConfigInput,
     orgId: string,
-  ): Promise<TIntegrationConfig> {
+  ): Promise<TIntegrationConfigWithMetadata> {
     const { apiCredential } = params;
 
     if (apiCredential.googleContentSafetyApi) {
-      return this.__private__setConfig(
+      return this.setConfigByIntegrationId(
         'GOOGLE_CONTENT_SAFETY_API',
         { apiKey: apiCredential.googleContentSafetyApi.apiKey },
         orgId,
       );
     }
-
     if (apiCredential.openAi) {
-      return this.__private__setConfig(
+      return this.setConfigByIntegrationId(
         'OPEN_AI',
         { apiKey: apiCredential.openAi.apiKey },
         orgId,
       );
     }
-
     if (apiCredential.zentropi) {
-      return this.__private__setConfig(
+      return this.setConfigByIntegrationId(
         'ZENTROPI',
         {
           apiKey: apiCredential.zentropi.apiKey,
@@ -71,50 +103,70 @@ class IntegrationAPI extends DataSource {
     throw new Error('No credentials provided');
   }
 
-  async getConfig(
+  async setConfigByIntegrationId(
+    integrationId: string,
+    credential: Record<string, unknown>,
     orgId: string,
-    integration: ConfigurableIntegration,
-  ): Promise<TIntegrationConfig | undefined> {
-    const credential = await this.signalAuthService.get(integration, orgId);
-    if (credential == null) {
-      return undefined;
+  ): Promise<TIntegrationConfigWithMetadata> {
+    const registry = getIntegrationRegistry();
+    const manifest = registry.getManifest(integrationId);
+    if (manifest == null) {
+      throw new Error(`Unknown integration: ${integrationId}`);
     }
-
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    return {
-      name: integration,
-      apiCredential: { name: integration, ...credential },
-    } as TIntegrationConfig;
-  }
-
-  async getAllIntegrationConfigs(orgId: string): Promise<TIntegrationConfig[]> {
-    const allConfigs = await Promise.all(
-      configurableIntegrations.map(async (integration) =>
-        this.getConfig(orgId, integration),
-      ),
-    );
-    return filterNullOrUndefined(allConfigs);
-  }
-
-  async __private__setConfig<T extends ConfigurableIntegration>(
-    integration: T,
-    credential: CredentialTypes[T],
-    orgId: string,
-  ): Promise<TIntegrationConfig> {
-    // When we're updating an existing credentials object, we have an id available, representing
-    // the credentials object we need to update. When no id is passed in, then we're creating
-    // a new credentials object.
-    const newCredential = await this.signalAuthService.set(
-      integration,
+    const newCredential = await this.signalAuthService.setByIntegrationId(
+      integrationId,
       orgId,
       credential,
     );
+    return mergeManifest(integrationId, newCredential, manifest);
+  }
 
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    return {
-      name: integration,
-      apiCredential: { name: integration, ...newCredential },
-    } as TIntegrationConfig;
+  async getConfig(
+    orgId: string,
+    integrationId: string,
+  ): Promise<TIntegrationConfigWithMetadata | undefined> {
+    const registry = getIntegrationRegistry();
+    const manifest = registry.getManifest(integrationId);
+    if (manifest == null) return undefined;
+    const credential = await this.signalAuthService.getByIntegrationId(
+      integrationId,
+      orgId,
+    );
+    if (credential == null) return undefined;
+    return mergeManifest(integrationId, credential, manifest);
+  }
+
+  async getConfigWithMetadata(
+    orgId: string,
+    integrationId: string,
+  ): Promise<TIntegrationConfigWithMetadata> {
+    const registry = getIntegrationRegistry();
+    const manifest = registry.getManifest(integrationId);
+    if (manifest == null) {
+      throw new Error(`Unknown integration: ${integrationId}`);
+    }
+    const credential = await this.signalAuthService.getByIntegrationId(
+      integrationId,
+      orgId,
+    );
+    const apiCredential =
+      credential ?? defaultCredentialForIntegrationId(integrationId);
+    return mergeManifest(integrationId, apiCredential, manifest);
+  }
+
+  getAvailableIntegrations() {
+    return getIntegrationRegistry().getAvailableIntegrations();
+  }
+
+  async getAllIntegrationConfigs(
+    orgId: string,
+  ): Promise<TIntegrationConfigWithMetadata[]> {
+    const ids = getIntegrationRegistry().getConfigurableIds();
+    return Promise.all(
+      ids.map(async (integrationId) =>
+        this.getConfigWithMetadata(orgId, integrationId),
+      ),
+    );
   }
 }
 

--- a/server/graphql/datasources/IntegrationApi.ts
+++ b/server/graphql/datasources/IntegrationApi.ts
@@ -48,7 +48,7 @@ function mergeManifest(
 ): TIntegrationConfigWithMetadata {
   return {
     name: integrationId,
-    apiCredential,
+    apiCredential: { ...apiCredential, name: integrationId },
     modelCard: manifest.modelCard,
     modelCardLearnMoreUrl: manifest.modelCardLearnMoreUrl,
     title: manifest.title,

--- a/server/graphql/datasources/RuleApi.ts
+++ b/server/graphql/datasources/RuleApi.ts
@@ -36,7 +36,6 @@ import {
 import {
   isSignalId,
   signalIsExternal,
-  type ExternalSignalType,
   type SignalId,
 } from '../../services/signalsService/index.js';
 import { type ConditionSetWithResultAsLogged } from '../../services/analyticsLoggers/index.js';
@@ -881,19 +880,16 @@ class RuleAPI extends DataSource {
           processCondition(subCondition);
         }
       } else if ('signal' in condition && condition.signal) {
-        // It's a leaf condition with a signal
+        // It's a leaf condition with a signal (type is String to support plugin signals)
         const { type, id } = condition.signal;
-        // GQLSignalType values map to ExternalSignalType (conditions can only
-        // contain user-visible external signals). Cast is safe since this comes
-        // from validated GraphQL input.
         let signalId: SignalId;
         if (type === 'CUSTOM') {
           // CUSTOM signals require an id field. The id comes from validated GraphQL
           // input where it's a required Scalars['ID'], so we can safely cast it.
           signalId = { type: 'CUSTOM' as const, id: id as NonEmptyString };
         } else {
-          // Built-in signals only need the type
-          signalId = { type: type as Exclude<ExternalSignalType, 'CUSTOM'> };
+          // Built-in and plugin signals: type is the signal type string
+          signalId = { type };
         }
         signalIds.push(signalId);
       }

--- a/server/graphql/datasources/integrationManifests.ts
+++ b/server/graphql/datasources/integrationManifests.ts
@@ -1,0 +1,13 @@
+/**
+ * Re-export built-in manifests and types from the integration registry
+ * so GraphQL datasources can use them without the registry depending on graphql.
+ */
+export {
+  BUILD_IN_MANIFESTS,
+  type AvailableIntegration,
+  type IntegrationManifestEntry,
+  type ModelCard,
+  type ModelCardField,
+  type ModelCardSection,
+  type ModelCardSubsection,
+} from '../../services/integrationRegistry/index.js';

--- a/server/graphql/generated.ts
+++ b/server/graphql/generated.ts
@@ -470,7 +470,7 @@ export type GQLConditionInputSignalInput = {
   readonly id: Scalars['ID'];
   readonly name?: InputMaybe<Scalars['String']>;
   readonly subcategory?: InputMaybe<Scalars['String']>;
-  readonly type: GQLSignalType;
+  readonly type: Scalars['String'];
 };
 
 export type GQLConditionMatchingValuesInput = {
@@ -1328,6 +1328,7 @@ export type GQLIntegration =
 export type GQLIntegrationApiCredential =
   | GQLGoogleContentSafetyApiIntegrationApiCredential
   | GQLOpenAiIntegrationApiCredential
+  | GQLPluginIntegrationApiCredential
   | GQLZentropiIntegrationApiCredential;
 
 export type GQLIntegrationApiCredentialInput = {
@@ -1339,7 +1340,14 @@ export type GQLIntegrationApiCredentialInput = {
 export type GQLIntegrationConfig = {
   readonly __typename?: 'IntegrationConfig';
   readonly apiCredential: GQLIntegrationApiCredential;
-  readonly name: GQLIntegration;
+  readonly docsUrl: Scalars['String'];
+  readonly logoUrl?: Maybe<Scalars['String']>;
+  readonly logoWithBackgroundUrl?: Maybe<Scalars['String']>;
+  readonly modelCard: GQLModelCard;
+  readonly modelCardLearnMoreUrl?: Maybe<Scalars['String']>;
+  readonly name: Scalars['String'];
+  readonly requiresConfig: Scalars['Boolean'];
+  readonly title: Scalars['String'];
 };
 
 export type GQLIntegrationConfigQueryResponse =
@@ -1379,6 +1387,16 @@ export type GQLIntegrationEmptyInputCredentialsError = GQLError & {
   readonly status: Scalars['Int'];
   readonly title: Scalars['String'];
   readonly type: ReadonlyArray<Scalars['String']>;
+};
+
+export type GQLIntegrationMetadata = {
+  readonly __typename?: 'IntegrationMetadata';
+  readonly docsUrl: Scalars['String'];
+  readonly logoUrl?: Maybe<Scalars['String']>;
+  readonly logoWithBackgroundUrl?: Maybe<Scalars['String']>;
+  readonly name: Scalars['String'];
+  readonly requiresConfig: Scalars['Boolean'];
+  readonly title: Scalars['String'];
 };
 
 export type GQLIntegrationNoInputCredentialsError = GQLError & {
@@ -2163,6 +2181,34 @@ export const GQLMetricsTimeDivisionOptions = {
 
 export type GQLMetricsTimeDivisionOptions =
   (typeof GQLMetricsTimeDivisionOptions)[keyof typeof GQLMetricsTimeDivisionOptions];
+export type GQLModelCard = {
+  readonly __typename?: 'ModelCard';
+  readonly modelName: Scalars['String'];
+  readonly releaseDate?: Maybe<Scalars['String']>;
+  readonly sections?: Maybe<ReadonlyArray<GQLModelCardSection>>;
+  readonly version: Scalars['String'];
+};
+
+export type GQLModelCardField = {
+  readonly __typename?: 'ModelCardField';
+  readonly label: Scalars['String'];
+  readonly value: Scalars['String'];
+};
+
+export type GQLModelCardSection = {
+  readonly __typename?: 'ModelCardSection';
+  readonly fields?: Maybe<ReadonlyArray<GQLModelCardField>>;
+  readonly id: Scalars['String'];
+  readonly subsections?: Maybe<ReadonlyArray<GQLModelCardSubsection>>;
+  readonly title: Scalars['String'];
+};
+
+export type GQLModelCardSubsection = {
+  readonly __typename?: 'ModelCardSubsection';
+  readonly fields: ReadonlyArray<GQLModelCardField>;
+  readonly title: Scalars['String'];
+};
+
 export type GQLModeratorSafetySettingsInput = {
   readonly moderatorSafetyBlurLevel: Scalars['Int'];
   readonly moderatorSafetyGrayscale: Scalars['Boolean'];
@@ -2336,6 +2382,7 @@ export type GQLMutation = {
   readonly setModeratorSafetySettings?: Maybe<GQLSetModeratorSafetySettingsSuccessResponse>;
   readonly setMrtChartConfigurationSettings?: Maybe<GQLSetMrtChartConfigurationSettingsSuccessResponse>;
   readonly setOrgDefaultSafetySettings?: Maybe<GQLSetModeratorSafetySettingsSuccessResponse>;
+  readonly setPluginIntegrationConfig: GQLSetIntegrationConfigResponse;
   readonly signUp: GQLSignUpResponse;
   readonly submitManualReviewDecision: GQLSubmitDecisionResponse;
   readonly updateAccountInfo?: Maybe<Scalars['Boolean']>;
@@ -2586,6 +2633,10 @@ export type GQLMutationSetMrtChartConfigurationSettingsArgs = {
 
 export type GQLMutationSetOrgDefaultSafetySettingsArgs = {
   orgDefaultSafetySettings: GQLModeratorSafetySettingsInput;
+};
+
+export type GQLMutationSetPluginIntegrationConfigArgs = {
+  input: GQLSetPluginIntegrationConfigInput;
 };
 
 export type GQLMutationSignUpArgs = {
@@ -3037,6 +3088,11 @@ export type GQLPlaceBoundsInput = {
   readonly southwestCorner: GQLLatLngInput;
 };
 
+export type GQLPluginIntegrationApiCredential = {
+  readonly __typename?: 'PluginIntegrationApiCredential';
+  readonly credential: Scalars['JSONObject'];
+};
+
 export type GQLPolicy = {
   readonly __typename?: 'Policy';
   readonly applyUserStrikeCountConfigToChildren?: Maybe<Scalars['Boolean']>;
@@ -3105,6 +3161,7 @@ export type GQLQuery = {
   readonly allRuleInsights: GQLAllRuleInsights;
   readonly apiKey: Scalars['String'];
   readonly appealSettings?: Maybe<GQLAppealSettings>;
+  readonly availableIntegrations: ReadonlyArray<GQLIntegrationMetadata>;
   readonly getCommentsForJob: ReadonlyArray<GQLManualReviewJobComment>;
   readonly getDecidedJob?: Maybe<GQLManualReviewJob>;
   readonly getDecidedJobFromJobId?: Maybe<GQLManualReviewJobWithDecisions>;
@@ -3247,7 +3304,7 @@ export type GQLQueryHashBankByIdArgs = {
 };
 
 export type GQLQueryIntegrationConfigArgs = {
-  name: GQLIntegration;
+  name: Scalars['String'];
 };
 
 export type GQLQueryInviteUserTokenArgs = {
@@ -3922,6 +3979,11 @@ export type GQLSetMrtChartConfigurationSettingsSuccessResponse = {
   readonly _?: Maybe<Scalars['Boolean']>;
 };
 
+export type GQLSetPluginIntegrationConfigInput = {
+  readonly credential: Scalars['JSONObject'];
+  readonly integrationId: Scalars['String'];
+};
+
 export type GQLSetUserStrikeThresholdInput = {
   readonly actions: ReadonlyArray<Scalars['String']>;
   readonly threshold: Scalars['Int'];
@@ -3970,7 +4032,13 @@ export type GQLSignal = {
   readonly eligibleInputs: ReadonlyArray<GQLSignalInputType>;
   readonly eligibleSubcategories: ReadonlyArray<GQLSignalSubcategory>;
   readonly id: Scalars['ID'];
-  readonly integration?: Maybe<GQLIntegration>;
+  readonly integration?: Maybe<Scalars['String']>;
+  /** Logo URL for the integration. Null if not set or when signal has no integration. */
+  readonly integrationLogoUrl?: Maybe<Scalars['String']>;
+  /** Logo-with-background URL for the integration. Null if not set or when signal has no integration. */
+  readonly integrationLogoWithBackgroundUrl?: Maybe<Scalars['String']>;
+  /** Display name for the signal’s integration (from registry manifest). Null when signal has no integration. */
+  readonly integrationTitle?: Maybe<Scalars['String']>;
   readonly name: Scalars['String'];
   readonly outputType: GQLSignalOutputType;
   readonly pricingStructure: GQLSignalPricingStructure;
@@ -3978,7 +4046,7 @@ export type GQLSignal = {
   readonly shouldPromptForMatchingValues: Scalars['Boolean'];
   readonly subcategory?: Maybe<Scalars['String']>;
   readonly supportedLanguages: GQLSupportedLanguages;
-  readonly type: GQLSignalType;
+  readonly type: Scalars['String'];
 };
 
 export type GQLSignalArgs = GQLAggregationSignalArgs;
@@ -4074,7 +4142,7 @@ export const GQLSignalType = {
 export type GQLSignalType = (typeof GQLSignalType)[keyof typeof GQLSignalType];
 export type GQLSignalWithScore = {
   readonly __typename?: 'SignalWithScore';
-  readonly integration?: Maybe<GQLIntegration>;
+  readonly integration?: Maybe<Scalars['String']>;
   readonly score: Scalars['String'];
   readonly signalName: Scalars['String'];
   readonly subcategory?: Maybe<Scalars['String']>;
@@ -5196,6 +5264,7 @@ export type GQLResolversTypes = {
   IntegrationApiCredential:
     | GQLResolversTypes['GoogleContentSafetyApiIntegrationApiCredential']
     | GQLResolversTypes['OpenAiIntegrationApiCredential']
+    | GQLResolversTypes['PluginIntegrationApiCredential']
     | GQLResolversTypes['ZentropiIntegrationApiCredential'];
   IntegrationApiCredentialInput: GQLIntegrationApiCredentialInput;
   IntegrationConfig: ResolverTypeWrapper<
@@ -5210,6 +5279,7 @@ export type GQLResolversTypes = {
   IntegrationConfigTooManyCredentialsError: ResolverTypeWrapper<GQLIntegrationConfigTooManyCredentialsError>;
   IntegrationConfigUnsupportedIntegrationError: ResolverTypeWrapper<GQLIntegrationConfigUnsupportedIntegrationError>;
   IntegrationEmptyInputCredentialsError: ResolverTypeWrapper<GQLIntegrationEmptyInputCredentialsError>;
+  IntegrationMetadata: ResolverTypeWrapper<GQLIntegrationMetadata>;
   IntegrationNoInputCredentialsError: ResolverTypeWrapper<GQLIntegrationNoInputCredentialsError>;
   InviteUserInput: GQLInviteUserInput;
   InviteUserToken: ResolverTypeWrapper<GQLInviteUserToken>;
@@ -5362,6 +5432,10 @@ export type GQLResolversTypes = {
     }
   >;
   MetricsTimeDivisionOptions: GQLMetricsTimeDivisionOptions;
+  ModelCard: ResolverTypeWrapper<GQLModelCard>;
+  ModelCardField: ResolverTypeWrapper<GQLModelCardField>;
+  ModelCardSection: ResolverTypeWrapper<GQLModelCardSection>;
+  ModelCardSubsection: ResolverTypeWrapper<GQLModelCardSubsection>;
   ModeratorSafetySettingsInput: GQLModeratorSafetySettingsInput;
   MrtJobEnqueueSourceInfo: ResolverTypeWrapper<GQLMrtJobEnqueueSourceInfo>;
   MutateAccessibleQueuesForUserSuccessResponse: ResolverTypeWrapper<GQLMutateAccessibleQueuesForUserSuccessResponse>;
@@ -5497,6 +5571,7 @@ export type GQLResolversTypes = {
   PendingInvite: ResolverTypeWrapper<GQLPendingInvite>;
   PlaceBounds: ResolverTypeWrapper<GQLPlaceBounds>;
   PlaceBoundsInput: GQLPlaceBoundsInput;
+  PluginIntegrationApiCredential: ResolverTypeWrapper<GQLPluginIntegrationApiCredential>;
   Policy: ResolverTypeWrapper<GQLPolicy>;
   PolicyActionCount: ResolverTypeWrapper<GQLPolicyActionCount>;
   PolicyNameExistsError: ResolverTypeWrapper<GQLPolicyNameExistsError>;
@@ -5619,6 +5694,7 @@ export type GQLResolversTypes = {
   SetIntegrationConfigSuccessResponse: ResolverTypeWrapper<GQLSetIntegrationConfigSuccessResponse>;
   SetModeratorSafetySettingsSuccessResponse: ResolverTypeWrapper<GQLSetModeratorSafetySettingsSuccessResponse>;
   SetMrtChartConfigurationSettingsSuccessResponse: ResolverTypeWrapper<GQLSetMrtChartConfigurationSettingsSuccessResponse>;
+  SetPluginIntegrationConfigInput: GQLSetPluginIntegrationConfigInput;
   SetUserStrikeThresholdInput: GQLSetUserStrikeThresholdInput;
   SignUpInput: GQLSignUpInput;
   SignUpResponse:
@@ -6043,6 +6119,7 @@ export type GQLResolversParentTypes = {
   IntegrationApiCredential:
     | GQLResolversParentTypes['GoogleContentSafetyApiIntegrationApiCredential']
     | GQLResolversParentTypes['OpenAiIntegrationApiCredential']
+    | GQLResolversParentTypes['PluginIntegrationApiCredential']
     | GQLResolversParentTypes['ZentropiIntegrationApiCredential'];
   IntegrationApiCredentialInput: GQLIntegrationApiCredentialInput;
   IntegrationConfig: Omit<GQLIntegrationConfig, 'apiCredential'> & {
@@ -6055,6 +6132,7 @@ export type GQLResolversParentTypes = {
   IntegrationConfigTooManyCredentialsError: GQLIntegrationConfigTooManyCredentialsError;
   IntegrationConfigUnsupportedIntegrationError: GQLIntegrationConfigUnsupportedIntegrationError;
   IntegrationEmptyInputCredentialsError: GQLIntegrationEmptyInputCredentialsError;
+  IntegrationMetadata: GQLIntegrationMetadata;
   IntegrationNoInputCredentialsError: GQLIntegrationNoInputCredentialsError;
   InviteUserInput: GQLInviteUserInput;
   InviteUserToken: GQLInviteUserToken;
@@ -6181,6 +6259,10 @@ export type GQLResolversParentTypes = {
   MessageWithIpAddress: Omit<GQLMessageWithIpAddress, 'message'> & {
     message: GQLResolversParentTypes['ContentItem'];
   };
+  ModelCard: GQLModelCard;
+  ModelCardField: GQLModelCardField;
+  ModelCardSection: GQLModelCardSection;
+  ModelCardSubsection: GQLModelCardSubsection;
   ModeratorSafetySettingsInput: GQLModeratorSafetySettingsInput;
   MrtJobEnqueueSourceInfo: GQLMrtJobEnqueueSourceInfo;
   MutateAccessibleQueuesForUserSuccessResponse: GQLMutateAccessibleQueuesForUserSuccessResponse;
@@ -6291,6 +6373,7 @@ export type GQLResolversParentTypes = {
   PendingInvite: GQLPendingInvite;
   PlaceBounds: GQLPlaceBounds;
   PlaceBoundsInput: GQLPlaceBoundsInput;
+  PluginIntegrationApiCredential: GQLPluginIntegrationApiCredential;
   Policy: GQLPolicy;
   PolicyActionCount: GQLPolicyActionCount;
   PolicyNameExistsError: GQLPolicyNameExistsError;
@@ -6406,6 +6489,7 @@ export type GQLResolversParentTypes = {
   SetIntegrationConfigSuccessResponse: GQLSetIntegrationConfigSuccessResponse;
   SetModeratorSafetySettingsSuccessResponse: GQLSetModeratorSafetySettingsSuccessResponse;
   SetMrtChartConfigurationSettingsSuccessResponse: GQLSetMrtChartConfigurationSettingsSuccessResponse;
+  SetPluginIntegrationConfigInput: GQLSetPluginIntegrationConfigInput;
   SetUserStrikeThresholdInput: GQLSetUserStrikeThresholdInput;
   SignUpInput: GQLSignUpInput;
   SignUpResponse:
@@ -8456,6 +8540,7 @@ export type GQLIntegrationApiCredentialResolvers<
   __resolveType: TypeResolveFn<
     | 'GoogleContentSafetyApiIntegrationApiCredential'
     | 'OpenAiIntegrationApiCredential'
+    | 'PluginIntegrationApiCredential'
     | 'ZentropiIntegrationApiCredential',
     ParentType,
     ContextType
@@ -8472,7 +8557,30 @@ export type GQLIntegrationConfigResolvers<
     ParentType,
     ContextType
   >;
-  name?: Resolver<GQLResolversTypes['Integration'], ParentType, ContextType>;
+  docsUrl?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  logoUrl?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  logoWithBackgroundUrl?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  modelCard?: Resolver<GQLResolversTypes['ModelCard'], ParentType, ContextType>;
+  modelCardLearnMoreUrl?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  name?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  requiresConfig?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >;
+  title?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -8589,6 +8697,32 @@ export type GQLIntegrationEmptyInputCredentialsErrorResolvers<
     ParentType,
     ContextType
   >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type GQLIntegrationMetadataResolvers<
+  ContextType = Context,
+  ParentType extends
+    GQLResolversParentTypes['IntegrationMetadata'] = GQLResolversParentTypes['IntegrationMetadata'],
+> = {
+  docsUrl?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  logoUrl?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  logoWithBackgroundUrl?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  name?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  requiresConfig?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >;
+  title?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -9750,6 +9884,70 @@ export type GQLMessageWithIpAddressResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type GQLModelCardResolvers<
+  ContextType = Context,
+  ParentType extends
+    GQLResolversParentTypes['ModelCard'] = GQLResolversParentTypes['ModelCard'],
+> = {
+  modelName?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  releaseDate?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  sections?: Resolver<
+    Maybe<ReadonlyArray<GQLResolversTypes['ModelCardSection']>>,
+    ParentType,
+    ContextType
+  >;
+  version?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type GQLModelCardFieldResolvers<
+  ContextType = Context,
+  ParentType extends
+    GQLResolversParentTypes['ModelCardField'] = GQLResolversParentTypes['ModelCardField'],
+> = {
+  label?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  value?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type GQLModelCardSectionResolvers<
+  ContextType = Context,
+  ParentType extends
+    GQLResolversParentTypes['ModelCardSection'] = GQLResolversParentTypes['ModelCardSection'],
+> = {
+  fields?: Resolver<
+    Maybe<ReadonlyArray<GQLResolversTypes['ModelCardField']>>,
+    ParentType,
+    ContextType
+  >;
+  id?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  subsections?: Resolver<
+    Maybe<ReadonlyArray<GQLResolversTypes['ModelCardSubsection']>>,
+    ParentType,
+    ContextType
+  >;
+  title?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type GQLModelCardSubsectionResolvers<
+  ContextType = Context,
+  ParentType extends
+    GQLResolversParentTypes['ModelCardSubsection'] = GQLResolversParentTypes['ModelCardSubsection'],
+> = {
+  fields?: Resolver<
+    ReadonlyArray<GQLResolversTypes['ModelCardField']>,
+    ParentType,
+    ContextType
+  >;
+  title?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type GQLMrtJobEnqueueSourceInfoResolvers<
   ContextType = Context,
   ParentType extends
@@ -10351,6 +10549,12 @@ export type GQLMutationResolvers<
       GQLMutationSetOrgDefaultSafetySettingsArgs,
       'orgDefaultSafetySettings'
     >
+  >;
+  setPluginIntegrationConfig?: Resolver<
+    GQLResolversTypes['SetIntegrationConfigResponse'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationSetPluginIntegrationConfigArgs, 'input'>
   >;
   signUp?: Resolver<
     GQLResolversTypes['SignUpResponse'],
@@ -11190,6 +11394,19 @@ export type GQLPlaceBoundsResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type GQLPluginIntegrationApiCredentialResolvers<
+  ContextType = Context,
+  ParentType extends
+    GQLResolversParentTypes['PluginIntegrationApiCredential'] = GQLResolversParentTypes['PluginIntegrationApiCredential'],
+> = {
+  credential?: Resolver<
+    GQLResolversTypes['JSONObject'],
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type GQLPolicyResolvers<
   ContextType = Context,
   ParentType extends
@@ -11334,6 +11551,11 @@ export type GQLQueryResolvers<
   apiKey?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   appealSettings?: Resolver<
     Maybe<GQLResolversTypes['AppealSettings']>,
+    ParentType,
+    ContextType
+  >;
+  availableIntegrations?: Resolver<
+    ReadonlyArray<GQLResolversTypes['IntegrationMetadata']>,
     ParentType,
     ContextType
   >;
@@ -12712,7 +12934,22 @@ export type GQLSignalResolvers<
   >;
   id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
   integration?: Resolver<
-    Maybe<GQLResolversTypes['Integration']>,
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  integrationLogoUrl?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  integrationLogoWithBackgroundUrl?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  integrationTitle?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
     ParentType,
     ContextType
   >;
@@ -12747,7 +12984,7 @@ export type GQLSignalResolvers<
     ParentType,
     ContextType
   >;
-  type?: Resolver<GQLResolversTypes['SignalType'], ParentType, ContextType>;
+  type?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -12814,7 +13051,7 @@ export type GQLSignalWithScoreResolvers<
     GQLResolversParentTypes['SignalWithScore'] = GQLResolversParentTypes['SignalWithScore'],
 > = {
   integration?: Resolver<
-    Maybe<GQLResolversTypes['Integration']>,
+    Maybe<GQLResolversTypes['String']>,
     ParentType,
     ContextType
   >;
@@ -13993,6 +14230,7 @@ export type GQLResolvers<ContextType = Context> = {
   IntegrationConfigTooManyCredentialsError?: GQLIntegrationConfigTooManyCredentialsErrorResolvers<ContextType>;
   IntegrationConfigUnsupportedIntegrationError?: GQLIntegrationConfigUnsupportedIntegrationErrorResolvers<ContextType>;
   IntegrationEmptyInputCredentialsError?: GQLIntegrationEmptyInputCredentialsErrorResolvers<ContextType>;
+  IntegrationMetadata?: GQLIntegrationMetadataResolvers<ContextType>;
   IntegrationNoInputCredentialsError?: GQLIntegrationNoInputCredentialsErrorResolvers<ContextType>;
   InviteUserToken?: GQLInviteUserTokenResolvers<ContextType>;
   InviteUserTokenExpiredError?: GQLInviteUserTokenExpiredErrorResolvers<ContextType>;
@@ -14047,6 +14285,10 @@ export type GQLResolvers<ContextType = Context> = {
   MatchingBanks?: GQLMatchingBanksResolvers<ContextType>;
   MatchingValues?: GQLMatchingValuesResolvers<ContextType>;
   MessageWithIpAddress?: GQLMessageWithIpAddressResolvers<ContextType>;
+  ModelCard?: GQLModelCardResolvers<ContextType>;
+  ModelCardField?: GQLModelCardFieldResolvers<ContextType>;
+  ModelCardSection?: GQLModelCardSectionResolvers<ContextType>;
+  ModelCardSubsection?: GQLModelCardSubsectionResolvers<ContextType>;
   MrtJobEnqueueSourceInfo?: GQLMrtJobEnqueueSourceInfoResolvers<ContextType>;
   MutateAccessibleQueuesForUserSuccessResponse?: GQLMutateAccessibleQueuesForUserSuccessResponseResolvers<ContextType>;
   MutateActionResponse?: GQLMutateActionResponseResolvers<ContextType>;
@@ -14093,6 +14335,7 @@ export type GQLResolvers<ContextType = Context> = {
   PartialItemsSuccessResponse?: GQLPartialItemsSuccessResponseResolvers<ContextType>;
   PendingInvite?: GQLPendingInviteResolvers<ContextType>;
   PlaceBounds?: GQLPlaceBoundsResolvers<ContextType>;
+  PluginIntegrationApiCredential?: GQLPluginIntegrationApiCredentialResolvers<ContextType>;
   Policy?: GQLPolicyResolvers<ContextType>;
   PolicyActionCount?: GQLPolicyActionCountResolvers<ContextType>;
   PolicyNameExistsError?: GQLPolicyNameExistsErrorResolvers<ContextType>;

--- a/server/graphql/modules/insights.ts
+++ b/server/graphql/modules/insights.ts
@@ -23,7 +23,7 @@ const typeDefs = /* GraphQL */ `
 
   type SignalWithScore {
     signalName: String!
-    integration: Integration
+    integration: String
     subcategory: String
     score: String!
   }

--- a/server/graphql/modules/org.ts
+++ b/server/graphql/modules/org.ts
@@ -4,6 +4,7 @@ import { AuthenticationError } from 'apollo-server-express';
 import { isCoopErrorOfType } from '../../utils/errors.js';
 import { __throw } from '../../utils/misc.js';
 import {
+  type GQLIntegrationConfig,
   type GQLMatchingBanksResolvers,
   type GQLMutationResolvers,
   type GQLOrgResolvers,
@@ -327,7 +328,9 @@ const Org: GQLOrgResolvers = {
       throw new AuthenticationError('User required.');
     }
 
-    return context.dataSources.integrationAPI.getAllIntegrationConfigs(org.id);
+    return context.dataSources.integrationAPI.getAllIntegrationConfigs(
+      org.id,
+    ) as Promise<GQLIntegrationConfig[]>;
   },
   // customOnly param fetches only the org's custom signals
   async signals(org, { customOnly }, context) {

--- a/server/graphql/modules/rule.ts
+++ b/server/graphql/modules/rule.ts
@@ -371,7 +371,7 @@ const typeDefs = /* GraphQL */ `
 
   input ConditionInputSignalInput {
     id: ID! # JsonOf<SignalId>
-    type: SignalType!
+    type: String!
     name: String
     subcategory: String
     args: SignalArgsInput

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -23,6 +23,7 @@
         "@node-saml/passport-saml": "^5.1.0",
         "@opentelemetry/api": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
+        "@roostorg/coop-integration-example": "^1.0.0",
         "@roostorg/types": "^1.1.1",
         "@sendgrid/mail": "^8.1.6",
         "@stdlib/stats-binomial-test": "^0.0.7",
@@ -3985,6 +3986,18 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "node_modules/@roostorg/coop-integration-example": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@roostorg/coop-integration-example/-/coop-integration-example-1.0.0.tgz",
+      "integrity": "sha512-vzb5sXSJHtg/tJxHOj0WbgVjf9ZKrul9zd1QsUGEScoEkHzybjISuELDM3F3IrUJMIdI+c5ISGto16VsC4cpCw==",
+      "license": "apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@roostorg/types": ">=1.0.0"
+      }
     },
     "node_modules/@roostorg/types": {
       "version": "1.1.1",

--- a/server/package.json
+++ b/server/package.json
@@ -37,6 +37,7 @@
     "@node-saml/passport-saml": "^5.1.0",
     "@opentelemetry/api": "^1.8.0",
     "@opentelemetry/semantic-conventions": "^1.22.0",
+    "@roostorg/coop-integration-example": "^1.0.0",
     "@roostorg/types": "^1.1.1",
     "@sendgrid/mail": "^8.1.6",
     "@stdlib/stats-binomial-test": "^0.0.7",

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -2,6 +2,7 @@ import { type Route } from '../utils/route-helpers.js';
 import ActionRoutes from './action/ActionRoutes.js';
 import ContentRoutes from './content/ContentRoutes.js';
 import GDPRRoutes from './gdpr/gdprRoutes.js';
+import IntegrationLogosRoutes from './integration_logos/IntegrationLogosRoutes.js';
 import ItemRoutes from './items/ItemRoutes.js';
 import PoliciesRoutes from './policies/PoliciesRoutes.js';
 import ReportingRoutes from './reporting/ReportingRoutes.js';
@@ -23,4 +24,5 @@ export default {
   UserScores: UserScoresRoutes,
   Actions: ActionRoutes,
   GDPR: GDPRRoutes,
+  IntegrationLogos: IntegrationLogosRoutes,
 } satisfies { [key: string]: Controller };

--- a/server/services/analyticsQueries/RuleActionInsights.ts
+++ b/server/services/analyticsQueries/RuleActionInsights.ts
@@ -10,10 +10,10 @@ import { type RuleEnvironment } from '../../rule_engine/RuleEngine.js';
 import { type NormalizedItemData } from '../../services/itemProcessingService/index.js';
 import {
   BuiltInThirdPartySignalType,
+  SignalType,
   UserCreatedExternalSignalType,
   integrationForSignalType,
   type Integration,
-  type SignalType,
 } from '../../services/signalsService/index.js';
 import { jsonParse, type JsonOf } from '../../utils/encoding.js';
 import {
@@ -476,7 +476,7 @@ type GatherSignalsConditionWithResult =
 type GatherSignalsLeafConditionWithResult = {
   signal?: {
     name: string;
-    type: SignalType;
+    type: string;
     subcategory?: string | null;
   } | null;
   result?: { score?: string | null } | null;
@@ -486,9 +486,11 @@ type GatherSignalsConditionSetWithResult = {
   conditions: GatherSignalsConditionWithResult[];
 };
 
-const signalResultShouldBeDisplayed = (type: SignalType) =>
+/** Includes built-in third-party, user-created, and plugin signal types (string). */
+const signalResultShouldBeDisplayed = (type: string) =>
   Object.hasOwn(BuiltInThirdPartySignalType, type) ||
-  Object.hasOwn(UserCreatedExternalSignalType, type);
+  Object.hasOwn(UserCreatedExternalSignalType, type) ||
+  !Object.hasOwn(SignalType, type); // plugin signal types not in SignalType enum
 
 /**
  * When we display signal results in the UI (specifically in the rule samples

--- a/server/services/moderationConfigService/types/rules.ts
+++ b/server/services/moderationConfigService/types/rules.ts
@@ -46,12 +46,8 @@ export type ConditionSignalInfo = {
       args: SignalArgsByType['AGGREGATION'];
     }
   | {
-      type: Exclude<SignalType, 'AGGREGATION'>;
-      // Our GQL input validation code assumes that, for all signals besides
-      // aggregation, the args must be undefined, so we want TS to give us a
-      // type error here if that ever becomes not true. Then, we can update the
-      // GQL validation code and any downstream code if the args for these other
-      // signals change.
+      // Exclude<SignalType, 'AGGREGATION'> | string to support plugin signal types (e.g. RANDOM_SIGNAL_SELECTION)
+      type: Exclude<SignalType, 'AGGREGATION'> | string;
       args?: Satisfies<
         SignalArgsByType[Exclude<SignalType, 'AGGREGATION'>],
         undefined

--- a/server/services/signalAuthService/dbTypes.ts
+++ b/server/services/signalAuthService/dbTypes.ts
@@ -1,6 +1,20 @@
 import { type ColumnType } from 'kysely';
 
+/** JSONB config blob; shape defined per integration (see @roostorg/types StoredIntegrationConfigPayload). */
+export type IntegrationConfigRow = {
+  org_id: string;
+  integration_id: string;
+  config: ColumnType<
+    Record<string, unknown>,
+    Record<string, unknown> | string,
+    Record<string, unknown> | string
+  >;
+  created_at: ColumnType<Date, never, never>;
+  updated_at: ColumnType<Date, never, never>;
+};
+
 export type SignalAuthServicePg = {
+  'signal_auth_service.integration_configs': IntegrationConfigRow;
   'signal_auth_service.google_content_safety_configs': {
     org_id: string;
     api_key: string;

--- a/server/services/signalsService/SignalsService.ts
+++ b/server/services/signalsService/SignalsService.ts
@@ -8,13 +8,16 @@ import { jsonStringify } from '../../utils/encoding.js';
 import { CoopError, ErrorType, makeNotFoundError } from '../../utils/errors.js';
 import { __throw, assertUnreachable } from '../../utils/misc.js';
 import { type CollapseCases } from '../../utils/typescript-types.js';
+import { getIntegrationRegistry } from '../integrationRegistry/index.js';
 import { instantiateBuiltInSignals } from './helpers/instantiateBuiltInSignals.js';
+import { loadPluginSignals } from './helpers/loadPluginSignals.js';
 import { makeCachedCredentialGetters } from './helpers/makeCachedCredentialsGetters.js';
 import { makeCachedFetchers } from './helpers/makeCachedFetchers.js';
 import {
   signalIsExternal,
   type SignalId,
   type SignalInputType,
+  type SignalOutputType,
   type SignalType,
 } from './index.js';
 import type UnusedCustomSignal from './signals/CustomSignal.js';
@@ -55,7 +58,15 @@ const publicSignalProps = [
  *   itself.
  */
 export type Signal = Simplify<
-  Pick<SignalBase<SignalInputType>, (typeof publicSignalProps)[number]>
+  Pick<
+    SignalBase<
+      SignalInputType,
+      SignalOutputType,
+      unknown,
+      SignalType | string
+    >,
+    (typeof publicSignalProps)[number]
+  >
 >;
 
 /**
@@ -100,10 +111,17 @@ export type SignalTypesToRunOutputTypes = {
   [K in SignalType]: ReturnType<SignalClassByType[K]['run']>;
 };
 
+/** All signals by type: built-in + plugin. Used for lookup and getSignalsForOrg. */
+type SignalsByType = Record<
+  string,
+  SignalBase<SignalInputType, SignalOutputType, unknown, SignalType | string>
+>;
+
 export class SignalsService {
   public readonly close: () => Promise<void>;
 
   private readonly builtInSignalsByType: BuiltInSignalsByType;
+  private readonly signalsByType: SignalsByType;
 
   constructor(
     private readonly tracer: Dependencies['Tracer'],
@@ -134,12 +152,17 @@ export class SignalsService {
       this.hmaService,
     );
 
+    const pluginEntries = getIntegrationRegistry().getPluginEntries();
+    const pluginSignals = loadPluginSignals(pluginEntries, signalAuthService);
+    this.signalsByType = {
+      ...this.builtInSignalsByType,
+      ...pluginSignals,
+    };
+
     this.close = async function () {
+      await cachedCredentialGetters.close();
       await Promise.all(
-        [
-          ...Object.values(cachedCredentialGetters),
-          ...Object.values(cachedFetchers),
-        ].map(async (it) => it.close()),
+        Object.values(cachedFetchers).map(async (it) => it.close()),
       );
     };
   }
@@ -161,36 +184,35 @@ export class SignalsService {
   }): Promise<Signal[]> {
     const { orgId, externalOnly = true } = opts;
 
-    const builtInSignals = Object.values(this.builtInSignalsByType).filter(
-      (signal) => isSignalEnabledForOrg(signal.id, orgId),
+    const allSignals = Object.values(this.signalsByType).filter((signal) =>
+      isSignalEnabledForOrg(signal.id, orgId),
     );
 
-    const finalBuiltInSignals = externalOnly
-      ? builtInSignals.filter((it) => signalIsExternal(it.id))
-      : builtInSignals;
+    const finalSignals = externalOnly
+      ? allSignals.filter((it) => signalIsExternal(it.id))
+      : allSignals;
 
-    return finalBuiltInSignals.map((it) =>
-      this.#signalInstanceToPublicSignal(it),
-    );
+    return finalSignals.map((it) => this.#signalInstanceToPublicSignal(it));
   }
 
   async #getSignalInstance<T extends SignalType>(
     ref: SignalReference<T>,
-  ): Promise<SignalBase<SignalInputType> | undefined> {
+  ): Promise<
+    | SignalBase<
+        SignalInputType,
+        SignalOutputType,
+        unknown,
+        SignalType | string
+      >
+    | undefined
+  > {
     const { signalId } = ref;
 
-    // In this switch, we don't have assertUnreachable in the default case, but
-    // TS will give an error if the the potential values that are left in
-    // `signalId.type` aren't all usable to index into builtinSignalsByType
-    // eslint-disable-next-line switch-statement/require-appropriate-default-case
-    switch (signalId.type) {
-      case 'CUSTOM':
-        throw new Error('not implemented');
-      default:
-        // For some reason, TS won't narrow the type based on the previous
-        // case expressions, so we explicitly narrow it here.
-        return this.builtInSignalsByType[signalId.type as Exclude<T, 'CUSTOM'>];
+    if (signalId.type === 'CUSTOM') {
+      throw new Error('not implemented');
     }
+
+    return this.signalsByType[signalId.type];
   }
 
   public async getSignal<T extends SignalType>(ref: SignalReference<T>) {
@@ -302,7 +324,11 @@ export class SignalsService {
     >;
   }
 
-  #signalInstanceToPublicSignal(it: ReadonlyDeep<SignalBase<SignalInputType>>) {
+  #signalInstanceToPublicSignal(
+    it: ReadonlyDeep<
+      SignalBase<SignalInputType, SignalOutputType, unknown, SignalType | string>
+    >,
+  ) {
     // This used to be implemented as simply `safePick(it, publicSignalProps)`,
     // but we found that this is such a hot path that lodash was adding very
     // noticeable overhead -- `_.pick` calls all kinds of internal lodash

--- a/server/services/signalsService/SignalsService.ts
+++ b/server/services/signalsService/SignalsService.ts
@@ -154,6 +154,13 @@ export class SignalsService {
 
     const pluginEntries = getIntegrationRegistry().getPluginEntries();
     const pluginSignals = loadPluginSignals(pluginEntries, signalAuthService);
+    const builtInIds = new Set(Object.keys(this.builtInSignalsByType));
+    const collision = Object.keys(pluginSignals).find((id) => builtInIds.has(id));
+    if (collision != null) {
+      throw new Error(
+        `Plugin signal type "${collision}" collides with a built-in signal; use a different signalTypeId.`,
+      );
+    }
     this.signalsByType = {
       ...this.builtInSignalsByType,
       ...pluginSignals,

--- a/server/services/signalsService/helpers/loadPluginSignals.ts
+++ b/server/services/signalsService/helpers/loadPluginSignals.ts
@@ -1,0 +1,91 @@
+/**
+ * Loads signal implementations from integration plugins and wraps them in
+ * PluginSignalAdapter so they can be registered and used in rules.
+ */
+
+import { createRequire } from 'module';
+import path from 'path';
+
+import { isCoopIntegrationPlugin } from '@roostorg/types';
+import PluginSignalAdapter, {
+  type PluginSignalDescriptor,
+} from '../signals/PluginSignalAdapter.js';
+import type {
+  SignalBase,
+  SignalInputType,
+} from '../signals/SignalBase.js';
+import type { PluginEntry } from '../../integrationRegistry/loadPlugins.js';
+import type { SignalAuthService } from '../../signalAuthService/index.js';
+import type { SignalOutputType } from '../types/SignalOutputType.js';
+
+export type PluginSignalsByType = Record<
+  string,
+  SignalBase<SignalInputType, SignalOutputType, unknown, string>
+>;
+
+/**
+ * For each plugin entry, requires the package, calls createSignals(context) if
+ * present, wraps each returned descriptor in PluginSignalAdapter, and returns
+ * a map of signalTypeId -> adapter. Uses getByIntegrationId for credential lookup.
+ */
+export function loadPluginSignals(
+  pluginEntries: readonly PluginEntry[],
+  signalAuthService: SignalAuthService,
+): PluginSignalsByType {
+  const require = createRequire(path.join(process.cwd(), 'package.json'));
+  const byType: PluginSignalsByType = {};
+
+  for (const { packageSpec, integrationId } of pluginEntries) {
+    let plugin: unknown;
+    try {
+      // eslint-disable-next-line security/detect-non-literal-require -- package spec from integrations config (deployment-controlled), not user input
+      plugin = require(packageSpec);
+    } catch (err: unknown) {
+      throw new Error(
+        `Failed to load integration package "${packageSpec}" for signals: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    const resolved: unknown =
+      (plugin as { default?: unknown }).default ?? plugin;
+    if (!isCoopIntegrationPlugin(resolved)) continue;
+    const createSignals = (resolved as { createSignals?: (ctx: unknown) => unknown[] }).createSignals;
+    if (typeof createSignals !== 'function') continue;
+
+    const getCredential = async (orgId: string) =>
+      signalAuthService.getByIntegrationId(integrationId, orgId);
+    const context = { integrationId, getCredential };
+    let signals: unknown[];
+    try {
+      const raw = createSignals(context);
+      signals = Array.isArray(raw) ? raw : [];
+    } catch (err: unknown) {
+      throw new Error(
+        `Plugin "${packageSpec}" createSignals failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    for (const item of signals) {
+      if (
+        item == null ||
+        typeof item !== 'object' ||
+        !('signalTypeId' in item) ||
+        !('signal' in item)
+      )
+        continue;
+      const { signalTypeId, signal: descriptor } = item as {
+        signalTypeId: string;
+        signal: unknown;
+      };
+      if (typeof signalTypeId !== 'string' || descriptor == null) continue;
+      if (signalTypeId in byType) {
+        throw new Error(
+          `Duplicate plugin signal type "${signalTypeId}" from package "${packageSpec}".`,
+        );
+      }
+      byType[signalTypeId] = new PluginSignalAdapter(
+        descriptor as PluginSignalDescriptor,
+      );
+    }
+  }
+
+  return byType;
+}

--- a/server/services/signalsService/helpers/makeCachedCredentialsGetters.ts
+++ b/server/services/signalsService/helpers/makeCachedCredentialsGetters.ts
@@ -2,12 +2,18 @@ import { type Dependencies } from '../../../iocContainer/index.js';
 import { cached } from '../../../utils/caching.js';
 import { type ConfigurableIntegration } from '../../signalAuthService/signalAuthService.js';
 
+type CredentialCache = {
+  (orgId: string): Promise<Record<string, unknown> | undefined>;
+  close(): Promise<void>;
+};
+
 export type CredentialGetters = ReturnType<typeof makeCachedCredentialGetters>;
 
 /**
  * Returns a set of functions that can be used for looking up an org's stored
  * API keys for a given third-party service, which is needed when running
- * signals that connect to that service.
+ * signals that connect to that service. Also provides getForIntegrationId for
+ * plugin integrations (any string id). Call close() to dispose all caches.
  */
 export function makeCachedCredentialGetters(
   signalAuthService: Dependencies['SignalAuthService'],
@@ -21,11 +27,40 @@ export function makeCachedCredentialGetters(
       directives: { freshUntilAge: 600 },
     });
 
+  const cacheByIntegrationId = new Map<string, CredentialCache>();
+
+  function getForIntegrationId(integrationId: string): CredentialCache {
+    let c = cacheByIntegrationId.get(integrationId);
+    if (c == null) {
+      c = cached({
+        producer: async (orgId: string) =>
+          signalAuthService.getByIntegrationId(integrationId, orgId),
+        directives: { freshUntilAge: 600 },
+      });
+      cacheByIntegrationId.set(integrationId, c);
+    }
+    return c;
+  }
+
+  async function close(): Promise<void> {
+    const builtIn = [
+      getApiCredentialForIntegration('GOOGLE_CONTENT_SAFETY_API'),
+      getApiCredentialForIntegration('OPEN_AI'),
+      getApiCredentialForIntegration('ZENTROPI'),
+    ];
+    await Promise.all([
+      ...builtIn.map(async (c) => c.close()),
+      ...Array.from(cacheByIntegrationId.values(), async (c) => c.close()),
+    ]);
+  }
+
   return {
     GOOGLE_CONTENT_SAFETY_API: getApiCredentialForIntegration(
       'GOOGLE_CONTENT_SAFETY_API',
     ),
     OPEN_AI: getApiCredentialForIntegration('OPEN_AI'),
     ZENTROPI: getApiCredentialForIntegration('ZENTROPI'),
+    getForIntegrationId,
+    close,
   };
 }

--- a/server/services/signalsService/helpers/makeCachedCredentialsGetters.ts
+++ b/server/services/signalsService/helpers/makeCachedCredentialsGetters.ts
@@ -27,6 +27,15 @@ export function makeCachedCredentialGetters(
       directives: { freshUntilAge: 600 },
     });
 
+  // Create built-in caches once so close() disposes the same instances in use.
+  const builtInCaches = {
+    GOOGLE_CONTENT_SAFETY_API: getApiCredentialForIntegration(
+      'GOOGLE_CONTENT_SAFETY_API',
+    ),
+    OPEN_AI: getApiCredentialForIntegration('OPEN_AI'),
+    ZENTROPI: getApiCredentialForIntegration('ZENTROPI'),
+  };
+
   const cacheByIntegrationId = new Map<string, CredentialCache>();
 
   function getForIntegrationId(integrationId: string): CredentialCache {
@@ -43,23 +52,14 @@ export function makeCachedCredentialGetters(
   }
 
   async function close(): Promise<void> {
-    const builtIn = [
-      getApiCredentialForIntegration('GOOGLE_CONTENT_SAFETY_API'),
-      getApiCredentialForIntegration('OPEN_AI'),
-      getApiCredentialForIntegration('ZENTROPI'),
-    ];
     await Promise.all([
-      ...builtIn.map(async (c) => c.close()),
+      ...Object.values(builtInCaches).map(async (c) => c.close()),
       ...Array.from(cacheByIntegrationId.values(), async (c) => c.close()),
     ]);
   }
 
   return {
-    GOOGLE_CONTENT_SAFETY_API: getApiCredentialForIntegration(
-      'GOOGLE_CONTENT_SAFETY_API',
-    ),
-    OPEN_AI: getApiCredentialForIntegration('OPEN_AI'),
-    ZENTROPI: getApiCredentialForIntegration('ZENTROPI'),
+    ...builtInCaches,
     getForIntegrationId,
     close,
   };

--- a/server/services/signalsService/signals/PluginSignalAdapter.ts
+++ b/server/services/signalsService/signals/PluginSignalAdapter.ts
@@ -1,0 +1,141 @@
+/**
+ * Adapts a plugin's PluginSignalDescriptor to the server's SignalBase so plugin
+ * signals can be registered and used in routing/enforcement rules.
+ */
+
+import type { SignalSubcategory } from '@roostorg/types';
+import { type ReadonlyDeep } from 'type-fest';
+
+import { type Language } from '../../../utils/language.js';
+import SignalBase, {
+  type SignalDisabledInfo,
+  type SignalErrorResult,
+  type SignalInput,
+  type SignalInputType,
+  type SignalResult,
+} from './SignalBase.js';
+import { type SignalOutputType } from '../types/SignalOutputType.js';
+import { type SignalPricingStructure } from '../types/SignalPricingStructure.js';
+
+/** Minimal descriptor shape from a plugin; matches @roostorg/types PluginSignalDescriptor. */
+export type PluginSignalDescriptor = Readonly<{
+  id: { type: string };
+  displayName: string;
+  description: string;
+  docsUrl: string | null;
+  recommendedThresholds: Readonly<{
+    highPrecisionThreshold: string | number;
+    highRecallThreshold: string | number;
+  }> | null;
+  supportedLanguages: readonly string[] | 'ALL';
+  pricingStructure: { type: 'FREE' | 'SUBSCRIPTION' };
+  eligibleInputs: readonly string[];
+  outputType: Readonly<{ scalarType: string }>;
+  getCost: () => number;
+  run: (input: unknown) => Promise<unknown>;
+  getDisabledInfo: (orgId: string) => Promise<
+    | { disabled: false; disabledMessage?: string }
+    | { disabled: true; disabledMessage: string }
+  >;
+  needsMatchingValues: boolean;
+  eligibleSubcategories: ReadonlyArray<{
+    id: string;
+    label: string;
+    description?: string;
+    childrenIds: readonly string[];
+  }>;
+  needsActionPenalties: boolean;
+  integration: string;
+  allowedInAutomatedRules: boolean;
+}>;
+
+/**
+ * Wraps a plugin-provided descriptor so it satisfies SignalBase and can be
+ * registered in the signals map and used by the rule engine.
+ */
+export default class PluginSignalAdapter extends SignalBase<
+  SignalInputType,
+  SignalOutputType,
+  unknown,
+  string
+> {
+  constructor(
+    private readonly descriptor: ReadonlyDeep<PluginSignalDescriptor>,
+  ) {
+    super();
+  }
+
+  override get id() {
+    return this.descriptor.id;
+  }
+
+  override get displayName() {
+    return this.descriptor.displayName;
+  }
+
+  override get description() {
+    return this.descriptor.description;
+  }
+
+  override get docsUrl() {
+    return this.descriptor.docsUrl;
+  }
+
+  override get recommendedThresholds() {
+    return this.descriptor.recommendedThresholds;
+  }
+
+  override get supportedLanguages() {
+    const L = this.descriptor.supportedLanguages;
+    return (L === 'ALL' ? 'ALL' : L) as readonly Language[] | 'ALL';
+  }
+
+  override get pricingStructure() {
+    return this.descriptor.pricingStructure as unknown as SignalPricingStructure;
+  }
+
+  override get eligibleInputs() {
+    return this.descriptor.eligibleInputs as readonly SignalInputType[];
+  }
+
+  override get outputType() {
+    return this.descriptor.outputType as SignalOutputType;
+  }
+
+  override getCost() {
+    return this.descriptor.getCost();
+  }
+
+  override async run(
+    input: SignalInput,
+  ): Promise<SignalResult<SignalOutputType> | SignalErrorResult> {
+    const result = await this.descriptor.run(input);
+    return result as SignalResult<SignalOutputType> | SignalErrorResult;
+  }
+
+  override async getDisabledInfo(orgId: string): Promise<SignalDisabledInfo> {
+    return this.descriptor.getDisabledInfo(orgId) as Promise<SignalDisabledInfo>;
+  }
+
+  override get needsMatchingValues() {
+    return this.descriptor.needsMatchingValues;
+  }
+
+  override get eligibleSubcategories() {
+    return this.descriptor.eligibleSubcategories as unknown as ReadonlyDeep<
+      SignalSubcategory[]
+    >;
+  }
+
+  override get needsActionPenalties() {
+    return this.descriptor.needsActionPenalties;
+  }
+
+  override get integration() {
+    return this.descriptor.integration;
+  }
+
+  override get allowedInAutomatedRules() {
+    return this.descriptor.allowedInAutomatedRules;
+  }
+}

--- a/server/services/signalsService/signals/SignalBase.ts
+++ b/server/services/signalsService/signals/SignalBase.ts
@@ -65,7 +65,7 @@ export type SignalInput<
   NeedsMatchingValues extends boolean = boolean,
   NeedsActionPenalties extends boolean = boolean,
   MatchingValue = T extends ScalarType ? ScalarTypeRuntimeType<T> : unknown,
-  Type extends SignalType = SignalType,
+  Type extends SignalType | string = SignalType,
 > = {
   value: T extends 'FULL_ITEM'
     ? TaggedItemData
@@ -88,9 +88,13 @@ export type SignalInput<
   // TODO: figure out a better, generalized way to capture signals' required params.
   contextId?: string;
   contentType?: string;
-  args?: ReadonlyDeep<SignalArgsByType[Type]>;
+  args?: ReadonlyDeep<
+    Type extends SignalType ? SignalArgsByType[Type] : unknown
+  >;
 
-  runtimeArgs?: ReadonlyDeep<RuntimeSignalArgsByType[Type]>;
+  runtimeArgs?: ReadonlyDeep<
+    Type extends SignalType ? RuntimeSignalArgsByType[Type] : unknown
+  >;
 };
 
 // The result of running a signal can be:
@@ -140,7 +144,7 @@ export default abstract class SignalBase<
   MatchingValue = Input extends ScalarType
     ? ScalarTypeRuntimeType<Input>
     : unknown,
-  Type extends SignalType = SignalType,
+  Type extends SignalType | string = SignalType,
 > {
   /**
    * See {@link SignalId}.
@@ -272,7 +276,8 @@ export default abstract class SignalBase<
 
   abstract get needsActionPenalties(): boolean;
 
-  abstract get integration(): Integration | null;
+  /** Built-in integration enum value, or integration id string for plugin signals. */
+  abstract get integration(): Integration | string | null;
 
   /**
    * Indicates whether this signal can be used in automated rules with actions.

--- a/server/services/signalsService/types/SignalId.ts
+++ b/server/services/signalsService/types/SignalId.ts
@@ -30,9 +30,8 @@ export type SignalId = InternalSignalId | ExternalSignalId;
 export type InternalSignalId = { type: InternalSignalType };
 export type ExternalSignalId =
   | { type: typeof SignalType.CUSTOM; id: NonEmptyString }
-  | {
-      type: Exclude<ExternalSignalType, typeof SignalType.CUSTOM>;
-    };
+  | { type: Exclude<ExternalSignalType, typeof SignalType.CUSTOM> }
+  | { type: string }; // plugin signal type ids (not in SignalType enum)
 
 export const InternalSignalIdArbitrary = fc.record({
   type: InternalSignalTypeArbitrary,
@@ -79,7 +78,7 @@ export function isSignalId(it: unknown): it is SignalId {
     typeof it === 'object' &&
     it !== null &&
     'type' in it &&
-    Object.hasOwn(SignalType, it.type as string) &&
+    typeof (it as { type: unknown }).type === 'string' &&
     (it.type === SignalType.CUSTOM
       ? 'id' in it && isNonEmptyString(it.id)
       : true)

--- a/server/services/signalsService/types/SignalType.ts
+++ b/server/services/signalsService/types/SignalType.ts
@@ -1,7 +1,6 @@
 import { makeEnumLike } from '@roostorg/types';
 
 import { enumToArbitrary } from '../../../test/propertyTestingHelpers.js';
-import { assertUnreachable } from '../../../utils/misc.js';
 import { Integration } from './Integration.js';
 
 // Internal signal types are always built-in signals.
@@ -85,8 +84,9 @@ export const UserCreatedExternalSignalTypeArbitrary = enumToArbitrary(
 );
 export const ExternalSignalTypeArbitrary = enumToArbitrary(ExternalSignalType);
 
+/** Accepts SignalType or plugin signal type string (e.g. RANDOM_SIGNAL_SELECTION). */
 // eslint-disable-next-line complexity
-export function integrationForSignalType(type: SignalType) {
+export function integrationForSignalType(type: SignalType | string) {
   switch (type) {
     case 'GOOGLE_CONTENT_SAFETY_API_IMAGE':
       return Integration.GOOGLE_CONTENT_SAFETY_API;
@@ -120,6 +120,7 @@ export function integrationForSignalType(type: SignalType) {
     case 'BENIGN_MODEL':
       return null;
     default:
-      assertUnreachable(type);
+      // Plugin signal types (e.g. RANDOM_SIGNAL_SELECTION): no built-in integration
+      return null;
   }
 }


### PR DESCRIPTION
## Context & Requests for Reviewers

Adds persistence and API for plugin integrations (migration + signal auth), exposes them via GraphQL (availableIntegrations, integrationConfigs, setPluginIntegrationConfig, signal logo URLs), and wires plugin signal loading (loadPluginSignals, PluginSignalAdapter) so plugin signals are available to the rule engine.

## Changes

- **Migration:** `integration_configs` table for per-org plugin config to allow any integration to store credential/configs in (JSONB) to be used on settings page.
- **Signal auth:** Read/write plugin config in `signalAuthService` / dbTypes.
- **GraphQL:** integrationManifests datasource; IntegrationApi uses registry + new config; availableIntegrations, org.integrationConfigs (incl. plugin), setPluginIntegrationConfig; signal resolvers for integrationLogoUrl / integrationLogoWithBackgroundUrl; rule/insights updates for plugin signals.
- **Plugin signals:** loadPluginSignals, PluginSignalAdapter, credential getters, SignalType/SignalId updates, SignalsService wiring.
- **Conditions/rules:** condition evaluator and rule types updated so rules can use plugin signals.