### PR TITLE
[Bug] Stop graphql-depth-limit crashes and related MRT/insights issues

### DIFF
--- a/client/src/webpages/dashboard/rules/dashboard/RulesDashboard.tsx
+++ b/client/src/webpages/dashboard/rules/dashboard/RulesDashboard.tsx
@@ -42,6 +42,7 @@ import {
   GQLRuleStatus,
   GQLSignalType,
   GQLUserPermission,
+  namedOperations,
   useGQLAddFavoriteRuleMutation,
   useGQLDeleteRuleMutation,
   useGQLRemoveFavoriteRuleMutation,
@@ -222,7 +223,7 @@ export default function RulesDashboard() {
   const onDeleteRule = (id: string) => {
     deleteRule({
       variables: { id },
-      refetchQueries: [{ query: RULES_QUERY }],
+      refetchQueries: [namedOperations.Query.Rules],
     });
   };
   const onAddFavoriteRule = useCallback(
@@ -232,7 +233,7 @@ export default function RulesDashboard() {
         variables: {
           ruleId,
         },
-        refetchQueries: [{ query: RULES_QUERY }],
+        refetchQueries: [namedOperations.Query.Rules],
       });
     },
     [addFavoriteRule],
@@ -244,7 +245,7 @@ export default function RulesDashboard() {
         variables: {
           ruleId,
         },
-        refetchQueries: [{ query: RULES_QUERY }],
+        refetchQueries: [namedOperations.Query.Rules],
       });
     },
     [removeFavoriteRule],

--- a/client/src/webpages/dashboard/rules/info/insights/RuleInsightsSamplesTable.tsx
+++ b/client/src/webpages/dashboard/rules/info/insights/RuleInsightsSamplesTable.tsx
@@ -843,20 +843,28 @@ export function getSignalName(
  */
 export function flattenRuleExecutionSampleForCSV(
   topLevelKey: string | null,
-  json: object,
+  json: object | null | undefined,
 ) {
   let result: { [key: string]: string } = {};
+  if (json == null || Array.isArray(json)) {
+    if (topLevelKey != null) {
+      result[topLevelKey] = json == null ? '' : JSON.stringify(json);
+    }
+    return result;
+  }
   Object.entries(json).forEach(([key, value]) => {
-    if (typeof value === 'object') {
+    const fullKey = topLevelKey ? `${topLevelKey}:${key}` : key;
+    if (value != null && typeof value === 'object' && !Array.isArray(value)) {
       result = {
         ...omit(result, key),
-        ...flattenRuleExecutionSampleForCSV(
-          topLevelKey ? `${topLevelKey}:${key}` : key,
-          value,
-        ),
+        ...flattenRuleExecutionSampleForCSV(fullKey, value),
       };
+    } else if (Array.isArray(value)) {
+      result[fullKey] = JSON.stringify(value);
+    } else if (value == null) {
+      result[fullKey] = '';
     } else {
-      result[topLevelKey ? `${topLevelKey}:${key}` : key] = value;
+      result[fullKey] = value;
     }
   });
   return result;

--- a/client/src/webpages/dashboard/rules/info/insights/tests/RuleInsightsSamplesTable.test.ts
+++ b/client/src/webpages/dashboard/rules/info/insights/tests/RuleInsightsSamplesTable.test.ts
@@ -71,5 +71,25 @@ describe('RuleInsightsSamplesTable tests', () => {
         'a:b:c:d:e': 1,
       });
     });
+    it('Null nested value renders as an empty cell', () => {
+      const content = { a: 1, b: null, c: { c1: null, c2: 'x' } };
+      expect(flattenRuleExecutionSampleForCSV(null, content)).toMatchObject({
+        a: 1,
+        b: '',
+        'c:c1': '',
+        'c:c2': 'x',
+      });
+    });
+    it('Null top-level input does not throw', () => {
+      expect(() => flattenRuleExecutionSampleForCSV(null, null)).not.toThrow();
+      expect(flattenRuleExecutionSampleForCSV(null, null)).toMatchObject({});
+    });
+    it('Array values are stringified rather than recursed into', () => {
+      const content = { tags: ['a', 'b'], n: 1 };
+      expect(flattenRuleExecutionSampleForCSV(null, content)).toMatchObject({
+        tags: '["a","b"]',
+        n: 1,
+      });
+    });
   });
 });

