### PR TITLE
fix: rename "Employee Safety" to "Wellness" in settings UI

### DIFF
--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -43,7 +43,7 @@ const MenuItemNames = makeEnumLike([
   'Integrations',
   'Appeal Settings',
   'Users',
-  'Employee Safety',
+  'Wellness',
   'NCMEC Settings',
   'SSO',
   'Organization',

--- a/client/src/webpages/dashboard/Dashboard.tsx
+++ b/client/src/webpages/dashboard/Dashboard.tsx
@@ -649,7 +649,7 @@ export default function Dashboard() {
             }
           : null,
         {
-          title: 'Employee Safety' as const,
+          title: 'Wellness' as const,
           urlPath: 'org_safety_settings',
           requiredPermissions: [GQLUserPermission.ManageOrg],
         },

--- a/client/src/webpages/settings/AccountSettings.tsx
+++ b/client/src/webpages/settings/AccountSettings.tsx
@@ -563,7 +563,7 @@ export default function AccountSettings() {
         )}
 
         <div className="mb-8">
-          <Heading>Safety Settings</Heading>
+          <Heading>Wellness</Heading>
           <Text size="SM">
             These are your personal default settings. Every time you view a
             reported image or video in Coop, these settings will be

--- a/client/src/webpages/settings/OrgSafetySettings.tsx
+++ b/client/src/webpages/settings/OrgSafetySettings.tsx
@@ -60,11 +60,11 @@ export default function ManualReviewSafetySettings() {
   const [saveSafetySettings, { loading: isSafetySettingsMutationLoading }] =
     useGQLSetOrgDefaultSafetySettingsMutation({
       onCompleted: () => {
-        toast.success('Default safety settings saved!');
+        toast.success('Default wellness settings saved!');
       },
       onError: () => {
         toast.error(
-          "Your organization's safety settings failed to save. Please try again.",
+          "Your organization's wellness settings failed to save. Please try again.",
         );
       },
     });
@@ -90,25 +90,25 @@ export default function ManualReviewSafetySettings() {
   }
 
   if (error || !data?.myOrg?.defaultInterfacePreferences) {
-    throw error ?? new Error('Could not load safety settings');
+    throw error ?? new Error('Could not load wellness settings');
   }
 
   return (
     <>
       <Helmet>
-        <title>Default Organization Safety Settings</title>
+        <title>Default Wellness Settings</title>
       </Helmet>
 
       <div className="w-[700px]">
         <Heading size="2XL" className="mb-2">
-          Standardize Your Organization's Safety Settings
+          Default Wellness Settings
         </Heading>
         <Text size="SM" className="mb-12">
-        Configure your organization's default safety settings. When a new 
-        employee joins your team and needs to use Coop, these settings 
-        will be applied by default to maintain their safety and well-being. 
-        If an employee wants to override these settings, they can do so in 
-        their personal Safety Settings.
+        Configure your organization's default wellness settings. When a new
+        user joins your team and needs to use Coop, these settings
+        will be applied by default to maintain their safety and well-being.
+        If a user wants to override these settings, they can do so in
+        their personal Wellness settings.
         </Text>
         <div className="flex gap-12 mb-8">
           <div className="flex flex-col gap-5 w-64 pt-10">


### PR DESCRIPTION
Closes #366.

## Context & Requests for Reviewers

"Employee Safety" assumes org members are employees, which doesn't fit contractors, volunteers, etc. Renames the user-visible copy to "Wellness" / "user".

Surfaces touched:
- Sidebar nav and dashboard route title
- Account settings personal section heading
- Org-level settings page (`settings/org_safety_settings`): browser title, page heading, body copy, save success/error toasts, thrown error message

## Tests

- [x] `/dashboard/settings/org_safety_settings` - all surfaces read "Wellness" / "user"
- [x] `/dashboard/settings/account` - personal section heading reads "Wellness"
- [x] `cd client && npm run lint` passes (0 errors)
- [x] No schema or URL changes - existing bookmarks and Apollo cache unaffected

### Before

<img width="2008" height="1107" alt="Screenshot 2026-04-30 at 22 43 25" src="https://github.com/user-attachments/assets/62fa7fbd-fb8b-4769-b42b-989752ab9ff2" />
<img width="2005" height="1112" alt="Screenshot 2026-04-30 at 22 43 08" src="https://github.com/user-attachments/assets/62f2f6c3-7638-4f04-af66-211cc13fbd61" />

### After

<img width="2056" height="1329" alt="Screenshot 2026-05-01 at 20 46 13" src="https://github.com/user-attachments/assets/0470ac59-5a81-4d82-ae15-b7b2ceb5ebd9" />
<img width="2056" height="1329" alt="Screenshot 2026-05-01 at 20 45 49" src="https://github.com/user-attachments/assets/6d231a7d-672e-4dd1-a1e3-160a3fa7f2b6" />


## (Optional) Rollout Plan

None
