### PR TITLE
chore(content-proxy): use native fetch

### DIFF
--- a/content-proxy/package-lock.json
+++ b/content-proxy/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "@babel/preset-env": "^7.24.5",
-        "axios": "1.14.0",
         "babel-jest": "^29.7.0",
         "cheerio": "^1.0.0",
         "express": "^4.20.0",
@@ -2911,17 +2910,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
-    "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
-      }
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -6404,15 +6392,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/ps-tree": {

--- a/content-proxy/package.json
+++ b/content-proxy/package.json
@@ -12,7 +12,6 @@
   "license": "ISC",
   "dependencies": {
     "@babel/preset-env": "^7.24.5",
-    "axios": "1.14.0",
     "babel-jest": "^29.7.0",
     "cheerio": "^1.0.0",
     "express": "^4.20.0",
@@ -32,11 +31,5 @@
     "ts-node": "^10.9.2",
     "tsc-watch": "^6.2.0",
     "typescript": "^5.4.5"
-  },
-  "overrides": {
-    "axios": "1.14.0"
-  },
-  "resolutions": {
-    "axios": "1.14.0"
   }
 }

--- a/content-proxy/src/index.ts
+++ b/content-proxy/src/index.ts
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import * as cheerio from 'cheerio';
 import express, { Request, Response } from 'express';
 import { chromium } from 'playwright';
@@ -322,10 +321,11 @@ app.get('/_assets/*.css', async (req: Request, res: Response) => {
   const assetUrl = `${CONTENT_BASE_URL}${req.originalUrl}`;
 
   try {
-    const response = await axios.get(assetUrl, { responseType: 'arraybuffer' });
+    const response = await fetch(assetUrl);
+    const buffer = await response.arrayBuffer();
 
     res.set('Content-Type', 'text/css');
-    return res.send(response.data);
+    return res.send(Buffer.from(buffer));
   } catch (error: any) {
     return res.status(500).send('Error fetching CSS asset');
   }
@@ -359,7 +359,8 @@ app.get('/_assets/*', async (req: Request, res: Response) => {
   const assetUrl = `${CONTENT_BASE_URL}${req.originalUrl}`;
 
   try {
-    const response = await axios.get(assetUrl, { responseType: 'arraybuffer' });
+    const response = await fetch(assetUrl);
+    const buffer = await response.arrayBuffer();
 
     // Determine content type based on the file extension
     const extension = assetUrl.split('.').pop()?.toLowerCase();
@@ -368,7 +369,7 @@ app.get('/_assets/*', async (req: Request, res: Response) => {
       : extensionContentTypeMap.default;
 
     res.set('Content-Type', contentType);
-    return res.send(response.data);
+    return res.send(Buffer.from(buffer));
   } catch (error: any) {
     return res.status(500).send('Error fetching asset');
   }


### PR DESCRIPTION
## Context & Requests for Reviewers

We can switch away from `axios` to using native fetch since we don't use
any of the extra feature axios provides.

This reduces the dependencies a little.

Note: I just saw this while roaming around the repo. if you're not interested in PRs like this, let me know and I will hold off 👍  

## Tests

Existing tests should cover this change, but I did run this locally and ensure images and what not still loaded.
