### PR TITLE
[Kysely] Migrate rule mutations and backtest list/cancel to Kysely

### DIFF
--- a/codegen.yaml
+++ b/codegen.yaml
@@ -107,6 +107,12 @@ generates:
         MatchingBanks: ../models/OrgModel.js#Org
         User: ../models/UserModel.js#User
         LocationBank: ./datasources/LocationBankApi.js#LocationBankWithoutFullPlacesAPIResponse
+        # TODO(Kysely migration): these parents will flip to
+        # `../models/rules/ruleTypes.js#Rule` once the Action/Policy resolvers
+        # and the remaining Sequelize-backed callers of `org.getRules()` /
+        # `user.getFavoriteRules()` are migrated off Sequelize. Until then the
+        # GraphQL Rule parent is the Sequelize instance type, and
+        # `buildGraphqlRuleParent` casts to it at the boundary.
         Rule: ../models/rules/RuleModel.js#Rule
         Condition: ../services/moderationConfigService/index.js#Condition
         ConditionWithResult: ../models/rules/RuleModel.js#ConditionWithResult

--- a/server/graphql/datasources/RuleApi.test.ts
+++ b/server/graphql/datasources/RuleApi.test.ts
@@ -1,0 +1,321 @@
+import { uid } from 'uid';
+
+import createContentItemTypes from '../../test/fixtureHelpers/createContentItemTypes.js';
+import createOrg from '../../test/fixtureHelpers/createOrg.js';
+import createUser from '../../test/fixtureHelpers/createUser.js';
+import { makeMockedServer } from '../../test/setupMockedServer.js';
+import { makeTestWithFixture } from '../../test/utils.js';
+import {
+  type GQLCreateContentRuleInput,
+  type GQLCreateUserRuleInput,
+  type GQLUpdateContentRuleInput,
+  type GQLUpdateUserRuleInput,
+} from '../generated.js';
+
+const minimalConditionSet = {
+  conjunction: 'AND' as const,
+  conditions: [
+    {
+      input: { type: 'FULL_ITEM' as const },
+      comparator: 'IS_NOT_PROVIDED' as const,
+    },
+  ],
+};
+
+describe('RuleAPI', () => {
+  const testWithRuleApiFixture = makeTestWithFixture(async () => {
+    const { deps, shutdown } = await makeMockedServer();
+    const { ModerationConfigService } = deps;
+    const { org, cleanup: orgCleanup } = await createOrg(
+      deps.Sequelize,
+      ModerationConfigService,
+      deps.ApiKeyService,
+      uid(),
+    );
+    const { user, cleanup: userCleanup } = await createUser(
+      deps.Sequelize,
+      org.id,
+    );
+    const { itemTypes, cleanup: itemTypesCleanup } =
+      await createContentItemTypes({
+        moderationConfigService: ModerationConfigService,
+        orgId: org.id,
+        includeCreator: true,
+        extra: {},
+      });
+
+    return {
+      deps,
+      org,
+      user,
+      itemTypes,
+      async cleanup() {
+        await itemTypesCleanup();
+        await userCleanup();
+        await orgCleanup();
+        await shutdown();
+      },
+    };
+  });
+
+  testWithRuleApiFixture(
+    'createContentRule + getGraphQLRuleFromId round-trip',
+    async ({ deps, user, org, itemTypes }) => {
+      const name = `Content rule ${uid()}`;
+      const rule = await deps.RuleAPIDataSource.createContentRule(
+        {
+          name,
+          description: null,
+          status: 'DRAFT',
+          contentTypeIds: [itemTypes[0].id],
+          conditionSet: minimalConditionSet,
+          actionIds: [],
+          policyIds: [],
+          tags: [],
+          maxDailyActions: null,
+        } satisfies GQLCreateContentRuleInput,
+        user.id,
+        org.id,
+      );
+
+      const fetched = await deps.RuleAPIDataSource.getGraphQLRuleFromId(
+        rule.id,
+        org.id,
+      );
+      expect(fetched.id).toBe(rule.id);
+      expect(fetched.name).toBe(name);
+
+      await deps.RuleAPIDataSource.deleteRule({ id: rule.id, orgId: org.id });
+    },
+  );
+
+  testWithRuleApiFixture(
+    'createUserRule + getGraphQLRuleFromId round-trip',
+    async ({ deps, user, org }) => {
+      const name = `User rule ${uid()}`;
+      const rule = await deps.RuleAPIDataSource.createUserRule(
+        {
+          name,
+          description: null,
+          status: 'DRAFT',
+          conditionSet: minimalConditionSet,
+          actionIds: [],
+          policyIds: [],
+          tags: [],
+          maxDailyActions: null,
+        } satisfies GQLCreateUserRuleInput,
+        user.id,
+        org.id,
+      );
+
+      const fetched = await deps.RuleAPIDataSource.getGraphQLRuleFromId(
+        rule.id,
+        org.id,
+      );
+      expect(fetched.id).toBe(rule.id);
+      expect(fetched.name).toBe(name);
+
+      await deps.RuleAPIDataSource.deleteRule({ id: rule.id, orgId: org.id });
+    },
+  );
+
+  testWithRuleApiFixture(
+    'updateUserRule without expirationTime leaves expirationTime unchanged',
+    async ({ deps, user, org }) => {
+      const future = new Date('2099-06-15T12:00:00.000Z');
+      const rule = await deps.RuleAPIDataSource.createUserRule(
+        {
+          name: `Expiration partial ${uid()}`,
+          description: null,
+          status: 'DRAFT',
+          conditionSet: minimalConditionSet,
+          actionIds: [],
+          policyIds: [],
+          tags: [],
+          maxDailyActions: null,
+          expirationTime: future,
+        } satisfies GQLCreateUserRuleInput,
+        user.id,
+        org.id,
+      );
+
+      await deps.RuleAPIDataSource.updateUserRule({
+        input: {
+          id: rule.id,
+          name: 'renamed-without-expiration-touch',
+        } satisfies GQLUpdateUserRuleInput,
+        orgId: org.id,
+      });
+
+      const plain = await deps.ModerationConfigService.getRuleByIdAndOrg(
+        rule.id,
+        org.id,
+        { readFromReplica: false },
+      );
+      expect(plain).not.toBeNull();
+      expect(plain!.expirationTime?.getTime()).toBe(future.getTime());
+
+      await deps.RuleAPIDataSource.deleteRule({ id: rule.id, orgId: org.id });
+    },
+  );
+
+  testWithRuleApiFixture(
+    'updateUserRule with status EXPIRED and omitted expirationTime sets expirationTime near now',
+    async ({ deps, user, org }) => {
+      const rule = await deps.RuleAPIDataSource.createUserRule(
+        {
+          name: `Expire status ${uid()}`,
+          description: null,
+          status: 'DRAFT',
+          conditionSet: minimalConditionSet,
+          actionIds: [],
+          policyIds: [],
+          tags: [],
+          maxDailyActions: null,
+        } satisfies GQLCreateUserRuleInput,
+        user.id,
+        org.id,
+      );
+
+      const before = Date.now();
+      await deps.RuleAPIDataSource.updateUserRule({
+        input: {
+          id: rule.id,
+          status: 'EXPIRED',
+        } satisfies GQLUpdateUserRuleInput,
+        orgId: org.id,
+      });
+      const after = Date.now();
+
+      const plain = await deps.ModerationConfigService.getRuleByIdAndOrg(
+        rule.id,
+        org.id,
+        { readFromReplica: false },
+      );
+      expect(plain).not.toBeNull();
+      expect(plain!.expirationTime).not.toBeNull();
+      const expMs = plain!.expirationTime!.getTime();
+      expect(expMs).toBeGreaterThanOrEqual(before);
+      expect(expMs).toBeLessThanOrEqual(after + 2000);
+
+      await deps.RuleAPIDataSource.deleteRule({ id: rule.id, orgId: org.id });
+    },
+  );
+
+  testWithRuleApiFixture(
+    'duplicate rule name yields RuleNameExistsError',
+    async ({ deps, user, org }) => {
+      const name = `Dup name ${uid()}`;
+      const first = await deps.RuleAPIDataSource.createUserRule(
+        {
+          name,
+          description: null,
+          status: 'DRAFT',
+          conditionSet: minimalConditionSet,
+          actionIds: [],
+          policyIds: [],
+          tags: [],
+          maxDailyActions: null,
+        } satisfies GQLCreateUserRuleInput,
+        user.id,
+        org.id,
+      );
+
+      await expect(
+        deps.RuleAPIDataSource.createUserRule(
+          {
+            name,
+            description: null,
+            status: 'DRAFT',
+            conditionSet: minimalConditionSet,
+            actionIds: [],
+            policyIds: [],
+            tags: [],
+            maxDailyActions: null,
+          } satisfies GQLCreateUserRuleInput,
+          user.id,
+          org.id,
+        ),
+      ).rejects.toMatchObject({ name: 'RuleNameExistsError' });
+
+      await deps.RuleAPIDataSource.deleteRule({ id: first.id, orgId: org.id });
+    },
+  );
+
+  testWithRuleApiFixture(
+    'updateContentRule fails when a running backtest exists and cancelRunningBacktests is false',
+    async ({ deps, user, org, itemTypes }) => {
+      const rule = await deps.RuleAPIDataSource.createContentRule(
+        {
+          name: `Backtest guard ${uid()}`,
+          description: null,
+          status: 'DRAFT',
+          contentTypeIds: [itemTypes[0].id],
+          conditionSet: minimalConditionSet,
+          actionIds: [],
+          policyIds: [],
+          tags: [],
+          maxDailyActions: null,
+        } satisfies GQLCreateContentRuleInput,
+        user.id,
+        org.id,
+      );
+
+      const now = new Date();
+      await deps.Sequelize.Backtest.create({
+        id: uid(),
+        ruleId: rule.id,
+        creatorId: user.id,
+        sampleDesiredSize: 10,
+        sampleStartAt: now,
+        sampleEndAt: now,
+      });
+
+      await expect(
+        deps.RuleAPIDataSource.updateContentRule({
+          input: {
+            id: rule.id,
+            name: 'should-not-apply',
+            cancelRunningBacktests: false,
+          } satisfies GQLUpdateContentRuleInput,
+          orgId: org.id,
+        }),
+      ).rejects.toMatchObject({ name: 'RuleHasRunningBacktestsError' });
+
+      await deps.RuleAPIDataSource.deleteRule({ id: rule.id, orgId: org.id });
+    },
+  );
+
+  testWithRuleApiFixture(
+    'deleteRule removes the rule row',
+    async ({ deps, user, org }) => {
+      const rule = await deps.RuleAPIDataSource.createUserRule(
+        {
+          name: `Delete me ${uid()}`,
+          description: null,
+          status: 'DRAFT',
+          conditionSet: minimalConditionSet,
+          actionIds: [],
+          policyIds: [],
+          tags: [],
+          maxDailyActions: null,
+        } satisfies GQLCreateUserRuleInput,
+        user.id,
+        org.id,
+      );
+
+      const ok = await deps.RuleAPIDataSource.deleteRule({
+        id: rule.id,
+        orgId: org.id,
+      });
+      expect(ok).toBe(true);
+
+      const plain = await deps.ModerationConfigService.getRuleByIdAndOrg(
+        rule.id,
+        org.id,
+        { readFromReplica: false },
+      );
+      expect(plain).toBeNull();
+    },
+  );
+});

