### PR TITLE
[Bug Fix] Surface Thread-kind items in user submission history

### DIFF
--- a/client/src/graphql/generated.ts
+++ b/client/src/graphql/generated.ts
@@ -16689,7 +16689,35 @@ export type GQLGetLatestUserSubmittedItemsQuery = {
             };
           };
         }
-      | { readonly __typename: 'ThreadItem' }
+      | {
+          readonly __typename: 'ThreadItem';
+          readonly id: string;
+          readonly submissionId: string;
+          readonly data: JsonObject;
+          readonly type: {
+            readonly __typename: 'ThreadItemType';
+            readonly id: string;
+            readonly name: string;
+            readonly baseFields: ReadonlyArray<{
+              readonly __typename: 'BaseField';
+              readonly name: string;
+              readonly type: GQLFieldType;
+              readonly required: boolean;
+              readonly container?: {
+                readonly __typename: 'Container';
+                readonly containerType: GQLContainerType;
+                readonly keyScalarType?: GQLScalarType | null;
+                readonly valueScalarType: GQLScalarType;
+              } | null;
+            }>;
+            readonly schemaFieldRoles: {
+              readonly __typename: 'ThreadSchemaFieldRoles';
+              readonly displayName?: string | null;
+              readonly createdAt?: string | null;
+              readonly creatorId?: string | null;
+            };
+          };
+        }
       | { readonly __typename: 'UserItem' };
   }>;
 };
@@ -35093,6 +35121,30 @@ export const GQLGetLatestUserSubmittedItemsDocument = gql`
               displayName
               parentId
               threadId
+              createdAt
+              creatorId
+            }
+          }
+        }
+        ... on ThreadItem {
+          id
+          submissionId
+          data
+          type {
+            id
+            name
+            baseFields {
+              name
+              type
+              required
+              container {
+                containerType
+                keyScalarType
+                valueScalarType
+              }
+            }
+            schemaFieldRoles {
+              displayName
               createdAt
               creatorId
             }

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobLatestSubmissionsWithThreadComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobLatestSubmissionsWithThreadComponent.tsx
@@ -58,6 +58,30 @@ gql`
             }
           }
         }
+        ... on ThreadItem {
+          id
+          submissionId
+          data
+          type {
+            id
+            name
+            baseFields {
+              name
+              type
+              required
+              container {
+                containerType
+                keyScalarType
+                valueScalarType
+              }
+            }
+            schemaFieldRoles {
+              displayName
+              createdAt
+              creatorId
+            }
+          }
+        }
       }
     }
   }
