### PR TITLE
fix: contain Radix Switch hidden inputs in proactive rule form

### DIFF
--- a/client/src/webpages/dashboard/rules/rule_form/RuleForm.tsx
+++ b/client/src/webpages/dashboard/rules/rule_form/RuleForm.tsx
@@ -1870,10 +1870,7 @@ export default function RuleForm() {
   */
 
   return (
-    // relative: contains the Radix Switch hidden inputs (rendered when the
-    // advanced settings section is expanded). Without a positioned ancestor
-    // they escape the inner scroll container and extend window scrollHeight
-    // past the form's content. See issue #168.
+    // relative to prevent overflow/scrolling issues; see issue #168
     <div className="flex flex-col test-start relative">
       <Helmet>
         <title>{id == null ? 'Create Rule' : 'Update Rule'}</title>

--- a/client/src/webpages/dashboard/rules/rule_form/RuleForm.tsx
+++ b/client/src/webpages/dashboard/rules/rule_form/RuleForm.tsx
@@ -1870,7 +1870,11 @@ export default function RuleForm() {
   */
 
   return (
-    <div className="flex flex-col test-start">
+    // relative: contains the Radix Switch hidden inputs (rendered when the
+    // advanced settings section is expanded). Without a positioned ancestor
+    // they escape the inner scroll container and extend window scrollHeight
+    // past the form's content. See issue #168.
+    <div className="flex flex-col test-start relative">
       <Helmet>
         <title>{id == null ? 'Create Rule' : 'Update Rule'}</title>
       </Helmet>


### PR DESCRIPTION
Closes #168.

## Context & Requests for Reviewers

Radix's `<Switch>` (used by the toggles in advanced settings) renders a hidden absolutely-positioned `<input>`. With no positioned ancestor, its containing block defaults to `<html>`, so it escapes the rule form's scroll container and extends document scroll height past the form's actual content, leaving the empty whitespace below "Create Rule" reported in the issue.

The fix adds `position: relative` to the form's outermost wrapper. That makes the form the containing block for the hidden inputs, keeping them inside the form's layout box and the scroll container's clip.

The bug only surfaces when Advanced Settings is expanded (that's when those Switches mount). Reproduced on Chrome and Firefox on macOS - broader than the original Firefox-only report.

## Tests

- [x] Reproduced the bug locally on Chrome on macOS at `/dashboard/rules/proactive/form/`: filled basic info -> condition -> action -> expanded Advanced Settings -> Scroll down ->  ~half-viewport empty space appeared below "Create Rule".
- [x] Confirmed the fix resolves it: empty space is gone with the change applied.
- [x] Confirmed the bug returns when the change is reverted (stashed the fix and re-tested).
- [x] Visual smoke check on `/dashboard/rules/proactive`, `/dashboard/rules/proactive/info/<id>`, edit-existing-rule, `/dashboard/rules/banks` - no regressions.
- [x] `cd client && npm run lint` passes (0 errors; warnings are pre-existing).

### Before
<img width="2056" height="1329" alt="Screenshot 2026-04-30 at 20 30 54" src="https://github.com/user-attachments/assets/f633b680-9abb-434d-98d1-559f760a1716" />

### After

https://github.com/user-attachments/assets/29f5b210-e990-4350-9ca0-93c7be56de26


## (Optional) Rollout Plan

None. UI-only single-line layout fix with a clarifying comment.


