### PR TITLE
[Vulnerability] Fix remaining lodash and jsonpath dependency vulnerabilities

### DIFF
--- a/migrator/package-lock.json
+++ b/migrator/package-lock.json
@@ -347,9 +347,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/long": {
@@ -985,9 +985,9 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "long": {
       "version": "5.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -965,16 +965,15 @@
       "license": "0BSD"
     },
     "node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-6.2.0.tgz",
-      "integrity": "sha512-TKm0Q0+wRlg354Qt3PyXc+sy6dCKxmNofBsgmHoFZNVHtzMQSSgNT+rUWdwBwObQ9bFHiUVsDIv8QqxKMiKmpw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-6.2.1.tgz",
+      "integrity": "sha512-shRr26TfVZ6KFBjzRYUj02gLNh6yaECz9gTGgI6riANw5sSH9PONwTsBRYkEgU+6IXiL7VQeCumahvxSGFbRlQ==",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/utils": "^11.0.0",
         "change-case-all": "1.0.15",
         "common-tags": "1.8.2",
         "import-from": "4.0.0",
-        "lodash": "~4.17.0",
         "tslib": "~2.6.0"
       },
       "engines": {
@@ -3913,9 +3912,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.sortby": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -33,7 +33,6 @@
         "@types/debug": "^4.1.5",
         "@types/express": "^4.17.17",
         "@types/express-session": "^1.17.4",
-        "@types/jsonpath": "^0.2.0",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/lodash": "^4.14.179",
         "@types/morgan": "^1.9.3",
@@ -128,7 +127,7 @@
         "jest-junit": "^16.0.0",
         "jest-light-runner": "^0.4.1",
         "js-yaml": "^4.1.0",
-        "jsonpath": "^1.3.0",
+        "jsonpath-plus": "^10.4.0",
         "supertest": "^6.2.2",
         "ts-node": "^10.9.1",
         "tsc-watch": "^4.6.0",
@@ -3037,6 +3036,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
       }
     },
     "node_modules/@lukeed/csprng": {
@@ -10704,11 +10729,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/jsonpath": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@types/jsonpath/-/jsonpath-0.2.0.tgz",
-      "integrity": "sha512-v7qlPA0VpKUlEdhghbDqRoKMxFB3h3Ch688TApBJ6v+XLDdvWCGLJIYiPKGZnS6MAOie+IorCfNYVHOPIHSWwQ=="
-    },
     "node_modules/@types/jsonwebtoken": {
       "version": "8.5.9",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.9.tgz",
@@ -13848,42 +13868,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/escodegen": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/escodegen/node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/eslint": {
       "version": "9.39.4",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
@@ -14048,13 +14032,6 @@
       "peerDependencies": {
         "eslint": ">=6"
       }
-    },
-    "node_modules/eslint-plugin-better-mutation/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/eslint-plugin-es": {
       "version": "3.0.1",
@@ -14443,19 +14420,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
-      "integrity": "sha512-S9VbPDU0adFErpDai3qDkjq8+G05ONtKzcyNrPKg/ZKa+tf879nX2KexNU95b31UoTJjRLInNBHHHjFPoCd7lQ==",
-      "dev": true,
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/esquery": {
@@ -17317,6 +17281,16 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -17373,16 +17347,23 @@
         "node": ">=6"
       }
     },
-    "node_modules/jsonpath": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.3.0.tgz",
-      "integrity": "sha512-0kjkYHJBkAy50Z5QzArZ7udmvxrJzkpKYW27fiF//BrMY7TQibYLl+FYIXN2BiYmwMIVzSfD8aDRj6IzgBX2/w==",
+    "node_modules/jsonpath-plus": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz",
+      "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esprima": "1.2.5",
-        "static-eval": "2.1.1",
-        "underscore": "1.13.6"
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -20056,16 +20037,6 @@
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
-    "node_modules/static-eval": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.1.1.tgz",
-      "integrity": "sha512-MgWpQ/ZjGieSVB3eOJVs4OA2LT/q1vx98KPCTTQPzq/aLr0YUXTsgryTXr4SLfR0ZfUUCiedM9n/ABeDIyy4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escodegen": "^2.1.0"
-      }
-    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -21158,13 +21129,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/underscore": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "7.24.5",

--- a/server/package.json
+++ b/server/package.json
@@ -47,7 +47,6 @@
     "@types/debug": "^4.1.5",
     "@types/express": "^4.17.17",
     "@types/express-session": "^1.17.4",
-    "@types/jsonpath": "^0.2.0",
     "@types/jsonwebtoken": "^8.5.8",
     "@types/lodash": "^4.14.179",
     "@types/morgan": "^1.9.3",
@@ -142,7 +141,7 @@
     "jest-junit": "^16.0.0",
     "jest-light-runner": "^0.4.1",
     "js-yaml": "^4.1.0",
-    "jsonpath": "^1.3.0",
+    "jsonpath-plus": "^10.4.0",
     "supertest": "^6.2.2",
     "ts-node": "^10.9.1",
     "tsc-watch": "^4.6.0",
@@ -166,6 +165,9 @@
     },
     "apollo-server-express": {
       "@types/express": "npm:@types/express@4.17.17"
+    },
+    "eslint-plugin-better-mutation": {
+      "lodash": "^4.18.1"
     }
   }
 }

--- a/server/test/extendExpect.ts
+++ b/server/test/extendExpect.ts
@@ -1,7 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import jestSnapshot from 'jest-snapshot';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import jsonPath from 'jsonpath';
+import { JSONPath } from 'jsonpath-plus';
 import lodash from 'lodash';
 
 const { toMatchSnapshot } = jestSnapshot;
@@ -55,9 +54,12 @@ expect.extend({
       if (isJsonPath(k)) {
         // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
         delete generatedPropertyMatchers[key];
-        jsonPath.paths(received, k).forEach((path) => {
-          set(generatedPropertyMatchers, path.slice(1), propertyMatchers[key]);
-        });
+        JSONPath({ path: k, json: received, resultType: 'path' }).forEach(
+          (pathStr: string) => {
+            const path = JSONPath.toPathArray(pathStr).slice(1);
+            set(generatedPropertyMatchers, path, propertyMatchers[key]);
+          },
+        );
       }
     });
 


### PR DESCRIPTION
## Context & Requests for Reviewers

Resolve Dependabot alerts for `lodash` and `underscore`/`jsonpath` across project. Clears root and migrator to 0 vulnerabilities, and reduces `server` from 7 to 3 (remaining are `kysely` and `apollo-server-core` which one is handle by another pr, and kysely will be done on a follow up given there will be some major code refactor)