--- a/client/src/webpages/dashboard/rules/rule_form/RuleForm.tsx
+++ b/client/src/webpages/dashboard/rules/rule_form/RuleForm.tsx
@@ -27,6 +27,7 @@ import {
   GQLConditionConjunction,
   GQLRuleStatus,
   GQLUserPermission,
+  namedOperations,
   useGQLContentRuleFormConfigQuery,
   useGQLCreateContentRuleMutation,
   useGQLCreateUserRuleMutation,
@@ -41,7 +42,6 @@ import { userHasPermissions } from '../../../../routing/permissions';
 import useRouteQueryParams from '../../../../routing/useRouteQueryParams';
 import { DAY, HOUR, MONTH, WEEK } from '../../../../utils/time';
 import { ModalInfo } from '../../types/ModalInfo';
-import { RULES_QUERY } from '../dashboard/RulesDashboard';
 import TextTokenInput from '../TextTokenInput';
 import {
   ConditionInput,
@@ -644,7 +644,7 @@ export default function RuleForm() {
   const onDeleteRule = (id: string) => {
     deleteRule({
       variables: { id },
-      refetchQueries: [{ query: RULES_QUERY }],
+      refetchQueries: [namedOperations.Query.Rules],
     });
   };
 
@@ -918,7 +918,7 @@ export default function RuleForm() {
           expirationTime: state.expirationTime ? format(state.expirationTime, 'yyyy-MM-dd HH:mm') : undefined,
         },
       },
-      refetchQueries: [{ query: RULES_QUERY }],
+      refetchQueries: [namedOperations.Query.Rules],
     });
   };
 
@@ -943,7 +943,7 @@ export default function RuleForm() {
         },
       },
       refetchQueries: [
-        { query: RULES_QUERY },
+        namedOperations.Query.Rules,
         { query: RULE_QUERY, variables: { id } },
       ],
     });
@@ -965,7 +965,7 @@ export default function RuleForm() {
           expirationTime: state.expirationTime ? format(state.expirationTime, 'yyyy-MM-dd HH:mm') : undefined,
         },
       },
-      refetchQueries: [{ query: RULES_QUERY }],
+      refetchQueries: [namedOperations.Query.Rules],
     });
   };
 
@@ -989,7 +989,7 @@ export default function RuleForm() {
         },
       },
       refetchQueries: [
-        { query: RULES_QUERY },
+        namedOperations.Query.Rules,
         { query: RULE_QUERY, variables: { id } },
       ],
     });

--- a/server/api.ts
+++ b/server/api.ts
@@ -19,7 +19,6 @@ import connectPgSimple from 'connect-pg-simple';
 import cors from 'cors';
 import express, { type ErrorRequestHandler } from 'express';
 import session from 'express-session';
-import depthLimit from 'graphql-depth-limit';
 import { buildContext, GraphQLLocalStrategy } from 'graphql-passport';
 import helmet from 'helmet';
 import passport from 'passport';
@@ -37,6 +36,7 @@ import resolvers, { type Context } from './graphql/resolvers.js';
 import { passwordMatchesHash } from './services/userManagementService/index.js';
 import typeDefs from './graphql/schema.js';
 import { authSchemaWrapper } from './graphql/utils/authorization.js';
+import { safeDepthLimit } from './graphql/utils/safeDepthLimit.js';
 import { type Dependencies } from './iocContainer/index.js';
 import { isEnvTrue, safeGetEnvInt } from './iocContainer/utils.js';
 import controllers from './routes/index.js';
@@ -388,7 +388,7 @@ export default async function makeApiServer(deps: Dependencies) {
         ? [ApolloServerPluginLandingPageDisabled()]
         : []),
     ],
