### PR TITLE
[deps] Batch root dependency bumps (closes #249, #267, #268, #269, #270)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@graphiql/create-fetcher": "^0.1.0",
         "@graphql-codegen/add": "^6.0.0",
-        "@graphql-codegen/cli": "^6.2.1",
+        "@graphql-codegen/cli": "^6.3.0",
         "@graphql-codegen/named-operations-object": "^4.0.0",
         "@graphql-codegen/typescript": "^5.0.9",
         "@graphql-codegen/typescript-operations": "^5.0.9",
@@ -438,13 +438,13 @@
       }
     },
     "node_modules/@graphql-codegen/add": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/add/-/add-6.0.0.tgz",
-      "integrity": "sha512-biFdaURX0KTwEJPQ1wkT6BRgNasqgQ5KbCI1a3zwtLtO7XTo7/vKITPylmiU27K5DSOWYnY/1jfSqUAEBuhZrQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/add/-/add-6.0.1.tgz",
+      "integrity": "sha512-MSylSekjpVWbOBw2A/2ssk1fPY54sYb6Qk2C4AX5u7s2R+2pMQ9ws7DTXo8VU9qwTgWwVp6vGfdQ0AMpAn4Iug==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^6.0.0",
-        "tslib": "~2.6.0"
+        "@graphql-codegen/plugin-helpers": "^6.3.0",
+        "tslib": "^2.8.0"
       },
       "engines": {
         "node": ">=16"
@@ -453,18 +453,24 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
+    "node_modules/@graphql-codegen/add/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/@graphql-codegen/cli": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-6.2.1.tgz",
-      "integrity": "sha512-E1B+5nBda2l89Pci5M0HcEj2Hmx2yhORFX+1T3rmwpQjdOiulo+h9JifWxKomUpjfbmU1YkBSd47CCGLFPU10A==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-6.3.0.tgz",
+      "integrity": "sha512-tlzSaM2oSnG6x8+QVc+cJ7NMJe+CN4tnSm/B8Uny/IpgSkAqP+RG8xaDxnrzwQZ+lz1ZXrBkNM6vzAGZhOaOGw==",
       "license": "MIT",
       "dependencies": {
         "@babel/generator": "^7.18.13",
         "@babel/template": "^7.18.10",
         "@babel/types": "^7.18.13",
-        "@graphql-codegen/client-preset": "^5.2.4",
-        "@graphql-codegen/core": "^5.0.1",
-        "@graphql-codegen/plugin-helpers": "^6.2.0",
+        "@graphql-codegen/client-preset": "^5.3.0",
+        "@graphql-codegen/core": "^5.0.2",
+        "@graphql-codegen/plugin-helpers": "^6.3.0",
         "@graphql-tools/apollo-engine-loader": "^8.0.28",
         "@graphql-tools/code-file-loader": "^8.1.28",
         "@graphql-tools/git-loader": "^8.0.32",
@@ -871,24 +877,24 @@
       }
     },
     "node_modules/@graphql-codegen/client-preset": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/client-preset/-/client-preset-5.2.4.tgz",
-      "integrity": "sha512-k4f9CoepkVznXRReCHBVnG/FeQVQgIOhgtkaJ6I9FcQRzUkrm9ASmQjOdNdMlZt0DHTU4nbVxIBGZW7gk1RavA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/client-preset/-/client-preset-5.3.0.tgz",
+      "integrity": "sha512-K9FON+j7qyxAUDuSGqI3ofb7lWTBs16oPTYpu14lhdL4DKZQSHLyc8EMYU9e3KcyQ/13gU/d6culOppzAuexLA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/template": "^7.20.7",
-        "@graphql-codegen/add": "^6.0.0",
-        "@graphql-codegen/gql-tag-operations": "5.1.4",
-        "@graphql-codegen/plugin-helpers": "^6.1.1",
-        "@graphql-codegen/typed-document-node": "^6.1.7",
-        "@graphql-codegen/typescript": "^5.0.9",
-        "@graphql-codegen/typescript-operations": "^5.0.9",
-        "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+        "@graphql-codegen/add": "^6.0.1",
+        "@graphql-codegen/gql-tag-operations": "5.2.0",
+        "@graphql-codegen/plugin-helpers": "^6.3.0",
+        "@graphql-codegen/typed-document-node": "^6.1.8",
+        "@graphql-codegen/typescript": "^5.0.10",
+        "@graphql-codegen/typescript-operations": "^5.1.0",
+        "@graphql-codegen/visitor-plugin-common": "^6.3.0",
         "@graphql-tools/documents": "^1.0.0",
         "@graphql-tools/utils": "^11.0.0",
         "@graphql-typed-document-node/core": "3.2.0",
