### PR TITLE
Pin busybox Docker image version to avoid supply chain risks

### DIFF
--- a/nodejs-instrumentation/Dockerfile
+++ b/nodejs-instrumentation/Dockerfile
@@ -23,7 +23,7 @@ RUN npm run build
 
 RUN npm prune --omit=dev
 
-FROM busybox
+FROM busybox:1.37.0
 
 COPY --from=build /operator-build/node_modules /autoinstrumentation/node_modules
 COPY --from=build /operator-build/transpiled/ /autoinstrumentation


### PR DESCRIPTION
Pinned version is what "latest" tag currently points to.

## Context & Requests for Reviewers

This is a minor change to mitigate a low-risk issue.

Closes: action item from [Working Group Meeting](https://github.com/roostorg/coop/discussions/120)