### PR TITLE
Add scrollbar when table is too big and increase max width

### DIFF
--- a/client/src/webpages/dashboard/Dashboard.tsx
+++ b/client/src/webpages/dashboard/Dashboard.tsx
@@ -725,7 +725,7 @@ export default function Dashboard() {
       {isUsingLegacyCSS ? (
         <>
           <div className="w-px h-full bg-[#e5e7eb]" />
-          <div className="flex justify-center w-full px-12 py-8 overflow-scroll scrollbar-hide">
+          <div className="flex justify-center w-full px-12 py-8 overflow-auto">
             <ErrorBoundary
               key={pathname}
               containedInLayout
@@ -738,7 +738,7 @@ export default function Dashboard() {
                   : '/dashboard'
               }
             >
-              <div className="w-full max-w-[1280px]">
+              <div className="w-full max-w-[1800px]">
                 {isCSSLoaded ? <Outlet /> : <FullScreenLoading />}
               </div>
             </ErrorBoundary>
@@ -753,7 +753,7 @@ export default function Dashboard() {
               buttonTitle={currentRouteHandle?.error?.buttonTitle}
               buttonLinkPath={currentRouteHandle?.error?.buttonLinkPath}
             >
-              <div className="w-full max-w-[1280px]">
+              <div className="w-full max-w-[1800px]">
                 <Outlet />
               </div>
             </ErrorBoundary>

--- a/client/src/webpages/dashboard/components/table/Table.tsx
+++ b/client/src/webpages/dashboard/components/table/Table.tsx
@@ -81,9 +81,9 @@ export default function Table(
         )}
         {topRightComponent}
       </div>
-      <div className="w-full border border-gray-200 border-solid rounded-md scrollbar-hide">
+      <div className="w-full border border-gray-200 border-solid rounded-md">
         <div
-          className={`overflow-x-auto overflow-y-scroll rounded-md scrollbar-hide ${
+          className={`overflow-x-auto overflow-y-auto rounded-md ${
             customMaxHeight ?? 'max-h-[1200px]'
           }`}
         >
@@ -219,7 +219,7 @@ export default function Table(
                           {cell.render('Cell')}
                         </Link>
                       ) : (
-                        <div className="flex items-center max-w-3xl px-4 py-2 overflow-scroll text-black hover:text-black scrollbar-hide">
+                        <div className="flex items-center max-w-3xl px-4 py-2 overflow-hidden text-ellipsis text-black hover:text-black">
                           {cell.render('Cell')}
                         </div>
                       );


### PR DESCRIPTION
## Context & Requests for Reviewers

On the queues view for smaller screens we were hiding information. Added a scroll in case the table has overflown. Also increase max width for bigger screens to show all information and removing dead space.

Before:
<img width="2451" height="657" alt="Screenshot 2026-03-27 at 10 43 40 AM" src="https://github.com/user-attachments/assets/7fa5644f-0f54-477a-839e-6fde6c3f1ecd" />
<img width="2490" height="688" alt="Screenshot 2026-03-27 at 10 43 48 AM" src="https://github.com/user-attachments/assets/abb982de-4c37-4558-96a5-24e3709feab7" />

After:
<img width="2537" height="660" alt="Screenshot 2026-03-27 at 10 49 08 AM" src="https://github.com/user-attachments/assets/accaaef3-1d1e-4bc6-9d6f-76e8ee2ae056" />
<img width="1074" height="537" alt="Screenshot 2026-03-27 at 10 49 18 AM" src="https://github.com/user-attachments/assets/b1e72f4c-4989-4a1e-9544-17f92703826c" />
