### PR TITLE
fix: open Jaeger URL cross-platform in npm up

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "generate:watch": "graphql-codegen --watch \"server/graphql/**/**.ts\"",
     "prepare": "husky install",
     "lint": "cd client && npm run lint; cd ../server && npm run lint",
-    "up": "docker compose up --detach postgres clickhouse hma scylla redis otel-collector && open http://localhost:16686",
+    "up": "docker compose up --detach postgres clickhouse hma scylla redis otel-collector && (open http://localhost:16686 || xdg-open http://localhost:16686)",
     "down": "docker compose down"
   },
   "dependencies": {


### PR DESCRIPTION
Tiny nit noticed when getting Coop running locally. Fall back to `xdg-open` to open the Jaeger URL on both both macOS and Linux. Fixes #355