### PR TITLE
fix: ErrorBoundary's and fixes for Rechart's Division By Zero errors

### DIFF
--- a/client/src/webpages/dashboard/mrt/visualization/ManualReviewDashboardInsightsFilterBy.tsx
+++ b/client/src/webpages/dashboard/mrt/visualization/ManualReviewDashboardInsightsFilterBy.tsx
@@ -202,12 +202,8 @@ export default function ManualReviewDashboardInsightsFilterBy(props: {
     };
   }, [filterByMenuVisible]);
 
-  if (error) {
-    throw error;
-  }
-
-  if (loading) {
-    return <ComponentLoading />;
+  if (error || loading) {
+    return loading ? <ComponentLoading /> : null;
   }
 
   const toggleColumn = (column: FilterByColumnName) => {

--- a/client/src/webpages/dashboard/overview/Overview.tsx
+++ b/client/src/webpages/dashboard/overview/Overview.tsx
@@ -22,6 +22,7 @@ import { useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 
 import DashboardHeader from '../components/DashboardHeader';
+import ErrorBoundary from '@/components/ErrorBoundary';
 import FullScreenLoading from '@/components/common/FullScreenLoading';
 
 import { ChartType } from '../rules/dashboard/visualization/RulesDashboardInsights';
@@ -198,15 +199,42 @@ export default function Overview() {
         <div className="flex flex-col w-full gap-4 mb-12">
           <div className="flex flex-col w-full gap-4 sm:flex-row">{cards}</div>
           <div className="flex w-full">
-            <RuleDashboardInsightsChart
-              lookback={LookbackLength.CUSTOM}
-              timeWindow={customTimeWindow}
-              timeDivision={timeDivision}
-              title="Total actions"
-              initialGroupBy="ACTION_ID"
-            />
+            <ErrorBoundary
+              containedInLayout
+              FallbackComponent={() => (
+                <div className="flex flex-col items-center justify-center w-full gap-3 p-6 rounded bg-slate-100">
+                  <div className="text-xl">
+                    No chart data available yet
+                  </div>
+                </div>
+              )}
+            >
+              <RuleDashboardInsightsChart
+                lookback={LookbackLength.CUSTOM}
+                timeWindow={customTimeWindow}
+                timeDivision={timeDivision}
+                title="Total actions"
+                initialGroupBy="ACTION_ID"
+              />
+            </ErrorBoundary>
           </div>
-          <div className="flex w-full gap-4">{charts}</div>
+          <div className="flex w-full gap-4">
+            {charts.map((chart) => (
+              <ErrorBoundary
+                key={chart.key}
+                containedInLayout
+                FallbackComponent={() => (
+                  <div className="flex flex-col items-center justify-center w-full gap-3 p-6 rounded bg-slate-100">
+                    <div className="text-xl">
+                      No chart data available yet
+                    </div>
+                  </div>
+                )}
+              >
+                {chart}
+              </ErrorBoundary>
+            ))}
+          </div>
         </div>
       )}
     </div>

--- a/client/src/webpages/dashboard/overview/OverviewChart.tsx
+++ b/client/src/webpages/dashboard/overview/OverviewChart.tsx
@@ -379,6 +379,10 @@ export default function OverviewChart(props: {
     return obj;
   });
 
+  const hasNonZeroData = finalChartData.some((row) =>
+    uniqueLines.some((line) => (row[line] ?? 0) > 0),
+  );
+
   const lineChart = uniqueLines.map((name, index) => {
     return (
       <Line
@@ -442,7 +446,7 @@ export default function OverviewChart(props: {
         </div>
       </div>
       <div className="z-10 flex flex-col w-full h-full min-h-[400px] pb-4">
-        {!loading && finalChartData.length === 0 ? (
+        {!loading && (finalChartData.length === 0 || uniqueLines.length === 0 || !hasNonZeroData) ? (
           emptyChart
         ) : (
           <ResponsiveContainer width="100%" height={400}>
@@ -460,6 +464,7 @@ export default function OverviewChart(props: {
                   tick={renderCustomYAxisTick}
                   tickLine={false}
                   stroke="#d4d4d8"
+                  domain={[0, (dataMax: number) => dataMax || 1]}
                   label={{
                     value: `Total ${titleCaseEnumString(metric)}`,
                     style: { textAnchor: 'middle' },

--- a/client/src/webpages/dashboard/rules/dashboard/visualization/RuleInsightsFilterBy.tsx
+++ b/client/src/webpages/dashboard/rules/dashboard/visualization/RuleInsightsFilterBy.tsx
@@ -95,12 +95,8 @@ export default function RuleInsightsFilterBy(props: {
     };
   }, [filterByMenuVisible]);
 
-  if (error) {
-    throw error;
-  }
-
-  if (loading) {
-    return <ComponentLoading />;
+  if (error || loading) {
+    return loading ? <ComponentLoading /> : null;
   }
 
   const toggleColumn = (column: FilterByColumnName) => {

--- a/client/src/webpages/dashboard/rules/dashboard/visualization/rulesDashboardInsightsChart.tsx
+++ b/client/src/webpages/dashboard/rules/dashboard/visualization/rulesDashboardInsightsChart.tsx
@@ -432,6 +432,10 @@ export default function RuleDashboardInsightsChart(props: {
     </div>
   );
 
+  const hasNonZeroData = finalChartData.some((row) =>
+    uniqueLines.some((line) => (row[line] ?? 0) > 0),
+  );
+
   const lineChart = uniqueLines.map((name, index) => {
     return (
       <Line
@@ -536,7 +540,7 @@ export default function RuleDashboardInsightsChart(props: {
         </div>
       </div>
       <div className="z-10 flex flex-col w-full h-full min-h-[400px] pb-4">
-        {!loading && finalChartData.length === 0 ? (
+        {!loading && (finalChartData.length === 0 || uniqueLines.length === 0 || !hasNonZeroData) ? (
           emptyChart
         ) : (
           <ResponsiveContainer width="100%" height={400}>
@@ -554,6 +558,7 @@ export default function RuleDashboardInsightsChart(props: {
                   tick={renderCustomYAxisTick}
                   tickLine={false}
                   stroke="#d4d4d8"
+                  domain={[0, (dataMax: number) => dataMax || 1]}
                   label={{
                     value: `Total Actions`,
                     style: { textAnchor: 'middle' },


### PR DESCRIPTION
## Context & Requests for Reviewers

Closes #94

- Add per-chart ErrorBoundary wrappers so a single chart failure doesn't crash the whole Overview page                                                                                    
- Add hasNonZeroData check to show empty state instead of rendering charts with all-zero data (which triggers Recharts Division by zero)                                                  
- Add YAxis domain guard to prevent zero-range domains                                                                                                                                    
- Stop RuleInsightsFilterBy and ManualReviewDashboardInsightsFilterBy from throwing on GraphQL query errors

## Tests

- [ ] Load Overview page with no data: should show empty chart states, not "Something Went Wrong"                                                                                        
- [ ] Load Overview page with real data: charts render normally                                                                                                                          
- [ ] Verify a single chart error doesn't take down the whole page 

