### PR TITLE
[Scylla] Stop connect failures and add visibility on connection errors

### DIFF
--- a/server/iocContainer/index.ts
+++ b/server/iocContainer/index.ts
@@ -3,7 +3,7 @@ import { createRequire } from 'module';
 import Bottle from '@ethanresnick/bottlejs';
 import opentelemetry from '@opentelemetry/api';
 import { makeDateString, type ItemIdentifier } from '@roostorg/types';
-import { types as scyllaTypes } from 'cassandra-driver';
+import { types as scyllaTypes, type Host as ScyllaHost } from 'cassandra-driver';
 import IORedis, { type Cluster } from 'ioredis';
 import {
   Kysely,
@@ -234,6 +234,7 @@ import {
 } from '../utils/correlationIds.js';
 import { getUsableCoreCount } from '../utils/cpu-helpers.js';
 import { jsonStringify, type JsonOf } from '../utils/encoding.js';
+import { logErrorJson, logJson } from '../utils/logging.js';
 import { __throw, assertUnreachable } from '../utils/misc.js';
 import SafeTracer from '../utils/SafeTracer.js';
 import {
@@ -310,7 +311,10 @@ export interface Dependencies {
   // that each dependent service can type its arg more specifically with the set
   // of tables it is responsible for / allowed to query.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Scylla: Scylla<any> & { close: () => Promise<void> };
+  Scylla: Scylla<any> & {
+    connect: () => Promise<void>;
+    close: () => Promise<void>;
+  };
 
   Sequelize: ReturnType<typeof makeDb>;
   OrgModel: ReturnType<typeof makeDb>['Org'];
@@ -723,9 +727,59 @@ export default async function getBottle() {
         consistency: scyllaTypes.consistencies.localQuorum,
       },
     });
+
+    // Surface cluster state changes so reconnect storms are visible in logs.
+    scyllaDriver.on('hostUp', (host: ScyllaHost) => {
+      // eslint-disable-next-line no-restricted-syntax
+      logJson(`scylla.hostUp address=${host.address}`);
+    });
+    scyllaDriver.on('hostDown', (host: ScyllaHost) => {
+      // eslint-disable-next-line no-restricted-syntax
+      logJson(`scylla.hostDown address=${host.address}`);
+    });
+    // Forward driver-internal warnings/errors (auth, TLS, connection drops,
+    // etc.); skip the very chatty `info`/`verbose` levels.
+    scyllaDriver.on(
+      'log',
+      (
+        level: 'verbose' | 'info' | 'warning' | 'error',
+        source: string,
+        message: string,
+        furtherInfo?: unknown,
+      ) => {
+        if (level !== 'warning' && level !== 'error') {
+          return;
+        }
+        const wrapped = new Error(`scylla.${level}: [${source}] ${message}`);
+        if (furtherInfo instanceof Error) {
+          wrapped.stack = furtherInfo.stack ?? wrapped.stack;
+        }
+        // eslint-disable-next-line no-restricted-syntax
+        logErrorJson({
+          message: `scylla.driver.${level}`,
+          error: wrapped,
+        });
+      },
+    );
+
+    // cassandra-driver leaks ~4 HostMap listeners per failed `Client._connect()`
+    // retry and never recreates the HostMap, so the default cap of 10 trips
+    // after ~3 failures. Raise it so transient blips don't spam the warning,
+    // but keep it bounded so a true runaway is still noticeable.
+    const controlConnection = (
+      scyllaDriver as unknown as {
+        controlConnection?: { hosts?: { setMaxListeners?: (n: number) => void } };
+      }
+    ).controlConnection;
+    controlConnection?.hosts?.setMaxListeners?.(50);
+
     class ClosableScylla<
       DB extends Record<string, Record<string, unknown>>,
     > extends Scylla<DB> {
+      /** Eagerly connect; idempotent once `connected` is true. */
+      async connect() {
+        return scyllaDriver.connect();
+      }
       async close() {
         return scyllaDriver.shutdown();
       }

--- a/server/iocContainer/index.ts
+++ b/server/iocContainer/index.ts
@@ -771,7 +771,7 @@ export default async function getBottle() {
         controlConnection?: { hosts?: { setMaxListeners?: (n: number) => void } };
       }
     ).controlConnection;
-    controlConnection?.hosts?.setMaxListeners?.(50);
+    controlConnection?.hosts?.setMaxListeners?.(15);
 
     class ClosableScylla<
       DB extends Record<string, Record<string, unknown>>,

--- a/server/workers_jobs/ItemProcessingWorker.ts
+++ b/server/workers_jobs/ItemProcessingWorker.ts
@@ -23,6 +23,7 @@ export default inject(
     'ContentApiLogger',
     'ModerationConfigService',
     'ItemInvestigationService',
+    'Scylla',
     'Meter',
     'itemSubmissionRetryQueueBulkWrite',
   ],
@@ -33,6 +34,7 @@ export default inject(
     contentApiLogger,
     moderationConfigService,
     ItemInvestigationService,
+    scylla,
     Meter,
     itemSubmissionRetryQueueBulkWrite,
   ) => {
@@ -42,6 +44,8 @@ export default inject(
     return {
       type: 'Worker' as const,
       async run(_signal) {
+        // Fail fast if Scylla is unreachable, instead of retry-looping per job.
+        await scylla.connect();
         queue = new Queue(ITEM_SUBMISSION_QUEUE_NAME, { connection: redis });
         const insertWithRetries = tracer.traced(
           {


### PR DESCRIPTION
## Context & Requests for Reviewers

A user reported a worker hitting 100% CPU and crashing, with only this in the logs:
> `MaxListenersExceededWarning: 11 add listeners added to [HostMap]`

`cassandra-driver` leaks ~4 listeners on its shared `HostMap` per failed `Client._connect()` retry (the `HostMap` is created once in `ControlConnection`'s ctor and never reset on reconnect). 11 listeners ≈ 3 failed attempts. With `BullWorker` concurrency 30, every job was independently triggering driver retries pinning CPU and slowly leaking memory, with zero diagnostic output.

This change adds logs on hostUp/hostDown so connect/auth/TLS failures are actually visible and helps debug. Also bumped the maxListeners to 15 to allow a couple more retries before warnings while still surfacing a true runaway.

Added a connect on startup also to help see misconfigured logs sooner.
