### PR TITLE
[Kysely] Migrate HashBank and Backtest GraphQL mappers off sequelize

### DIFF
--- a/codegen.yaml
+++ b/codegen.yaml
@@ -95,10 +95,10 @@ generates:
         EnqueueToMrtAction: ../services/moderationConfigService/types/actions.js#EnqueueToMrtAction
         EnqueueToNcmecAction: ../services/moderationConfigService/types/actions.js#EnqueueToNcmecAction
         EnqueueAuthorToMrtAction: ../services/moderationConfigService/types/actions.js#EnqueueAuthorToMrtAction
-        Backtest: ../models/rules/BacktestModel.js#Backtest
+        Backtest: ../graphql/datasources/ruleKyselyPersistence.js#GraphQLBacktestParent
         ContentType: ../services/moderationConfigService/types/itemTypes.js#ItemType
         DerivedFieldSource: ../services/derivedFieldsService/helpers.js#DerivedFieldSpecSource
-        HashBank: ../models/HashBankModel.js#HashBank
+        HashBank: ../services/hmaService/index.js#HashBank
         Org: ../graphql/datasources/orgKyselyPersistence.js#GraphQLOrgParent
         # NB: `MatchingBanks` is currently resolved by returning the `Org`
         # parent, and its sub-resolvers only read `org.id`. A bit unusual, as

--- a/server/graphql/datasources/RuleApi.ts
+++ b/server/graphql/datasources/RuleApi.ts
@@ -7,7 +7,7 @@ import { type Kysely } from 'kysely';
 import { uid } from 'uid';
 
 import { inject, type Dependencies } from '../../iocContainer/index.js';
-import { type Backtest } from '../../models/rules/BacktestModel.js';
+import { type GraphQLBacktestParent } from './ruleKyselyPersistence.js';
 import { type ActionCountsInput } from '../../services/actionStatisticsService/index.js';
 import { type AggregationClause } from '../../services/aggregationsService/index.js';
 import { type ConditionSetWithResultAsLogged } from '../../services/analyticsLoggers/index.js';