-        "tslib": "~2.6.0"
+        "tslib": "^2.8.0"
       },
       "engines": {
         "node": ">=16"
@@ -903,16 +909,22 @@
         }
       }
     },
+    "node_modules/@graphql-codegen/client-preset/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/@graphql-codegen/core": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/core/-/core-5.0.1.tgz",
-      "integrity": "sha512-eQD7aXpKkKvaydMv5Bu0FnKCPnNMAhZ3vZW+K4Rl9IAC2w5PDv9lJhs3YTWM9W58zNOZpGQGT2F0ekS3QNIiKw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/core/-/core-5.0.2.tgz",
+      "integrity": "sha512-7RX0wwjoWPlLG/tUmpaTK91ZZqHcACNWpRL0nGnnJaJrORie9pgmX8JPrcwBgYiHSC+3ERo9xY91RFPem/VrpQ==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^6.1.1",
+        "@graphql-codegen/plugin-helpers": "^6.3.0",
         "@graphql-tools/schema": "^10.0.0",
         "@graphql-tools/utils": "^11.0.0",
-        "tslib": "~2.6.0"
+        "tslib": "^2.8.0"
       },
       "engines": {
         "node": ">=16"
@@ -921,17 +933,23 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
+    "node_modules/@graphql-codegen/core/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/@graphql-codegen/gql-tag-operations": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/gql-tag-operations/-/gql-tag-operations-5.1.4.tgz",
-      "integrity": "sha512-tDj/0a1U7rDH3PQgLeA+PlgBNb593MIJ43oAOKMRgJPwIQ9T7p2oqBRLxwfFZFTDLwnwsGZ7xIKqIcGgyAIj5Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/gql-tag-operations/-/gql-tag-operations-5.2.0.tgz",
+      "integrity": "sha512-B9gtJ4ziqpIv+7mHqwjtpYLFOuv0GmmRGpNDoWKM2VIx4OQqgI84d6OHKYCVeO7yu3mUr0QPvUgkSyuLVrdukA==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^6.1.1",
-        "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+        "@graphql-codegen/plugin-helpers": "^6.3.0",
+        "@graphql-codegen/visitor-plugin-common": "^6.3.0",
         "@graphql-tools/utils": "^11.0.0",
         "auto-bind": "~4.0.0",
-        "tslib": "~2.6.0"
+        "tslib": "^2.8.0"
       },
       "engines": {
         "node": ">=16"
@@ -939,6 +957,12 @@
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
+    },
+    "node_modules/@graphql-codegen/gql-tag-operations/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@graphql-codegen/named-operations-object": {
       "version": "4.0.0",
@@ -965,16 +989,16 @@
       "license": "0BSD"
     },
     "node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-6.2.1.tgz",
-      "integrity": "sha512-shRr26TfVZ6KFBjzRYUj02gLNh6yaECz9gTGgI6riANw5sSH9PONwTsBRYkEgU+6IXiL7VQeCumahvxSGFbRlQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-6.3.0.tgz",
+      "integrity": "sha512-Auc+/B7okDx9+pVgLVliZtZLYh6iltWXlnzzM+bRE+zh1T4r3hKbnr8xAmtT937ArfSgk5GHcQHr8LfPYnrRBg==",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/utils": "^11.0.0",
         "change-case-all": "1.0.15",
         "common-tags": "1.8.2",
         "import-from": "4.0.0",
