### PR TITLE
[Bug Fix] Refresh recent actions list after submitting an action

### DIFF
--- a/client/src/components/ItemAction.tsx
+++ b/client/src/components/ItemAction.tsx
@@ -1,4 +1,5 @@
 import {
+  namedOperations,
   useGQLBulkActionExecutionMutation,
   useGQLBulkActionsFormDataQuery,
 } from '@/graphql/generated';
@@ -23,6 +24,10 @@ export default function ItemAction(props: {
 
   const { data: queryData } = useGQLBulkActionsFormDataQuery();
   const [bulkAction, { loading }] = useGQLBulkActionExecutionMutation({
+    refetchQueries: [
+      namedOperations.Query.ItemActionHistory,
+      namedOperations.Query.GetRecentDecisions,
+    ],
     onCompleted: (data) => {
       const results = data?.bulkExecuteActions?.results ?? [];
       const anyFailed = results.some((r) => r.success === false);


### PR DESCRIPTION
## Context & Requests for Reviewers

Fixes #227.

Submitting an action via the Investigation UI's "Action on this item" form did not update the "Recent Actions on this {ItemType}" table, nor the dashboard's "Recent Decisions" list. Users had to do a full browser refresh (F5) to see the action they had just taken.

Added a refetch on the bulk action mutation to ensure stale data is refetch and updated on the view.