--- a/server/graphql/datasources/RuleApi.ts
+++ b/server/graphql/datasources/RuleApi.ts
@@ -4,18 +4,14 @@ import { type Exception } from '@opentelemetry/api';
 import { makeEnumLike } from '@roostorg/types';
 
 import { type Kysely } from 'kysely';
-import Sequelize from 'sequelize';
 import { uid } from 'uid';
 
 import { inject, type Dependencies } from '../../iocContainer/index.js';
-import {
-  isEmptyResultSetError,
-  isUniqueConstraintError,
-} from '../../models/errors.js';
 import { type User } from '../../models/UserModel.js';
 import { type ActionCountsInput } from '../../services/actionStatisticsService/index.js';
 import { type AggregationClause } from '../../services/aggregationsService/index.js';
 import { type ConditionSetWithResultAsLogged } from '../../services/analyticsLoggers/index.js';
+import { type CombinedPg } from '../../services/combinedDbTypes.js';
 import {
   RuleType,
   type Condition,
@@ -40,17 +36,11 @@ import {
   warehouseDateToDate,
 } from '../../storage/dataWarehouse/warehouseSchema.js';
 import { toCorrelationId } from '../../utils/correlationIds.js';
-import {
-  type JsonOf,
-  jsonParse,
-  jsonStringify,
-  tryJsonParse,
-} from '../../utils/encoding.js';
+import { jsonParse, jsonStringify, tryJsonParse } from '../../utils/encoding.js';
 import { makeNotFoundError } from '../../utils/errors.js';
-import { assertUnreachable, patchInPlace } from '../../utils/misc.js';
+import { assertUnreachable } from '../../utils/misc.js';
 import { takeLast } from '../../utils/sql.js';
 import {
-  type Mutable,
   type NonEmptyString,
   type RequiredWithoutNull,
 } from '../../utils/typescript-types.js';
@@ -67,10 +57,39 @@ import {
 } from '../generated.js';
 import { oneOfInputToTaggedUnion } from '../utils/inputHelpers.js';
 import { type CursorInfo, type Edge } from '../utils/paginationHandler.js';
+import { buildGraphqlRuleParent } from './buildGraphqlRuleParent.js';
+import {
+  isPostgresUniqueViolation,
+  kyselyCancelRunningBacktestsForRule,
+  kyselyCreateRule,
+  kyselyDeleteRule,
+  kyselyHasRunningBacktestsForRule,
+  kyselyListBacktestsForRule,
+  kyselyUpdateRule,
+} from './ruleKyselyPersistence.js';
 import { locationAreaInputToLocationArea } from './LocationBankApi.js';
 import { unauthenticatedError } from '../utils/errors.js';
+import {
+  makeKyselyTransactionWithRetry,
+  type KyselyTransactionWithRetry,
+} from '../../utils/kyselyTransactionWithRetry.js';
 
-const { Op, Transaction } = Sequelize;
+/**
+ * Normalize the GraphQL `expirationTime` input scalar into a shape our
+ * persistence layer can apply partially:
+ *
+ * - `undefined` → don't touch the column on update.
+ * - `null`      → clear the expiration.
+ * - otherwise   → coerce the scalar (string or Date) into a `Date`.
+ */
+function normalizeExpirationInput(
+  value: string | Date | null | undefined,
+): Date | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  return new Date(value);
+}
+
 const SortOrder = makeEnumLike(['ASC', 'DESC']);
 type SortOrder = (typeof SortOrder)[keyof typeof SortOrder];
 
