### PR TITLE
[Performance] Add Apollo retry and cache org metadata separately from paginated queries

### DIFF
--- a/client/src/graphql/generated.ts
+++ b/client/src/graphql/generated.ts
@@ -10146,6 +10146,54 @@ export type GQLManualReviewDecisionComponentFieldsFragment =
   | GQLManualReviewDecisionComponentFieldsTransformJobAndRecreateInQueueDecisionComponentFragment
   | GQLManualReviewDecisionComponentFieldsUserOrRelatedActionDecisionComponentFragment;
 
+export type GQLOrgLookupDataQueryVariables = Exact<{ [key: string]: never }>;
+
+export type GQLOrgLookupDataQuery = {
+  readonly __typename: 'Query';
+  readonly myOrg?: {
+    readonly __typename: 'Org';
+    readonly id: string;
+    readonly actions: ReadonlyArray<
+      | {
+          readonly __typename: 'CustomAction';
+          readonly id: string;
+          readonly name: string;
+        }
+      | {
+          readonly __typename: 'EnqueueAuthorToMrtAction';
+          readonly id: string;
+          readonly name: string;
+        }
+      | {
+          readonly __typename: 'EnqueueToMrtAction';
+          readonly id: string;
+          readonly name: string;
+        }
+      | {
+          readonly __typename: 'EnqueueToNcmecAction';
+          readonly id: string;
+          readonly name: string;
+        }
+    >;
+    readonly policies: ReadonlyArray<{
+      readonly __typename: 'Policy';
+      readonly id: string;
+      readonly name: string;
+    }>;
+    readonly users: ReadonlyArray<{
+      readonly __typename: 'User';
+      readonly id: string;
+      readonly firstName: string;
+      readonly lastName: string;
+    }>;
+    readonly mrtQueues: ReadonlyArray<{
+      readonly __typename: 'ManualReviewQueue';
+      readonly id: string;
+      readonly name: string;
+    }>;
+  } | null;
+};
+
 export type GQLGetRecentDecisionsQueryVariables = Exact<{
   input: GQLRecentDecisionsInput;
 }>;
@@ -10255,48 +10303,6 @@ export type GQLGetRecentDecisionsQuery = {
         }
     >;
   }>;
