### PR TITLE
Make Kysely work with NoOp data warehouse adapter

### DIFF
--- a/server/storage/dataWarehouse/DataWarehouseFactory.ts
+++ b/server/storage/dataWarehouse/DataWarehouseFactory.ts
@@ -27,6 +27,7 @@ import {
   type DataWarehouseProvider as IDataWarehouseProvider,
   type TransactionFunction,
 } from './IDataWarehouse.js';
+import { type Kysely } from 'kysely';
 import type {
   AnalyticsSchema,
   BulkWriteConfig,
@@ -70,6 +71,22 @@ export type DataWarehouseConfig =
       provider: 'noop';
       analyticsProvider?: AnalyticsProvider;
     };
+
+class NoOpKyselyDialect implements IDataWarehouseDialect {
+  getKyselyInstance(): Kysely<any> {
+    // Return a proxy that throws only when a query is actually executed,
+    // allowing services to hold a reference without crashing at startup.
+    return new Proxy({} as Kysely<any>, {
+      get(_target, prop) {
+        if (prop === 'destroy') return async () => {};
+        return () => {
+          throw new Error('NoOp dialect: Kysely queries are not supported');
+        };
+      },
+    });
+  }
+  async destroy(): Promise<void> {}
+}
 
 class WarehouseAdapterBridge implements IDataWarehouse {
   constructor(
@@ -225,7 +242,7 @@ export class DataWarehouseFactory {
       case 'postgresql':
         throw new Error('PostgreSQL Kysely dialect not yet implemented');
       case 'noop':
-        throw new Error('NoOp provider does not support Kysely dialect');
+        return new NoOpKyselyDialect();
       default:
         return assertUnreachable(
           config,

--- a/server/storage/dataWarehouse/DataWarehouseFactory.ts
+++ b/server/storage/dataWarehouse/DataWarehouseFactory.ts
@@ -74,8 +74,8 @@ export type DataWarehouseConfig =
 
 class NoOpKyselyDialect implements IDataWarehouseDialect {
   getKyselyInstance(): Kysely<any> {
-    // Return a proxy that throws only when a query is actually executed,
-    // allowing services to hold a reference without crashing at startup.
+    // Return a proxy so services can hold a Kysely reference without
+    // crashing at startup; any attempt to build or execute a query throws.
     return new Proxy({} as Kysely<any>, {
       get(_target, prop) {
         if (prop === 'destroy') return async () => {};

--- a/server/storage/dataWarehouse/DataWarehouseFactory.ts
+++ b/server/storage/dataWarehouse/DataWarehouseFactory.ts
@@ -79,6 +79,8 @@ class NoOpKyselyDialect implements IDataWarehouseDialect {
     return new Proxy({} as Kysely<any>, {
       get(_target, prop) {
         if (prop === 'destroy') return async () => {};
+        if (prop === 'then') return undefined; // not thenable
+        if (typeof prop === 'symbol') return undefined;
         return () => {
           throw new Error('NoOp dialect: Kysely queries are not supported');
         };


### PR DESCRIPTION
## Context & Requests for Reviewers
When trying to deploy coop with a `NoOp` warehouse adapter, I ran into errors about there being no Kysely dialect for that adapter. This changes the behavior to instead only throw errors when queries are actually attempted, instead of on startup.

## Tests
Was able to successfully deploy this code to AWS. Also was able to run locally still.
