### PR TITLE
[deps] Batch /server dependency bumps (closes #240, #248, #251, #254, #256)

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2780,9 +2780,9 @@
       }
     },
     "node_modules/@ioredis/commands": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.0.tgz",
-      "integrity": "sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
+      "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
@@ -12885,6 +12885,36 @@
         "uuid": "11.1.0"
       }
     },
+    "node_modules/bullmq/node_modules/@ioredis/commands": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.0.tgz",
+      "integrity": "sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow==",
+      "license": "MIT"
+    },
+    "node_modules/bullmq/node_modules/ioredis": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.9.2.tgz",
+      "integrity": "sha512-tAAg/72/VxOUW7RQSX1pIxJVucYKcjFjfvj60L57jrZpYCHC3XN0WCQ3sNYL4Gmvv+7GPvTAjc+KSdeNuE8oWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.5.0",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/bullmq/node_modules/uuid": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
@@ -16073,12 +16103,12 @@
       }
     },
     "node_modules/ioredis": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.9.2.tgz",
-      "integrity": "sha512-tAAg/72/VxOUW7RQSX1pIxJVucYKcjFjfvj60L57jrZpYCHC3XN0WCQ3sNYL4Gmvv+7GPvTAjc+KSdeNuE8oWQ==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
+      "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
       "license": "MIT",
       "dependencies": {
-        "@ioredis/commands": "1.5.0",
+        "@ioredis/commands": "1.5.1",
         "cluster-key-slot": "^1.1.0",
         "debug": "^4.3.4",
         "denque": "^2.1.0",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12850,48 +12850,18 @@
       }
     },
     "node_modules/bullmq": {
-      "version": "5.67.3",
-      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.67.3.tgz",
-      "integrity": "sha512-eeQobOJn8M0Rj8tcZCVFLrimZgJQallJH1JpclOoyut2nDNkDwTEPMVcZzLeSR2fGeIVbfJTjU96F563Qkge5A==",
+      "version": "5.75.2",
+      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.75.2.tgz",
+      "integrity": "sha512-5GDO2L5OfzogDxzJCeT7icYdI41vQZ5Wuw2z4EqpfPc1m4/gxyg0sEATULGPdR1sMw0kwCPqbehiIPseXxBX9A==",
       "license": "MIT",
       "dependencies": {
         "cron-parser": "4.9.0",
-        "ioredis": "5.9.2",
+        "ioredis": "5.10.1",
         "msgpackr": "1.11.5",
         "node-abort-controller": "3.1.1",
-        "semver": "7.7.3",
+        "semver": "7.7.4",
         "tslib": "2.8.1",
         "uuid": "11.1.0"
-      }
-    },
-    "node_modules/bullmq/node_modules/@ioredis/commands": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.0.tgz",
-      "integrity": "sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow==",
-      "license": "MIT"
-    },
-    "node_modules/bullmq/node_modules/ioredis": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.9.2.tgz",
-      "integrity": "sha512-tAAg/72/VxOUW7RQSX1pIxJVucYKcjFjfvj60L57jrZpYCHC3XN0WCQ3sNYL4Gmvv+7GPvTAjc+KSdeNuE8oWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@ioredis/commands": "1.5.0",
-        "cluster-key-slot": "^1.1.0",
-        "debug": "^4.3.4",
-        "denque": "^2.1.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.isarguments": "^3.1.0",
-        "redis-errors": "^1.2.0",
-        "redis-parser": "^3.0.0",
-        "standard-as-callback": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=12.22.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ioredis"
       }
     },
     "node_modules/bullmq/node_modules/uuid": {
@@ -19644,9 +19614,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -3643,9 +3643,10 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.22.0.tgz",
-      "integrity": "sha512-CAOgFOKLybd02uj/GhCdEeeBjOS0yeoDeo/CA7ASBSmenpZHAKGB3iDm/rv3BQLcabb/OprDEsSQ1y0P8A7Siw==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
       }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -56,7 +56,7 @@
         "eslint-plugin-switch-statement": "^0.0.11",
         "express": "^4.17.1",
         "express-session": "^1.17.2",
-        "fast-check": "^3.0.0",
+        "fast-check": "^4.6.0",
         "form-data": "^4.0.0",
         "form-data-encoder": "^4.0.2",
         "formdata-node": "^6.0.3",
@@ -14804,9 +14804,9 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "node_modules/fast-check": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.12.0.tgz",
-      "integrity": "sha512-SqahE9mlL3+lhjJ39joMLwcj6F+24hfZdf/tchlNO8sHcTdrUUdA5P/ZbSFZM9Xpzs36XaneGwE0FWepm/zyOA==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.6.0.tgz",
+      "integrity": "sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA==",
       "funding": [
         {
           "type": "individual",
@@ -14817,12 +14817,29 @@
           "url": "https://opencollective.com/fast-check"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "pure-rand": "^6.0.0"
+        "pure-rand": "^8.0.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=12.17.0"
       }
+    },
+    "node_modules/fast-check/node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -19107,6 +19124,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.2.tgz",
       "integrity": "sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2245,21 +2245,21 @@
       "integrity": "sha512-Ft4tmMM8vfuQOD3jpmvCYPEXoLhWLXWh/Mkeql09d3+9FFMaQBdFdo8GBmhQ01z+D6P3NkqNq02rbb4oBkhjLw=="
     },
     "node_modules/@clickhouse/client": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@clickhouse/client/-/client-1.13.0.tgz",