-  readonly myOrg?: {
-    readonly __typename: 'Org';
-    readonly id: string;
-    readonly actions: ReadonlyArray<
-      | {
-          readonly __typename: 'CustomAction';
-          readonly id: string;
-          readonly name: string;
-        }
-      | {
-          readonly __typename: 'EnqueueAuthorToMrtAction';
-          readonly id: string;
-          readonly name: string;
-        }
-      | {
-          readonly __typename: 'EnqueueToMrtAction';
-          readonly id: string;
-          readonly name: string;
-        }
-      | {
-          readonly __typename: 'EnqueueToNcmecAction';
-          readonly id: string;
-          readonly name: string;
-        }
-    >;
-    readonly policies: ReadonlyArray<{
-      readonly __typename: 'Policy';
-      readonly id: string;
-      readonly name: string;
-    }>;
-    readonly users: ReadonlyArray<{
-      readonly __typename: 'User';
-      readonly id: string;
-      readonly firstName: string;
-      readonly lastName: string;
-    }>;
-    readonly mrtQueues: ReadonlyArray<{
-      readonly __typename: 'ManualReviewQueue';
-      readonly id: string;
-      readonly name: string;
-    }>;
-  } | null;
 };
 
 export type GQLGetSkipsForRecentDecisionsQueryVariables = Exact<{
@@ -32702,28 +32708,8 @@ export type GQLRecentDecisionsSummaryDataQueryResult = Apollo.QueryResult<
   GQLRecentDecisionsSummaryDataQuery,
   GQLRecentDecisionsSummaryDataQueryVariables
 >;
-export const GQLGetRecentDecisionsDocument = gql`
-  query GetRecentDecisions($input: RecentDecisionsInput!) {
-    getRecentDecisions(input: $input) {
-      id
-      jobId
-      queueId
-      reviewerId
-      itemId
-      itemTypeId
-      decisions {
-        ... on ManualReviewDecisionComponentBase {
-          ...ManualReviewDecisionComponentFields
-        }
-      }
-      relatedActions {
-        ... on ManualReviewDecisionComponentBase {
-          ...ManualReviewDecisionComponentFields
-        }
-      }
-      createdAt
-      decisionReason
-    }
+export const GQLOrgLookupDataDocument = gql`
+  query OrgLookupData {
     myOrg {
       id
       actions {
@@ -32745,6 +32731,121 @@ export const GQLGetRecentDecisionsDocument = gql`
         id
         name
       }
+    }
+  }
+`;
+
+/**
+ * __useGQLOrgLookupDataQuery__
+ *
+ * To run a query within a React component, call `useGQLOrgLookupDataQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGQLOrgLookupDataQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGQLOrgLookupDataQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGQLOrgLookupDataQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    GQLOrgLookupDataQuery,
+    GQLOrgLookupDataQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<GQLOrgLookupDataQuery, GQLOrgLookupDataQueryVariables>(
+    GQLOrgLookupDataDocument,
+    options,
+  );
+}
+export function useGQLOrgLookupDataLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GQLOrgLookupDataQuery,
+    GQLOrgLookupDataQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GQLOrgLookupDataQuery,
+    GQLOrgLookupDataQueryVariables
+  >(GQLOrgLookupDataDocument, options);
+}
+// @ts-ignore
+export function useGQLOrgLookupDataSuspenseQuery(
+  baseOptions?: Apollo.SuspenseQueryHookOptions<
+    GQLOrgLookupDataQuery,
+    GQLOrgLookupDataQueryVariables
+  >,
+): Apollo.UseSuspenseQueryResult<
+  GQLOrgLookupDataQuery,
+  GQLOrgLookupDataQueryVariables
+>;
+export function useGQLOrgLookupDataSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GQLOrgLookupDataQuery,
+        GQLOrgLookupDataQueryVariables
+      >,
+): Apollo.UseSuspenseQueryResult<
+  GQLOrgLookupDataQuery | undefined,
+  GQLOrgLookupDataQueryVariables
+>;
+export function useGQLOrgLookupDataSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GQLOrgLookupDataQuery,
+        GQLOrgLookupDataQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GQLOrgLookupDataQuery,
+    GQLOrgLookupDataQueryVariables
+  >(GQLOrgLookupDataDocument, options);
+}
+export type GQLOrgLookupDataQueryHookResult = ReturnType<
+  typeof useGQLOrgLookupDataQuery
+>;
+export type GQLOrgLookupDataLazyQueryHookResult = ReturnType<
+  typeof useGQLOrgLookupDataLazyQuery
+>;
+export type GQLOrgLookupDataSuspenseQueryHookResult = ReturnType<
+  typeof useGQLOrgLookupDataSuspenseQuery
+>;
+export type GQLOrgLookupDataQueryResult = Apollo.QueryResult<
+  GQLOrgLookupDataQuery,
+  GQLOrgLookupDataQueryVariables
+>;
+export const GQLGetRecentDecisionsDocument = gql`
+  query GetRecentDecisions($input: RecentDecisionsInput!) {
+    getRecentDecisions(input: $input) {
+      id
+      jobId
+      queueId
+      reviewerId
+      itemId
+      itemTypeId
+      decisions {
+        ... on ManualReviewDecisionComponentBase {
+          ...ManualReviewDecisionComponentFields
+        }
+      }
+      relatedActions {
+        ... on ManualReviewDecisionComponentBase {
+          ...ManualReviewDecisionComponentFields
+        }
+      }
+      createdAt
+      decisionReason
     }
   }
   ${GQLManualReviewDecisionComponentFieldsFragmentDoc}
@@ -42998,6 +43099,7 @@ export const namedOperations = {
     getResolvedJobsForUser: 'getResolvedJobsForUser',
     getSkippedJobsForUser: 'getSkippedJobsForUser',
     RecentDecisionsSummaryData: 'RecentDecisionsSummaryData',
+    OrgLookupData: 'OrgLookupData',
     GetRecentDecisions: 'GetRecentDecisions',
     getSkipsForRecentDecisions: 'getSkipsForRecentDecisions',
     GetDecidedJob: 'GetDecidedJob',

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -3,11 +3,14 @@ import { TooltipProvider } from '@/coop-ui/Tooltip';
 import {
   ApolloClient,
   ApolloProvider,
+  from,
   gql,
+  HttpLink,
   InMemoryCache,
   StoreObject,
 } from '@apollo/client';
 import { KeyFieldsContext } from '@apollo/client/cache/inmemory/policies';
+import { RetryLink } from '@apollo/client/link/retry';
 import { createRoot } from 'react-dom/client';
 import { HelmetProvider } from 'react-helmet-async';
 import { QueryClient, QueryClientProvider } from 'react-query';
@@ -40,12 +43,21 @@ gql`
   }
 `;
 
-// Apollo Client
-const client = new ApolloClient({
+const httpLink = new HttpLink({
   uri:
     import.meta.env.MODE === 'production'
       ? '/api/v1/graphql'
       : 'http://localhost:3000/api/v1/graphql',
+});
+
+const retryLink = new RetryLink({
+  delay: { initial: 300, max: 5000, jitter: true },
+  attempts: { max: 3, retryIf: (error) => Boolean(error) },
+});
+
+// Apollo Client
+const client = new ApolloClient({
+  link: from([retryLink, httpLink]),
   cache: new InMemoryCache({
     typePolicies: {
       ConditionInputField: {

--- a/client/src/webpages/dashboard/mrt/ManualReviewQueuesDashboard.tsx
+++ b/client/src/webpages/dashboard/mrt/ManualReviewQueuesDashboard.tsx
@@ -181,7 +181,7 @@ const columnLabels: Record<ColumnId, string> = {
 };
 
 export default function ManualReviewQueuesDashboard() {
-  const { loading, data, refetch } = useGQLManualReviewQueuesQuery({
+  const { loading, error, data, refetch } = useGQLManualReviewQueuesQuery({
     fetchPolicy: 'no-cache',
     pollInterval: 5000,
   });
@@ -682,6 +682,9 @@ export default function ManualReviewQueuesDashboard() {
         }),
     [dataValues, onAddFavoriteQueue, onRemoveFavoriteQueue],
   );
+  if (error) {
+    throw error;
+  }
   if (loading) {
     return <FullScreenLoading />;
   }

--- a/client/src/webpages/dashboard/mrt/ManualReviewRecentDecisions.tsx
+++ b/client/src/webpages/dashboard/mrt/ManualReviewRecentDecisions.tsx
@@ -23,6 +23,7 @@ import {
   useGQLGetDecidedJobLazyQuery,
   useGQLGetRecentDecisionsLazyQuery,
   useGQLGetSkipsForRecentDecisionsLazyQuery,
+  useGQLOrgLookupDataQuery,
 } from '../../../graphql/generated';
 import { assertUnreachable } from '../../../utils/misc';
 import {
@@ -71,27 +72,7 @@ gql`
     }
   }
 
-  query GetRecentDecisions($input: RecentDecisionsInput!) {
-    getRecentDecisions(input: $input) {
-      id
-      jobId
-      queueId
-      reviewerId
-      itemId
-      itemTypeId
-      decisions {
-        ... on ManualReviewDecisionComponentBase {
-          ...ManualReviewDecisionComponentFields
-        }
-      }
-      relatedActions {
-        ... on ManualReviewDecisionComponentBase {
-          ...ManualReviewDecisionComponentFields
-        }
-      }
-      createdAt
-      decisionReason
-    }
+  query OrgLookupData {
     myOrg {
       id
       actions {
@@ -113,6 +94,29 @@ gql`
         id
         name
       }
+    }
+  }
+
+  query GetRecentDecisions($input: RecentDecisionsInput!) {
+    getRecentDecisions(input: $input) {
+      id
+      jobId
+      queueId
+      reviewerId
+      itemId
+      itemTypeId
+      decisions {
+        ... on ManualReviewDecisionComponentBase {
+          ...ManualReviewDecisionComponentFields
+        }
+      }
+      relatedActions {
+        ... on ManualReviewDecisionComponentBase {
+          ...ManualReviewDecisionComponentFields
+        }
+      }
+      createdAt
+      decisionReason
     }
   }
 
@@ -149,6 +153,10 @@ export default function ManualReviewRecentDecisions() {
   const [unsavedFilterValue, setUnsavedFilterValue] = useState<
     RecentDecisionsFilterInput | undefined
   >(undefined);
+
+  const { data: orgLookupData } = useGQLOrgLookupDataQuery({
+    fetchPolicy: 'cache-and-network',
+  });
 
   const { data: decidedJobFromJobIdData } = useGQLGetDecidedJobFromJobIdQuery({
     variables: { id: jobId! },
@@ -285,35 +293,35 @@ export default function ManualReviewRecentDecisions() {
       if (!reviewerId) {
         return 'Automatic';
       }
-      const reviewer = allDecisionsData?.myOrg?.users.find(
+      const reviewer = orgLookupData?.myOrg?.users.find(
         (user) => user.id === reviewerId,
       );
       return reviewer
         ? `${reviewer.firstName} ${reviewer.lastName}`
         : 'Unknown';
     },
-    [allDecisionsData?.myOrg?.users],
+    [orgLookupData?.myOrg?.users],
   );
 
   const getQueueName = useCallback(
     (queueId: string) =>
-      allDecisionsData?.myOrg?.mrtQueues.find((queue) => queue.id === queueId)
+      orgLookupData?.myOrg?.mrtQueues.find((queue) => queue.id === queueId)
         ?.name ?? 'Unknown',
-    [allDecisionsData?.myOrg],
+    [orgLookupData?.myOrg],
   );
 
   const getActionName = useCallback(
     (actionId: string) =>
-      allDecisionsData?.myOrg?.actions.find((action) => action.id === actionId)
+      orgLookupData?.myOrg?.actions.find((action) => action.id === actionId)
         ?.name ?? 'Unknown',
-    [allDecisionsData?.myOrg],
+    [orgLookupData?.myOrg],
   );
 
   const getPolicyName = useCallback(
     (policyId: string) =>
-      allDecisionsData?.myOrg?.policies.find((policy) => policy.id === policyId)
+      orgLookupData?.myOrg?.policies.find((policy) => policy.id === policyId)
         ?.name ?? 'Unknown',
-    [allDecisionsData?.myOrg],
+    [orgLookupData?.myOrg],
   );
 
   const getDecisionColorNamePairs = useCallback(
@@ -399,7 +407,7 @@ export default function ManualReviewRecentDecisions() {
   );
 
   const dataValues = useMemo(() => {
-    if (!allDecisionsData || !allDecisionsData.myOrg) {
+    if (!allDecisionsData || !orgLookupData?.myOrg) {
       return undefined;
     }
     const allDecisions = [
@@ -435,6 +443,7 @@ export default function ManualReviewRecentDecisions() {
     });
   }, [
     allDecisionsData,
+    orgLookupData?.myOrg,
     decidedJobFromJobIdData?.getDecidedJobFromJobId?.decision,
     getDecisionColorNamePairs,
     getPoliciesFromDecision,


### PR DESCRIPTION
## Context & Requests for Reviewers

The Recent Decisions page was re-fetching the full org metadata (users, queues, policies, actions) on every single pagination click, filter change, and CSV download row even if that data had not change and more than likely doesn't change frequently. This PR splits it into its own cached query so pagination only fetches what actually changes (the decisions). The data would be re-fetch when the user does a full page reload. so it only works as in browser cache to prevent hitting the endpoint too often.

This Pr also adds a `RetryLink` to the Apollo Client so transient network hiccups retry automatically instead of immediately throwing to the error boundary and nuking the page.
