### PR TITLE
[Code Simplification] Remove use of body-parser for native express json

### DIFF
--- a/server/api.ts
+++ b/server/api.ts
@@ -19,7 +19,6 @@ import {
   ApolloServerPluginLandingPageGraphQLPlayground,
 } from 'apollo-server-core';
 import { ApolloServer } from 'apollo-server-express';
-import bodyParser from 'body-parser';
 import connectPgSimple from 'connect-pg-simple';
 import cors from 'cors';
 import express, { type ErrorRequestHandler } from 'express';
@@ -240,7 +239,7 @@ export default async function makeApiServer(deps: Dependencies) {
 
   app.post(
     `/saml/login/:orgId/callback`,
-    bodyParser.urlencoded({ extended: false }),
+    express.urlencoded({ extended: false }),
     passport.authenticate('saml', {
       failureRedirect: '/',
       failureFlash: true,

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -51,7 +51,6 @@
         "apollo-server-express": "^3.10.3",
         "avsc": "^5.7.7",
         "bcryptjs": "^2.4.3",
-        "body-parser": "^1.20.2",
         "bullmq": "^5.0.0",
         "cassandra-driver": "^4.8.0",
         "cls-hooked": "^4.2.2",

--- a/server/package.json
+++ b/server/package.json
@@ -65,7 +65,6 @@
     "apollo-server-express": "^3.10.3",
     "avsc": "^5.7.7",
     "bcryptjs": "^2.4.3",
-    "body-parser": "^1.20.2",
     "bullmq": "^5.0.0",
     "cassandra-driver": "^4.8.0",
     "cls-hooked": "^4.2.2",


### PR DESCRIPTION
## Context & Requests for Reviewers

Part of code simplification this removes the body parser package as we have express and there is an existing way to parse json. 

## Tests

tested locally.