### PR TITLE
Add repository field to published packages for npm provenance

### DIFF
--- a/migrator/package-lock.json
+++ b/migrator/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@roostorg/db-migrator",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@roostorg/db-migrator",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "ISC",
       "dependencies": {
         "@total-typescript/ts-reset": "^0.5.1",
@@ -465,27 +465,28 @@
       }
     },
     "node_modules/sequelize": {
-      "version": "6.32.1",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.32.1.tgz",
-      "integrity": "sha512-3Iv0jruv57Y0YvcxQW7BE56O7DC1BojcfIrqh6my+IQwde+9u/YnuYHzK+8kmZLhLvaziRT1eWu38nh9yVwn/g==",
+      "version": "6.37.8",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.37.8.tgz",
+      "integrity": "sha512-HJ0IQFqcTsTiqbEgiuioYFMSD00TP6Cz7zoTti+zVVBwVe9fEhev9cH6WnM3XU31+ABS356durAb99ZuOthnKw==",
       "funding": [
         {
           "type": "opencollective",
           "url": "https://opencollective.com/sequelize"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@types/debug": "^4.1.8",
         "@types/validator": "^13.7.17",
         "debug": "^4.3.4",
-        "dottie": "^2.0.4",
+        "dottie": "^2.0.6",
         "inflection": "^1.13.4",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.43",
-        "pg-connection-string": "^2.6.0",
+        "pg-connection-string": "^2.6.1",
         "retry-as-promised": "^7.0.4",
-        "semver": "^7.5.1",
+        "semver": "^7.5.4",
         "sequelize-pool": "^7.1.0",
         "toposort-class": "^1.0.1",
         "uuid": "^8.3.2",
@@ -1072,21 +1073,21 @@
       }
     },
     "sequelize": {
-      "version": "6.32.1",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.32.1.tgz",
-      "integrity": "sha512-3Iv0jruv57Y0YvcxQW7BE56O7DC1BojcfIrqh6my+IQwde+9u/YnuYHzK+8kmZLhLvaziRT1eWu38nh9yVwn/g==",
+      "version": "6.37.8",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.37.8.tgz",
+      "integrity": "sha512-HJ0IQFqcTsTiqbEgiuioYFMSD00TP6Cz7zoTti+zVVBwVe9fEhev9cH6WnM3XU31+ABS356durAb99ZuOthnKw==",
       "requires": {
         "@types/debug": "^4.1.8",
         "@types/validator": "^13.7.17",
         "debug": "^4.3.4",
-        "dottie": "^2.0.4",
+        "dottie": "^2.0.6",
         "inflection": "^1.13.4",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.43",
-        "pg-connection-string": "^2.6.0",
+        "pg-connection-string": "^2.6.1",
         "retry-as-promised": "^7.0.4",
-        "semver": "^7.5.1",
+        "semver": "^7.5.4",
         "sequelize-pool": "^7.1.0",
         "toposort-class": "^1.0.1",
         "uuid": "^8.3.2",

--- a/migrator/package.json
+++ b/migrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roostorg/db-migrator",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "CLI tool for managing database migrations and seeding. Designed for modern scalable systems.",
   "type": "module",
   "scripts": {
@@ -15,6 +15,11 @@
   "files": [
     "build"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/roostorg/coop",
+    "directory": "migrator"
+  },
   "author": "Roostorg",
   "license": "ISC",
   "dependencies": {

--- a/types/package.json
+++ b/types/package.json
@@ -10,6 +10,11 @@
     "prepublishOnly": "npm run build",
     "test": "npm run build && node --test transpiled/test_scripts/"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/roostorg/coop",
+    "directory": "types"
+  },
   "author": "Roostorg",
   "files": [
     "transpiled"


### PR DESCRIPTION
## Context & Requests for Reviewers

As seen on https://github.com/roostorg/coop/actions/runs/23366011303/job/67979984974 package publishing failed due to missing repository field.

This pr adds the repository field to `types/package.json` and `migrator/package.json` to fix npm publish failures caused by sigstore provenance verification

