### PR TITLE
[Sidebar] Change permission to view policies

### DIFF
--- a/client/src/webpages/dashboard/Dashboard.tsx
+++ b/client/src/webpages/dashboard/Dashboard.tsx
@@ -570,7 +570,7 @@ export default function Dashboard() {
       title: 'Policies' as const,
       urlPath: 'policies',
       icon: SparklesFilled,
-      requiredPermissions: [GQLUserPermission.ManageOrg],
+      requiredPermissions: [GQLUserPermission.ManagePolicies],
     },
     !isDemoOrg && {
       title: 'Review Console' as const,


### PR DESCRIPTION
## Context & Requests for Reviewers

This change allows users with the correct permissions to view the Policies tab.

## Tests

Roles that should see the tab:
Rules Manager
Moderator Manager
Moderator
Child Safety Moderator