@@ -105,28 +129,40 @@ export default function ManualReviewJobLatestSubmissionsWithThreadComponent(prop
 
   const dataValues = useMemo(() => {
     return data?.latestItemsCreatedBy.map((itemSubmission) => {
-      if (itemSubmission.latest.__typename !== 'ContentItem') {
-        return undefined;
+      const item = itemSubmission.latest;
+      if (item.__typename === 'ContentItem') {
+        const createdAt = getFieldValueForRole(item, 'createdAt');
+        const threadId = getFieldValueForRole(item, 'threadId');
+        const creatorId = getFieldValueForRole(item, 'creatorId');
+        return {
+          itemId: item.id,
+          itemData: item.data,
+          itemTypeId: item.type.id,
+          itemTypeName: item.type.name,
+          itemTypeFields: item.type.baseFields,
+          dateCreated: createdAt,
+          threadId,
+          creatorId,
+        };
       }
-      const createdAt = getFieldValueForRole(
-        itemSubmission.latest,
-        'createdAt',
-      );
-      const threadId = getFieldValueForRole(itemSubmission.latest, 'threadId');
-      const creatorId = getFieldValueForRole(
-        itemSubmission.latest,
-        'creatorId',
-      );
-      return {
-        itemId: itemSubmission.latest.id,
-        itemData: itemSubmission.latest.data,
-        itemTypeId: itemSubmission.latest.type.id,
-        itemTypeName: itemSubmission.latest.type.name,
-        itemTypeFields: itemSubmission.latest.type.baseFields,
-        dateCreated: createdAt,
-        threadId,
-        creatorId,
-      };
+      // For Thread-kind items, the item itself is the thread (it's the
+      // top-level post, with replies/comments as child Content items pointing
+      // back at it via their `threadId` role).
+      if (item.__typename === 'ThreadItem') {
+        const createdAt = getFieldValueForRole(item, 'createdAt');
+        const creatorId = getFieldValueForRole(item, 'creatorId');
+        return {
+          itemId: item.id,
+          itemData: item.data,
+          itemTypeId: item.type.id,
+          itemTypeName: item.type.name,
+          itemTypeFields: item.type.baseFields,
+          dateCreated: createdAt,
+          threadId: { id: item.id, typeId: item.type.id },
+          creatorId,
+        };
+      }
+      return undefined;
     });
   }, [data]);
 

--- a/server/services/itemProcessingService/makeItemSubmission.test.ts
+++ b/server/services/itemProcessingService/makeItemSubmission.test.ts
@@ -1,0 +1,142 @@
+import { ScalarTypes, type Field, type FieldType } from '@roostorg/types';
+
+import { instantiateOpaqueType } from '../../utils/typescript-types.js';
+import {
+  type ContentItemType,
+  type ContentSchemaFieldRoles,
+  type ThreadItemType,
+  type ThreadSchemaFieldRoles,
+  type UserItemType,
+  type UserSchemaFieldRoles,
+} from '../moderationConfigService/index.js';
+import { getCreator } from './makeItemSubmission.js';
+import { type NormalizedItemData } from './toNormalizedItemDataOrErrors.js';
+
+// Field roles like `creatorId` resolve to RELATED_ITEM in the schema, which is
+// stored as `{ id, typeId }` in normalized data.
+const creatorIdField = {
+  name: 'authorId',
+  type: ScalarTypes.RELATED_ITEM,
+  required: false,
+  container: null,
+} as const satisfies Field<FieldType>;
+
+const baseSchema = [
+  creatorIdField,
+  {
+    name: 'displayName',
+    type: ScalarTypes.STRING,
+    required: false,
+    container: null,
+  } as const,
+  {
+    name: 'createdAt',
+    type: ScalarTypes.DATETIME,
+    required: true,
+    container: null,
+  } as const,
+] as const satisfies readonly [Field<FieldType>, ...Field<FieldType>[]];
+
+const baseTypeFields = {
+  id: 'test',
+  name: 'test',
+  description: null,
+  version: '1',
+  schemaVariant: 'original',
+  orgId: 'test-org',
+  schema: baseSchema,
+} as const;
+
+function makeContentItemType(
+  schemaFieldRoles: ContentSchemaFieldRoles,
+): ContentItemType {
+  return { ...baseTypeFields, kind: 'CONTENT', schemaFieldRoles };
+}
+
+function makeThreadItemType(
+  schemaFieldRoles: ThreadSchemaFieldRoles,
+): ThreadItemType {
+  return { ...baseTypeFields, kind: 'THREAD', schemaFieldRoles };
+}
+
+function makeUserItemType(
+  schemaFieldRoles: UserSchemaFieldRoles,
+): UserItemType {
+  return {
+    ...baseTypeFields,
+    kind: 'USER',
+    isDefaultUserType: false,
+    schemaFieldRoles,
+  };
+}
+
+const expectedCreator = { id: 'creator-id', typeId: 'creator-type-id' };
+
+const itemDataWithCreator = instantiateOpaqueType<NormalizedItemData>({
+  authorId: expectedCreator,
+  displayName: 'a post',
+  createdAt: '2024-01-01T00:00:00.000Z',
+});
+
+const itemDataWithoutCreator = instantiateOpaqueType<NormalizedItemData>({
+  displayName: 'a post',
+  createdAt: '2024-01-01T00:00:00.000Z',
+});
+
+describe('getCreator', () => {
+  describe('CONTENT items', () => {
+    test('returns the value of the creatorId field role', () => {
+      const itemType = makeContentItemType({
+        creatorId: 'authorId',
+        threadId: 'createdAt',
+        createdAt: 'createdAt',
+      });
+      expect(getCreator(itemType, itemDataWithCreator)).toEqual(
+        expectedCreator,
+      );
+    });
+
+    test('returns undefined when the creatorId role is not configured', () => {
+      const itemType = makeContentItemType({});
+      expect(getCreator(itemType, itemDataWithCreator)).toBeUndefined();
+    });
+
+    test('returns undefined when the creatorId field is missing from the data', () => {
+      const itemType = makeContentItemType({
+        creatorId: 'authorId',
+        threadId: 'createdAt',
+        createdAt: 'createdAt',
+      });
+      expect(getCreator(itemType, itemDataWithoutCreator)).toBeUndefined();
+    });
+  });
+
+  describe('THREAD items', () => {
+    test('returns the value of the creatorId field role', () => {
+      const itemType = makeThreadItemType({ creatorId: 'authorId' });
+      expect(getCreator(itemType, itemDataWithCreator)).toEqual(
+        expectedCreator,
+      );
+    });
+
+    test('returns undefined when the creatorId role is not configured', () => {
+      const itemType = makeThreadItemType({});
+      expect(getCreator(itemType, itemDataWithCreator)).toBeUndefined();
+    });
+
+    test('returns undefined when the creatorId field is missing from the data', () => {
+      const itemType = makeThreadItemType({ creatorId: 'authorId' });
+      expect(getCreator(itemType, itemDataWithoutCreator)).toBeUndefined();
+    });
+  });
+
+  describe('USER items', () => {
+    // User items are not "created by" themselves; we never want to populate
+    // a creator for them, even if the schema happens to include a field
+    // pointing at another item.
+    test('always returns undefined', () => {
+      const itemType = makeUserItemType({});
+      expect(getCreator(itemType, itemDataWithCreator)).toBeUndefined();
+    });
+  });
+});

--- a/server/services/itemProcessingService/makeItemSubmission.ts
+++ b/server/services/itemProcessingService/makeItemSubmission.ts
@@ -287,7 +287,10 @@ export async function rawItemSubmissionToItemSubmission(
   };
 }
 
-function getCreator(itemType: ItemType, itemData: NormalizedItemData) {
+export function getCreator(
+  itemType: ItemType,
+  itemData: NormalizedItemData,
+) {
   switch (itemType.kind) {
     case 'USER':
       return undefined;

--- a/server/services/itemProcessingService/makeItemSubmission.ts
+++ b/server/services/itemProcessingService/makeItemSubmission.ts
@@ -93,8 +93,9 @@ export type ItemSubmission<Type extends ItemType = ItemType> = Opaque<
     /**
      * The ItemIdentifier for the user that created this item.
      *
-     * NB: this only applies to content items; user items don't list the user as
-     * the item's creator, and threads don't (yet) have creators.
+     * Populated from the item type's `creatorId` field role for both CONTENT
+     * and THREAD item types. USER items don't list themselves as their own
+     * creator.
      *
      * NB: this could be generated from the schema and field roles on the
      * itemType, but to support older users who submitted the creator as a
@@ -288,9 +289,9 @@ export async function rawItemSubmissionToItemSubmission(
 
 function getCreator(itemType: ItemType, itemData: NormalizedItemData) {
   switch (itemType.kind) {
-    case 'THREAD':
     case 'USER':
       return undefined;
+    case 'THREAD':
     case 'CONTENT':
       return getFieldValueForRole(
         itemType.schema,


### PR DESCRIPTION
There was a bug where `Thread` kind items submitted with a `creatorId` schema field role were silently being dropped from creator-keyed surfaces. This was due to `getCreator` in `makeItemSubmission.ts` hard-coded `undefined` for `kind: THREAD`, so every Thread submission was written to Scylla with an empty `item_creator_identifier`. 

As a result the `item_submission_by_creator` materialized view never indexed Thread items by their actual author, and `latestItemsCreatedBy` returned nothing for users whose only submissions were Threads.

This is the root cause for orgs that model their platform as "top-level post = Thread, replies = Content with threadId pointing back at the post": those top-level posts never appeared on the user the user investigation surface.

Note: existing Thread rows in Scylla were written with a nil `item_creator_identifier` and will not be retroactively reindexed; only Thread submissions received after this change will appear in creator-keyed queries.