-      "integrity": "sha512-uK+zqPaJnAoq3QIOvUNbHtbWUhyg2A/aSbdJtrY2+kawp4SMBLcfIbB9ucRv5Yht1CAa3b24CiUlypkmgarukg==",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/@clickhouse/client/-/client-1.18.2.tgz",
+      "integrity": "sha512-fuquQswRSHWM6D079ZeuGqkMOsqtcUPL06UdTnowmoeeYjVrqisfVmvnw8pc3OeKS4kVb91oygb/MfLDiMs0TQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@clickhouse/client-common": "1.13.0"
+        "@clickhouse/client-common": "1.18.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@clickhouse/client-common": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@clickhouse/client-common/-/client-common-1.13.0.tgz",
-      "integrity": "sha512-QlGUMd3EaKkIRLCv0WW8Rw9cOlqhwQPT+ucNWY8eC4UALsMhJLpa0H7Cd7MYc9CEtTv/xlr3IcYw5Tdho4Hr2g==",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/@clickhouse/client-common/-/client-common-1.18.2.tgz",
+      "integrity": "sha512-J0SG6q9V31ydxonglpj9xhNRsUxCsF71iEZ784yldqMYwsHixj/9xHFDgBDX3DuMiDx/kPDfXnf+pimp08wIBA==",
       "license": "Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -35,7 +35,7 @@
         "@types/debug": "^4.1.5",
         "@types/express": "^4.17.17",
         "@types/express-session": "^1.17.4",
-        "@types/jsonwebtoken": "^8.5.8",
+        "@types/jsonwebtoken": "^9.0.10",
         "@types/lodash": "^4.14.179",
         "@types/morgan": "^1.9.3",
         "@types/node": "^18.11.9",
@@ -11060,10 +11060,12 @@
       "license": "MIT"
     },
     "node_modules/@types/jsonwebtoken": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.9.tgz",
-      "integrity": "sha512-272FMnFGzAVMGtu9tkr29hRL6bZj4Zs1KZNeHLnKqAvp06tAIcarTMwOh8/8bz4FmKRcMxZhZNeUAQsNLoiPhg==",
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "license": "MIT",
       "dependencies": {
+        "@types/ms": "*",
         "@types/node": "*"
       }
     },

--- a/server/package.json
+++ b/server/package.json
@@ -70,7 +70,7 @@
     "eslint-plugin-switch-statement": "^0.0.11",
     "express": "^4.17.1",
     "express-session": "^1.17.2",
-    "fast-check": "^3.0.0",
+    "fast-check": "^4.6.0",
     "form-data": "^4.0.0",
     "form-data-encoder": "^4.0.2",
     "formdata-node": "^6.0.3",

--- a/server/package.json
+++ b/server/package.json
@@ -49,7 +49,7 @@
     "@types/debug": "^4.1.5",
     "@types/express": "^4.17.17",
     "@types/express-session": "^1.17.4",
-    "@types/jsonwebtoken": "^8.5.8",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/lodash": "^4.14.179",
     "@types/morgan": "^1.9.3",
     "@types/node": "^18.11.9",


### PR DESCRIPTION
Batches five Dependabot PRs targeting the `/server` workspace so they can be tested together.

| Package | From | To | Orig |
|---|---|---|---|
| `@types/jsonwebtoken` (dev) | `^8.5.8` | `^9.0.10` | #254 |
| `fast-check` (dev) | `^3.0.0` | `^4.6.0` | #240 |
| `ioredis` | `^5.9.2` | `^5.10.1` | #256 |
| `@clickhouse/client` | `^1.13.0` | `^1.18.2` | #251 |
| `@opentelemetry/semantic-conventions` | `^1.22.0` | `^1.40.0` | #248 |

`server/package-lock.json` regenerated to coherent versions.

## Coordinated bump required for compatibility

| Package | From | To |
|---|---|---|
| `bullmq` (transitive resolution) | `5.67.3` | `5.75.2` |

`bullmq@5.67.3` pins `ioredis` to exactly `5.9.2`, so bumping the top-level `ioredis` to `5.10.1` produced two copies of `ioredis` in `node_modules` (top-level + nested under bullmq). That broke `tsc` because our consumers of bullmq's `Queue` were getting incompatible `Redis` types from the two copies. `bullmq@5.75.2` pins `ioredis@5.10.1`, which lets npm dedupe; no `package.json` constraint change needed (was already `^5.0.0`).

## Test plan

```bash
cd server
npm ci
npm run typecheck    # green locally on this branch
npm run build
npm run test:ci
npm run test:integ
```

## Rollout

I'll close #240, #248, #251, #254, #256 with a link back to this PR once it's approved.