### PR TITLE
move CI checks into docker-compose services

### DIFF
--- a/.github/workflows/apply_pr_checks.yaml
+++ b/.github/workflows/apply_pr_checks.yaml
@@ -29,21 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-      - run: npm ci
-      - name: Generate graphql
-        run: |
-          npm run generate
-          if [[ -z "$(git status --porcelain)" ]]; then
-            echo "Generated GraphQL is up to date."
-          else
-            echo "GraphQL re-generation required!!"
-            echo "::error:: $(git status)"
-            exit 1
-          fi
+      - name: Check generated GraphQL is up to date
+        run: docker compose run --rm --quiet-pull codegen-check
 
   check_migration_order:
     runs-on: ubuntu-latest
@@ -135,14 +122,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Lint
-        run: docker compose run --quiet-pull lint
+        run: docker compose run --rm --quiet-pull lint
 
       - name: Build server
-        run: DOCKER_BUILDKIT=1 docker build . --target build_backend
+        run: docker compose build build-backend
 
       - name: Migrate CI DBs and Test
         run: |
-          docker compose run --quiet-pull test
+          docker compose run --rm --quiet-pull test
           echo "ATTENTION: If this step fails, look in the next step for the migration logs."
 
       - # Only output the migration logs if the prior step failed, as they
@@ -171,10 +158,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Lint client
-        run: docker compose run --quiet-pull lint-client
+        run: docker compose run --rm --quiet-pull lint-client
 
       - name: Build client
-        # Without DOCKER_BUILDKIT we'll attempt to build the backend as well
-        run: DOCKER_BUILDKIT=1 docker build client
+        run: docker compose build build-client
 
 

--- a/.github/workflows/apply_pr_checks.yaml
+++ b/.github/workflows/apply_pr_checks.yaml
@@ -125,7 +125,7 @@ jobs:
         run: docker compose run --rm --quiet-pull backend npm run lint
 
       - name: Build server
-        run: docker compose build backend
+        run: docker compose run --rm --quiet-pull backend npm run build
 
       - name: Migrate CI DBs and Test
         run: |
@@ -161,6 +161,6 @@ jobs:
         run: docker compose run --rm --quiet-pull client npm run lint
 
       - name: Build client
-        run: docker compose build client
+        run: docker compose run --rm --quiet-pull client npm run build
 
 

--- a/.github/workflows/apply_pr_checks.yaml
+++ b/.github/workflows/apply_pr_checks.yaml
@@ -122,10 +122,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Lint
-        run: docker compose run --rm --quiet-pull lint
+        run: docker compose run --rm --quiet-pull backend npm run lint
 
       - name: Build server
-        run: docker compose build build-backend
+        run: docker compose build backend
 
       - name: Migrate CI DBs and Test
         run: |
@@ -158,9 +158,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Lint client
-        run: docker compose run --rm --quiet-pull lint-client
+        run: docker compose run --rm --quiet-pull client npm run lint
 
       - name: Build client
-        run: docker compose build build-client
+        run: docker compose build client
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@
 # native modules, and we don't really care about the larger image size.
 FROM node:24.14.1-bullseye-slim AS server_base
 WORKDIR /app
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
 
 COPY ["server/package.json", "server/package-lock.json", "./"]
 RUN npm ci

--- a/README.md
+++ b/README.md
@@ -96,6 +96,39 @@ The `server/bin` folder contains utility scripts for managing the Coop server:
 
 See `server/bin/README.md` for detailed usage instructions and examples.
 
+## Running CI Locally
+
+All PR checks are defined as `docker compose` services to reproduce any CI job locally.
+
+| CI job | Local command |
+| --- | --- |
+| `check_generated_graphql` | `docker compose run --rm codegen-check` |
+| `check_api_server` (lint) | `docker compose run --rm lint` |
+| `check_api_server` (build) | `docker compose build build-backend` |
+| `check_api_server` (test) | `docker compose run --rm test` |
+| `run_frontend_checks_if_changed` (lint) | `docker compose run --rm lint-client` |
+| `run_frontend_checks_if_changed` (build) | `docker compose build build-client` |
+
+Run the full suite (stops at first failure):
+
+```bash
+docker compose run --rm codegen-check \
+  && docker compose run --rm lint \
+  && docker compose build build-backend \
+  && docker compose run --rm test \
+  && docker compose run --rm lint-client \
+  && docker compose build build-client
+```
+
+Tear down:
+
+```bash
+docker compose down        # stop containers, keep DB volumes
+docker compose down -v     # also drop DB volumes (fresh DBs next run)
+```
+
+`check_migration_order` runs only in GitHub Actions — it's GitHub-specific and not needed locally. When adding a migration, use `date -u +"%Y.%m.%dT%H.%M.%S"` for the filename prefix and CI will pass.
+
 # Code Structure
 
 Server Code ( `/server` ):

--- a/README.md
+++ b/README.md
@@ -103,21 +103,21 @@ All PR checks are defined as `docker compose` services to reproduce any CI job l
 | CI job | Local command |
 | --- | --- |
 | `check_generated_graphql` | `docker compose run --rm codegen-check` |
-| `check_api_server` (lint) | `docker compose run --rm lint` |
-| `check_api_server` (build) | `docker compose build build-backend` |
+| `check_api_server` (lint) | `docker compose run --rm backend npm run lint` |
+| `check_api_server` (build) | `docker compose build backend` |
 | `check_api_server` (test) | `docker compose run --rm test` |