@@ -670,7 +670,7 @@ class RuleAPI {
   async createBacktest(
     _input: GQLCreateBacktestInput,
     _user: GraphQLUserParent,
-  ): Promise<Backtest> {
+  ): Promise<GraphQLBacktestParent> {
     throw new Error(
       'createBacktest is temporarily disabled (TODO BACKTEST_RETROACTION: no UI / env to validate).',
     );

--- a/server/graphql/datasources/ruleKyselyPersistence.ts
+++ b/server/graphql/datasources/ruleKyselyPersistence.ts
@@ -2,6 +2,7 @@ import { type Insertable, type Kysely, type Updateable, sql } from 'kysely';
 
 import { computeRuleStatusFromRow } from '../../models/rules/ruleTypes.js';
 import { type CombinedPg } from '../../services/combinedDbTypes.js';
+import { type BacktestStatusDb } from '../../services/coreAppTables.js';
 import { makeNotFoundError } from '../../utils/errors.js';
 import {
   RuleAlarmStatus,
@@ -9,7 +10,25 @@ import {
   RuleType,
   type ConditionSet,
 } from '../../services/moderationConfigService/index.js';
-import { type Backtest } from '../../models/rules/BacktestModel.js';
+
+export type GraphQLBacktestParent = {
+  id: string;
+  ruleId: string;
+  creatorId: string;
+  sampleDesiredSize: number;
+  sampleActualSize: number;
+  sampleStartAt: Date;
+  sampleEndAt: Date;
+  samplingComplete: boolean;
+  contentItemsProcessed: number;
+  contentItemsMatched: number;
+  status: BacktestStatusDb;
+  createdAt: Date;
+  updatedAt: Date;
+  cancelationDate: Date | null;
+  correctedContentItemsProcessed: number;
+  correctedContentItemsMatched: number;
+};
 
 /** Matches `public.backtests.status` when generated value is RUNNING. */
 const backtestRunningPredicate = sql<boolean>`cancelation_date is null
@@ -344,7 +363,7 @@ export async function kyselyListBacktestsForRule(
   kysely: Kysely<CombinedPg>,
   ruleId: string,
   backtestIds?: readonly string[] | null,
-): Promise<Backtest[]> {
+): Promise<GraphQLBacktestParent[]> {
   let q = kysely
     .selectFrom('public.backtests')
     .selectAll()
@@ -353,10 +372,10 @@ export async function kyselyListBacktestsForRule(
     q = q.where('id', 'in', [...backtestIds]);
   }
   const rows = await q.execute();
-  return rows.map((r) => mapBacktestRowToGqlParent(r)) as unknown as Backtest[];
+  return rows.map((r) => mapBacktestRowToGqlParent(r));
 }
 
-function mapBacktestRowToGqlParent(r: {
+export function mapBacktestRowToGqlParent(r: {
   id: string;
   rule_id: string;
   creator_id: string;
@@ -367,11 +386,13 @@ function mapBacktestRowToGqlParent(r: {
   sampling_complete: boolean;
   content_items_processed: number;
   content_items_matched: number;
-  status: string;
+  status: BacktestStatusDb;
   created_at: Date;
   updated_at: Date;
   cancelation_date: Date | null;
-}) {
+}): GraphQLBacktestParent {
+  // Queues deliver sampled items at-least-once, so processed/matched counters
+  // can rarely exceed sample_actual_size. Clamp the values exposed to clients.
   const correctedContentItemsProcessed = Math.min(
     r.sample_actual_size,
     r.content_items_processed,

--- a/server/graphql/generated.ts
+++ b/server/graphql/generated.ts
@@ -8,6 +8,7 @@ import { JsonObject, JsonValue } from 'type-fest';
 
 import type { UserHistoryForGQL } from '../graphql/datasources/InvestigationApi.js';
 import type { GraphQLOrgParent } from '../graphql/datasources/orgKyselyPersistence.js';
+import type { GraphQLBacktestParent } from '../graphql/datasources/ruleKyselyPersistence.js';
 import type { GraphQLUserParent } from '../graphql/datasources/userKyselyPersistence.js';
 import type {
   ContentItemTypeResolversParentType,
@@ -18,11 +19,10 @@ import type {
   UserItemTypeResolversParentType,
 } from '../graphql/modules/itemType.js';
 import type { ReportingInsights } from '../graphql/modules/reporting.js';
-import type { HashBank } from '../models/HashBankModel.js';
-import type { Backtest } from '../models/rules/BacktestModel.js';
 import type { Rule } from '../models/rules/RuleModel.js';
 import type { SignalWithScore } from '../services/analyticsQueries/RuleActionInsights.js';
 import type { DerivedFieldSpecSource } from '../services/derivedFieldsService/helpers.js';
+import type { HashBank } from '../services/hmaService/index.js';
 import type {
   ContentAppealReviewJobPayload,
   ContentManualReviewJobPayload,
@@ -5444,7 +5444,7 @@ export type GQLResolversTypes = {
   AppealSettings: ResolverTypeWrapper<GQLAppealSettings>;
   AppealSettingsInput: GQLAppealSettingsInput;
   AutomaticCloseDecisionComponent: ResolverTypeWrapper<GQLAutomaticCloseDecisionComponent>;
-  Backtest: ResolverTypeWrapper<Backtest>;
+  Backtest: ResolverTypeWrapper<GraphQLBacktestParent>;
   BacktestStatus: GQLBacktestStatus;
   BaseField: ResolverTypeWrapper<GQLBaseField>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
@@ -6274,7 +6274,7 @@ export type GQLResolversParentTypes = {
   AppealSettings: GQLAppealSettings;
   AppealSettingsInput: GQLAppealSettingsInput;
   AutomaticCloseDecisionComponent: GQLAutomaticCloseDecisionComponent;
-  Backtest: Backtest;
+  Backtest: GraphQLBacktestParent;
   BaseField: GQLBaseField;
   Boolean: Scalars['Boolean']['output'];
   CannotDeleteDefaultUserError: GQLCannotDeleteDefaultUserError;

--- a/server/graphql/modules/backtest.resolver.test.ts
+++ b/server/graphql/modules/backtest.resolver.test.ts
@@ -1,5 +1,125 @@
 import { UserRole } from '../../models/types/permissioning.js';
+import {
+  type GraphQLBacktestParent,
+  mapBacktestRowToGqlParent,
+} from '../datasources/ruleKyselyPersistence.js';
 import { resolvers } from './backtest.js';
+
+function makeBacktestRow(overrides: Partial<{
+  id: string;
+  rule_id: string;
+  creator_id: string;
+  sample_desired_size: number;
+  sample_actual_size: number;
+  sample_start_at: Date;
+  sample_end_at: Date;
+  sampling_complete: boolean;
+  content_items_processed: number;
+  content_items_matched: number;
+  status: 'RUNNING' | 'COMPLETE' | 'CANCELED';
+  created_at: Date;
+  updated_at: Date;
+  cancelation_date: Date | null;
+}> = {}) {
+  const now = new Date('2026-01-01T00:00:00Z');
+  return {
+    id: 'bt-1',
+    rule_id: 'rule-1',
+    creator_id: 'user-1',
+    sample_desired_size: 100,
+    sample_actual_size: 80,
+    sample_start_at: now,
+    sample_end_at: now,
+    sampling_complete: true,
+    content_items_processed: 50,
+    content_items_matched: 10,
+    status: 'COMPLETE' as const,
+    created_at: now,
+    updated_at: now,
+    cancelation_date: null,
+    ...overrides,
+  };
+}
+
+describe('mapBacktestRowToGqlParent', () => {
+  it('round-trips snake_case columns to camelCase fields', () => {
+    const row = makeBacktestRow();
+    const parent = mapBacktestRowToGqlParent(row);
+    expect(parent).toMatchObject({
+      id: row.id,
+      ruleId: row.rule_id,
+      creatorId: row.creator_id,
+      sampleDesiredSize: row.sample_desired_size,
+      sampleActualSize: row.sample_actual_size,
+      sampleStartAt: row.sample_start_at,
+      sampleEndAt: row.sample_end_at,
+      samplingComplete: row.sampling_complete,
+      contentItemsProcessed: row.content_items_processed,
+      contentItemsMatched: row.content_items_matched,
+      status: row.status,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      cancelationDate: row.cancelation_date,
+    });
+  });
+
+  it('clamps correctedContentItemsProcessed at sampleActualSize when items overshoot', () => {
+    // Queues deliver at-least-once, so processed can exceed actual size.
+    const parent = mapBacktestRowToGqlParent(
+      makeBacktestRow({
+        sample_actual_size: 80,
+        content_items_processed: 95,
+        content_items_matched: 5,
+      }),
+    );
+    expect(parent.correctedContentItemsProcessed).toBe(80);
+  });
+
+  it('clamps correctedContentItemsMatched at correctedContentItemsProcessed', () => {
+    const parent = mapBacktestRowToGqlParent(
+      makeBacktestRow({
+        sample_actual_size: 80,
+        content_items_processed: 50,
+        content_items_matched: 60,
+      }),
+    );
+    expect(parent.correctedContentItemsProcessed).toBe(50);
+    expect(parent.correctedContentItemsMatched).toBe(50);
+  });
+
+  it('passes through processed/matched values when below the clamp ceilings', () => {
+    const parent = mapBacktestRowToGqlParent(
+      makeBacktestRow({
+        sample_actual_size: 80,
+        content_items_processed: 30,
+        content_items_matched: 5,
+      }),
+    );
+    expect(parent.correctedContentItemsProcessed).toBe(30);
+    expect(parent.correctedContentItemsMatched).toBe(5);
+  });
+});
+
+describe('Backtest field resolvers', () => {
+  function parent(
+    overrides: Partial<GraphQLBacktestParent> = {},
+  ): GraphQLBacktestParent {
+    return {
+      ...mapBacktestRowToGqlParent(makeBacktestRow()),
+      ...overrides,
+    };
+  }
+
+  it('Backtest.contentItemsProcessed returns the corrected (clamped) value', () => {
+    const source = parent({ correctedContentItemsProcessed: 42 });
+    expect(resolvers.Backtest.contentItemsProcessed(source)).toBe(42);
+  });
+
+  it('Backtest.contentItemsMatched returns the corrected (clamped) value', () => {
+    const source = parent({ correctedContentItemsMatched: 7 });
+    expect(resolvers.Backtest.contentItemsMatched(source)).toBe(7);
+  });
+});
 
 describe('backtest resolvers', () => {
   describe('Mutation.createBacktest', () => {

--- a/server/graphql/modules/backtest.ts
+++ b/server/graphql/modules/backtest.ts
@@ -1,9 +1,9 @@
-import { type Backtest } from '../../models/rules/BacktestModel.js';
 import {
   hasPermission,
   UserPermission,
 } from '../../models/types/permissioning.js';
 import { type RuleExecutionResult } from '../datasources/RuleApi.js';
+import { type GraphQLBacktestParent } from '../datasources/ruleKyselyPersistence.js';
 import { type GQLMutationCreateBacktestArgs } from '../generated.js';
 import { type Context } from '../resolvers.js';
 import {
@@ -77,14 +77,14 @@ const typeDefs = /* GraphQL */ `
 
 const resolvers = {
   Backtest: {
-    contentItemsProcessed(source: Backtest) {
+    contentItemsProcessed(source: GraphQLBacktestParent) {
       return source.correctedContentItemsProcessed;
     },
-    contentItemsMatched(source: Backtest) {
+    contentItemsMatched(source: GraphQLBacktestParent) {
       return source.correctedContentItemsMatched;
     },
     results: makeConnectionResolver<
-      Backtest,
+      GraphQLBacktestParent,
       { ts: number },
       RuleExecutionResult,
       Context,

--- a/server/models/HashBankModel.ts
+++ b/server/models/HashBankModel.ts
@@ -1,8 +1,0 @@
-import { type HashBank as HashBankType } from '../services/hmaService/index.js';
-
-// Re-export the HashBank type for GraphQL generated types
-export type HashBank = HashBankType;
-
-// This file exists to provide the HashBank type import that GraphQL codegen expects
-// The actual HashBank functionality is implemented in the HMA service
-export default HashBank;


### PR DESCRIPTION
## Context & Requests for Reviewers

Continues the `Sequelize` -> `Kysely` migration by repointing two more codegen mappers off `models/*Model.ts`.

`models/rules/BacktestModel.ts` itself stays around in this PR — `RuleModel.hasMany(models.Backtest)` and `UserModel.hasMany(models.Backtest)` Sequelize associations still wire it into the boot graph. Removing the model belongs in the IoC / Sequelize cleanup PR alongside `Rule` / `User` model deletion.
