### PR TITLE
Fix `create-org` and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,12 @@ and then follow the steps below:
    (cd server && npm install)
    (cd db && npm install)
    ```
-3. Make sure the `.env` files for `/server` and `db` are populated (including ClickHouse credentials). Run database migrations:
+3. Make sure the `.env` files for `/server` and `db` are populated (including ClickHouse credentials). Create databases and run migrations:
    ```bash
+   npm run db:create -- --env staging --db api-server-pg
+   npm run db:create -- --env staging --db scylla
+   npm run db:create -- --env staging --db clickhouse
+
    npm run db:update -- --env staging --db api-server-pg
    npm run db:update -- --env staging --db scylla
    npm run db:update -- --env staging --db clickhouse

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ npm install \
 5. Create an organization and admin user:
 ```bash
    npm run create-org
+
+6. Run `cd server && npm run copy-assets`
 ```
    
 Use the credentials provided to log in at `http://localhost:3000`.

--- a/server/bin/create-org-and-user.ts
+++ b/server/bin/create-org-and-user.ts
@@ -37,6 +37,12 @@ const argv = await yargs(hideBin(process.argv))
       type: 'string',
       demandOption: true,
       description: 'Organization website URL',
+      coerce: (value: string) => {
+        if (!/^https?:\/\//i.test(value)) {
+          return `https://${value}`;
+        }
+        return value;
+      },
     },
     firstName: {
       type: 'string',
@@ -65,26 +71,25 @@ async function createOrgAndUser() {
     const orgId = uid();
     const userId = uid();
 
-    // Create signing keys
-    await container.SigningKeyPairService.createAndStoreSigningKeys(orgId);
-
-    // Create API key
-    const { apiKey: rawApiKey, record: apiKeyRecord } =
-      await container.ApiKeyService.createApiKey(
-        orgId,
-        'Main API Key',
-        'Primary API key for organization',
-        null,
-      );
-
+    // Create org first so FK-dependent tables can reference it
     const org = await kyselyOrgInsert({
       db: container.KyselyPg,
       id: orgId,
       email: argv.email,
       name: argv.name,
       websiteUrl: argv.website,
-      apiKeyId: apiKeyRecord.id,
     });
+
+    // Create signing keys and API key (both reference org via FK)
+    await container.SigningKeyPairService.createAndStoreSigningKeys(orgId);
+
+    const { apiKey: rawApiKey } =
+      await container.ApiKeyService.createApiKey(
+        orgId,
+        'Main API Key',
+        'Primary API key for organization',
+        null,
+      );
 
     // Initialize org settings
     await Promise.all([


### PR DESCRIPTION
## Context & Requests for Reviewers
I ran into a few bumps running `coop` locally, so this PR introduces the changes I need to make to unblock myself.
- `npm run create-org` wasn't working because the org wasn't created before trying to make the key, so I reordered that.
- `websiteUrl` for `create-org` needs to pass kysely's URL validation, so I added a step in the CLI to prepend `https://` if a scheme isn't provided by the caller
- I had to run `npm run db:create` for all the dbs before migrating, so I added that as a step to the README.

## Tests

ran `npm run create-org` locally successfully
