### PR TITLE
client: fix sidebar flickering and space shifting when nativating from settings to dashboard

### DIFF
--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -270,7 +270,7 @@ export default function Sidebar(props: SidebarProps) {
     <div
       className={`relative flex flex-col justify-between bg-white ${
         collapsed ? '' : 'min-w-[250px]'
-      } text-[14px]`}
+      } text-[14px] leading-normal`}
     >
       <div className="flex flex-col p-[14px]">
         <div className="flex items-center justify-between mb-[24px]">

--- a/client/src/hooks/useDynamicLegacyCSS.ts
+++ b/client/src/hooks/useDynamicLegacyCSS.ts
@@ -1,8 +1,6 @@
 import { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
 
 const useDynamicLegacyCSS = (isUsingLegacyCSS: boolean) => {
-  const { pathname } = useLocation();
   const [cssLoaded, setCssLoaded] = useState(false);
 
   useEffect(() => {
@@ -21,7 +19,7 @@ const useDynamicLegacyCSS = (isUsingLegacyCSS: boolean) => {
     } else {
       setCssLoaded(true);
     }
-  }, [pathname, isUsingLegacyCSS]);
+  }, [isUsingLegacyCSS]);
 
   return cssLoaded;
 };

--- a/client/src/webpages/dashboard/Dashboard.tsx
+++ b/client/src/webpages/dashboard/Dashboard.tsx
@@ -67,7 +67,6 @@ import OrgSafetySettings from '../settings/OrgSafetySettings';
 import NCMECSettings from '../settings/NCMECSettings';
 import SSOSettings from '../settings/SSOSettings';
 import MatchingBanksDashboard from './banks/MatchingBanksDashboard';
-import Layout from './Layout';
 import ManualReviewAppealSettings from './mrt/ManualReviewAppealSettings';
 import Overview from './overview/Overview';
 import PolicyForm from './policies/PolicyForm';
@@ -707,58 +706,61 @@ export default function Dashboard() {
     return <FullScreenLoading />;
   }
 
-  if (isUsingLegacyCSS) {
-    return (
-      <div className="flex w-full h-screen">
-        <Helmet>
-          <title>Home</title>
-        </Helmet>
-        <Sidebar
-          menuItems={menuItems}
-          settingsMenuItems={settingsMenuItems}
-          selectedMenuItem={selectedMenuItem}
-          setSelectedMenuItem={setSelectedMenuItem}
-          permissions={permissions}
-          logout={async () => logout()}
-          isDemoOrg={isDemoOrg}
-        />
-        <div className="w-px h-full bg-[#e5e7eb]" />
-        <div className="flex justify-center w-full px-12 py-8 overflow-scroll scrollbar-hide">
-          <ErrorBoundary
-            key={pathname}
-            containedInLayout
-            buttonTitle={
-              currentRouteHandle?.error?.buttonTitle ?? 'Return to dashboard'
-            }
-            buttonLinkPath={
-              currentRouteHandle?.error?.buttonLinkPath
-                ? `/dashboard/${currentRouteHandle.error.buttonLinkPath}`
-                : '/dashboard'
-            }
-          >
-            <div className="w-full max-w-[1280px]">
-              {isCSSLoaded ? <Outlet /> : <FullScreenLoading />}
-            </div>
-          </ErrorBoundary>
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <Layout
-      sidebarSlot={
-        <Sidebar
-          menuItems={menuItems}
-          settingsMenuItems={settingsMenuItems}
-          selectedMenuItem={selectedMenuItem}
-          setSelectedMenuItem={setSelectedMenuItem}
-          permissions={permissions}
-          logout={async () => logout()}
-          isDemoOrg={isDemoOrg}
-        />
-      }
-    />
+    <div
+      className={`flex w-full h-screen${isUsingLegacyCSS ? '' : ' bg-slate-50'}`}
+    >
+      <Helmet>
+        <title>Home</title>
+      </Helmet>
+      <Sidebar
+        menuItems={menuItems}
+        settingsMenuItems={settingsMenuItems}
+        selectedMenuItem={selectedMenuItem}
+        setSelectedMenuItem={setSelectedMenuItem}
+        permissions={permissions}
+        logout={async () => logout()}
+        isDemoOrg={isDemoOrg}
+      />
+      {isUsingLegacyCSS ? (
+        <>
+          <div className="w-px h-full bg-[#e5e7eb]" />
+          <div className="flex justify-center w-full px-12 py-8 overflow-scroll scrollbar-hide">
+            <ErrorBoundary
+              key={pathname}
+              containedInLayout
+              buttonTitle={
+                currentRouteHandle?.error?.buttonTitle ?? 'Return to dashboard'
+              }
+              buttonLinkPath={
+                currentRouteHandle?.error?.buttonLinkPath
+                  ? `/dashboard/${currentRouteHandle.error.buttonLinkPath}`
+                  : '/dashboard'
+              }
+            >
+              <div className="w-full max-w-[1280px]">
+                {isCSSLoaded ? <Outlet /> : <FullScreenLoading />}
+              </div>
+            </ErrorBoundary>
+          </div>
+        </>
+      ) : (
+        <main className="flex flex-col flex-grow overflow-y-auto min-h-0">
+          <div className="p-10">
+            <ErrorBoundary
+              key={pathname}
+              containedInLayout
+              buttonTitle={currentRouteHandle?.error?.buttonTitle}
+              buttonLinkPath={currentRouteHandle?.error?.buttonLinkPath}
+            >
+              <div className="w-full max-w-[1280px]">
+                <Outlet />
+              </div>
+            </ErrorBoundary>
+          </div>
+        </main>
+      )}
+    </div>
   );
 }
 


### PR DESCRIPTION
## Context & Requests for Reviewers

Fix sidebar menu flickering and line-height shift when navigating between dashboard settings pages (e.g., Item Types → Organization → Integrations).

Before:
<img width="277" height="1231" alt="Screenshot 2026-03-23 at 1 21 25 PM" src="https://github.com/user-attachments/assets/5f86ddba-f908-40c0-bcf3-eb9299bdc449" />
<img width="263" height="1215" alt="Screenshot 2026-03-23 at 1 22 07 PM" src="https://github.com/user-attachments/assets/ebac9636-3c38-4ce1-8cf7-daa23d52d1cd" />

After:
<img width="243" height="1199" alt="Screenshot 2026-03-23 at 1 21 48 PM" src="https://github.com/user-attachments/assets/a94f1d07-5e6f-4a8e-b421-49c6836bf690" />
