### PR TITLE
Add ssl tls support, recharts patch, body schema validation

### DIFF
--- a/client/src/rechartsScaleWrapper.js
+++ b/client/src/rechartsScaleWrapper.js
@@ -1,43 +1,78 @@
 /**
- * Wrapper around recharts-scale that catches [DecimalError] Division by zero.
- * Aliased via craco.config.js so recharts imports this instead of the original.
+ * Wrapper around `recharts-scale/es6/getNiceTickValues` that recovers from
+ * `[DecimalError] Division by zero` errors thrown by upstream when a chart
+ * receives a degenerate domain (e.g., all values identical, or non-numeric).
+ *
+ * Aliased via `resolve.alias` in `client/vite.config.ts`, so any `recharts`
+ * import of `recharts-scale/es6/getNiceTickValues` resolves to this module
+ * instead of the upstream implementation. We use Vite's alias — not craco —
+ * because this app is built with Vite, not Create React App.
  */
 const actual = require('recharts-scale/es6/getNiceTickValues');
 
-function getNiceTickValues(domain, tickCount, allowDecimals) {
+const DEFAULT_TICK_COUNT = 5;
+
+/**
+ * Build a plain linear set of ticks as a last resort when upstream can't
+ * compute one. Safe for any `tickCount >= 1` (returns a single tick when
+ * `tickCount === 1`, avoiding its own division-by-zero).
+ */
+function fallbackTicks(domain, tickCount) {
+  const count =
+    Number.isInteger(tickCount) && tickCount > 0 ? tickCount : DEFAULT_TICK_COUNT;
+  const min = typeof domain[0] === 'number' ? domain[0] : 0;
+  const max = typeof domain[1] === 'number' && domain[1] > min ? domain[1] : min + 1;
+  if (count === 1) return [min];
+  const step = (max - min) / (count - 1);
+  const ticks = new Array(count);
+  for (let i = 0; i < count; i++) {
+    ticks[i] = min + step * i;
+  }
+  return ticks;
+}
+
+function isDivisionByZeroError(err) {
+  // `recharts-scale` uses `decimal.js` under the hood, which tags the error
+  // with `name === 'DecimalError'`. Fall back to a message-substring check
+  // for older versions that don't set `name`.
+  return (
+    (err && err.name === 'DecimalError') ||
+    (err && typeof err.message === 'string' && err.message.includes('Division by zero'))
+  );
+}
+
+function safelyCall(fn, fnName, domain, tickCount, allowDecimals) {
   try {
-    return actual.getNiceTickValues(domain, tickCount, allowDecimals);
-  } catch (e) {
-    if (e.message && e.message.includes('Division by zero')) {
-      const min = typeof domain[0] === 'number' ? domain[0] : 0;
-      const max = typeof domain[1] === 'number' && domain[1] > min ? domain[1] : min + 1;
-      const step = (max - min) / ((tickCount || 5) - 1);
-      const ticks = [];
-      for (let i = 0; i < (tickCount || 5); i++) {
-        ticks.push(min + step * i);
-      }
-      return ticks;
-    }
-    throw e;
+    return fn(domain, tickCount, allowDecimals);
+  } catch (err) {
+    if (!isDivisionByZeroError(err)) throw err;
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[rechartsScaleWrapper] ${fnName} threw DecimalError; using linear fallback.`,
+      { domain, tickCount },
+    );
+    return fallbackTicks(domain, tickCount);
   }
 }
 
+function getNiceTickValues(domain, tickCount, allowDecimals) {
+  return safelyCall(
+    actual.getNiceTickValues,
+    'getNiceTickValues',
+    domain,
+    tickCount,
+    allowDecimals,
+  );
+}
+
 function getTickValuesFixedDomain(domain, tickCount, allowDecimals) {
-  try {
-    return actual.getTickValuesFixedDomain(domain, tickCount, allowDecimals);
-  } catch (e) {
-    if (e.message && e.message.includes('Division by zero')) {
-      const min = typeof domain[0] === 'number' ? domain[0] : 0;
-      const max = typeof domain[1] === 'number' && domain[1] > min ? domain[1] : min + 1;
-      const step = (max - min) / ((tickCount || 5) - 1);
-      const ticks = [];
-      for (let i = 0; i < (tickCount || 5); i++) {
-        ticks.push(min + step * i);
-      }
-      return ticks;
-    }
-    throw e;
-  }
+  return safelyCall(
+    actual.getTickValuesFixedDomain,
+    'getTickValuesFixedDomain',
+    domain,
+    tickCount,
+    allowDecimals,
+  );
 }
 
 exports.getNiceTickValues = getNiceTickValues;

--- a/client/src/rechartsScaleWrapper.js
+++ b/client/src/rechartsScaleWrapper.js
@@ -1,0 +1,44 @@
+/**
+ * Wrapper around recharts-scale that catches [DecimalError] Division by zero.
+ * Aliased via craco.config.js so recharts imports this instead of the original.
+ */
+const actual = require('recharts-scale/es6/getNiceTickValues');
+
+function getNiceTickValues(domain, tickCount, allowDecimals) {
+  try {
+    return actual.getNiceTickValues(domain, tickCount, allowDecimals);
+  } catch (e) {
+    if (e.message && e.message.includes('Division by zero')) {
+      const min = typeof domain[0] === 'number' ? domain[0] : 0;
+      const max = typeof domain[1] === 'number' && domain[1] > min ? domain[1] : min + 1;
+      const step = (max - min) / ((tickCount || 5) - 1);
+      const ticks = [];
+      for (let i = 0; i < (tickCount || 5); i++) {
+        ticks.push(min + step * i);
+      }
+      return ticks;
+    }
+    throw e;
+  }
+}
+
+function getTickValuesFixedDomain(domain, tickCount, allowDecimals) {
+  try {
+    return actual.getTickValuesFixedDomain(domain, tickCount, allowDecimals);
+  } catch (e) {
+    if (e.message && e.message.includes('Division by zero')) {
+      const min = typeof domain[0] === 'number' ? domain[0] : 0;
+      const max = typeof domain[1] === 'number' && domain[1] > min ? domain[1] : min + 1;
+      const step = (max - min) / ((tickCount || 5) - 1);
+      const ticks = [];
+      for (let i = 0; i < (tickCount || 5); i++) {
+        ticks.push(min + step * i);
+      }
+      return ticks;
+    }
+    throw e;
+  }
+}
+
+exports.getNiceTickValues = getNiceTickValues;
+exports.getTickValuesFixedDomain = getTickValuesFixedDomain;

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -15,6 +15,13 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      // Redirect `recharts-scale/es6/getNiceTickValues` through our wrapper so
+      // we can recover from upstream's DecimalError "Division by zero" on
+      // degenerate chart domains. See `src/rechartsScaleWrapper.js`.
+      'recharts-scale/es6/getNiceTickValues': path.resolve(
+        __dirname,
+        './src/rechartsScaleWrapper.js',
+      ),
     },
   },
   build: {

--- a/server/api.ts
+++ b/server/api.ts
@@ -33,8 +33,9 @@ import resolvers, { type Context } from './graphql/resolvers.js';
 import typeDefs from './graphql/schema.js';
 import { authSchemaWrapper } from './graphql/utils/authorization.js';
 import { type Dependencies } from './iocContainer/index.js';
-import { safeGetEnvInt } from './iocContainer/utils.js';
+import { isEnvTrue, safeGetEnvInt } from './iocContainer/utils.js';
 import controllers from './routes/index.js';
+import { createBodySchemaValidator } from './utils/bodySchemaValidation.js';
 import { jsonStringify } from './utils/encoding.js';
 import {
   ErrorType,
@@ -140,7 +141,9 @@ export default async function makeApiServer(deps: Dependencies) {
     user: DATABASE_USER,
     password: DATABASE_PASSWORD,
     database: DATABASE_NAME,
-    ssl: process.env.DATABASE_SSL === 'true' ? { rejectUnauthorized: false } : undefined,
+    // NB: `rejectUnauthorized: false` keeps the connection encrypted but skips
+    // certificate validation.
+    ssl: isEnvTrue('DATABASE_SSL') ? { rejectUnauthorized: false } : undefined,
   };
 
   app.use(
@@ -439,9 +442,16 @@ export default async function makeApiServer(deps: Dependencies) {
   Object.entries(controllers).forEach(([_k, controller]) => {
     controller.routes.forEach((it) => {
       const handler = it.handler(deps);
+      const handlers = Array.isArray(handler) ? handler : [handler];
+      // If the route declares a bodySchema, validate the request body against
+      // it before any handler runs. Routes without a schema (e.g., GETs) skip
+      // validation entirely.
+      const middlewares = it.bodySchema
+        ? [createBodySchemaValidator(it.bodySchema), ...handlers]
+        : handlers;
       app[it.method](
         path.join(controller.pathPrefix, it.path),
-        ...(Array.isArray(handler) ? handler : [handler]),
+        ...middlewares,
       );
     });
   });

--- a/server/api.ts
+++ b/server/api.ts
@@ -134,12 +134,19 @@ export default async function makeApiServer(deps: Dependencies) {
     DATABASE_PASSWORD,
   } = process.env;
 
-  const connectionString = `postgres://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}`;
+  const conObject = {
+    host: DATABASE_HOST,
+    port: Number(DATABASE_PORT),
+    user: DATABASE_USER,
+    password: DATABASE_PASSWORD,
+    database: DATABASE_NAME,
+    ssl: process.env.DATABASE_SSL === 'true' ? { rejectUnauthorized: false } : undefined,
+  };
 
   app.use(
     session({
       secret: process.env.SESSION_SECRET!,
-      store: new sessionStore({ conString: connectionString }),
+      store: new sessionStore({ conObject }),
       cookie: {
         secure: process.env.NODE_ENV === 'production',
         httpOnly: true,

--- a/server/iocContainer/index.ts
+++ b/server/iocContainer/index.ts
@@ -456,6 +456,7 @@ export default async function getBottle() {
     max: 30,
     application_name:
       getEnvVarOrWarn('OTEL_SERVICE_NAME') ?? 'unknown-coop-service',
+    ssl: process.env.DATABASE_SSL === 'true' ? { rejectUnauthorized: false } : undefined,
   });
 
   const bottle = new Bottle<Dependencies>();
@@ -525,6 +526,7 @@ export default async function getBottle() {
           maxRetriesPerRequest: null,
           port: parseInt(process.env.REDIS_PORT ?? '6379'),
           host: safeGetEnvVar('REDIS_HOST'),
+          ...(process.env.REDIS_TLS === 'true' ? { tls: {} } : {}),
         }),
   );
 
@@ -685,6 +687,13 @@ export default async function getBottle() {
       },
       localDataCenter: safeGetEnvVar('SCYLLA_LOCAL_DATACENTER'),
       keyspace: 'item_investigation_service',
+      protocolOptions: {
+        port: parseInt(process.env.SCYLLA_PORT ?? '9042'),
+      },
+      sslOptions: process.env.SCYLLA_SSL === 'true' ? {
+        host: safeGetEnvVar('SCYLLA_HOSTS').split(',')[0].trim(),
+        rejectUnauthorized: true,
+      } : undefined,
       pooling: {
         coreConnectionsPerHost: {
           [scyllaTypes.distance.local]: 3,

--- a/server/iocContainer/index.ts
+++ b/server/iocContainer/index.ts
@@ -244,7 +244,7 @@ import {
 } from '../utils/typescript-types.js';
 import { registerGqlDataSources } from './services/gqlDataSources.js';
 import { registerWorkersAndJobs } from './services/workersAndJobs.js';
-import { register, safeGetEnvVar } from './utils.js';
+import { isEnvTrue, register, safeGetEnvVar } from './utils.js';
 
 // the otel instrumentation currently intercepts require statements. support for
 // esm support is experimental so we should wait until it is stable
@@ -456,7 +456,7 @@ export default async function getBottle() {
     max: 30,
     application_name:
       getEnvVarOrWarn('OTEL_SERVICE_NAME') ?? 'unknown-coop-service',
-    ssl: process.env.DATABASE_SSL === 'true' ? { rejectUnauthorized: false } : undefined,
+    ssl: isEnvTrue('DATABASE_SSL') ? { rejectUnauthorized: false } : undefined,
   });
 
   const bottle = new Bottle<Dependencies>();
@@ -526,7 +526,9 @@ export default async function getBottle() {
           maxRetriesPerRequest: null,
           port: parseInt(process.env.REDIS_PORT ?? '6379'),
           host: safeGetEnvVar('REDIS_HOST'),
-          ...(process.env.REDIS_TLS === 'true' ? { tls: {} } : {}),
+          ...(isEnvTrue('REDIS_TLS')
+            ? { tls: { servername: safeGetEnvVar('REDIS_HOST') } }
+            : {}),
         }),
   );
 
@@ -677,10 +679,18 @@ export default async function getBottle() {
   // keyspace aware and it's very annoying and likely error prone to be
   // switching keyspaces with `USE KEYSPACE` all the time.
   bottle.factory('Scylla', () => {
+    const contactPoints = safeGetEnvVar('SCYLLA_HOSTS')
+      .split(',')
+      .map((it) => it.trim())
+      .filter((it) => it.length > 0);
+    // For TLS hostname verification we need an SNI value that matches the
+    // server cert. Prefer an explicit `SCYLLA_SSL_SERVERNAME` (e.g., the
+    // Keyspaces regional endpoint) over inferring one from `SCYLLA_HOSTS`,
+    // which may contain multiple contact points with different cert names.
+    const sslServerName =
+      process.env.SCYLLA_SSL_SERVERNAME ?? contactPoints[0];
     const scyllaDriver = new ScyllaClient({
-      contactPoints: safeGetEnvVar('SCYLLA_HOSTS')
-        .split(',')
-        .map((it) => it.trim()),
+      contactPoints,
       credentials: {
         username: safeGetEnvVar('SCYLLA_USERNAME'),
         password: safeGetEnvVar('SCYLLA_PASSWORD'),
@@ -690,10 +700,12 @@ export default async function getBottle() {
       protocolOptions: {
         port: parseInt(process.env.SCYLLA_PORT ?? '9042'),
       },
-      sslOptions: process.env.SCYLLA_SSL === 'true' ? {
-        host: safeGetEnvVar('SCYLLA_HOSTS').split(',')[0].trim(),
-        rejectUnauthorized: true,
-      } : undefined,
+      sslOptions: isEnvTrue('SCYLLA_SSL')
+        ? {
+            host: sslServerName,
+            rejectUnauthorized: true,
+          }
+        : undefined,
       pooling: {
         coreConnectionsPerHost: {
           [scyllaTypes.distance.local]: 3,

--- a/server/iocContainer/utils.ts
+++ b/server/iocContainer/utils.ts
@@ -664,6 +664,17 @@ export function safeGetEnvVar(varName: string): string {
 }
 
 /**
+ * Returns true when the env var is set to a truthy value. Accepts `true`, `1`,
+ * and `yes` (case-insensitive) so callers don't have to worry about casing or
+ * common aliases. Any other value (including unset) returns false.
+ */
+export function isEnvTrue(varName: string): boolean {
+  const raw = process.env[varName];
+  if (raw == null) return false;
+  return ['true', '1', 'yes'].includes(raw.trim().toLowerCase());
+}
+
+/**
  * Gets an env var and parses it as a positive integer. Returns `defaultValue`
  * if the variable is unset or invalid, logging an error on misconfiguration.
  */

--- a/server/models/sequelizeSetup.ts
+++ b/server/models/sequelizeSetup.ts
@@ -58,7 +58,7 @@ export const makeSequelize = () =>
       // Think about how/if we'll do this w/ our kysely connection pools.
     },
     dialectOptions: {
-      //ssl: true,
+      ssl: process.env.DATABASE_SSL === 'true' ? { rejectUnauthorized: false } : undefined,
       query_timeout: 1_000_000,
       idle_in_transaction_session_timeout: 300_000,
     },

--- a/server/models/sequelizeSetup.ts
+++ b/server/models/sequelizeSetup.ts
@@ -8,6 +8,7 @@
 import clsHooked from 'cls-hooked';
 import pkg, { type Transaction, type TransactionOptions } from 'sequelize';
 
+import { isEnvTrue } from '../iocContainer/utils.js';
 import { safeGet } from '../utils/misc.js';
 
 const { Sequelize } = pkg;
@@ -58,7 +59,7 @@ export const makeSequelize = () =>
       // Think about how/if we'll do this w/ our kysely connection pools.
     },
     dialectOptions: {
-      ssl: process.env.DATABASE_SSL === 'true' ? { rejectUnauthorized: false } : undefined,
+      ssl: isEnvTrue('DATABASE_SSL') ? { rejectUnauthorized: false } : undefined,
       query_timeout: 1_000_000,
       idle_in_transaction_session_timeout: 300_000,
     },

--- a/server/utils/bodySchemaValidation.test.ts
+++ b/server/utils/bodySchemaValidation.test.ts
@@ -1,0 +1,107 @@
+import type { Request, Response } from 'express';
+
+import { createBodySchemaValidator } from './bodySchemaValidation.js';
+import { CoopError } from './errors.js';
+
+const schema: Record<string, unknown> = {
+  $schema: 'http://json-schema.org/draft-04/schema#',
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    count: { type: 'integer' },
+  },
+  required: ['name'],
+  additionalProperties: false,
+};
+
+function invoke(
+  middleware: ReturnType<typeof createBodySchemaValidator>,
+  body: unknown,
+) {
+  const req: Partial<Request> = { body };
+  const res: Partial<Response> = {};
+  const next = jest.fn();
+  middleware(req as Request, res as Response, next);
+  return { next };
+}
+
+function firstNextArg(next: ReturnType<typeof jest.fn>): unknown {
+  return next.mock.calls[0]?.[0];
+}
+
+describe('createBodySchemaValidator', () => {
+  test('passes valid bodies through to next()', () => {
+    const middleware = createBodySchemaValidator(schema);
+    const { next } = invoke(middleware, { name: 'ok', count: 3 });
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  test('allows optional fields to be omitted', () => {
+    const middleware = createBodySchemaValidator(schema);
+    const { next } = invoke(middleware, { name: 'ok' });
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  test('forwards a BadRequestError when a required field is missing', () => {
+    const middleware = createBodySchemaValidator(schema);
+    const { next } = invoke(middleware, { count: 3 });
+
+    expect(next).toHaveBeenCalledTimes(1);
+    const err = firstNextArg(next);
+    expect(err).toBeInstanceOf(CoopError);
+    expect(err).toMatchObject({
+      name: 'BadRequestError',
+      status: 400,
+      title: 'Request body failed schema validation.',
+    });
+    // Error message should reference the missing field, not crash.
+    expect((err as CoopError).detail).toContain('name');
+  });
+
+  test('forwards a BadRequestError when a field has the wrong type', () => {
+    const middleware = createBodySchemaValidator(schema);
+    const { next } = invoke(middleware, { name: 'ok', count: 'not-a-number' });
+
+    expect(next).toHaveBeenCalledTimes(1);
+    const err = firstNextArg(next);
+    expect(err).toBeInstanceOf(CoopError);
+    expect(err).toMatchObject({
+      name: 'BadRequestError',
+      status: 400,
+      pointer: '/count',
+    });
+  });
+
+  test('rejects unknown additional properties when the schema forbids them', () => {
+    const middleware = createBodySchemaValidator(schema);
+    const { next } = invoke(middleware, { name: 'ok', surprise: true });
+
+    expect(next).toHaveBeenCalledTimes(1);
+    const err = firstNextArg(next);
+    expect(err).toBeInstanceOf(CoopError);
+    expect(err).toMatchObject({ name: 'BadRequestError', status: 400 });
+  });
+
+  test('rejects non-object bodies (e.g., undefined from a request with no body)', () => {
+    const middleware = createBodySchemaValidator(schema);
+    const { next } = invoke(middleware, undefined);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    const err = firstNextArg(next);
+    expect(err).toBeInstanceOf(CoopError);
+    expect(err).toMatchObject({ name: 'BadRequestError', status: 400 });
+  });
+
+  test('does not leak Ajv internals (schemaPath / params) in the error detail', () => {
+    const middleware = createBodySchemaValidator(schema);
+    const { next } = invoke(middleware, { name: 42 });
+
+    const err = firstNextArg(next) as CoopError;
+    expect(err.detail ?? '').not.toContain('schemaPath');
+    expect(err.detail ?? '').not.toContain('params');
+  });
+});

--- a/server/utils/bodySchemaValidation.ts
+++ b/server/utils/bodySchemaValidation.ts
@@ -1,22 +1,82 @@
 import type { RequestHandler } from 'express';
-import _Ajv from 'ajv-draft-04';
+import _Ajv, { type ErrorObject } from 'ajv-draft-04';
 
+import { makeBadRequestError } from './errors.js';
+
+// `ajv-draft-04` is a CJS module; under our `"module": "NodeNext"` ESM setup
+// the real constructor ends up at `_Ajv.default`. This matches the pattern
+// used elsewhere in this codebase (see `services/ncmecService/ncmecService.ts`
+// and `services/partialItemsService/partialItemsService.ts`).
 const Ajv = _Ajv as unknown as typeof _Ajv.default;
-const ajv = new Ajv();
 
+// Module-level singleton: Ajv internally caches compiled schemas by reference,
+// and `ajv.compile` is idempotent per schema object.
+const ajv = new Ajv({
+  // Report every validation error, not just the first one, so the response
+  // tells the caller about all their mistakes at once.
+  allErrors: true,
+  // Fail loudly if a schema uses keywords Ajv doesn't understand — that's
+  // almost always a bug in the route definition rather than something we
+  // want to silently ignore at runtime.
+  strictSchema: true,
+});
+
+/**
+ * Build an Express middleware that validates `req.body` against `schema`.
+ *
+ * On failure the middleware forwards a `BadRequestError` (a `CoopError`) to the
+ * standard Express error handler, which serializes it into the project's
+ * canonical `{ errors: [...] }` shape. We intentionally do NOT echo the raw
+ * Ajv error objects back to the client: those include `params`, `schemaPath`,
+ * and sometimes slices of the request body, which can leak implementation
+ * details or user-supplied data back in the response.
+ */
 export function createBodySchemaValidator(
+  // We intentionally take a permissive schema type here. The `Route.bodySchema`
+  // field is already typed against its specific `ReqBody` at route-definition
+  // sites; this middleware only forwards the schema to Ajv at runtime, which
+  // doesn't care about the TS-side body type.
   schema: Record<string, unknown>,
 ): RequestHandler {
   const validate = ajv.compile(schema);
-  return (req, res, next) => {
+
+  return (req, _res, next) => {
     if (validate(req.body)) {
       next();
-    } else {
-      res.status(400).json({
-        error: 'VALIDATION_ERROR',
-        message: 'Request body failed schema validation',
-        details: validate.errors,
-      });
+      return;
     }
+
+    const errors = validate.errors ?? [];
+    next(
+      makeBadRequestError('Request body failed schema validation.', {
+        shouldErrorSpan: false,
+        pointer: errors[0] && toJsonPointer(errors[0]),
+        detail: formatErrors(errors),
+      }),
+    );
   };
+}
+
+/**
+ * Ajv's `instancePath` is already a JSON Pointer (e.g. `/items/0/name`), so we
+ * just normalise an empty string (root) to `undefined` and return it.
+ */
+function toJsonPointer(err: ErrorObject): string | undefined {
+  return err.instancePath.length > 0 ? err.instancePath : undefined;
+}
+
+/**
+ * Build a short human-readable summary of the validation errors. We only
+ * include Ajv's own `message` (which is derived from the schema, not the
+ * request body) and the JSON Pointer into the request. No `params`,
+ * `schemaPath`, or raw input data are exposed.
+ */
+function formatErrors(errors: readonly ErrorObject[]): string {
+  if (errors.length === 0) return 'Unknown validation error.';
+  return errors
+    .map((err) => {
+      const loc = err.instancePath || '/';
+      return `${loc}: ${err.message ?? 'invalid value'}`;
+    })
+    .join('; ');
 }

--- a/server/utils/bodySchemaValidation.ts
+++ b/server/utils/bodySchemaValidation.ts
@@ -1,0 +1,22 @@
+import type { RequestHandler } from 'express';
+import _Ajv from 'ajv-draft-04';
+
+const Ajv = _Ajv as unknown as typeof _Ajv.default;
+const ajv = new Ajv();
+
+export function createBodySchemaValidator(
+  schema: Record<string, unknown>,
+): RequestHandler {
+  const validate = ajv.compile(schema);
+  return (req, res, next) => {
+    if (validate(req.body)) {
+      next();
+    } else {
+      res.status(400).json({
+        error: 'VALIDATION_ERROR',
+        message: 'Request body failed schema validation',
+        details: validate.errors,
+      });
+    }
+  };
+}


### PR DESCRIPTION
## Context & Requests for Reviewers

SSL/TLS Support
- Add env-var-driven SSL/TLS support for PostgreSQL (Sequelize, Kysely pg pool, session store), Redis (IORedis), and Scylla/Keyspaces connections
- Controlled by `DATABASE_SSL`, `REDIS_TLS`, and `SCYLLA_SSL` env vars — no behavior change when unset
- Fixes locally-built Docker images failing to connect to AWS RDS (`no pg_hba.conf entry ... no encryption`) and ElastiCache

ReCharts
- Add `rechartsScaleWrapper.js` that wraps `recharts-scale` to guard against division-by-zero errors
- Alias `recharts-scale` to the wrapper via craco config

Body Schema Validation
- Add `bodySchemaValidation.ts` middleware for validating request bodies against schemas
- Wire it into the controller route registration in `api.ts`

## Tests

Unit tests added for `createBodySchemaValidator` middleware (`server/utils/bodySchemaValidation.test.ts`):
- Validates that valid request bodies pass through to next()
- Validates that optional fields can be omitted
- Validates that missing required fields return 400 with VALIDATION_ERROR
- Validates that wrong field types return 400 with VALIDATION_ERROR                                                                                                                                                              

SSL/TLS changes were manually verified by deploying to the dev ECS environment with `DATABASE_SSL=true` and `REDIS_TLS=true` set in the task definition. Confirmed successful connections to RDS and ElastiCache.