-        "tslib": "~2.6.0"
+        "tslib": "^2.8.0"
       },
       "engines": {
         "node": ">=16"
@@ -982,16 +1006,22 @@
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
+    },
+    "node_modules/@graphql-codegen/plugin-helpers/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@graphql-codegen/schema-ast": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/schema-ast/-/schema-ast-5.0.1.tgz",
-      "integrity": "sha512-svLffXddnXxq1qFXQqqh+zYrxdiMnIKm+CXCUv0MYhLh0R4L5vpnaTzIUCk3icHNNXhKRm2uBD70+K8VY0xiCg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/schema-ast/-/schema-ast-5.0.2.tgz",
+      "integrity": "sha512-jl1F/9IjRkJisEb9B0ayG4QGqYlPldLRy8ojDdmL9NE1NsdB5ROfxQnSqyC3g+wuvBhWX7kZgMRQYn3RU1I5bA==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^6.1.1",
+        "@graphql-codegen/plugin-helpers": "^6.3.0",
         "@graphql-tools/utils": "^11.0.0",
-        "tslib": "~2.6.0"
+        "tslib": "^2.8.0"
       },
       "engines": {
         "node": ">=16"
@@ -999,18 +1029,24 @@
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
+    },
+    "node_modules/@graphql-codegen/schema-ast/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@graphql-codegen/typed-document-node": {
-      "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typed-document-node/-/typed-document-node-6.1.7.tgz",
-      "integrity": "sha512-VLL9hB+YPigc/W2QYCkSNMZrkKv42nTchb9mJ0h5VY98YmW/zWb6NeYM80iHSpk8ZvHsuUT5geA53/s1phO2NQ==",
+      "version": "6.1.8",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typed-document-node/-/typed-document-node-6.1.8.tgz",
+      "integrity": "sha512-+qDdiJSQ7Ol+vpLMAH8ZJok50CvlYxA6seQ7cwEa3emXt8MmH5hh3zdc9unQlPc7bynoJHRCgoKk7E0B7hry0w==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^6.1.1",
-        "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+        "@graphql-codegen/plugin-helpers": "^6.3.0",
+        "@graphql-codegen/visitor-plugin-common": "^6.3.0",
         "auto-bind": "~4.0.0",
         "change-case-all": "1.0.15",
-        "tslib": "~2.6.0"
+        "tslib": "^2.8.0"
       },
       "engines": {
         "node": ">=16"
@@ -1019,17 +1055,23 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
+    "node_modules/@graphql-codegen/typed-document-node/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/@graphql-codegen/typescript": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-5.0.9.tgz",
-      "integrity": "sha512-YlIZ4nqdFdzr5vxuNtQtZnnMYuZ5cLYB2HaGhGI2zvqHxCmkBjIRpu/5sfccawKy23wetV+aoWvoNqxGKIryig==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-5.0.10.tgz",
+      "integrity": "sha512-Pa8OFmL9TdhEYnLYJLYA9EhP8eEeivP/YDYq4Nb8LQaL7GXm4TGX8zELYaCM9Fu8M3iZb7iQGMt7qc+1lXz8XQ==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^6.1.1",
-        "@graphql-codegen/schema-ast": "^5.0.1",
-        "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+        "@graphql-codegen/plugin-helpers": "^6.3.0",
+        "@graphql-codegen/schema-ast": "^5.0.2",
+        "@graphql-codegen/visitor-plugin-common": "^6.3.0",
         "auto-bind": "~4.0.0",
-        "tslib": "~2.6.0"
+        "tslib": "^2.8.0"
       },
       "engines": {
         "node": ">=16"
@@ -1039,16 +1081,16 @@
       }
     },
     "node_modules/@graphql-codegen/typescript-operations": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-5.0.9.tgz",
