### PR TITLE
.devops/migrator: Update locks

### DIFF
--- a/.devops/migrator/package-lock.json
+++ b/.devops/migrator/package-lock.json
@@ -2406,9 +2406,9 @@
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-3.0.1.tgz",
+      "integrity": "sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==",
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -7419,9 +7419,9 @@
       }
     },
     "@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-3.0.1.tgz",
+      "integrity": "sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg=="
     },
     "@total-typescript/ts-reset": {
       "version": "0.5.1",
@@ -8415,7 +8415,7 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
       "requires": {
-        "@tootallnate/once": "2",
+        "@tootallnate/once": "^3.0.1",
         "agent-base": "6",
         "debug": "4"
       },

--- a/.devops/migrator/package.json
+++ b/.devops/migrator/package.json
@@ -31,5 +31,10 @@
     "@types/pg": "^8.10.2",
     "dotenv": "^16.0.0",
     "typescript": "^5.2.2"
+  },
+  "overrides": {
+    "snowflake-sdk": {
+      "@tootallnate/once": "^3.0.1"
+    }
   }
 }


### PR DESCRIPTION
## Context & Requests for Reviewers

This change doesn't introduce functional changes - its goal is to reduce warnings reported by npm audit in preparation for Dependabot automatic updates.

Fixes: #107

## Tests

With this PR applied `npm audit` should report no warnings in `.devops/migrator` directory.