@@ -269,25 +288,45 @@ function parseAggregationClauseInput(
  */
 class RuleAPI {
   private readonly warehouse: Kysely<DataWarehousePublicSchema>;
+  private readonly kysely: Kysely<CombinedPg>;
+  private readonly kyselyTransactionWithRetry: KyselyTransactionWithRetry<CombinedPg>;
+
+  private readonly graphQlRuleParentDeps: Parameters<
+    typeof buildGraphqlRuleParent
+  >[1];
 
   constructor(
     dialect: Dependencies['DataWarehouseDialect'],
     public readonly ruleInsights: Dependencies['RuleActionInsights'],
     private readonly actionStats: Dependencies['ActionStatisticsService'],
+    private readonly kyselyPg: Dependencies['KyselyPg'],
     private readonly models: Dependencies['Sequelize'],
+    private readonly moderationConfigService: Dependencies['ModerationConfigService'],
     private readonly tracer: Dependencies['Tracer'],
     private readonly signalsService: Dependencies['SignalsService'],
   ) {
-    this.warehouse = dialect.getKyselyInstance() as Kysely<DataWarehousePublicSchema>;
+    this.warehouse =
+      dialect.getKyselyInstance() as Kysely<DataWarehousePublicSchema>;
+    this.kysely = this.kyselyPg as Kysely<CombinedPg>;
+    this.kyselyTransactionWithRetry = makeKyselyTransactionWithRetry(
+      this.kysely,
+    );
+    this.graphQlRuleParentDeps = {
+      moderationConfigService: this.moderationConfigService,
+      // TODO(Kysely migration): replace with a ModerationConfigService /
+      // user-service-backed lookup once users are migrated off Sequelize.
+      findUserByIdAndOrg: async (opts) =>
+        this.models.User.findOne({ where: opts.where }),
+    };
   }
 
   async getGraphQLRuleFromId(id: string, orgId: string) {
-    const rule = await this.models.Rule.findByPk(id, { rejectOnEmpty: true });
-    if (rule.orgId !== orgId) {
+    const plain = await this.moderationConfigService.getRuleByIdAndOrg(id, orgId);
+    if (plain == null) {
       throw unauthenticatedError('User not authenticated to fetch this rule');
     }
 
-    return rule;
+    return buildGraphqlRuleParent(plain, this.graphQlRuleParentDeps);
   }
 
   async createContentRule(
@@ -335,7 +374,9 @@ class RuleAPI {
       parentId,
     } = input;
 
-    if (ruleType === RuleType.CONTENT && input.contentTypeIds.length === 0) {
+    const contentTypeIds: readonly string[] =
+      input.ruleType === RuleType.CONTENT ? input.contentTypeIds : [];
+    if (ruleType === RuleType.CONTENT && contentTypeIds.length === 0) {
       throw makeRuleIsMissingContentTypeError({ shouldErrorSpan: true });
     }
 
@@ -345,47 +386,43 @@ class RuleAPI {
       await this.validateSignalsAllowedInAutomatedRules(conditionSet, orgId);
     }
 
-    const rule = this.models.Rule.build({
-      id: uid(),
-      name,
-      description,
-      tags: tags.slice(),
-      status,
-      conditionSet: transformConditionForDB(conditionSet),
-      maxDailyActions,
-      expirationTime: (expirationTime as Date | null | undefined) ?? undefined,
-      creatorId: userId,
-      orgId,
-      ruleType,
-      parentId,
-    });
+    const ruleId = uid();
 
     try {
-      await this.models.transactionWithRetry(async () => {
-        // Save rule to 'rules' table before adding assocs, to give it
-        // a record for foreign keys to reference and test name uniqueness.
-        await rule.save();
-
-        if (ruleType === RuleType.CONTENT) {
-          await rule.setContentTypes(
-            input.contentTypeIds as Mutable<typeof input.contentTypeIds>,
-          );
-        }
-
-        // The Mutable casts are used to work around a sequelize typings bug.
-        await rule.setActions(actionIds as Mutable<typeof actionIds>);
-        await rule.setPolicies(policyIds as Mutable<typeof policyIds>);
-
-        // TODO: is this needed?
-        await rule.save();
+      await this.kyselyTransactionWithRetry(async (trx) => {
+        await kyselyCreateRule(trx, {
+          id: ruleId,
+          name,
+          description: description ?? null,
+          status,
+          conditionSet: transformConditionForDB(conditionSet),
+          tags: tags.slice(),
+          maxDailyActions: maxDailyActions ?? null,
+          expirationTime: normalizeExpirationInput(expirationTime),
+          creatorId: userId,
+          orgId,
+          ruleType,
+          parentId,
+          actionIds,
+          policyIds,
+          contentTypeIds,
+        });
       });
     } catch (e) {
-      throw isUniqueConstraintError(e)
+      throw isPostgresUniqueViolation(e)
         ? makeRuleNameExistsError({ shouldErrorSpan: true })
         : e;
     }
 
-    return rule;
+    const plain = await this.moderationConfigService.getRuleByIdAndOrg(
+      ruleId,
+      orgId,
+      { readFromReplica: false },
+    );
+    if (plain == null) {
+      throw new Error('Rule was created but could not be reloaded');
+    }
+    return buildGraphqlRuleParent(plain, this.graphQlRuleParentDeps);
   }
 
   async updateContentRule(opts: {
@@ -407,7 +444,6 @@ class RuleAPI {
     });
   }
 
-  // eslint-disable-next-line complexity
   private async updateRule(opts: {
     input:
       | (GQLUpdateContentRuleInput & { ruleType: typeof RuleType.CONTENT })
@@ -431,63 +467,30 @@ class RuleAPI {
       parentId,
     } = input;
 
-    const rule = await this.models.Rule.findOne({
-      where: { id, orgId },
-      rejectOnEmpty: true,
-    }).catch((e) => {
-      throw isEmptyResultSetError(e)
-        ? makeNotFoundError('Rule not found', {
-            detail: `Could not find rule with id ${id}`,
-            shouldErrorSpan: true,
-          })
-        : e;
-    });
+    const existing = await this.moderationConfigService.getRuleByIdAndOrg(
+      id,
+      orgId,
+      { readFromReplica: false },
+    );
+    if (existing == null) {
+      throw makeNotFoundError('Rule not found', {
+        detail: `Could not find rule with id ${id}`,
+        shouldErrorSpan: true,
+      });
+    }
 
     if (conditionSet != null && !conditionInputIsValid(conditionSet)) {
       throw new Error('Invalid condition set input');
     }
 
-    // In the case of a content rule update, it's okay if the contentTypeIds isn't
-    // provided, since that will just be a no-op via the patchInPlace, but if it
-    // is provided, we need to check to make sure there are actually content type
-    // IDs present, since an empty list is invalid for content rules.
-    if (
-      ruleType === 'CONTENT' &&
-      input.contentTypeIds &&
-      input.contentTypeIds.length === 0
-    ) {
+    // In the case of a content rule update, it's okay if the contentTypeIds
+    // isn't provided, since that will be a no-op in persistence. But if it
+    // *is* provided, we need to check there are actually content type IDs
+    // present, since an empty list is invalid for content rules.
+    const contentTypeIds =
+      input.ruleType === RuleType.CONTENT ? input.contentTypeIds : undefined;
+    if (contentTypeIds != null && contentTypeIds.length === 0) {
       throw makeRuleIsMissingContentTypeError({ shouldErrorSpan: true });
-    }
-
-    patchInPlace(rule, {
-      name: name ?? undefined,
-      description,
-      conditionSet:
-        conditionSet == null
-          ? undefined
-          : transformConditionForDB(conditionSet),
-      tags: tags?.slice() ?? undefined,
-      ruleType,
-    });
-
-    if (status && rule.status !== status) {
-      rule.status = status;
-    }
-
-    if (rule.maxDailyActions !== maxDailyActions) {
-      // If maxDailyActions is undefined, it needs to be explicitly converted
-      // to null because postgres doesn't understand undefined
-      rule.maxDailyActions = maxDailyActions ?? null;
-    }
-
-    if (rule.expirationTime !== expirationTime) {
-      // If expirationTime is undefined, it needs to be explicitly converted
-      // to null because postgres doesn't understand undefined
-      rule.expirationTime = (expirationTime as Date | null | undefined) ?? null;
-    }
-
-    if (rule.parentId !== parentId) {
-      rule.parentId = parentId ?? null;
     }
 
     // Validate that signals used in automated rules are allowed
@@ -496,7 +499,7 @@ class RuleAPI {
     // that are restricted to routing rules only.
     const willHaveActions = actionIds
       ? actionIds.length > 0
-      : (await rule.getActions()).length > 0;
+      : (await this.moderationConfigService.getActionsForRuleId(id)).length > 0;
 
     if (willHaveActions && conditionSet) {
       await this.validateSignalsAllowedInAutomatedRules(conditionSet, orgId);
@@ -507,7 +510,7 @@ class RuleAPI {
     // active backtests for this rule because, if there are, we should fail the
     // update unless the user's asked to cancel the backtests explicitly.
     if (!cancelRunningBacktests) {
-      if (await this.models.Backtest.hasRunningBacktestsForRule(rule.id)) {
+      if (await kyselyHasRunningBacktestsForRule(this.kysely, id)) {
         throw makeRuleHasRunningBacktestsError({ shouldErrorSpan: true });
       }
     }
@@ -518,47 +521,55 @@ class RuleAPI {
     // use SERIALIZABLE to make the update + backtest cancelation logically
     // linearizable w/r/t concurrently started backtests, but that's overkill.
     try {
-      await this.models.sequelize.transaction(
-        { isolationLevel: Transaction.ISOLATION_LEVELS.REPEATABLE_READ },
-        async () => {
-          if (ruleType === 'CONTENT' && input.contentTypeIds) {
-            await rule.setContentTypes(
-              input.contentTypeIds as Mutable<typeof input.contentTypeIds>,
-            );
-          }
-
-          // TODO: this is not safe. Let's one org link to a different org's
-          // policies/actions.
-          if (actionIds) {
-            await rule.setActions(actionIds as Mutable<typeof actionIds>);
-          }
-          if (policyIds) {
-            await rule.setPolicies(policyIds as Mutable<typeof policyIds>);
-          }
-
-          await rule.save();
-
-          // Finally, if the user asked to delete any running backtests, do it.
+      await this.kysely
+        .transaction()
+        .setIsolationLevel('repeatable read')
+        .execute(async (trx) => {
+          await kyselyUpdateRule(trx, {
+            id,
+            orgId,
+            name,
+            description,
+            conditionSet:
+              conditionSet == null
+                ? undefined
+                : transformConditionForDB(conditionSet),
+            tags: tags?.slice(),
+            ruleType,
+            status: status ?? undefined,
+            maxDailyActions,
+            expirationTime: normalizeExpirationInput(expirationTime),
+            parentId,
+            actionIds: actionIds ?? undefined,
+            policyIds: policyIds ?? undefined,
+            contentTypeIds: contentTypeIds ?? undefined,
+          });
           if (cancelRunningBacktests) {
-            await this.models.Backtest.cancelRunningBacktestsForRule(rule.id);
+            await kyselyCancelRunningBacktestsForRule(trx, id);
           }
-        },
-      );
+        });
     } catch (e) {
-      throw isUniqueConstraintError(e)
+      throw isPostgresUniqueViolation(e)
         ? makeRuleNameExistsError({ shouldErrorSpan: true })
         : e;
     }
 
-    return rule;
+    const plain = await this.moderationConfigService.getRuleByIdAndOrg(id, orgId, {
+      readFromReplica: false,
+    });
+    if (plain == null) {
+      throw new Error('Rule was updated but could not be reloaded');
+    }
+    return buildGraphqlRuleParent(plain, this.graphQlRuleParentDeps);
   }
 
   async deleteRule(opts: { id: string; orgId: string }) {
     const { id, orgId } = opts;
 
     try {
-      const rule = await this.models.Rule.findOne({ where: { id, orgId } });
-      await rule?.destroy();
+      await this.kysely.transaction().execute(async (trx) => {
+        await kyselyDeleteRule(trx, id, orgId);
+      });
     } catch (exception) {
       const activeSpan = this.tracer.getActiveSpan();
       if (activeSpan?.isRecording()) {
@@ -633,7 +644,7 @@ class RuleAPI {
     }
   }
 
-  async createBacktest(_input: any, _user: User) {
+  async createBacktest(_input: unknown, _user: User) {
     throw new Error('Not Implemented');
 
     // const id = uid();
@@ -779,15 +790,11 @@ class RuleAPI {
         userId: it.userId ?? undefined,
         userTypeId: it.userTypeId ?? undefined,
         content: (it.content ?? '') as string,
-        result: it.result
-          ? jsonParse(
-              it.result as JsonOf<ConditionSetWithResultAsLogged>,
-            )
-          : null,
+        result: it.result ? jsonParse(it.result) : null,
         environment: it.environment as RuleStatus,
         passed: it.passed,
         ruleId: it.ruleId,
-        ruleName: it.ruleName ?? '',
+        ruleName: it.ruleName,
         tags: [...it.tags],
       },
       cursor: { ts: warehouseDateToDate(it.ts).valueOf() },
@@ -798,12 +805,7 @@ class RuleAPI {
     ruleId: string,
     backtestIds?: readonly string[] | null,
   ) {
-    return this.models.Backtest.findAll({
-      where: {
-        ruleId,
-        ...(backtestIds ? { id: { [Op.in]: backtestIds } } : {}),
-      },
-    });
+    return kyselyListBacktestsForRule(this.kysely, ruleId, backtestIds);
   }
 
   /**
@@ -928,7 +930,9 @@ export default inject(
     'DataWarehouseDialect',
     'RuleActionInsights',
     'ActionStatisticsService',
+    'KyselyPg',
     'Sequelize',
+    'ModerationConfigService',
     'Tracer',
     'SignalsService',
   ],

--- a/server/graphql/datasources/RuleApi.ts
+++ b/server/graphql/datasources/RuleApi.ts
@@ -59,7 +59,6 @@ import { oneOfInputToTaggedUnion } from '../utils/inputHelpers.js';
 import { type CursorInfo, type Edge } from '../utils/paginationHandler.js';
 import { buildGraphqlRuleParent } from './buildGraphqlRuleParent.js';
 import {
-  isPostgresUniqueViolation,
   kyselyCancelRunningBacktestsForRule,
   kyselyCreateRule,
   kyselyDeleteRule,
@@ -69,6 +68,7 @@ import {
 } from './ruleKyselyPersistence.js';
 import { locationAreaInputToLocationArea } from './LocationBankApi.js';
 import { unauthenticatedError } from '../utils/errors.js';
+import { isUniqueViolationError } from '../../utils/kysely.js';
 import {
   makeKyselyTransactionWithRetry,
   type KyselyTransactionWithRetry,
@@ -409,7 +409,7 @@ class RuleAPI {
         });
       });
     } catch (e) {
-      throw isPostgresUniqueViolation(e)
+      throw isUniqueViolationError(e)
         ? makeRuleNameExistsError({ shouldErrorSpan: true })
         : e;
     }
@@ -549,7 +549,7 @@ class RuleAPI {
           }
         });
     } catch (e) {
-      throw isPostgresUniqueViolation(e)
+      throw isUniqueViolationError(e)
         ? makeRuleNameExistsError({ shouldErrorSpan: true })
         : e;
     }

--- a/server/graphql/datasources/buildGraphqlRuleParent.ts
+++ b/server/graphql/datasources/buildGraphqlRuleParent.ts
@@ -1,0 +1,55 @@
+import { type Rule as SequelizeRule } from '../../models/rules/RuleModel.js';
+import { type User } from '../../models/UserModel.js';
+import {
+  type PlainRuleWithLatestVersion,
+  type Rule as RuleGraphqlParent,
+} from '../../models/rules/ruleTypes.js';
+import { type ModerationConfigService } from '../../services/moderationConfigService/index.js';
+
+type FindUserByIdAndOrg = (opts: {
+  where: { id: string; orgId: string };
+}) => Promise<User | null>;
+
+/**
+ * Builds a GraphQL Rule parent (plain row fields + the three association
+ * getters our resolvers actually use) backed by ModerationConfigService
+ * reads and a Sequelize-backed User lookup for the creator.
+ *
+ * The returned object only implements the {@link RuleGraphqlParent} contract
+ * (`getCreator` / `getActions` / `getPolicies`). We cast to `SequelizeRule`
+ * at the return to satisfy the GraphQL codegen parent type that still points
+ * at `RuleModel.Rule`; resolvers that reach for Sequelize-only methods like
+ * `save` / `destroy` / `getContentTypes` / `getBacktests` on this value will
+ * blow up at runtime. The cast will be removed once `codegen.yaml` is flipped
+ * to `ruleTypes.js#Rule` (see the TODO there).
+ */
+export function buildGraphqlRuleParent(
+  plain: PlainRuleWithLatestVersion,
+  deps: {
+    moderationConfigService: ModerationConfigService;
+    findUserByIdAndOrg: FindUserByIdAndOrg;
+  },
+): SequelizeRule {
+  const parent: RuleGraphqlParent = {
+    ...plain,
+    async getCreator() {
+      const user = await deps.findUserByIdAndOrg({
+        where: { id: plain.creatorId, orgId: plain.orgId },
+      });
+      if (user == null) {
+        throw new Error(`User not found for rule creator ${plain.creatorId}`);
+      }
+      return user;
+    },
+    async getActions() {
+      return deps.moderationConfigService.getActionsForRuleId(plain.id);
+    },
+    async getPolicies() {
+      const byRule = await deps.moderationConfigService.getPoliciesByRuleIds([
+        plain.id,
+      ]);
+      return byRule[plain.id] ?? [];
+    },
+  };
+  return parent as unknown as SequelizeRule;
+}

--- a/server/graphql/datasources/ruleKyselyPersistence.ts
+++ b/server/graphql/datasources/ruleKyselyPersistence.ts
@@ -1,0 +1,399 @@
+import { type Kysely, type Updateable, sql } from 'kysely';
+
+import { computeRuleStatusFromRow } from '../../models/rules/ruleTypes.js';
+import { type CombinedPg } from '../../services/combinedDbTypes.js';
+import { makeNotFoundError } from '../../utils/errors.js';
+import {
+  RuleAlarmStatus,
+  RuleStatus,
+  RuleType,
+  type ConditionSet,
+} from '../../services/moderationConfigService/index.js';
+import { safeGet } from '../../utils/misc.js';
+import { type Backtest } from '../../models/rules/BacktestModel.js';
+
+/** Matches `public.backtests.status` when generated value is RUNNING. */
+const backtestRunningPredicate = sql<boolean>`cancelation_date is null
+  and (sampling_complete = false or content_items_processed < sample_actual_size)`;
+
+export function isPostgresUniqueViolation(error: unknown): boolean {
+  return safeGet(error, ['code']) === '23505';
+}
+
+/**
+ * Applies the legacy `status` virtual-setter semantics from the Sequelize Rule
+ * model: setting `status = EXPIRED` promotes `expiration_time` to max(existing, now);
+ * any other status maps 1:1 onto `status_if_unexpired`.
+ */
+function mapRuleStatusToColumns(
+  status: RuleStatus,
+  expirationTime: Date | null | undefined,
+): {
+  status_if_unexpired: Exclude<RuleStatus, typeof RuleStatus.EXPIRED>;
+  expiration_time: Date | null;
+} {
+  if (status === RuleStatus.EXPIRED) {
+    const et =
+      expirationTime != null
+        ? new Date(Math.max(expirationTime.getTime(), Date.now()))
+        : new Date();
+    return {
+      status_if_unexpired: RuleStatus.DRAFT,
+      expiration_time: et,
+    };
+  }
+  return {
+    status_if_unexpired: status,
+    expiration_time: expirationTime ?? null,
+  };
+}
+
+async function replaceRuleActions(
+  trx: Kysely<CombinedPg>,
+  ruleId: string,
+  actionIds: readonly string[],
+) {
+  await trx.deleteFrom('public.rules_and_actions').where('rule_id', '=', ruleId).execute();
+  if (actionIds.length === 0) {
+    return;
+  }
+  await trx
+    .insertInto('public.rules_and_actions')
+    .values(actionIds.map((actionId) => ({ rule_id: ruleId, action_id: actionId })))
+    .execute();
+}
+
+async function replaceRulePolicies(
+  trx: Kysely<CombinedPg>,
+  ruleId: string,
+  policyIds: readonly string[],
+) {
+  await trx.deleteFrom('public.rules_and_policies').where('rule_id', '=', ruleId).execute();
+  if (policyIds.length === 0) {
+    return;
+  }
+  const now = new Date();
+  await trx
+    .insertInto('public.rules_and_policies')
+    .values(
+      policyIds.map((policyId) => ({
+        rule_id: ruleId,
+        policy_id: policyId,
+        created_at: now,
+        updated_at: now,
+      })),
+    )
+    .execute();
+}
+
+async function replaceRuleItemTypes(
+  trx: Kysely<CombinedPg>,
+  ruleId: string,
+  itemTypeIds: readonly string[],
+) {
+  await trx.deleteFrom('public.rules_and_item_types').where('rule_id', '=', ruleId).execute();
+  if (itemTypeIds.length === 0) {
+    return;
+  }
+  await trx
+    .insertInto('public.rules_and_item_types')
+    .values(
+      itemTypeIds.map((itemTypeId) => ({
+        rule_id: ruleId,
+        item_type_id: itemTypeId,
+      })),
+    )
+    .execute();
+}
+
+export async function kyselyCreateRule(
+  trx: Kysely<CombinedPg>,
+  input: {
+    id: string;
+    name: string;
+    description: string | null;
+    status: RuleStatus;
+    conditionSet: ConditionSet;
+    tags: readonly string[];
+    maxDailyActions: number | null;
+    expirationTime: Date | null | undefined;
+    creatorId: string;
+    orgId: string;
+    ruleType: RuleType;
+    parentId: string | null | undefined;
+    actionIds: readonly string[];
+    policyIds: readonly string[];
+    contentTypeIds: readonly string[];
+  },
+): Promise<void> {
+  const { status_if_unexpired, expiration_time } = mapRuleStatusToColumns(
+    input.status,
+    input.expirationTime,
+  );
+  const now = new Date();
+
+  // `public.rules.created_at` / `updated_at` are NOT NULL in Postgres; Kysely
+  // `dbTypes` mark them `GeneratedAlways` so they are omitted from
+  // `Insertable`, but inserts must still supply values at runtime.
+  await trx
+    .insertInto('public.rules')
+    .values({
+      id: input.id,
+      name: input.name,
+      description: input.description,
+      status_if_unexpired,
+      tags: [...input.tags],
+      max_daily_actions: input.maxDailyActions,
+      daily_actions_run: 0,
+      last_action_date: null,
+      org_id: input.orgId,
+      creator_id: input.creatorId,
+      expiration_time,
+      condition_set: input.conditionSet,
+      alarm_status: RuleAlarmStatus.INSUFFICIENT_DATA,
+      alarm_status_set_at: now,
+      rule_type: input.ruleType,
+      parent_id: input.parentId ?? null,
+      created_at: now,
+      updated_at: now,
+    } as never)
+    .execute();
+
+  await replaceRuleActions(trx, input.id, input.actionIds);
+  await replaceRulePolicies(trx, input.id, input.policyIds);
+  if (input.ruleType === RuleType.CONTENT) {
+    await replaceRuleItemTypes(trx, input.id, input.contentTypeIds);
+  }
+}
+
+export async function kyselyUpdateRule(
+  trx: Kysely<CombinedPg>,
+  input: {
+    id: string;
+    orgId: string;
+    name?: string | null;
+    description: string | null | undefined;
+    conditionSet: ConditionSet | undefined;
+    tags: string[] | undefined;
+    ruleType: RuleType;
+    status?: RuleStatus | null;
+    maxDailyActions: number | null | undefined;
+    expirationTime: Date | null | undefined;
+    parentId: string | null | undefined;
+    actionIds: readonly string[] | undefined;
+    policyIds: readonly string[] | undefined;
+    contentTypeIds: readonly string[] | undefined;
+  },
+): Promise<void> {
+  const existing = await trx
+    .selectFrom('public.rules')
+    .select(['id', 'status_if_unexpired', 'expiration_time', 'rule_type'])
+    .where('id', '=', input.id)
+    .where('org_id', '=', input.orgId)
+    .executeTakeFirst();
+
+  if (existing == null) {
+    throw makeNotFoundError('Rule not found', {
+      detail: `Could not find rule with id ${input.id}`,
+      shouldErrorSpan: true,
+    });
+  }
+
+  const existingStatusIfUnexpired = existing.status_if_unexpired as Exclude<
+    RuleStatus,
+    typeof RuleStatus.EXPIRED
+  >;
+
+  // Track intended status / expiration changes separately from the existing
+  // row values so we only write columns that actually change. This matches
+  // Sequelize's "dirty attribute" flush semantics and, crucially, avoids
+  // clobbering an existing `expiration_time` when the caller doesn't pass
+  // one (the GraphQL input makes `expirationTime` optional).
+  let statusIfUnexpiredChanged = false;
+  let status_if_unexpired: Exclude<RuleStatus, typeof RuleStatus.EXPIRED> =
+    existingStatusIfUnexpired;
+  let expirationTimeChanged = false;
+  let expiration_time: Date | null = existing.expiration_time;
+
+  const { status, expirationTime: expirationTimeInput } = input;
+  const existingStatus = computeRuleStatusFromRow(
+    existing.expiration_time,
+    existingStatusIfUnexpired,
+  );
+  if (status && existingStatus !== status) {
+    const mapped = mapRuleStatusToColumns(status, existing.expiration_time);
+    if (status === RuleStatus.EXPIRED) {
+      expiration_time = mapped.expiration_time;
+      expirationTimeChanged = true;
+    } else {
+      status_if_unexpired = mapped.status_if_unexpired;
+      statusIfUnexpiredChanged = true;
+    }
+  }
+
+  // Explicit `expirationTime` input wins over any status-driven expiration
+  // derived above. Only overwrite when the caller actually sent a value —
+  // `undefined` means "don't touch this column".
+  if (expirationTimeInput !== undefined) {
+    expiration_time = expirationTimeInput;
+    expirationTimeChanged = true;
+  }
+
+  const patch: Updateable<CombinedPg['public.rules']> = {};
+  if (input.name != null) {
+    patch.name = input.name;
+  }
+  if (input.description !== undefined) {
+    patch.description = input.description;
+  }
+  if (input.conditionSet !== undefined) {
+    patch.condition_set = input.conditionSet;
+  }
+  if (input.tags !== undefined) {
+    patch.tags = input.tags;
+  }
+  if (input.maxDailyActions !== undefined) {
+    patch.max_daily_actions = input.maxDailyActions;
+  }
+  if (input.parentId !== undefined) {
+    patch.parent_id = input.parentId;
+  }
+  if (input.ruleType !== existing.rule_type) {
+    patch.rule_type = input.ruleType;
+  }
+  if (statusIfUnexpiredChanged) {
+    patch.status_if_unexpired = status_if_unexpired;
+  }
+  if (expirationTimeChanged) {
+    patch.expiration_time = expiration_time;
+  }
+
+  if (Object.keys(patch).length > 0) {
+    await trx
+      .updateTable('public.rules')
+      .set(patch)
+      .where('id', '=', input.id)
+      .where('org_id', '=', input.orgId)
+      .execute();
+  }
+
+  if (input.actionIds != null) {
+    await replaceRuleActions(trx, input.id, input.actionIds);
+  }
+  if (input.policyIds != null) {
+    await replaceRulePolicies(trx, input.id, input.policyIds);
+  }
+  if (input.ruleType === RuleType.CONTENT && input.contentTypeIds != null) {
+    await replaceRuleItemTypes(trx, input.id, input.contentTypeIds);
+  }
+}
+
+export async function kyselyDeleteRule(
+  trx: Kysely<CombinedPg>,
+  id: string,
+  orgId: string,
+): Promise<boolean> {
+  const row = await trx
+    .selectFrom('public.rules')
+    .select('id')
+    .where('id', '=', id)
+    .where('org_id', '=', orgId)
+    .executeTakeFirst();
+  if (row == null) {
+    return false;
+  }
+
+  await trx.deleteFrom('public.backtests').where('rule_id', '=', id).execute();
+  await trx
+    .deleteFrom('public.users_and_favorite_rules')
+    .where('rule_id', '=', id)
+    .execute();
+  await trx.deleteFrom('public.rules').where('id', '=', id).where('org_id', '=', orgId).execute();
+  return true;
+}
+
+export async function kyselyHasRunningBacktestsForRule(
+  kysely: Kysely<CombinedPg>,
+  ruleId: string,
+): Promise<boolean> {
+  const row = await kysely
+    .selectFrom('public.backtests')
+    .select('id')
+    .where('rule_id', '=', ruleId)
+    .where(backtestRunningPredicate)
+    .executeTakeFirst();
+  return row != null;
+}
+
+export async function kyselyCancelRunningBacktestsForRule(
+  trx: Kysely<CombinedPg>,
+  ruleId: string,
+): Promise<void> {
+  const now = new Date();
+  await trx
+    .updateTable('public.backtests')
+    .set({ cancelation_date: now, updated_at: now })
+    .where('rule_id', '=', ruleId)
+    .where(backtestRunningPredicate)
+    .execute();
+}
+
+export async function kyselyListBacktestsForRule(
+  kysely: Kysely<CombinedPg>,
+  ruleId: string,
+  backtestIds?: readonly string[] | null,
+): Promise<Backtest[]> {
+  let q = kysely
+    .selectFrom('public.backtests')
+    .selectAll()
+    .where('rule_id', '=', ruleId);
+  if (backtestIds != null && backtestIds.length > 0) {
+    q = q.where('id', 'in', [...backtestIds]);
+  }
+  const rows = await q.execute();
+  return rows.map((r) => mapBacktestRowToGqlParent(r)) as unknown as Backtest[];
+}
+
+function mapBacktestRowToGqlParent(r: {
+  id: string;
+  rule_id: string;
+  creator_id: string;
+  sample_desired_size: number;
+  sample_actual_size: number;
+  sample_start_at: Date;
+  sample_end_at: Date;
+  sampling_complete: boolean;
+  content_items_processed: number;
+  content_items_matched: number;
+  status: string;
+  created_at: Date;
+  updated_at: Date;
+  cancelation_date: Date | null;
+}) {
+  const correctedContentItemsProcessed = Math.min(
+    r.sample_actual_size,
+    r.content_items_processed,
+  );
+  const correctedContentItemsMatched = Math.min(
+    correctedContentItemsProcessed,
+    r.content_items_matched,
+  );
+  return {
+    id: r.id,
+    ruleId: r.rule_id,
+    creatorId: r.creator_id,
+    sampleDesiredSize: r.sample_desired_size,
+    sampleActualSize: r.sample_actual_size,
+    sampleStartAt: r.sample_start_at,
+    sampleEndAt: r.sample_end_at,
+    samplingComplete: r.sampling_complete,
+    contentItemsProcessed: r.content_items_processed,
+    contentItemsMatched: r.content_items_matched,
+    status: r.status,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+    cancelationDate: r.cancelation_date,
+    correctedContentItemsProcessed,
+    correctedContentItemsMatched,
+  };
+}

--- a/server/graphql/datasources/ruleKyselyPersistence.ts
+++ b/server/graphql/datasources/ruleKyselyPersistence.ts
@@ -1,4 +1,4 @@
-import { type Kysely, type Updateable, sql } from 'kysely';
+import { type Insertable, type Kysely, type Updateable, sql } from 'kysely';
 
 import { computeRuleStatusFromRow } from '../../models/rules/ruleTypes.js';
 import { type CombinedPg } from '../../services/combinedDbTypes.js';
@@ -9,16 +9,11 @@ import {
   RuleType,
   type ConditionSet,
 } from '../../services/moderationConfigService/index.js';
-import { safeGet } from '../../utils/misc.js';
 import { type Backtest } from '../../models/rules/BacktestModel.js';
 
 /** Matches `public.backtests.status` when generated value is RUNNING. */
 const backtestRunningPredicate = sql<boolean>`cancelation_date is null
   and (sampling_complete = false or content_items_processed < sample_actual_size)`;
-
-export function isPostgresUniqueViolation(error: unknown): boolean {
-  return safeGet(error, ['code']) === '23505';
-}
 
 /**
  * Applies the legacy `status` virtual-setter semantics from the Sequelize Rule
@@ -134,29 +129,36 @@ export async function kyselyCreateRule(
 
   // `public.rules.created_at` / `updated_at` are NOT NULL in Postgres; Kysely
   // `dbTypes` mark them `GeneratedAlways` so they are omitted from
-  // `Insertable`, but inserts must still supply values at runtime.
+  // `Insertable`, but inserts must still supply values at runtime. Build the
+  // values against an `Insertable & { created_at; updated_at }` so every
+  // column is still type-checked, then narrow back to `Insertable` at the
+  // call site (a safe widening, not a `never` escape hatch).
+  const ruleValues: Insertable<CombinedPg['public.rules']> & {
+    created_at: Date;
+    updated_at: Date;
+  } = {
+    id: input.id,
+    name: input.name,
+    description: input.description,
+    status_if_unexpired,
+    tags: [...input.tags],
+    max_daily_actions: input.maxDailyActions,
+    daily_actions_run: 0,
+    last_action_date: null,
+    org_id: input.orgId,
+    creator_id: input.creatorId,
+    expiration_time,
+    condition_set: input.conditionSet,
+    alarm_status: RuleAlarmStatus.INSUFFICIENT_DATA,
+    alarm_status_set_at: now,
+    rule_type: input.ruleType,
+    parent_id: input.parentId ?? null,
+    created_at: now,
+    updated_at: now,
+  };
   await trx
     .insertInto('public.rules')
-    .values({
-      id: input.id,
-      name: input.name,
-      description: input.description,
-      status_if_unexpired,
-      tags: [...input.tags],
-      max_daily_actions: input.maxDailyActions,
-      daily_actions_run: 0,
-      last_action_date: null,
-      org_id: input.orgId,
-      creator_id: input.creatorId,
-      expiration_time,
-      condition_set: input.conditionSet,
-      alarm_status: RuleAlarmStatus.INSUFFICIENT_DATA,
-      alarm_status_set_at: now,
-      rule_type: input.ruleType,
-      parent_id: input.parentId ?? null,
-      created_at: now,
-      updated_at: now,
-    } as never)
+    .values(ruleValues as Insertable<CombinedPg['public.rules']>)
     .execute();
 
   await replaceRuleActions(trx, input.id, input.actionIds);

--- a/server/graphql/modules/backtest.resolver.test.ts
+++ b/server/graphql/modules/backtest.resolver.test.ts
@@ -1,0 +1,44 @@
+import { UserRole } from '../../models/types/permissioning.js';
+import { resolvers } from './backtest.js';
+
+describe('backtest resolvers', () => {
+  describe('Mutation.createBacktest', () => {
+    it('does not call getRuleByIdAndOrg when the user lacks RUN_BACKTEST', async () => {
+      const getRuleByIdAndOrg = jest.fn();
+      const createBacktest = jest.fn();
+
+      const ctx = {
+        getUser: () => ({
+          id: 'user-1',
+          orgId: 'org-1',
+          role: UserRole.MODERATOR,
+        }),
+        services: {
+          ModerationConfigService: { getRuleByIdAndOrg },
+        },
+        dataSources: {
+          ruleAPI: { createBacktest },
+        },
+      };
+
+      await expect(
+        (resolvers.Mutation as { createBacktest: (...a: unknown[]) => Promise<unknown> })
+          .createBacktest(
+            {},
+            {
+              input: {
+                ruleId: 'rule-1',
+                sampleDesiredSize: 10,
+                sampleStartAt: new Date().toISOString(),
+                sampleEndAt: new Date().toISOString(),
+              },
+            },
+            ctx as never,
+          ),
+      ).rejects.toThrow('User not authorized to create backtests.');
+
+      expect(getRuleByIdAndOrg).not.toHaveBeenCalled();
+      expect(createBacktest).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/server/graphql/modules/backtest.ts
+++ b/server/graphql/modules/backtest.ts
@@ -113,15 +113,19 @@ const resolvers = {
       // TODO: figure out an architecture/patterns for permission checks
       // and this type of validation. Make our error handling consistent.
       const user = context.getUser();
-      const rule = await context.services.Sequelize.Rule.findByPk(
-        params.input.ruleId,
-      );
-
       if (user == null) {
         throw unauthenticatedError('Authenticated user required');
-      } else if (!hasPermission(UserPermission.RUN_BACKTEST, user.role)) {
+      }
+      if (!hasPermission(UserPermission.RUN_BACKTEST, user.role)) {
         throw forbiddenError('User not authorized to create backtests.');
-      } else if (!rule || user.orgId !== rule.orgId) {
+      }
+
+      const rule =
+        await context.services.ModerationConfigService.getRuleByIdAndOrg(
+          params.input.ruleId,
+          user.orgId,
+        );
+      if (rule == null) {
         throw forbiddenError('Invalid rule.');
       }
 

--- a/server/graphql/modules/retroaction.resolver.test.ts
+++ b/server/graphql/modules/retroaction.resolver.test.ts
@@ -1,0 +1,43 @@
+import { UserRole } from '../../models/types/permissioning.js';
+import { resolvers } from './retroaction.js';
+
+describe('retroaction resolvers', () => {
+  describe('Mutation.runRetroaction', () => {
+    it('does not call getRuleByIdAndOrg when the user lacks RUN_RETROACTION', async () => {
+      const getRuleByIdAndOrg = jest.fn();
+      const runRetroaction = jest.fn();
+
+      const ctx = {
+        getUser: () => ({
+          id: 'user-1',
+          orgId: 'org-1',
+          role: UserRole.MODERATOR,
+        }),
+        services: {
+          ModerationConfigService: { getRuleByIdAndOrg },
+        },
+        dataSources: {
+          ruleAPI: { runRetroaction },
+        },
+      };
+
+      await expect(
+        (resolvers.Mutation as { runRetroaction: (...a: unknown[]) => Promise<unknown> })
+          .runRetroaction(
+            {},
+            {
+              input: {
+                ruleId: 'rule-1',
+                startAt: new Date(),
+                endAt: new Date(),
+              },
+            },
+            ctx as never,
+          ),
+      ).rejects.toThrow('User not authorized to run retroaction.');
+
+      expect(getRuleByIdAndOrg).not.toHaveBeenCalled();
+      expect(runRetroaction).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/server/graphql/modules/retroaction.ts
+++ b/server/graphql/modules/retroaction.ts
@@ -40,15 +40,19 @@ const resolvers = {
       // TODO: figure out an architecture/patterns for permission checks
       // and this type of validation. Make our error handling consistent.
       const user = context.getUser();
-      const rule = await context.services.Sequelize.Rule.findByPk(
-        params.input.ruleId,
-      );
-
       if (user == null) {
         throw unauthenticatedError('Authenticated user required');
-      } else if (!hasPermission(UserPermission.RUN_RETROACTION, user.role)) {
-        throw forbiddenError('User not authorized to create backtests.');
-      } else if (!rule || user.orgId !== rule.orgId) {
+      }
+      if (!hasPermission(UserPermission.RUN_RETROACTION, user.role)) {
+        throw forbiddenError('User not authorized to run retroaction.');
+      }
+
+      const rule =
+        await context.services.ModerationConfigService.getRuleByIdAndOrg(
+          params.input.ruleId,
+          user.orgId,
+        );
+      if (rule == null) {
         throw forbiddenError('Invalid rule.');
       }
 

--- a/server/services/moderationConfigService/moderationConfigService.test.ts
+++ b/server/services/moderationConfigService/moderationConfigService.test.ts
@@ -17,7 +17,11 @@ import { type Satisfies } from '../../utils/typescript-types.js';
 import { type ModerationConfigServicePg } from './dbTypes.js';
 import {
   type Action,
+  type ConditionSet,
   type ItemType,
+  RuleAlarmStatus,
+  RuleStatus,
+  RuleType,
   type Policy,
   type UserItemType,
 } from './index.js';
@@ -174,6 +178,93 @@ describe('ModerationConfigService', () => {
     await sutWithPrimary[method]({ ...filters, readFromReplica: false });
     await sutWithReadReplica[method]({ ...filters, readFromReplica: true });
   }
+
+  const minimalRuleConditionSet = {
+    conjunction: 'AND' as const,
+    conditions: [
+      {
+        input: { type: 'FULL_ITEM' as const },
+        comparator: 'IS_NOT_PROVIDED' as const,
+      },
+    ],
+  } satisfies ConditionSet;
+
+  describe('#getRuleByIdAndOrg', () => {
+    const testWithRuleRow = makeTestWithFixture(async () => {
+      const { org, cleanup: orgCleanup } = await createOrg(
+        { Org: container.Sequelize.Org },
+        container.ModerationConfigService,
+        container.ApiKeyService,
+        uid(),
+      );
+      const { user, cleanup: userCleanup } = await createUser(
+        container.Sequelize,
+        org.id,
+      );
+      const ruleId = uid();
+      await container.Sequelize.Rule.create({
+        id: ruleId,
+        orgId: org.id,
+        creatorId: user.id,
+        name: 'getRuleByIdAndOrg fixture rule',
+        description: null,
+        status: RuleStatus.DRAFT,
+        statusIfUnexpired: RuleStatus.DRAFT,
+        tags: [],
+        conditionSet: minimalRuleConditionSet,
+        ruleType: RuleType.USER,
+        alarmStatus: RuleAlarmStatus.INSUFFICIENT_DATA,
+      });
+
+      return {
+        org,
+        user,
+        ruleId,
+        async cleanup() {
+          await container.Sequelize.Rule.destroy({
+            where: { id: ruleId },
+            force: true,
+          });
+          await userCleanup();
+          await orgCleanup();
+        },
+      };
+    });
+
+    testWithRuleRow(
+      'returns the rule when the org id matches the rule row',
+      async ({ org, ruleId }) => {
+        const row = await sutWithPrimary.getRuleByIdAndOrg(ruleId, org.id, {
+          readFromReplica: false,
+        });
+        expect(row).not.toBeNull();
+        expect(row!.id).toBe(ruleId);
+        expect(row!.orgId).toBe(org.id);
+      },
+    );
+
+    testWithRuleRow(
+      'returns null when the org id does not match (IDOR guard)',
+      async ({ ruleId }) => {
+        const { org: otherOrg, cleanup: otherOrgCleanup } = await createOrg(
+          { Org: container.Sequelize.Org },
+          container.ModerationConfigService,
+          container.ApiKeyService,
+          uid(),
+        );
+        try {
+          const row = await sutWithPrimary.getRuleByIdAndOrg(
+            ruleId,
+            otherOrg.id,
+            { readFromReplica: false },
+          );
+          expect(row).toBeNull();
+        } finally {
+          await otherOrgCleanup();
+        }
+      },
+    );
+  });
 
   // NB: there is an ordering dependency between these tests, as the creation
   // tests run first and then the read tests assert on the presence of their

--- a/server/services/moderationConfigService/moderationConfigService.ts
+++ b/server/services/moderationConfigService/moderationConfigService.ts
@@ -301,6 +301,14 @@ export class ModerationConfigService implements ReturnsModerationConfigTypes {
     return this.ruleReadOps.getEnabledRulesForItemType(itemTypeId);
   }
 
+  async getRuleByIdAndOrg(
+    ruleId: string,
+    orgId: string,
+    opts?: { readFromReplica?: boolean },
+  ): Promise<PlainRuleWithLatestVersion | null> {
+    return this.ruleReadOps.getRuleByIdAndOrg(ruleId, orgId, opts);
+  }
+
   async findEnabledUserRules(): Promise<PlainRuleWithLatestVersion[]> {
     return this.ruleReadOps.findEnabledUserRules();
   }

--- a/server/services/moderationConfigService/modules/ItemTypeOperations.ts
+++ b/server/services/moderationConfigService/modules/ItemTypeOperations.ts
@@ -119,6 +119,12 @@ export default class ItemTypeOperations {
     });
   }
 
+  /** Drop cached latest item types for this org after a DB write (MV + in-memory cache can disagree). */
+  private async invalidateLatestItemTypesCache(orgId: string): Promise<void> {
+    // `cached()` always attaches invalidate; the type keeps it optional for other producers.
+    await this.latestItemTypesCache.invalidate!(orgId);
+  }
+
   async getItemTypes(opts: {
     orgId: string;
     directives?: ConsumerDirectives;
@@ -236,6 +242,7 @@ export default class ItemTypeOperations {
       .returning('id')
       .executeTakeFirstOrThrow();
 
+    await this.invalidateLatestItemTypesCache(orgId);
     return (await this.latestItemTypesCache(orgId, { maxAge: 0 })).find(
       (it): it is ReadonlyDeep<UserItemType> =>
         it.kind === 'USER' && it.id === userItemTypeId,
@@ -277,6 +284,7 @@ export default class ItemTypeOperations {
       .returning('id')
       .executeTakeFirstOrThrow();
 
+    await this.invalidateLatestItemTypesCache(orgId);
     return (await this.latestItemTypesCache(orgId, { maxAge: 0 })).find(
       (it): it is ReadonlyDeep<ContentItemType> =>
         it.kind === 'CONTENT' && it.id === contentItemTypeId,
@@ -332,6 +340,7 @@ export default class ItemTypeOperations {
       .returning('id')
       .executeTakeFirstOrThrow();
 
+    await this.invalidateLatestItemTypesCache(orgId);
     return (await this.latestItemTypesCache(orgId, { maxAge: 0 })).find(
       (it): it is ReadonlyDeep<ContentItemType> =>
         it.kind === 'CONTENT' && it.id === contentItemTypeId,
@@ -369,6 +378,7 @@ export default class ItemTypeOperations {
       .returning('id')
       .executeTakeFirstOrThrow();
 
+    await this.invalidateLatestItemTypesCache(orgId);
     return (await this.latestItemTypesCache(orgId, { maxAge: 0 })).find(
       (it): it is ReadonlyDeep<ThreadItemType> =>
         it.kind === 'THREAD' && it.id === threadItemTypeId,
@@ -416,6 +426,7 @@ export default class ItemTypeOperations {
       .returning('id')
       .executeTakeFirstOrThrow();
 
+    await this.invalidateLatestItemTypesCache(orgId);
     return (await this.latestItemTypesCache(orgId, { maxAge: 0 })).find(
       (it): it is ReadonlyDeep<ThreadItemType> =>
         it.kind === 'THREAD' && it.id === threadItemTypeId,
@@ -455,6 +466,7 @@ export default class ItemTypeOperations {
       .returning('id')
       .executeTakeFirstOrThrow();
 
+    await this.invalidateLatestItemTypesCache(orgId);
     return (await this.latestItemTypesCache(orgId, { maxAge: 0 })).find(
       (it): it is ReadonlyDeep<UserItemType> =>
         it.kind === 'USER' && it.id === userItemTypeId,
@@ -506,6 +518,7 @@ export default class ItemTypeOperations {
       .returning('id')
       .executeTakeFirstOrThrow();
 
+    await this.invalidateLatestItemTypesCache(orgId);
     return (await this.latestItemTypesCache(orgId, { maxAge: 0 })).find(
       (it): it is ReadonlyDeep<UserItemType> =>
         it.kind === 'USER' && it.id === userItemTypeId,
@@ -554,7 +567,7 @@ export default class ItemTypeOperations {
           .executeTakeFirst();
       });
 
-    // Refetch item types to evict deleted item from the cache
+    await this.invalidateLatestItemTypesCache(orgId);
     await this.latestItemTypesCache(orgId, { maxAge: 0 });
 
     return res.numDeletedRows === 1n;

--- a/server/services/moderationConfigService/modules/RuleReadOperations.ts
+++ b/server/services/moderationConfigService/modules/RuleReadOperations.ts
@@ -119,6 +119,33 @@ export default class RuleReadOperations {
     return rows.map(rowToPlainRuleWithLatest);
   }
 
+  /**
+   * Loads a single rule (with latest version row) scoped to an org.
+   * Used for GraphQL rule parents and permission checks without Sequelize.
+   *
+   * @param opts.readFromReplica — When false, reads from the primary (e.g. immediately after writes).
+   */
+  async getRuleByIdAndOrg(
+    ruleId: string,
+    orgId: string,
+    opts?: { readFromReplica?: boolean },
+  ): Promise<PlainRuleWithLatestVersion | null> {
+    const readFromReplica = opts?.readFromReplica ?? true;
+    const pg = readFromReplica ? this.pgQueryReplica : this.pgQuery;
+    const row = (await pg
+      .selectFrom('public.rules as r')
+      .leftJoin('public.rules_latest_versions as rlv', 'rlv.rule_id', 'r.id')
+      .select(ruleSelect)
+      .where('r.id', '=', ruleId)
+      .where('r.org_id', '=', orgId)
+      .executeTakeFirst()) as RuleRow | undefined;
+
+    if (row == null) {
+      return null;
+    }
+    return rowToPlainRuleWithLatest(row);
+  }
+
   async findEnabledUserRules() {
     const today = String(getUtcDateOnlyString());
     const rows = (await this.pgQueryReplica

--- a/server/services/signalsService/signals/aggregation/AggregationSignal.test.ts
+++ b/server/services/signalsService/signals/aggregation/AggregationSignal.test.ts
@@ -134,7 +134,7 @@ describe('AggregationSignal', () => {
       org,
       dateProvider,
       async cleanup() {
-        await rule.destroy();
+        await RuleAPIDataSource.deleteRule({ id: rule.id, orgId: org.id });
         await itemTypesCleanup();
         await userCleanup();
         await orgCleanup();


### PR DESCRIPTION
## Context & Requests for Reviewers

Phase 2 of the Sequelize → Kysely migration, continuing from #225. This slice moves the Rule create/update/delete mutations and the backtest list / running-check / cancel paths off Sequelize onto Kysely + `ModerationConfigService`. `backtest` and `retroaction` resolvers now fetch rules via the new `ModerationConfigService.getRuleByIdAndOrg`, and the GraphQL Rule parent is built from a plain row via a small helper instead of a Sequelize instance.

Also fixes a latent bug where `expiration_time` was being overwritten on every rule update even when the GraphQL input omitted `expirationTime`. The new update path diffs against the existing row and only writes columns that actually changed.

Added some tests as I was feeling that we did not have enough testing for the feature and to ensure kysely migration didn't break anything.