-      "integrity": "sha512-jJFdJKMS5Cqisb5QMi7xXHPsJH9yHBMYOxBc8laFkFjHk/AOqJK90qCKbO9lwwTMPZUDe6N/HslmA0ax4J0zsg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-5.1.0.tgz",
+      "integrity": "sha512-JlmjbFl0EnsfMDIYvTE1Q0kAOrntVEZ+ZfBqWTP91g4e0F/TzuwJ/V4tiFmeDf5dx/rf9AK4VkPehIdxu7TYhw==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^6.1.1",
-        "@graphql-codegen/typescript": "^5.0.9",
-        "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+        "@graphql-codegen/plugin-helpers": "^6.3.0",
+        "@graphql-codegen/typescript": "^5.0.10",
+        "@graphql-codegen/visitor-plugin-common": "^6.3.0",
         "auto-bind": "~4.0.0",
-        "tslib": "~2.6.0"
+        "tslib": "^2.8.0"
       },
       "engines": {
         "node": ">=16"
@@ -1062,6 +1104,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@graphql-codegen/typescript-operations/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@graphql-codegen/typescript-react-apollo": {
       "version": "4.4.1",
@@ -1114,13 +1162,19 @@
         }
       }
     },
+    "node_modules/@graphql-codegen/typescript/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/@graphql-codegen/visitor-plugin-common": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-6.2.4.tgz",
-      "integrity": "sha512-iwiVCc7Mv8/XAa3K35AdFQ9chJSDv/gYEnBeQFF/Sq/W8EyJoHypOGOTTLk7OSrWO4xea65ggv0e7fGt7rPJjQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-6.3.0.tgz",
+      "integrity": "sha512-vGBoE+4huzZyNhyGSAhXAkdROHlwKxxuziZm4XtP1mxe7nuI+VgyOmXebafLijbmuDsptPXQN0C/htL54O8hrg==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^6.1.1",
+        "@graphql-codegen/plugin-helpers": "^6.3.0",
         "@graphql-tools/optimize": "^2.0.0",
         "@graphql-tools/relay-operation-optimizer": "^7.1.1",
         "@graphql-tools/utils": "^11.0.0",
@@ -1129,7 +1183,7 @@
         "dependency-graph": "^1.0.0",
         "graphql-tag": "^2.11.0",
         "parse-filepath": "^1.0.2",
-        "tslib": "~2.6.0"
+        "tslib": "^2.8.0"
       },
       "engines": {
         "node": ">=16"
@@ -1137,6 +1191,12 @@
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
+    },
+    "node_modules/@graphql-codegen/visitor-plugin-common/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@graphql-hive/signal": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
       },
       "devDependencies": {
         "@ianvs/prettier-plugin-sort-imports": "^4.1.0",
-        "@types/express": "^4.17.10",
+        "@types/express": "^5.0.6",
         "@types/jest": "^26.0.20",
         "@types/node": "^14.14.20",
         "@types/passport": "^1.0.5",
@@ -1857,25 +1857,36 @@
       }
     },
     "node_modules/@types/express": {
-      "version": "4.17.16",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.31",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.33",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
-        "@types/range-parser": "*"
+        "@types/range-parser": "*",
+        "@types/send": "*"
       }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -1937,11 +1948,6 @@
         "node": ">= 10.14.2"
       }
     },
-    "node_modules/@types/mime": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/node": {
       "version": "14.18.36",
       "license": "MIT"
