### PR TITLE
[Kysely] Migrate MRT action/policy id lookups off Sequelize

### DIFF
--- a/server/services/manualReviewToolService/manualReviewToolQueries.ts
+++ b/server/services/manualReviewToolService/manualReviewToolQueries.ts
@@ -1,5 +1,3 @@
-import { Op } from 'sequelize';
-
 import { inject } from '../../iocContainer/index.js';
 import { cached } from '../../utils/caching.js';
 import { jsonParse, jsonStringify } from '../../utils/encoding.js';
@@ -9,21 +7,22 @@ import { type Action } from '../moderationConfigService/index.js';
 type ActionKey = { ids: readonly string[]; orgId: string };
 
 export const makeGetActionsByIdEventuallyConsistent = inject(
-  ['ActionModel'],
-  (Action) =>
+  ['ModerationConfigService'],
+  (moderationConfigService) =>
     cached({
       keyGeneration: {
         toString: (it: ActionKey) =>
           jsonStringify({ ...it, ids: [...it.ids].sort() }),
         fromString: (it) => jsonParse(it),
       },
-      async producer(actionIds) {
-        return Action.findAll({
-          where: {
-            id: { [Op.in]: actionIds.ids },
-            orgId: actionIds.orgId,
-          },
-          // NB: CollapseCases needed to prevent excessive stack depth TS errors downstream
+      async producer(actionIds: ActionKey) {
+        if (actionIds.ids.length === 0) {
+          return [] as CollapseCases<Action>[];
+        }
+        return moderationConfigService.getActions({
+          orgId: actionIds.orgId,
+          ids: actionIds.ids,
+          readFromReplica: true,
         }) as Promise<CollapseCases<Action>[]>;
       },
       directives: { freshUntilAge: 10, maxStale: [0, 2, 2] },
@@ -37,12 +36,19 @@ export type GetActionsByIdEventuallyConsistent = ReturnType<
 type PolicyKey = { ids: readonly string[]; orgId: string };
 
 export const makeGetPoliciesByIdEventuallyConsistent = inject(
-  ['PolicyModel'],
-  (Policy) =>
+  ['ModerationConfigService'],
+  (moderationConfigService) =>
     cached({
+      keyGeneration: {
+        toString: (it: PolicyKey) =>
+          jsonStringify({ ...it, ids: [...it.ids].sort() }),
+        fromString: (it) => jsonParse(it),
+      },
       async producer(key: PolicyKey) {
-        return Policy.findAll({
-          where: { id: { [Op.in]: key.ids }, orgId: key.orgId },
+        return moderationConfigService.getPoliciesByIds({
+          orgId: key.orgId,
+          ids: key.ids,
+          readFromReplica: true,
         });
       },
       directives: { freshUntilAge: 10, maxStale: [0, 2, 2] },

--- a/server/services/manualReviewToolService/manualReviewToolQueries.ts
+++ b/server/services/manualReviewToolService/manualReviewToolQueries.ts
@@ -2,7 +2,7 @@ import { inject } from '../../iocContainer/index.js';
 import { cached } from '../../utils/caching.js';
 import { jsonParse, jsonStringify } from '../../utils/encoding.js';
 import { type CollapseCases } from '../../utils/typescript-types.js';
-import { type Action } from '../moderationConfigService/index.js';
+import { type Action, type Policy } from '../moderationConfigService/index.js';
 
 type ActionKey = { ids: readonly string[]; orgId: string };
 
@@ -45,6 +45,9 @@ export const makeGetPoliciesByIdEventuallyConsistent = inject(
         fromString: (it) => jsonParse(it),
       },
       async producer(key: PolicyKey) {
+        if (key.ids.length === 0) {
+          return [] as Policy[];
+        }
         return moderationConfigService.getPoliciesByIds({
           orgId: key.orgId,
           ids: key.ids,

--- a/server/services/moderationConfigService/moderationConfigService.ts
+++ b/server/services/moderationConfigService/moderationConfigService.ts
@@ -309,6 +309,14 @@ export class ModerationConfigService implements ReturnsModerationConfigTypes {
     return this.policyOps.getPolicies(opts);
   }
 
+  async getPoliciesByIds(opts: {
+    orgId: string;
+    ids: readonly string[];
+    readFromReplica?: boolean;
+  }) {
+    return this.policyOps.getPoliciesByIds(opts);
+  }
+
   async getPolicy(opts: {
     orgId: string;
     policyId: string;

--- a/server/services/moderationConfigService/modules/PolicyOperations.ts
+++ b/server/services/moderationConfigService/modules/PolicyOperations.ts
@@ -84,6 +84,26 @@ export default class PolicyOperations {
     return results.map((it) => this.#dbResultToPolicy(it));
   }
 
+  async getPoliciesByIds(opts: {
+    orgId: string;
+    ids: readonly string[];
+    readFromReplica?: boolean;
+  }): Promise<Policy[]> {
+    const { orgId, ids, readFromReplica } = opts;
+    if (ids.length === 0) {
+      return [];
+    }
+    const pgQuery = this.#getPgQuery(readFromReplica ?? true);
+    const results = (await pgQuery
+      .selectFrom('public.policies')
+      .select(policyDbSelection)
+      .where('org_id', '=', orgId)
+      .where('id', 'in', [...ids])
+      .execute()) as PolicyDbResult[];
+
+    return results.map((it) => this.#dbResultToPolicy(it));
+  }
+
   async getPoliciesByRuleIds(opts: {
     ruleIds: readonly string[];
     readFromReplica?: boolean;


### PR DESCRIPTION
## Context & Requests for Reviewers

This change moves the cached “load by id list” helpers used by the manual review tool (and shared consumers) from Sequelize models to `ModerationConfigService`, so reads go through the same Kysely-backed path as the rest of moderation config.


