### PR TITLE
[Kysely] Migration of condition result types off sequelize

### DIFF
--- a/codegen.yaml
+++ b/codegen.yaml
@@ -114,11 +114,11 @@ generates:
         # `buildGraphqlRuleParent` casts to it at the boundary.
         Rule: ../models/rules/RuleModel.js#Rule
         Condition: ../services/moderationConfigService/index.js#Condition
-        ConditionWithResult: ../models/rules/RuleModel.js#ConditionWithResult
+        ConditionWithResult: ../services/moderationConfigService/index.js#ConditionWithResult
         ConditionSet: ../services/moderationConfigService/index.js#ConditionSet
-        ConditionSetWithResult: ../models/rules/RuleModel.js#ConditionSetWithResult
+        ConditionSetWithResult: ../services/moderationConfigService/index.js#ConditionSetWithResult
         LeafCondition: ../services/moderationConfigService/index.js#LeafCondition
-        LeafConditionWithResult: ../models/rules/RuleModel.js#LeafConditionWithResult
+        LeafConditionWithResult: ../services/moderationConfigService/index.js#LeafConditionWithResult
         UserRule: ../models/rules/RuleModel.js#Rule
         ContentRule: ../models/rules/RuleModel.js#Rule
         RuleInsights: ../models/rules/RuleModel.js#Rule

--- a/server/condition_evaluator/condition.ts
+++ b/server/condition_evaluator/condition.ts
@@ -16,14 +16,12 @@
 import _ from 'lodash';
 import { type ReadonlyDeep } from 'type-fest';
 
-import {
-  ConditionCompletionOutcome,
-  ConditionFailureOutcome,
-  type ConditionOutcome,
-} from '../models/rules/RuleModel.js';
 import { getFieldDerivationCost } from '../services/derivedFieldsService/index.js';
 import {
   type Condition,
+  ConditionCompletionOutcome,
+  ConditionFailureOutcome,
+  type ConditionOutcome,
   type ConditionSet,
 } from '../services/moderationConfigService/index.js';
 import { type SignalId } from '../services/signalsService/index.js';

--- a/server/condition_evaluator/conditionSet.test.ts
+++ b/server/condition_evaluator/conditionSet.test.ts
@@ -1,8 +1,8 @@
 import fc from 'fast-check';
 import _ from 'lodash';
 
-import { ConditionCompletionOutcome } from '../models/rules/RuleModel.js';
 import {
+  ConditionCompletionOutcome,
   ConditionConjunction,
   type LeafCondition,
 } from '../services/moderationConfigService/index.js';

--- a/server/condition_evaluator/conditionSet.ts
+++ b/server/condition_evaluator/conditionSet.ts
@@ -1,20 +1,18 @@
 import _ from 'lodash';
 import { type ReadonlyDeep } from 'type-fest';
 
-import {
-  ConditionCompletionOutcome,
-  ConditionFailureOutcome,
-  type ConditionOutcome,
-  type ConditionSetWithResult,
-  type ConditionWithResult,
-  type LeafConditionWithResult,
-} from '../models/rules/RuleModel.js';
 import { type RuleEvaluationContext } from '../rule_engine/RuleEvaluator.js';
 import { type AggregationClause } from '../services/aggregationsService/index.js';
 import {
+  ConditionCompletionOutcome,
   ConditionConjunction,
+  ConditionFailureOutcome,
+  type ConditionOutcome,
   type ConditionSet,
+  type ConditionSetWithResult,
+  type ConditionWithResult,
   type LeafCondition,
+  type LeafConditionWithResult,
 } from '../services/moderationConfigService/index.js';
 import { equalLengthZip } from '../utils/fp-helpers.js';
 import { assertUnreachable } from '../utils/misc.js';

--- a/server/condition_evaluator/leafCondition.test.ts
+++ b/server/condition_evaluator/leafCondition.test.ts
@@ -1,7 +1,7 @@
 import fc from 'fast-check';
 
-import { ConditionCompletionOutcome } from '../models/rules/RuleModel.js';
 import type { RuleEvaluationContext } from '../rule_engine/RuleEvaluator.js';