@@ -1955,21 +1961,37 @@
       }
     },
     "node_modules/@types/qs": {
-      "version": "6.9.7",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
-      "version": "1.2.4",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/serve-static": {
-      "version": "1.15.0",
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/mime": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
         "@types/node": "*"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "concurrently": "^6.5.1",
         "lint-staged": "^15.5.2",
         "node-worker-threads-pool": "^1.5.1",
-        "pg": "^8.5.1",
+        "pg": "^8.20.0",
         "sequelize-cli": "^6.2.0"
       },
       "devDependencies": {
@@ -2217,13 +2217,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer-writer": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "license": "MIT",
@@ -4388,10 +4381,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/packet-reader": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
     "node_modules/param-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -4506,19 +4495,22 @@
       }
     },
     "node_modules/pg": {
-      "version": "8.9.0",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
       "dependencies": {
-        "buffer-writer": "2.0.0",
-        "packet-reader": "1.0.0",
-        "pg-connection-string": "^2.5.0",
-        "pg-pool": "^3.5.2",
-        "pg-protocol": "^1.6.0",
-        "pg-types": "^2.1.0",
-        "pgpass": "1.x"
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
       },
       "engines": {
-        "node": ">= 8.0.0"
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
       },
       "peerDependencies": {
         "pg-native": ">=3.0.1"
@@ -4529,10 +4521,18 @@
         }
       }
     },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/pg-connection-string": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.4.tgz",
-      "integrity": "sha512-v+Z7W/0EO707aNMaAEfiGnGL9sxxumwLl2fJvCQtMn9Fxsg+lPpPkdcyBSv/KFgpGdYkMfn+EI1Or2EHjpgLCA=="
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
@@ -4542,14 +4542,18 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.5.2",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
       "license": "MIT",
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.6.0",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
       "license": "MIT"
     },
     "node_modules/pg-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@graphql-codegen/typescript-operations": "^5.0.9",
         "@graphql-codegen/typescript-react-apollo": "^4.4.1",
         "@graphql-codegen/typescript-resolvers": "^5.1.7",
-        "concurrently": "^6.5.1",
+        "concurrently": "^9.2.1",
         "lint-staged": "^15.5.2",
         "node-worker-threads-pool": "^1.5.1",
         "pg": "^8.5.1",
@@ -2472,55 +2472,27 @@
       }
     },
     "node_modules/concurrently": {
-      "version": "6.5.1",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
       "license": "MIT",
       "dependencies": {
-        "chalk": "^4.1.0",
-        "date-fns": "^2.16.1",
-        "lodash": "^4.17.21",
-        "rxjs": "^6.6.3",
-        "spawn-command": "^0.0.2-1",
-        "supports-color": "^8.1.0",
-        "tree-kill": "^1.2.2",
-        "yargs": "^16.2.0"
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
       },
       "bin": {
-        "concurrently": "bin/concurrently.js"
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
       },
       "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/concurrently/node_modules/cliui": {
-      "version": "7.0.4",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/concurrently/node_modules/yargs": {
-      "version": "16.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "node": ">=18"
       },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/concurrently/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
     },
     "node_modules/config-chain": {
@@ -2627,17 +2599,6 @@
       "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.3.tgz",
       "integrity": "sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==",
       "license": "MIT"
-    },
-    "node_modules/date-fns": {
-      "version": "2.29.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.11"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
-      }
     },
     "node_modules/debounce": {
       "version": "2.2.0",
@@ -4776,18 +4737,13 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "6.6.7",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
+        "tslib": "^2.1.0"
       }
