### PR TITLE
fix: Add MRT backfill job

### DIFF
--- a/server/workers_jobs/RefreshMRTDecisionsMaterializedViewJob.ts
+++ b/server/workers_jobs/RefreshMRTDecisionsMaterializedViewJob.ts
@@ -25,9 +25,11 @@ export default inject(
           throw new Error('No last_insert timestamp found for the table');
         }
 
-        const oneMinutePrevious = new Date(
-          lastTimestamp.last_insert.valueOf() - MINUTE_MS,
-        );
+        // When last_insert is null (fresh deploy), do a full backfill
+        const isInitialBackfill = lastTimestamp.last_insert == null;
+        const oneMinutePrevious = isInitialBackfill
+          ? new Date(0)
+          : new Date(lastTimestamp.last_insert.valueOf() - MINUTE_MS);
 
         const insertedRows = await trx
           .insertInto('manual_review_tool.dim_mrt_decisions_materialized')


### PR DESCRIPTION
## Context & Requests for Reviewers

`RefreshMRTDecisionsMaterializedViewJob` crashes when `last_insert` is `null`, so the MRT analytics dashboard never gets data. This fix treats null as an initial backfill instead of crashing.

## Tests

Verified in deployment: materialized table went from 0 to 243 rows after applying this fix. Dashboard populated correctly.

<img width="1188" height="1128" alt="Screenshot 2026-04-28 at 11 19 52" src="https://github.com/user-attachments/assets/4c4d2ffb-8260-4b8a-a57f-b78038761b23" />
<img width="508" height="458" alt="Screenshot 2026-04-28 at 3 08 58 PM" src="https://github.com/user-attachments/assets/369924e2-7194-483b-be72-992168a015db" />