-| `run_frontend_checks_if_changed` (lint) | `docker compose run --rm lint-client` |
-| `run_frontend_checks_if_changed` (build) | `docker compose build build-client` |
+| `run_frontend_checks_if_changed` (lint) | `docker compose run --rm client npm run lint` |
+| `run_frontend_checks_if_changed` (build) | `docker compose build client` |
 
 Run the full suite (stops at first failure):
 
 ```bash
 docker compose run --rm codegen-check \
-  && docker compose run --rm lint \
-  && docker compose build build-backend \
+  && docker compose run --rm backend npm run lint \
+  && docker compose build backend \
   && docker compose run --rm test \
-  && docker compose run --rm lint-client \
-  && docker compose build build-client
+  && docker compose run --rm client npm run lint \
+  && docker compose build client
 ```
 
 Tear down:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -118,6 +118,39 @@ services:
       - ./client/.eslintrc.cjs:/app/.eslintrc.cjs
       - ./client/eslint.config.mjs:/app/eslint.config.mjs
 
+  # Regenerates GraphQL types and fails if the working tree drifts. Mirrors
+  # the `check_generated_graphql` CI job. node_modules is in a dedicated
+  # volume so the install doesn't clobber the host's node_modules with
+  # linux-built binaries.
+  codegen-check:
+    image: node:24.14.1-bullseye
+    working_dir: /src
+    command: bash -c 'set -e
+                      && npm ci
+                      && npm run generate
+                      && git diff --exit-code -- "*generated.ts"'
+    volumes:
+      - .:/src
+      - codegen_node_modules:/src/node_modules
+
+  # Builds the server image. Equivalent to `docker build . --target
+  # build_backend` in the `check_api_server` CI job. Run with
+  # `docker compose build build-backend`.
+  build-backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: build_backend
+    command: ['true']
+
+  # Builds the client image. Equivalent to `docker build client` in the
+  # `run_frontend_checks_if_changed` CI job. Run with
+  # `docker compose build build-client`.
+  build-client:
+    build:
+      context: client
+    command: ['true']
+
   jaeger:
     image: jaegertracing/all-in-one:1.76.0
     ports:
@@ -166,3 +199,4 @@ volumes:
   scylla_data:
   redis_data:
   clickhouse_data:
+  codegen_node_modules:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -122,11 +122,12 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      target: build_backend
+      target: server_base
 
   client:
     build:
       context: client
+      target: client_base
     volumes:
       - ./client/eslint:/app/eslint
       - ./client/.eslintrc.cjs:/app/.eslintrc.cjs

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -100,56 +100,37 @@ services:
       redis:
         condition: service_started
 
-
-  lint:
+  # Regenerate GraphQL types and fail if the working tree drifts. 
+  # Mirrors the `check_generated_graphql` CI job. 
+  # node_modules is in a dedicated volume so the install doesn't clobber the host's node_modules.
+  codegen-check:
     build:
       context: .
       dockerfile: Dockerfile
       target: server_base
-    command: npm run lint
-
-  lint-client:
-    build:
-      context: client
-      target: client_base
-    command: npm run lint
-    volumes:
-      - ./client/eslint:/app/eslint
-      - ./client/.eslintrc.cjs:/app/.eslintrc.cjs
-      - ./client/eslint.config.mjs:/app/eslint.config.mjs
-
-  # Regenerates GraphQL types and fails if the working tree drifts. Mirrors
-  # the `check_generated_graphql` CI job. node_modules is in a dedicated
-  # volume so the install doesn't clobber the host's node_modules with
-  # linux-built binaries.
-  codegen-check:
-    image: node:24.14.1-bullseye
     working_dir: /src
     command: bash -c 'set -e
+                      && git config --global --add safe.directory /src
                       && npm ci
                       && npm run generate
-                      && git diff --exit-code -- "*generated.ts"'
+                      && [[ -z "$(git status --porcelain)" ]]'
     volumes:
       - .:/src
       - codegen_node_modules:/src/node_modules
 
-  # Builds the server image. Equivalent to `docker build . --target
-  # build_backend` in the `check_api_server` CI job. Run with
-  # `docker compose build build-backend`.
-  build-backend:
+  backend:
     build:
       context: .
       dockerfile: Dockerfile
       target: build_backend
-    command: ['true']
 
-  # Builds the client image. Equivalent to `docker build client` in the
-  # `run_frontend_checks_if_changed` CI job. Run with
-  # `docker compose build build-client`.
-  build-client:
+  client:
     build:
       context: client
-    command: ['true']
+    volumes:
+      - ./client/eslint:/app/eslint
+      - ./client/.eslintrc.cjs:/app/.eslintrc.cjs
+      - ./client/eslint.config.mjs:/app/eslint.config.mjs
 
   jaeger:
     image: jaegertracing/all-in-one:1.76.0


### PR DESCRIPTION
## Summary
- Every CI check is now a compose service 
  
## Why                                                                                     
AGENTS.md and docs that describe "how to run CI locally" had started to drift from the 
workflow YAML. With the checks defined in compose, there is one source of truth. 

## What reviewers should look at 
- `docker-compose.yaml` — three new services 
- `.github/workflows/apply_pr_checks.yaml` — simplified

## Commands                                                                       
  - `docker compose run --rm codegen-check`
  - `docker compose run --rm backend npm run lint`
  - `docker compose run --rm backend npm run build`
  - `docker compose run --rm client npm run lint`
  - `docker compose run --rm client npm run build`
  - `docker compose run --rm test`
 
## Out of scope   
- `check_migration_order` intentionally stays inline in the workflow as it is GitHub-specific 