+import { ConditionCompletionOutcome } from '../services/moderationConfigService/index.js';
 import { SignalType } from '../services/signalsService/index.js';
 import {
   LeafConditionArbitrary,

--- a/server/condition_evaluator/leafCondition.ts
+++ b/server/condition_evaluator/leafCondition.ts
@@ -12,11 +12,6 @@ import {
   type TaggedItemData,
 } from '../models/rules/item-type-fields.js';
 import {
-  ConditionCompletionOutcome,
-  ConditionFailureOutcome,
-  type ConditionResult,
-} from '../models/rules/RuleModel.js';
-import {
   getUserFromRuleInput,
   isFullSubmission,
   type RuleEvaluationContext,
@@ -31,10 +26,13 @@ import {
 } from '../services/itemProcessingService/index.js';
 import {
   CoopInput,
-  ValueComparator,
+  ConditionCompletionOutcome,
+  ConditionFailureOutcome,
   type ConditionInput,
+  type ConditionResult,
   type ConditionSignalInfo,
   type LeafCondition,
+  ValueComparator,
 } from '../services/moderationConfigService/index.js';
 import {
   isSignalErrorResult,

--- a/server/graphql/generated.ts
+++ b/server/graphql/generated.ts
@@ -20,12 +20,7 @@ import type { ReportingInsights } from '../graphql/modules/reporting.js';
 import type { HashBank } from '../models/HashBankModel.js';
 import type { Backtest } from '../models/rules/BacktestModel.js';
 import type { ItemType } from '../models/rules/ItemTypeModel.js';
-import type {
-  ConditionSetWithResult,
-  ConditionWithResult,
-  LeafConditionWithResult,
-  Rule,
-} from '../models/rules/RuleModel.js';
+import type { Rule } from '../models/rules/RuleModel.js';
 import type { User } from '../models/UserModel.js';
 import type { SignalWithScore } from '../services/analyticsQueries/RuleActionInsights.js';
 import type { DerivedFieldSpecSource } from '../services/derivedFieldsService/helpers.js';
@@ -46,7 +41,10 @@ import type { RoutingRuleWithoutVersion } from '../services/manualReviewToolServ
 import type {
   Condition,
   ConditionSet,
+  ConditionSetWithResult,
+  ConditionWithResult,
   LeafCondition,
+  LeafConditionWithResult,
 } from '../services/moderationConfigService/index.js';
 import type {
   CustomAction,

--- a/server/graphql/modules/investigation.ts
+++ b/server/graphql/modules/investigation.ts
@@ -3,7 +3,7 @@ import { type DateString } from '@roostorg/types';
 
 import _ from 'lodash';
 
-import { type ConditionSetWithResult } from '../../models/rules/RuleModel.js';
+import { type ConditionSetWithResult } from '../../services/moderationConfigService/index.js';
 import {
   getFieldValueForRole,
   type ItemSubmission,

--- a/server/models/rules/RuleModel.ts
+++ b/server/models/rules/RuleModel.ts
@@ -22,18 +22,6 @@ import { type User } from '../UserModel.js';
 import { type SequelizeAction } from './ActionModel.js';
 import { type RuleLatestVersion } from './RuleLatestVersionModel.js';
 
-export {
-  ConditionCompletionOutcome,
-  ConditionFailureOutcome,
-  type ConditionOutcome,
-  type ConditionCompletionMetadata,
-  type ConditionFailureMetadata,
-  type ConditionResult,
-  type ConditionWithResult,
-  type ConditionSetWithResult,
-  type LeafConditionWithResult,
-} from './ruleTypes.js';
-
 const { Model, Op } = sequelize;
 const { without } = _;
 

--- a/server/models/rules/ruleTypes.ts
+++ b/server/models/rules/ruleTypes.ts
@@ -1,74 +1,12 @@
-import { type ScalarType, type TaggedScalar } from '@roostorg/types';
-
 import {
   type RuleAlarmStatus,
   RuleStatus,
   type RuleType,
   type ConditionSet,
-  type LeafCondition,
   type Action,
   type Policy,
 } from '../../services/moderationConfigService/index.js';
-import { type SerializableError } from '../../utils/errors.js';
-import {
-  type NonEmptyArray,
-  type WithUndefined,
-} from '../../utils/typescript-types.js';
 import { type User } from '../UserModel.js';
-import { type TaggedItemData } from './item-type-fields.js';
-
-export enum ConditionCompletionOutcome {
-  PASSED = 'PASSED',
-  FAILED = 'FAILED',
-  INAPPLICABLE = 'INAPPLICABLE',
-}
-
-export enum ConditionFailureOutcome {
-  ERRORED = 'ERRORED',
-}
-
-export type ConditionOutcome =
-  | ConditionCompletionOutcome
-  | ConditionFailureOutcome;
-
-export type ConditionCompletionMetadata = {
-  score?: string;
-  matchedValue?: string;
-};
-
-export type ConditionFailureMetadata = {
-  error?: SerializableError;
-};
-
-type ConditionResultCommonMetadata = {
-  signalInputValues?: (TaggedScalar<ScalarType> | TaggedItemData)[];
-};
-
-// prettier-ignore
-export type ConditionResult =
-  | ({ outcome: ConditionCompletionOutcome }
-        & ConditionCompletionMetadata
-        & Partial<Pick<ConditionFailureMetadata, 'error'>>
-        & ConditionResultCommonMetadata)
-  | ({ outcome: ConditionFailureOutcome; }
-        & ConditionFailureMetadata
-        & WithUndefined<ConditionCompletionMetadata>
-        & ConditionResultCommonMetadata)
-
-export type ConditionWithResult =
-  | LeafConditionWithResult
-  | ConditionSetWithResult;
-
-export type ConditionSetWithResult = Omit<ConditionSet, 'conditions'> & {
-  conditions:
-    | NonEmptyArray<LeafConditionWithResult>
-    | NonEmptyArray<ConditionSetWithResult>;
-  result?: ConditionResult;
-};
-
-export type LeafConditionWithResult = LeafCondition & {
-  result?: ConditionResult;
-};
 
 export type RuleLatestVersionRow = {
   ruleId: string;

--- a/server/rule_engine/RuleEngine.ts
+++ b/server/rule_engine/RuleEngine.ts
@@ -7,14 +7,14 @@ import {
 } from '../condition_evaluator/conditionSet.js';
 import { type Dependencies } from '../iocContainer/index.js';
 import { inject } from '../iocContainer/utils.js';
-import { ConditionCompletionOutcome } from '../models/rules/RuleModel.js';
 import { type PlainRuleWithLatestVersion } from '../models/rules/ruleTypes.js';
 import { evaluateAggregationRuntimeArgsForItem } from '../services/aggregationsService/index.js';
 import { type ItemSubmission } from '../services/itemProcessingService/index.js';
 import {
-  RuleStatus,
   type Action,
+  ConditionCompletionOutcome,
   type ConditionSet,
+  RuleStatus,
 } from '../services/moderationConfigService/index.js';
 import { type RuleExecutionCorrelationId } from '../services/analyticsLoggers/index.js';
 import {

--- a/server/rule_engine/RuleEvaluator.ts
+++ b/server/rule_engine/RuleEvaluator.ts
@@ -6,7 +6,6 @@ import { getConditionSetResults } from '../condition_evaluator/conditionSet.js';
 import makeGetDerivedFieldValueWithCache from '../condition_evaluator/getDerivedFieldValue.js';
 import { type Dependencies } from '../iocContainer/index.js';
 import { inject } from '../iocContainer/utils.js';
-import { type ConditionSetWithResult } from '../models/rules/RuleModel.js';
 import {
   type DerivedFieldSpec,
   type DerivedFieldValue,
@@ -14,6 +13,7 @@ import {
 import { type ItemSubmission } from '../services/itemProcessingService/index.js';
 import {
   type ConditionSet,
+  type ConditionSetWithResult,
   type ItemType,
 } from '../services/moderationConfigService/index.js';
 import { type TransientRunSignalWithCache } from '../services/orgAwareSignalExecutionService/index.js';

--- a/server/services/analyticsLoggers/ReportingRuleExecutionLogger.ts
+++ b/server/services/analyticsLoggers/ReportingRuleExecutionLogger.ts
@@ -3,9 +3,9 @@ import { type ReadonlyDeep } from 'type-fest';
 
 import { type Dependencies } from '../../iocContainer/index.js';
 import { inject } from '../../iocContainer/utils.js';
-import { type ConditionSetWithResult } from '../../models/rules/RuleModel.js';
 import { type RuleEnvironment } from '../../rule_engine/RuleEngine.js';
 import { type ItemSubmission } from '../../services/itemProcessingService/index.js';
+import { type ConditionSetWithResult } from '../../services/moderationConfigService/index.js';
 import { type ReportingRuleExecutionCorrelationId } from '../../services/reportingService/index.js';
 import { fromCorrelationId } from '../../utils/correlationIds.js';
 import { jsonStringify } from '../../utils/encoding.js';

--- a/server/services/analyticsLoggers/RoutingRuleExecutionLogger.ts
+++ b/server/services/analyticsLoggers/RoutingRuleExecutionLogger.ts
@@ -3,12 +3,12 @@ import { type ReadonlyDeep } from 'type-fest';
 
 import { type Dependencies } from '../../iocContainer/index.js';
 import { inject } from '../../iocContainer/utils.js';
-import { type ConditionSetWithResult } from '../../models/rules/RuleModel.js';
 import {
   isFullSubmission,
   type RuleInput,
 } from '../../rule_engine/RuleEvaluator.js';
 import { type ManualReviewJobKind } from '../../services/manualReviewToolService/index.js';
+import { type ConditionSetWithResult } from '../../services/moderationConfigService/index.js';
 import { fromCorrelationId } from '../../utils/correlationIds.js';
 import { jsonStringifyUnstable } from '../../utils/encoding.js';
 import { getUtcDateOnlyString } from '../../utils/time.js';

--- a/server/services/analyticsLoggers/RuleExecutionLogger.ts
+++ b/server/services/analyticsLoggers/RuleExecutionLogger.ts
@@ -3,8 +3,8 @@ import { type ReadonlyDeep } from 'type-fest';
 
 import { type Dependencies } from '../../iocContainer/index.js';
 import { inject } from '../../iocContainer/utils.js';
-import { type ConditionSetWithResult } from '../../models/rules/RuleModel.js';
 import { type RuleEnvironment } from '../../rule_engine/RuleEngine.js';
+import { type ConditionSetWithResult } from '../../services/moderationConfigService/index.js';
 import { fromCorrelationId } from '../../utils/correlationIds.js';
 import { jsonStringifyUnstable } from '../../utils/encoding.js';
 

--- a/server/services/analyticsLoggers/ruleExecutionLoggingUtils.ts
+++ b/server/services/analyticsLoggers/ruleExecutionLoggingUtils.ts
@@ -1,14 +1,14 @@
 import { type ReadonlyDeep } from 'type-fest';
 
 import { isConditionSet } from '../../condition_evaluator/condition.js';
+import { type LocationArea } from '../../models/types/locationArea.js';
+import { type DerivedFieldSpec } from '../../services/derivedFieldsService/index.js';
 import {
   type ConditionResult,
   type ConditionSetWithResult,
+  type CoopInput,
   type LeafConditionWithResult,
-} from '../../models/rules/RuleModel.js';
-import { type LocationArea } from '../../models/types/locationArea.js';
-import { type DerivedFieldSpec } from '../../services/derivedFieldsService/index.js';
-import { type CoopInput } from '../../services/moderationConfigService/index.js';
+} from '../../services/moderationConfigService/index.js';
 import { isSignalId } from '../../services/signalsService/index.js';
 import { type CorrelationId } from '../../utils/correlationIds.js';
 import { jsonParse, tryJsonParse, type JsonOf } from '../../utils/encoding.js';

--- a/server/services/analyticsQueries/RuleActionInsights.ts
+++ b/server/services/analyticsQueries/RuleActionInsights.ts
@@ -5,9 +5,9 @@ import { match } from 'ts-pattern';
 import { formatClickhouseQuery } from '../../plugins/warehouse/utils/clickhouseSql.js';
 import { type Dependencies } from '../../iocContainer/index.js';
 import { inject } from '../../iocContainer/utils.js';
-import type { ConditionWithResult } from '../../models/rules/RuleModel.js';
 import { type RuleEnvironment } from '../../rule_engine/RuleEngine.js';
 import { type NormalizedItemData } from '../../services/itemProcessingService/index.js';
+import { type ConditionWithResult } from '../../services/moderationConfigService/index.js';
 import {
   BuiltInThirdPartySignalType,
   SignalType,

--- a/server/services/moderationConfigService/index.ts
+++ b/server/services/moderationConfigService/index.ts
@@ -30,6 +30,18 @@ export {
 } from './types/rules.js';
 
 export {
+  ConditionCompletionOutcome,
+  ConditionFailureOutcome,
+  ConditionOutcome,
+  ConditionCompletionMetadata,
+  ConditionFailureMetadata,
+  ConditionResult,
+  ConditionWithResult,
+  ConditionSetWithResult,
+  LeafConditionWithResult,
+} from './types/conditionResults.js';
+
+export {
   Action,
   ActionType,
   CustomAction,

--- a/server/services/moderationConfigService/types/conditionResults.ts
+++ b/server/services/moderationConfigService/types/conditionResults.ts
@@ -1,0 +1,69 @@
+import { type ScalarType, type TaggedScalar } from '@roostorg/types';
+
+import { type TaggedItemData } from '../../../models/rules/item-type-fields.js';
+import { type SerializableError } from '../../../utils/errors.js';
+import {
+  type NonEmptyArray,
+  type WithUndefined,
+} from '../../../utils/typescript-types.js';
+import { type ConditionSet, type LeafCondition } from './rules.js';
+
+/**
+ * Outcome + result types for condition evaluation. Lived on
+ * `models/rules/RuleModel.ts` (via `ruleTypes.ts`) for historical reasons but
+ * they don't depend on Sequelize — moving them here keeps them importable from
+ * Sequelize-free code paths once the `models/*Model.ts` files are deleted.
+ */
+
+export enum ConditionCompletionOutcome {
+  PASSED = 'PASSED',
+  FAILED = 'FAILED',
+  INAPPLICABLE = 'INAPPLICABLE',
+}
+
+export enum ConditionFailureOutcome {
+  ERRORED = 'ERRORED',
+}
+
+export type ConditionOutcome =
+  | ConditionCompletionOutcome
+  | ConditionFailureOutcome;
+
+export type ConditionCompletionMetadata = {
+  score?: string;
+  matchedValue?: string;
+};
+
+export type ConditionFailureMetadata = {
+  error?: SerializableError;
+};
+
+type ConditionResultCommonMetadata = {
+  signalInputValues?: (TaggedScalar<ScalarType> | TaggedItemData)[];
+};
+
+// prettier-ignore
+export type ConditionResult =
+  | ({ outcome: ConditionCompletionOutcome }
+        & ConditionCompletionMetadata
+        & Partial<Pick<ConditionFailureMetadata, 'error'>>
+        & ConditionResultCommonMetadata)
+  | ({ outcome: ConditionFailureOutcome; }
+        & ConditionFailureMetadata
+        & WithUndefined<ConditionCompletionMetadata>
+        & ConditionResultCommonMetadata)
+
+export type ConditionWithResult =
+  | LeafConditionWithResult
+  | ConditionSetWithResult;
+
+export type ConditionSetWithResult = Omit<ConditionSet, 'conditions'> & {
+  conditions:
+    | NonEmptyArray<LeafConditionWithResult>
+    | NonEmptyArray<ConditionSetWithResult>;
+  result?: ConditionResult;
+};
+
+export type LeafConditionWithResult = LeafCondition & {
+  result?: ConditionResult;
+};

--- a/server/test/arbitraries/Condition.ts
+++ b/server/test/arbitraries/Condition.ts
@@ -3,10 +3,8 @@ import fc, { type Arbitrary } from 'fast-check';
 import { outcomeToNullableBool } from '../../condition_evaluator/condition.js';
 import {
   ConditionCompletionOutcome,
-  ConditionFailureOutcome,
-} from '../../models/rules/RuleModel.js';
-import {
   ConditionConjunction,
+  ConditionFailureOutcome,
   ValueComparator,
   type ConditionInput,
   type ConditionSet,


### PR DESCRIPTION
## Context & Requests for Reviewers

Moves the nine condition-result types out of `server/models/rules/RuleModel.ts` (via `ruleTypes.ts`) into a new Sequelize-free home at `server/services/moderationConfigService/types/conditionResults.ts`, and flips the three associated GraphQL codegen mappers. This is pure prep work for the final Sequelize removal no real logic changes yet.

The reasoning behind this is that the codegen mapper for Rule, Backtest and ItemType would be blocked on the RuleModel.ts still being the top level home for these types even tho they do not depend on sequelize. Moving this would allow us to stop the transitive imports from the models. And keeping prs on the smaller side for review.

Follow up pr will do the actual flip on the codegen and the RuleModel.ts itself.