### PR TITLE
feat: divine fork scaffolding (CI, ownership, docs)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # CODEOWNERS file for managing repository permissions
 # Format: path-pattern @username @org/team-name
 
-# Maintainers: Default owners for all files
-* @juanmrad @vinaysrao1 @pawiecz @cassidyjames @julietshen @dom-notion
+# Divine maintainers
+* @mbradley @notthatkindofdrliz
 
-# Docs contributors
-docs/ @roostorg/roosters
+# Upstream ROOST maintainers (for upstream sync PRs)
+# * @juanmrad @vinaysrao1 @pawiecz @cassidyjames @julietshen @dom-notion

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,3 +14,7 @@ Are there any special things that have to be done before this can be deployed
 to prod (e.g., other blocking PRs; manual load testing/validation that needs to
 be done on staging; etc.)? If so, please note them here.
  -->
+
+## Public Artifact Review
+
+- [ ] Titles, descriptions, branch names, screenshots, and linked artifacts avoid partner, customer, brand, campaign, or other sensitive external names unless explicitly approved

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -1,0 +1,66 @@
+name: Build and Push Docker Images
+
+on:
+  push:
+    branches:
+      - main
+      - 'divine/*'
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+  ORG: divinevideo
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      matrix:
+        include:
+          - image: coop-server
+            context: .
+            dockerfile: Dockerfile
+            target: build_server
+          - image: coop-worker
+            context: .
+            dockerfile: Dockerfile
+            target: build_worker_runner
+          - image: coop-client
+            context: ./client
+            dockerfile: client/Dockerfile
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.image }}
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          target: ${{ matrix.target || '' }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/semantic_pr.yml
+++ b/.github/workflows/semantic_pr.yml
@@ -1,0 +1,12 @@
+name: Semantic PR
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  semantic-pull-request:
+    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/semantic_pull_request.yml@v1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# COOP (Content Operations & Oversight Platform)
+
+ROOST's moderation review tool. Being evaluated for Divine's moderation review surface.
+
+## Cross-Repo Coordination
+
+This repo is **Layer 4** (review surface evaluation) in the auto-hide evolution plan. Read the coordination doc at session start:
+`~/code/support-trust-safety/docs/moderation/auto-hide-evolution-plan.md`
+
+When you make decisions or discover constraints that affect other layers, update that doc and flag it for the user.
+
+## Evaluation Goals
+
+1. Get COOP running locally
+2. Define Divine Item Types: map Nostr events to COOP Content Items, pubkeys to User Items
+3. Wire COOP Actions to relay-manager RPC endpoints (ban, restrict, allow)
+4. Bridge Osprey verdicts into COOP item submissions (flag_for_review creates review job)
+5. Assess NCMEC CyberTipline integration feasibility (requires ESP registration)
+
+## Key capabilities to evaluate
+
+- Manual Review Tool (queues, routing, job assignment, decisioning)
+- NCMEC CyberTipline integration (hash matching, review queue, CyberTip submission)
+- Signals framework (pluggable classifiers)
+- Actions system (calls external APIs to execute decisions)
+- User strike system and appeals
+- Plugin architecture for custom integrations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,27 +1,50 @@
 # COOP (Content Operations & Oversight Platform)
 
-ROOST's moderation review tool. Being evaluated for Divine's moderation review surface.
+Divine's moderation review surface. Fork of [roostorg/coop](https://github.com/roostorg/coop).
 
 ## Cross-Repo Coordination
 
-This repo is **Layer 4** (review surface evaluation) in the auto-hide evolution plan. Read the coordination doc at session start:
+This repo is **Layer 4** (human review surface) in the moderation pipeline. Read the coordination doc at session start:
 `~/code/support-trust-safety/docs/moderation/auto-hide-evolution-plan.md`
 
 When you make decisions or discover constraints that affect other layers, update that doc and flag it for the user.
 
-## Evaluation Goals
+## Architecture
 
-1. Get COOP running locally
-2. Define Divine Item Types: map Nostr events to COOP Content Items, pubkeys to User Items
-3. Wire COOP Actions to relay-manager RPC endpoints (ban, restrict, allow)
-4. Bridge Osprey verdicts into COOP item submissions (flag_for_review creates review job)
-5. Assess NCMEC CyberTipline integration feasibility (requires ESP registration)
+COOP receives flagged content from Osprey (rules engine) via REST API submission. Human moderators review items in the Manual Review Tool (MRT), then take actions (Ban User, Delete Content, Hide Content, Age Restrict) that fire webhooks to the relay-manager adapter.
 
-## Key capabilities to evaluate
+```
+Osprey verdict (flag_for_review) → COOP REST API → MRT queue
+Moderator decision → COOP webhook → adapter → relay-manager RPC
+```
 
-- Manual Review Tool (queues, routing, job assignment, decisioning)
-- NCMEC CyberTipline integration (hash matching, review queue, CyberTip submission)
-- Signals framework (pluggable classifiers)
-- Actions system (calls external APIs to execute decisions)
-- User strike system and appeals
-- Plugin architecture for custom integrations
+## Divine Integration Points
+
+- **Item Type:** "User Report" with fields for report metadata + media (VIDEO/IMAGE)
+- **Actions:** CUSTOM_ACTION webhooks to adapter service
+- **Adapter:** `support-trust-safety/scripts/coop-webhook-adapter.mjs` translates webhooks to relay-manager RPC
+- **Bridge import:** `support-trust-safety/scripts/coop-bridge-import.sh` pulls Kind 1984 reports from staging relay
+
+## Deployment
+
+Images build via GitHub Actions to `ghcr.io/divinevideo/coop-server`, `coop-worker`, `coop-client`.
+K8s manifests live in `divine-iac-coreconfig/k8s/applications/coop/`.
+
+## Staging Dependencies
+
+- **PostgreSQL:** shared CNPG cluster in `postgres-clusters` namespace
+- **Redis:** shared sentinel cluster in `redis-clusters` namespace
+- **ClickHouse:** ClickHouse operator available; needs a ClickHouseInstallation CR
+- **ScyllaDB:** not available on cluster; env vars stubbed with dummy values (MRT workflow does not require Scylla on the critical path)
+
+## Local Dev
+
+```bash
+docker compose up -d postgres redis clickhouse scylla
+docker compose run migrations
+# Then run server and client separately or via docker compose
+```
+
+## Upstream Sync
+
+Pull from `upstream` (roostorg/coop), push divine-specific changes to `origin` (divinevideo/coop).


### PR DESCRIPTION
## Context & Requests for Reviewers

Initial divine-specific scaffolding for the divinevideo/coop fork.

- **build-and-push.yaml**: builds coop-server, coop-worker, coop-client images to ghcr.io/divinevideo/ on pushes to main and divine/* branches
- **semantic_pr.yml**: conventional commit enforcement (matches all other divine repos)
- **CODEOWNERS**: divine team reviewers
- **CLAUDE.md**: updated from "evaluation" framing to production review surface with staging deployment notes and cross-repo coordination pointers
- **PR template**: added public artifact review checkbox

## Tests

No code changes. CI workflows are additive. Existing apply_pr_checks.yaml is unchanged.

## Rollout Plan

Merge to main triggers the first image build. K8s manifests in divine-iac-coreconfig will reference the resulting images.

## Public Artifact Review

- [x] Titles, descriptions, branch names, screenshots, and linked artifacts avoid partner, customer, brand, campaign, or other sensitive external names unless explicitly approved