-    },
-    "node_modules/rxjs/node_modules/tslib": {
-      "version": "1.14.1",
-      "license": "0BSD"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -4894,8 +4850,13 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.7.4",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4969,10 +4930,6 @@
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
-    },
-    "node_modules/spawn-command": {
-      "version": "0.0.2-1",
-      "license": "MIT"
     },
     "node_modules/split2": {
       "version": "4.1.0",
@@ -5456,7 +5413,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.6.2",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@types/jest": "^26.0.20",
         "@types/node": "^14.14.20",
         "@types/passport": "^1.0.5",
-        "@types/validator": "^13.1.3",
+        "@types/validator": "^13.15.10",
         "husky": "^8.0.1",
         "prettier": "^3.0.1",
         "ts-node": "^10.9.1",
@@ -1974,10 +1974,11 @@
       }
     },
     "node_modules/@types/validator": {
-      "version": "13.11.9",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.9.tgz",
-      "integrity": "sha512-FCTsikRozryfayPuiI46QzH3fnrOoctTjvOYZkho9BTFLCOZ2rgZJHMOVgCOfttjPJcgOx52EpkY0CMfy87MIw==",
-      "dev": true
+      "version": "13.15.10",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
+      "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@graphiql/create-fetcher": "^0.1.0",
     "@graphql-codegen/add": "^6.0.0",
-    "@graphql-codegen/cli": "^6.2.1",
+    "@graphql-codegen/cli": "^6.3.0",
     "@graphql-codegen/named-operations-object": "^4.0.0",
     "@graphql-codegen/typescript": "^5.0.9",
     "@graphql-codegen/typescript-operations": "^5.0.9",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "concurrently": "^6.5.1",
     "lint-staged": "^15.5.2",
     "node-worker-threads-pool": "^1.5.1",
-    "pg": "^8.5.1",
+    "pg": "^8.20.0",
     "sequelize-cli": "^6.2.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@graphql-codegen/typescript-operations": "^5.0.9",
     "@graphql-codegen/typescript-react-apollo": "^4.4.1",
     "@graphql-codegen/typescript-resolvers": "^5.1.7",
-    "concurrently": "^6.5.1",
+    "concurrently": "^9.2.1",
     "lint-staged": "^15.5.2",
     "node-worker-threads-pool": "^1.5.1",
     "pg": "^8.5.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/jest": "^26.0.20",
     "@types/node": "^14.14.20",
     "@types/passport": "^1.0.5",
-    "@types/validator": "^13.1.3",
+    "@types/validator": "^13.15.10",
     "husky": "^8.0.1",
     "prettier": "^3.0.1",
     "ts-node": "^10.9.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^4.1.0",
-    "@types/express": "^4.17.10",
+    "@types/express": "^5.0.6",
     "@types/jest": "^26.0.20",
     "@types/node": "^14.14.20",
     "@types/passport": "^1.0.5",


### PR DESCRIPTION
Combines five Dependabot bumps for the root workspace into a single PR for easier review and testing.

## Bumps included
| Package | From | To | Type | Original PR |
|---|---|---|---|---|
| `@graphql-codegen/cli` | 6.2.1 | 6.3.0 | dep (minor) | #270 |
| `@types/express` | 4.17.16 | 5.0.6 | devDep (major types) | #269 |
| `@types/validator` | 13.11.9 | 13.15.10 | devDep (minor) | #268 |
| `concurrently` | 6.5.1 | 9.2.1 | dep (major) | #267 |
| `pg` | 8.9.0 | 8.20.0 | dep (minor) | #249 |

## Impact
- `concurrently` is only used by the `start` / `compile` npm scripts at the root with `--kill-others`, which is still supported in v9.
- `@graphql-codegen/cli` is used by `generate` / `generate:watch`. The 6.2 → 6.3 jump is a minor and `codegen.yaml` is unchanged.
- Root `pg` is only used as a peer for `sequelize-cli` (which declares `pg: ">=8.0"`). The `/server` workspace pins its own `pg` and is unaffected.
- `@types/express` and `@types/validator` are root-level devDeps with no consumers in root TypeScript code (no `*.ts` at root). They flow through to client/server only via their own `package.json`.

## Test plan
\`\`\`bash
# from repo root
rm -rf node_modules
npm ci

# Verify the script-runner used by start/compile
./node_modules/.bin/concurrently --version    # → 9.2.1

# Verify graphql-codegen still loads + can resolve config
node -e "console.log(require('@graphql-codegen/cli/package.json').version)"   # → 6.3.0
npm run generate                              # regenerates client + server graphql/generated.ts

# Verify pg loads at root
node -e "const pg=require('pg'); console.log(typeof pg.Client)"   # → function
\`\`\`

Once merged I'll close #270, #269, #268, #267, #249 with a link back here.