### PR TITLE
dependabot: Drop malformed dependency groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,6 @@ updates:
         update-types: ["version-update:semver-major"]
 
   # Enable version updates for npm
-  # Cover / directory dependencies
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
@@ -31,30 +30,17 @@ updates:
         applies-to: 'security-updates'
         patterns:
           - '*'
-
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'weekly'
-    groups:
       root-prod:
         dependency-type: 'production'
         applies-to: 'version-updates'
         patterns:
           - '*'
-
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'weekly'
-    groups:
       root-dev:
         dependency-type: 'development'
         applies-to: 'version-updates'
         patterns:
           - '*'
 
-  # Cover /db directory dependencies
   - package-ecosystem: 'npm'
     directory: '/db'
     schedule:
@@ -65,30 +51,17 @@ updates:
         applies-to: 'security-updates'
         patterns:
           - '*'
-
-  - package-ecosystem: 'npm'
-    directory: '/db'
-    schedule:
-      interval: 'weekly'
-    groups:
       db-prod:
         dependency-type: 'production'
         applies-to: 'version-updates'
         patterns:
           - '*'
-
-  - package-ecosystem: 'npm'
-    directory: '/db'
-    schedule:
-      interval: 'weekly'
-    groups:
       db-dev:
         dependency-type: 'development'
         applies-to: 'version-updates'
         patterns:
           - '*'
 
-  # Cover /migrator directory dependencies
   - package-ecosystem: 'npm'
     directory: '/migrator'
     schedule:
@@ -99,30 +72,17 @@ updates:
         applies-to: 'security-updates'
         patterns:
           - '*'
-
-  - package-ecosystem: 'npm'
-    directory: '/migrator'
-    schedule:
-      interval: 'weekly'
-    groups:
       migrator-prod:
         dependency-type: 'production'
         applies-to: 'version-updates'
         patterns:
           - '*'
-
-  - package-ecosystem: 'npm'
-    directory: '/migrator'
-    schedule:
-      interval: 'weekly'
-    groups:
       migrator-dev:
         dependency-type: 'development'
         applies-to: 'version-updates'
         patterns:
           - '*'
 
-  # Cover /server directory dependencies
   - package-ecosystem: 'npm'
     directory: '/server'
     schedule:
@@ -133,30 +93,17 @@ updates:
         applies-to: 'security-updates'
         patterns:
           - '*'
-
-  - package-ecosystem: 'npm'
-    directory: '/server'
-    schedule:
-      interval: 'weekly'
-    groups:
       server-prod:
         dependency-type: 'production'
         applies-to: 'version-updates'
         patterns:
           - '*'
-
-  - package-ecosystem: 'npm'
-    directory: '/server'
-    schedule:
-      interval: 'weekly'
-    groups:
       server-dev:
         dependency-type: 'development'
         applies-to: 'version-updates'
         patterns:
           - '*'
 
-  # Cover /client directory dependencies
   - package-ecosystem: 'npm'
     directory: '/client'
     schedule:
@@ -167,30 +114,17 @@ updates:
         applies-to: 'security-updates'
         patterns:
           - '*'
-
-  - package-ecosystem: 'npm'
-    directory: '/client'
-    schedule:
-      interval: 'weekly'
-    groups:
       client-prod:
         dependency-type: 'production'
         applies-to: 'version-updates'
         patterns:
           - '*'
-
-  - package-ecosystem: 'npm'
-    directory: '/client'
-    schedule:
-      interval: 'weekly'
-    groups:
       client-dev:
         dependency-type: 'development'
         applies-to: 'version-updates'
         patterns:
           - '*'
 
-  # Cover /nodejs-instrumentation directory dependencies
   - package-ecosystem: 'npm'
     directory: '/nodejs-instrumentation'
     schedule:
@@ -201,23 +135,11 @@ updates:
         applies-to: 'security-updates'
         patterns:
           - '*'
-
-  - package-ecosystem: 'npm'
-    directory: '/nodejs-instrumentation'
-    schedule:
-      interval: 'weekly'
-    groups:
       nodejs-instrumentation-prod:
         dependency-type: 'production'
         applies-to: 'version-updates'
         patterns:
           - '*'
-
-  - package-ecosystem: 'npm'
-    directory: '/nodejs-instrumentation'
-    schedule:
-      interval: 'weekly'
-    groups:
       nodejs-instrumentation-dev:
         dependency-type: 'development'
         applies-to: 'version-updates'


### PR DESCRIPTION
## Context & Requests for Reviewers

Previous recipe was too verbose and broke Dependabot uniqueness constraints on package ecosystem/directory combination (see https://github.com/roostorg/coop/runs/72814997757).