-    validationRules: [depthLimit(safeGetEnvInt('GRAPHQL_MAX_DEPTH', 10))],
+    validationRules: [safeDepthLimit(safeGetEnvInt('GRAPHQL_MAX_DEPTH', 10))],
     introspection: process.env.NODE_ENV !== 'production',
     formatError(formattedError, error) {
       // unwrapResolverError removes the GraphQLError wrapper added by graphql-js

--- a/server/graphql/modules/manualReviewTool.ts
+++ b/server/graphql/modules/manualReviewTool.ts
@@ -1630,20 +1630,25 @@ const ManualReviewQueue: GQLManualReviewQueueResolvers = {
   async jobs(queue, { ids: jobIds, limit }, context) {
     const { orgId, id: queueId } = queue;
 
-    if (!jobIds) {
+    if (jobIds == null) {
       return context.services.ManualReviewToolService.getAllJobsForQueue({
         orgId,
         queueId,
         limit: limit ?? undefined,
       });
-    } else {
-      return context.services.ManualReviewToolService.getJobsForQueue({
-        orgId,
-        queueId,
-        jobIds,
-        isAppealsQueue: queue.isAppealsQueue,
-      });
     }
+    // Empty array means "filter to no IDs" -> result is always []. Short-circuit
+    // so we don't open a Bull/Redis queue handle per reviewable queue on every
+    // MRT page load before a job has been dequeued.
+    if (jobIds.length === 0) {
+      return [];
+    }
+    return context.services.ManualReviewToolService.getJobsForQueue({
+      orgId,
+      queueId,
+      jobIds,
+      isAppealsQueue: queue.isAppealsQueue,
+    });
   },
   async pendingJobCount(queue, _, context) {
     const { orgId, id: queueId } = queue;

--- a/server/graphql/utils/safeDepthLimit.test.ts
+++ b/server/graphql/utils/safeDepthLimit.test.ts
@@ -1,0 +1,88 @@
+import {
+  buildSchema,
+  parse,
+  validate,
+  type DocumentNode,
+  type GraphQLSchema,
+} from 'graphql';
+
+import { safeDepthLimit } from './safeDepthLimit.js';
+
+const schema: GraphQLSchema = buildSchema(`
+  type Query {
+    me: User
+  }
+  type User {
+    id: ID!
+    name: String
+    friends: [User!]!
+  }
+`);
+
+function parseQuery(source: string): DocumentNode {
+  return parse(source);
+}
+
+describe('safeDepthLimit', () => {
+  test('rejects queries deeper than the configured maximum', () => {
+    const doc = parseQuery(`
+      query {
+        me {
+          friends {
+            friends {
+              friends {
+                id
+              }
+            }
+          }
+        }
+      }
+    `);
+    const errors = validate(schema, doc, [safeDepthLimit(2)]);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].message).toMatch(/exceeds maximum operation depth/);
+  });
+
+  test('allows queries within the configured maximum', () => {
+    const doc = parseQuery(`
+      query {
+        me {
+          id
+        }
+      }
+    `);
+    const errors = validate(schema, doc, [safeDepthLimit(5)]);
+    expect(errors).toEqual([]);
+  });
+
+  test('does not throw when a query references an undefined fragment', () => {
+    const doc = parseQuery(`
+      query {
+        me {
+          ...MissingFields
+        }
+      }
+    `);
+    expect(() => validate(schema, doc, [safeDepthLimit(10)])).not.toThrow();
+  });
+
+  test('logs the offending operation name when it falls back', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const doc = parseQuery(`
+        query MyOp {
+          me { ...MissingFields }
+        }
+      `);
+      validate(schema, doc, [safeDepthLimit(10)]);
+      expect(warn).toHaveBeenCalledTimes(1);
+      const message = warn.mock.calls[0][0] as string;
+      expect(message).toContain('safeDepthLimit');
+      expect(message).toContain('MyOp');
+    } finally {
+      warn.mockRestore();
+      error.mockRestore();
+    }
+  });
+});

--- a/server/graphql/utils/safeDepthLimit.ts
+++ b/server/graphql/utils/safeDepthLimit.ts
@@ -1,0 +1,37 @@
+import depthLimit from 'graphql-depth-limit';
+import { Kind, type ValidationContext } from 'graphql';
+
+// `graphql-depth-limit@1.1.0` throws when a query references an undefined
+// fragment (it dereferences `undefined.kind`). Swallow so other validation
+// rules can report the real error instead of crashing the request with a 500.
+export function safeDepthLimit(
+  maxDepth: number,
+  options?: Parameters<typeof depthLimit>[1],
+  callback?: Parameters<typeof depthLimit>[2],
+) {
+  const inner = depthLimit(maxDepth, options, callback);
+  return (context: ValidationContext) => {
+    try {
+      return inner(context);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[safeDepthLimit] depth-limit validation crashed; falling back. ' +
+          `operations=[${getOperationNames(context).join(',')}] ` +
+          `error=${message}`,
+      );
+      return {};
+    }
+  };
+}
+
+function getOperationNames(context: ValidationContext): string[] {
+  const names: string[] = [];
+  for (const def of context.getDocument().definitions) {
+    if (def.kind === Kind.OPERATION_DEFINITION) {
+      names.push(def.name?.value ?? '<anonymous>');
+    }
+  }
+  return names;
+}


### PR DESCRIPTION
## Context & Requests for Reviewers
A bundle of fixes for the user-reported MRT outage and adjacent issues. Mostly from what I understood from the provided logs. Added some logging to help debug further on what query may be causing this problem.

- `safeDepthLimit` wraps `graphql-depth-limit` so an undefined fragment in a query no longer crashes validation with a 500. Logs the offending operation name.
- `ManualReviewQueue.jobs(ids: [])` short-circuits to `[]` instead of opening a Bull/Redis queue handle per reviewable queue.
- `flattenRuleExecutionSampleForCSV` guards `null`/array values so the rule insights samples table doesn't crash on `Object.entries(null)`.
