### PR TITLE
[Kysely] Migrate test fixtures and bin script off sequelize

### DIFF
--- a/server/api.ts
+++ b/server/api.ts
@@ -14,11 +14,11 @@ import {
   SEMATTRS_EXCEPTION_STACKTRACE,
   SEMATTRS_EXCEPTION_TYPE,
 } from '@opentelemetry/semantic-conventions';
-import { GraphQLError, type GraphQLFormattedError } from 'graphql';
 import connectPgSimple from 'connect-pg-simple';
 import cors from 'cors';
 import express, { type ErrorRequestHandler } from 'express';
 import session from 'express-session';
+import { GraphQLError, type GraphQLFormattedError } from 'graphql';
 import { buildContext, GraphQLLocalStrategy } from 'graphql-passport';
 import helmet from 'helmet';
 import passport from 'passport';
@@ -33,13 +33,13 @@ import {
   kyselyUserFindById,
 } from './graphql/datasources/userKyselyPersistence.js';
 import resolvers, { type Context } from './graphql/resolvers.js';
-import { passwordMatchesHash } from './services/userManagementService/index.js';
 import typeDefs from './graphql/schema.js';
 import { authSchemaWrapper } from './graphql/utils/authorization.js';
 import { safeDepthLimit } from './graphql/utils/safeDepthLimit.js';
 import { type Dependencies } from './iocContainer/index.js';
 import { isEnvTrue, safeGetEnvInt } from './iocContainer/utils.js';
 import controllers from './routes/index.js';
+import { passwordMatchesHash } from './services/userManagementService/index.js';
 import { createBodySchemaValidator } from './utils/bodySchemaValidation.js';
 import { jsonStringify } from './utils/encoding.js';
 import {
@@ -187,9 +187,8 @@ export default async function makeApiServer(deps: Dependencies) {
             );
           }
 
-          const samlSettings = await deps.OrgSettingsService.getSamlSettings(
-            orgId,
-          );
+          const samlSettings =
+            await deps.OrgSettingsService.getSamlSettings(orgId);
 
           if (!samlSettings)
             return done(
@@ -230,7 +229,7 @@ export default async function makeApiServer(deps: Dependencies) {
             );
           }
 
-          return done(null, user as any);
+          return done(null, user);
         } catch (e) {
           return done(
             makeInternalServerError('Unknown error during login attempt', {
@@ -253,7 +252,7 @@ export default async function makeApiServer(deps: Dependencies) {
             );
           }
 
-          return done(null, user as any);
+          return done(null, user);
         } catch (e) {
           return done(
             makeInternalServerError('Unknown error during login attempt', {
@@ -405,7 +404,7 @@ export default async function makeApiServer(deps: Dependencies) {
       // For all other errors (CoopError, unexpected errors, context errors),
       // sanitize to remove sensitive details and reformat for the client.
       const sanitizedError = sanitizeError(
-        rawError instanceof Error ? rawError : (error as Error),
+        rawError instanceof Error ? rawError : error,
       );
       const { title: sanitizedErrorTitle, ...extensions } = sanitizedError;
 
@@ -430,10 +429,10 @@ export default async function makeApiServer(deps: Dependencies) {
           code: extensions.type.includes(ErrorType.Unauthenticated)
             ? 'UNAUTHENTICATED'
             : extensions.type.includes(ErrorType.Unauthorized)
-            ? 'FORBIDDEN'
-            : extensions.type.includes(ErrorType.InvalidUserInput)
-            ? 'BAD_USER_INPUT'
-            : 'INTERNAL_SERVER_ERROR',
+              ? 'FORBIDDEN'
+              : extensions.type.includes(ErrorType.InvalidUserInput)
+                ? 'BAD_USER_INPUT'
+                : 'INTERNAL_SERVER_ERROR',
         },
         message: sanitizedErrorTitle,
       };
@@ -447,11 +446,12 @@ export default async function makeApiServer(deps: Dependencies) {
     '/graphql',
     express.json(),
     expressMiddleware(apolloServer, {
-      context: async ({ req, res }) => ({
-        ...buildContext({ req, res }),
-        services: makeGqlServices(deps),
-        dataSources: deps.DataSources,
-      } as unknown as Context),
+      context: async ({ req, res }) =>
+        ({
+          ...buildContext({ req, res }),
+          services: makeGqlServices(deps),
+          dataSources: deps.DataSources,
+        }) as unknown as Context,
     }),
   );
 
@@ -465,10 +465,7 @@ export default async function makeApiServer(deps: Dependencies) {
       const middlewares = it.bodySchema
         ? [createBodySchemaValidator(it.bodySchema), ...handlers]
         : handlers;
-      app[it.method](
-        path.join(controller.pathPrefix, it.path),
-        ...middlewares,
-      );
+      app[it.method](path.join(controller.pathPrefix, it.path), ...middlewares);
     });
   });
 

--- a/server/bin/create-org-and-user.ts
+++ b/server/bin/create-org-and-user.ts
@@ -2,7 +2,7 @@
 /* eslint-disable no-console */
 /**
  * Script to create a new organization and admin user
- * 
+ *
  * Usage:
  *   npm run create-org -- \
  *     --name "My Org" \
@@ -12,13 +12,14 @@
  *     --lastName "Doe" \
  *     --password "securePassword123"
  */
-
 import { uid } from 'uid';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
 import { kyselyOrgInsert } from '../graphql/datasources/orgKyselyPersistence.js';
+import { kyselyUserInsert } from '../graphql/datasources/userKyselyPersistence.js';
 import getBottle from '../iocContainer/index.js';
+import { UserRole } from '../models/types/permissioning.js';
 import { hashPassword } from '../services/userManagementService/index.js';
 
 const argv = await yargs(hideBin(process.argv))
@@ -83,13 +84,12 @@ async function createOrgAndUser() {
     // Create signing keys and API key (both reference org via FK)
     await container.SigningKeyPairService.createAndStoreSigningKeys(orgId);
 
-    const { apiKey: rawApiKey } =
-      await container.ApiKeyService.createApiKey(
-        orgId,
-        'Main API Key',
-        'Primary API key for organization',
-        null,
-      );
+    const { apiKey: rawApiKey } = await container.ApiKeyService.createApiKey(
+      orgId,
+      'Main API Key',
+      'Primary API key for organization',
+      null,
+    );
 
     // Initialize org settings
     await Promise.all([
@@ -110,15 +110,16 @@ async function createOrgAndUser() {
 
     // Hash the password and create the admin user
     const hashedPassword = await hashPassword(argv.password);
-    const user = await container.Sequelize.User.create({
+    const user = await kyselyUserInsert({
+      db: container.KyselyPg,
       id: userId,
+      orgId,
       email: argv.email,
       password: hashedPassword,
       firstName: argv.firstName,
       lastName: argv.lastName,
-      role: 'ADMIN',
+      role: UserRole.ADMIN,
       approvedByAdmin: true,
-      orgId,
       loginMethods: ['password'],
     });
 
@@ -141,7 +142,9 @@ async function createOrgAndUser() {
     console.log('\n' + '═'.repeat(60));
     console.log('🔑 API KEY (STORE THIS SECURELY!)');
     console.log('═'.repeat(60));
-    console.log('\nNew API key generated successfully! Please copy and store it securely.\n');
+    console.log(
+      '\nNew API key generated successfully! Please copy and store it securely.\n',
+    );
     console.log(`API Key: ${rawApiKey}\n`);
     console.log('⚠️  This API key will not be shown again. Save it now!');
     console.log('═'.repeat(60) + '\n');
@@ -152,14 +155,14 @@ async function createOrgAndUser() {
   } catch (error: unknown) {
     console.error('\n❌ Error creating organization and user:\n');
     console.error(error);
-    
+
     // Try to close resources even on error
     try {
       await container.closeSharedResourcesForShutdown();
     } catch (shutdownError) {
       console.error('Error during shutdown:', shutdownError);
     }
-    
+
     process.exit(1);
   }
 }
@@ -168,4 +171,3 @@ createOrgAndUser().catch((error) => {
   console.error('Unhandled error:', error);
   process.exit(1);
 });
-

--- a/server/condition_evaluator/conditionSet.test.ts
+++ b/server/condition_evaluator/conditionSet.test.ts
@@ -1,5 +1,6 @@
 import fc from 'fast-check';
 import _ from 'lodash';
+import type { ReadonlyDeep } from 'type-fest';
 
 import {
   ConditionCompletionOutcome,
@@ -9,7 +10,6 @@ import {
 import {
   getSignalIdString,
   type ExternalSignalId,
-  type SignalId,
 } from '../services/signalsService/index.js';
 import {
   ConditionOutcomeArbitrary as anyOutcomeArbitrary,
@@ -27,7 +27,6 @@ import {
   getConditionSetResults,
   tryGetOutcomeFromPartialOutcomes,
 } from './conditionSet.js';
-import type { ReadonlyDeep } from 'type-fest';
 
 const { sampleSize, shuffle, groupBy } = _;
 const { AND, OR, XOR } = ConditionConjunction;
@@ -35,9 +34,11 @@ const { AND, OR, XOR } = ConditionConjunction;
 describe('Condition Evaluation', () => {
   describe('getConditionSetResults', () => {
     test('should run conditions in cost order, skipping unnecessary ones', async () => {
-      const stubRunLeafCondition = jest.fn(async (_it: ReadonlyDeep<LeafCondition>) => ({
-        outcome: ConditionCompletionOutcome.PASSED,
-      }));
+      const stubRunLeafCondition = jest.fn(
+        async (_it: ReadonlyDeep<LeafCondition>) => ({
+          outcome: ConditionCompletionOutcome.PASSED,
+        }),
+      );
 
       await fc.assert(
         fc
@@ -70,9 +71,7 @@ describe('Condition Evaluation', () => {
 
                 return async (id: ExternalSignalId) =>
                   costsBySignalId.get(getSignalIdString(id))!;
-              })() satisfies (id: ExternalSignalId) => Promise<number> as (
-                id: SignalId,
-              ) => Promise<number>;
+              })() satisfies (id: ExternalSignalId) => Promise<number>;
 
               const conditions = leafConditionsAndCostsWithUniqueSignalIds.map(
                 (it) => it[0],
@@ -242,11 +241,11 @@ describe('Condition Evaluation', () => {
               outcomesByType['true']?.length === 1 && !outcomesByType['null']
                 ? true
                 : // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                outcomesByType['null']?.length > 0 &&
-                  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                  (outcomesByType['true']?.length ?? 0) < 2
-                ? null
-                : false,
+                  outcomesByType['null']?.length > 0 &&
+                    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                    (outcomesByType['true']?.length ?? 0) < 2
+                  ? null
+                  : false,
             );
           }),
         );

--- a/server/condition_evaluator/leafCondition.ts
+++ b/server/condition_evaluator/leafCondition.ts
@@ -25,14 +25,14 @@ import {
   type ItemSubmission,
 } from '../services/itemProcessingService/index.js';
 import {
-  CoopInput,
   ConditionCompletionOutcome,
   ConditionFailureOutcome,
+  CoopInput,
+  ValueComparator,
   type ConditionInput,
   type ConditionResult,
   type ConditionSignalInfo,
   type LeafCondition,
-  ValueComparator,
 } from '../services/moderationConfigService/index.js';
 import {
   isSignalErrorResult,
@@ -119,13 +119,11 @@ export async function runLeafCondition(
   const { input: conditionInput, signal } = condition;
   const { input: ruleInput } = evaluationContext;
 
-
   // Figure out what data we're going to extract to pass to the signal.
   const selectedValueOrValues = await (conditionInput.type !==
   'CONTENT_DERIVED_FIELD'
     ? getSignalInputValueOrValues(conditionInput, ruleInput)
     : evaluationContext.getDerivedFieldValue(conditionInput.spec));
-
 
   // We got an error computing the value for a derived field.
   if (isCoopError(selectedValueOrValues)) {
@@ -162,7 +160,6 @@ export async function runLeafCondition(
       ? selectedValueOrValues
       : [selectedValueOrValues];
 
-
   // Now, transform the extracted content values by running them through the
   // signal. If the signal is null, we just treat it as the identity function
   // and leave the extracted values as-is. (A null/identity signal often happens
@@ -188,15 +185,15 @@ export async function runLeafCondition(
               ? ruleInput.data['spectrum-context-id']
                 ? String(ruleInput.data['spectrum-context-id'])
                 : ruleInput.data['spectrum_context_id']
-                ? String(ruleInput.data['spectrum_context_id'])
-                : ruleInput.itemType.kind === 'CONTENT'
-                ? getFieldValueForRole(
-                    ruleInput.itemType.schema,
-                    ruleInput.itemType.schemaFieldRoles,
-                    'threadId',
-                    ruleInput.data,
-                  )?.id
-                : undefined
+                  ? String(ruleInput.data['spectrum_context_id'])
+                  : ruleInput.itemType.kind === 'CONTENT'
+                    ? getFieldValueForRole(
+                        ruleInput.itemType.schema,
+                        ruleInput.itemType.schemaFieldRoles,
+                        'threadId',
+                        ruleInput.data,
+                      )?.id
+                    : undefined
               : undefined,
             contentType: isFullSubmission(ruleInput)
               ? ruleInput.itemType.name
@@ -459,7 +456,7 @@ export function extractContentValueOrValues(
             schemaFields.filter(
               (it) => getScalarType(it) === ScalarTypes.IMAGE,
             ),
-          ) as TaggedScalar<ScalarTypes['IMAGE']>[];
+          );
 
         case CoopInput.ANY_GEOHASH:
           return getValuesFromFields(
@@ -467,7 +464,7 @@ export function extractContentValueOrValues(
             schemaFields.filter(
               (it) => getScalarType(it) === ScalarTypes.GEOHASH,
             ),
-          ) as TaggedScalar<ScalarTypes['GEOHASH']>[];
+          );
 
         case CoopInput.ANY_VIDEO:
           return getValuesFromFields(
@@ -475,7 +472,7 @@ export function extractContentValueOrValues(
             schemaFields.filter(
               (it) => getScalarType(it) === ScalarTypes.VIDEO,
             ),
-          ) as TaggedScalar<ScalarTypes['VIDEO']>[];
+          );
 
         case CoopInput.POLICY_ID:
         case CoopInput.SOURCE:

--- a/server/graphql/datasources/ActionApi.ts
+++ b/server/graphql/datasources/ActionApi.ts
@@ -100,8 +100,7 @@ class ActionAPI {
         callbackUrlHeaders,
         callbackUrlBody,
         applyUserStrikes: applyUserStrikes ?? undefined,
-        parameters:
-          parameters === undefined ? undefined : (parameters ?? []),
+        parameters: parameters === undefined ? undefined : (parameters ?? []),
       },
       itemTypeIds: itemTypeIds ?? undefined,
     });
@@ -209,10 +208,12 @@ class ActionAPI {
 
           const triggered = actions.map((action) => ({
             action,
-            matchingRules: undefined as undefined,
-            ruleEnvironment: undefined as undefined,
+            matchingRules: undefined,
+            ruleEnvironment: undefined,
             policies,
-            customMrtApiParamDecisionPayload: validatedParameters.get(action.id),
+            customMrtApiParamDecisionPayload: validatedParameters.get(
+              action.id,
+            ),
           }));
 
           // If the item isn't found, pass it along to the action publisher
@@ -221,7 +222,11 @@ class ActionAPI {
           // never been submitted to us at all.
           const targetItem = itemSubmission ?? {
             itemId,
-            itemType: { id: itemType.id, kind: itemType.kind, name: itemType.name },
+            itemType: {
+              id: itemType.id,
+              kind: itemType.kind,
+              name: itemType.name,
+            },
           };
           return this.actionPublisher.publishActions(triggered, {
             orgId,
@@ -250,10 +255,15 @@ class ActionAPI {
     const out = new Map<string, Record<string, unknown> | undefined>();
     for (const action of actions) {
       const spec = parseStoredParameters(
-        action.actionType === 'CUSTOM_ACTION' ? action.customMrtApiParams : null,
+        action.actionType === 'CUSTOM_ACTION'
+          ? action.customMrtApiParams
+          : null,
       );
       const supplied = rawByActionId?.[action.id];
-      if (spec.length === 0 && (supplied === undefined || Object.keys(supplied).length === 0)) {
+      if (
+        spec.length === 0 &&
+        (supplied === undefined || Object.keys(supplied).length === 0)
+      ) {
         // No spec, no values — nothing to do for this action.
         continue;
       }
@@ -261,7 +271,10 @@ class ActionAPI {
       // keys, etc. Validation runs even when no values are supplied so that
       // missing-required-with-no-default is caught.
       const validated = validateActionParameterValues(spec, supplied ?? null);
-      out.set(action.id, Object.keys(validated).length > 0 ? validated : undefined);
+      out.set(
+        action.id,
+        Object.keys(validated).length > 0 ? validated : undefined,
+      );
     }
     return out;
   }

--- a/server/graphql/datasources/LocationBankApi.ts
+++ b/server/graphql/datasources/LocationBankApi.ts
@@ -8,9 +8,9 @@ import { type LocationArea } from '../../models/types/locationArea.js';
 import { type CombinedPg } from '../../services/combinedDbTypes.js';
 import { makeLocationBankNameExistsError } from '../../services/moderationConfigService/index.js';
 import { type PlacesApiService } from '../../services/placesApiService/index.js';
+import { makeNotFoundError } from '../../utils/errors.js';
 import { isUniqueViolationError } from '../../utils/kysely.js';
 import { makeKyselyTransactionWithRetry } from '../../utils/kyselyTransactionWithRetry.js';
-import { makeNotFoundError } from '../../utils/errors.js';
 import { safePick } from '../../utils/misc.js';
 import {
   type GQLCreateLocationBankInput,
@@ -78,12 +78,12 @@ class LocationBankAPI {
 
   async getGraphQLLocationBankFromId(opts: { id: string; orgId: string }) {
     const { id, orgId } = opts;
-    const row = (await this.db
+    const row = await this.db
       .selectFrom('public.location_banks')
       .select(['id', 'name', 'description', 'org_id', 'owner_id'])
       .where('id', '=', id)
       .where('org_id', '=', orgId)
-      .executeTakeFirst()) as LocationBankRow | undefined;
+      .executeTakeFirst();
 
     if (row == null) {
       throw makeNotFoundError('Location bank not found', {
@@ -165,12 +165,12 @@ class LocationBankAPI {
       ? await this.expandLocationAreaInputs(id, locationsToAdd)
       : undefined;
 
-    const row = (await this.db
+    const row = await this.db
       .selectFrom('public.location_banks')
       .select(['id', 'name', 'description', 'org_id', 'owner_id'])
       .where('id', '=', id)
       .where('org_id', '=', orgId)
-      .executeTakeFirst()) as LocationBankRow | undefined;
+      .executeTakeFirst();
 
     if (row == null) {
       throw makeNotFoundError('Location bank not found', {
@@ -184,7 +184,7 @@ class LocationBankAPI {
 
     const nextName = name ?? row.name;
     const nextDescription =
-      description !== undefined ? description ?? null : row.description;
+      description !== undefined ? (description ?? null) : row.description;
 
     try {
       return await this.transactionWithRetry(async (trx) => {

--- a/server/graphql/datasources/RuleApi.test.ts
+++ b/server/graphql/datasources/RuleApi.test.ts
@@ -35,7 +35,7 @@ describe('RuleAPI', () => {
       uid(),
     );
     const { user, cleanup: userCleanup } = await createUser(
-      deps.Sequelize,
+      deps.KyselyPg,
       org.id,
     );
     const { itemTypes, cleanup: itemTypesCleanup } =
@@ -264,14 +264,17 @@ describe('RuleAPI', () => {
       );
 
       const now = new Date();
-      await deps.Sequelize.Backtest.create({
-        id: uid(),
-        ruleId: rule.id,
-        creatorId: user.id,
-        sampleDesiredSize: 10,
-        sampleStartAt: now,
-        sampleEndAt: now,
-      });
+      await deps.KyselyPg.insertInto('public.backtests')
+        .values({
+          id: uid(),
+          rule_id: rule.id,
+          creator_id: user.id,
+          sample_desired_size: 10,
+          sample_start_at: now,
+          sample_end_at: now,
+          updated_at: now,
+        })
+        .execute();
 
       await expect(
         deps.RuleAPIDataSource.updateContentRule({

--- a/server/graphql/datasources/RuleApi.ts
+++ b/server/graphql/datasources/RuleApi.ts
@@ -2,17 +2,18 @@
 
 import { type Exception } from '@opentelemetry/api';
 import { makeEnumLike } from '@roostorg/types';
-
 import { type Kysely } from 'kysely';
 import { uid } from 'uid';
 
 import { inject, type Dependencies } from '../../iocContainer/index.js';
-import { type GraphQLBacktestParent } from './ruleKyselyPersistence.js';
 import { type ActionCountsInput } from '../../services/actionStatisticsService/index.js';
 import { type AggregationClause } from '../../services/aggregationsService/index.js';
 import { type ConditionSetWithResultAsLogged } from '../../services/analyticsLoggers/index.js';
 import { type CombinedPg } from '../../services/combinedDbTypes.js';
 import {
+  makeRuleHasRunningBacktestsError,
+  makeRuleIsMissingContentTypeError,
+  makeRuleNameExistsError,
   RuleType,
   type Condition,
   type ConditionInput,
@@ -22,22 +23,26 @@ import {
   type RuleStatus,
 } from '../../services/moderationConfigService/index.js';
 import {
-  makeRuleHasRunningBacktestsError,
-  makeRuleIsMissingContentTypeError,
-  makeRuleNameExistsError,
-} from '../../services/moderationConfigService/index.js';
-import {
   isSignalId,
   signalIsExternal,
   type SignalId,
 } from '../../services/signalsService/index.js';
 import {
-  type DataWarehousePublicSchema,
   warehouseDateToDate,
+  type DataWarehousePublicSchema,
 } from '../../storage/dataWarehouse/warehouseSchema.js';
 import { toCorrelationId } from '../../utils/correlationIds.js';
-import { jsonParse, jsonStringify, tryJsonParse } from '../../utils/encoding.js';
+import {
+  jsonParse,
+  jsonStringify,
+  tryJsonParse,
+} from '../../utils/encoding.js';
 import { makeNotFoundError } from '../../utils/errors.js';
+import { isUniqueViolationError } from '../../utils/kysely.js';
+import {
+  makeKyselyTransactionWithRetry,
+  type KyselyTransactionWithRetry,
+} from '../../utils/kyselyTransactionWithRetry.js';
 import { assertUnreachable } from '../../utils/misc.js';
 import { takeLast } from '../../utils/sql.js';
 import {
@@ -56,9 +61,11 @@ import {
   type GQLUpdateContentRuleInput,
   type GQLUpdateUserRuleInput,
 } from '../generated.js';
+import { unauthenticatedError } from '../utils/errors.js';
 import { oneOfInputToTaggedUnion } from '../utils/inputHelpers.js';
 import { type CursorInfo, type Edge } from '../utils/paginationHandler.js';
 import { buildGraphqlRuleParent } from './buildGraphqlRuleParent.js';
+import { locationAreaInputToLocationArea } from './LocationBankApi.js';
 import {
   kyselyCancelRunningBacktestsForRule,
   kyselyCreateRule,
@@ -66,18 +73,12 @@ import {
   kyselyHasRunningBacktestsForRule,
   kyselyListBacktestsForRule,
   kyselyUpdateRule,
+  type GraphQLBacktestParent,
 } from './ruleKyselyPersistence.js';
 import {
-  type GraphQLUserParent,
   kyselyUserFindByIdAndOrg,
+  type GraphQLUserParent,
 } from './userKyselyPersistence.js';
-import { locationAreaInputToLocationArea } from './LocationBankApi.js';
-import { unauthenticatedError } from '../utils/errors.js';
-import { isUniqueViolationError } from '../../utils/kysely.js';
-import {
-  makeKyselyTransactionWithRetry,
-  type KyselyTransactionWithRetry,
-} from '../../utils/kyselyTransactionWithRetry.js';
 
 /**
  * Normalize the GraphQL `expirationTime` input scalar into a shape our
@@ -323,7 +324,10 @@ class RuleAPI {
   }
 
   async getGraphQLRuleFromId(id: string, orgId: string) {
-    const plain = await this.moderationConfigService.getRuleByIdAndOrg(id, orgId);
+    const plain = await this.moderationConfigService.getRuleByIdAndOrg(
+      id,
+      orgId,
+    );
     if (plain == null) {
       throw unauthenticatedError('User not authenticated to fetch this rule');
     }
@@ -569,9 +573,13 @@ class RuleAPI {
         : e;
     }
 
-    const plain = await this.moderationConfigService.getRuleByIdAndOrg(id, orgId, {
-      readFromReplica: false,
-    });
+    const plain = await this.moderationConfigService.getRuleByIdAndOrg(
+      id,
+      orgId,
+      {
+        readFromReplica: false,
+      },
+    );
     if (plain == null) {
       throw new Error('Rule was updated but could not be reloaded');
     }
@@ -735,9 +743,7 @@ class RuleAPI {
     // have to use our helper that implements "takeLast" in SQL.
     const finalQuery =
       takeFrom === 'start'
-        ? filteredResultsQuery
-            .orderBy('ts', desiredSort.order)
-            .limit(count)
+        ? filteredResultsQuery.orderBy('ts', desiredSort.order).limit(count)
         : takeLast(this.warehouse, filteredResultsQuery, [desiredSort], count);
 
     const results = await finalQuery.execute();
@@ -751,7 +757,7 @@ class RuleAPI {
         itemTypeId: it.itemTypeId,
         userId: it.userId ?? undefined,
         userTypeId: it.userTypeId ?? undefined,
-        content: (it.content ?? '') as string,
+        content: it.content ?? '',
         result: it.result ? jsonParse(it.result) : null,
         environment: it.environment as RuleStatus,
         passed: it.passed,

--- a/server/graphql/datasources/ruleKyselyPersistence.ts
+++ b/server/graphql/datasources/ruleKyselyPersistence.ts
@@ -1,15 +1,15 @@
-import { type Insertable, type Kysely, type Updateable, sql } from 'kysely';
+import { sql, type Insertable, type Kysely, type Updateable } from 'kysely';
 
 import { computeRuleStatusFromRow } from '../../models/rules/ruleTypes.js';
 import { type CombinedPg } from '../../services/combinedDbTypes.js';
 import { type BacktestStatusDb } from '../../services/coreAppTables.js';
-import { makeNotFoundError } from '../../utils/errors.js';
 import {
   RuleAlarmStatus,
   RuleStatus,
   RuleType,
   type ConditionSet,
 } from '../../services/moderationConfigService/index.js';
+import { makeNotFoundError } from '../../utils/errors.js';
 
 export type GraphQLBacktestParent = {
   id: string;
@@ -67,13 +67,18 @@ async function replaceRuleActions(
   ruleId: string,
   actionIds: readonly string[],
 ) {
-  await trx.deleteFrom('public.rules_and_actions').where('rule_id', '=', ruleId).execute();
+  await trx
+    .deleteFrom('public.rules_and_actions')
+    .where('rule_id', '=', ruleId)
+    .execute();
   if (actionIds.length === 0) {
     return;
   }
   await trx
     .insertInto('public.rules_and_actions')
-    .values(actionIds.map((actionId) => ({ rule_id: ruleId, action_id: actionId })))
+    .values(
+      actionIds.map((actionId) => ({ rule_id: ruleId, action_id: actionId })),
+    )
     .execute();
 }
 
@@ -82,7 +87,10 @@ async function replaceRulePolicies(
   ruleId: string,
   policyIds: readonly string[],
 ) {
-  await trx.deleteFrom('public.rules_and_policies').where('rule_id', '=', ruleId).execute();
+  await trx
+    .deleteFrom('public.rules_and_policies')
+    .where('rule_id', '=', ruleId)
+    .execute();
   if (policyIds.length === 0) {
     return;
   }
@@ -105,7 +113,10 @@ async function replaceRuleItemTypes(
   ruleId: string,
   itemTypeIds: readonly string[],
 ) {
-  await trx.deleteFrom('public.rules_and_item_types').where('rule_id', '=', ruleId).execute();
+  await trx
+    .deleteFrom('public.rules_and_item_types')
+    .where('rule_id', '=', ruleId)
+    .execute();
   if (itemTypeIds.length === 0) {
     return;
   }
@@ -175,10 +186,7 @@ export async function kyselyCreateRule(
     created_at: now,
     updated_at: now,
   };
-  await trx
-    .insertInto('public.rules')
-    .values(ruleValues as Insertable<CombinedPg['public.rules']>)
-    .execute();
+  await trx.insertInto('public.rules').values(ruleValues).execute();
 
   await replaceRuleActions(trx, input.id, input.actionIds);
   await replaceRulePolicies(trx, input.id, input.policyIds);
@@ -329,7 +337,11 @@ export async function kyselyDeleteRule(
     .deleteFrom('public.users_and_favorite_rules')
     .where('rule_id', '=', id)
     .execute();
-  await trx.deleteFrom('public.rules').where('id', '=', id).where('org_id', '=', orgId).execute();
+  await trx
+    .deleteFrom('public.rules')
+    .where('id', '=', id)
+    .where('org_id', '=', orgId)
+    .execute();
   return true;
 }
 

--- a/server/graphql/datasources/userKyselyPersistence.test.ts
+++ b/server/graphql/datasources/userKyselyPersistence.test.ts
@@ -131,7 +131,7 @@ describe('userKyselyPersistence', () => {
     );
 
     testWithFixture(
-      "throws an invariant error when password/loginMethods disagree (CHECK constraint shape)",
+      'throws an invariant error when password/loginMethods disagree (CHECK constraint shape)',
       async ({ deps, org }) => {
         await expect(
           kyselyUserInsert({
@@ -340,7 +340,7 @@ describe('userKyselyPersistence', () => {
     // constraint. This protects against regressions if we ever loosen
     // `validateUserUpdatePatch`.
     testWithFixture(
-      "clearing password on a password-login user violates password_null_when_not_present",
+      'clearing password on a password-login user violates password_null_when_not_present',
       async ({ deps, org }) => {
         const input = {
           ...samlUserInput(org.id),
@@ -364,8 +364,7 @@ describe('userKyselyPersistence', () => {
         const input = samlUserInput(org.id);
         await kyselyUserInsert({ db: deps.KyselyPg, ...input });
         try {
-          const beforeRow = await deps.KyselyPg
-            .selectFrom('public.users')
+          const beforeRow = await deps.KyselyPg.selectFrom('public.users')
             .select(['updated_at'])
             .where('id', '=', input.id)
             .executeTakeFirstOrThrow();
@@ -379,8 +378,7 @@ describe('userKyselyPersistence', () => {
           expect(updated!.firstName).toBe('Updated');
           expect(updated!.approvedByAdmin).toBe(true);
 
-          const afterRow = await deps.KyselyPg
-            .selectFrom('public.users')
+          const afterRow = await deps.KyselyPg.selectFrom('public.users')
             .select(['updated_at'])
             .where('id', '=', input.id)
             .executeTakeFirstOrThrow();
@@ -401,9 +399,8 @@ describe('userKyselyPersistence', () => {
         const input = samlUserInput(org.id);
         await kyselyUserInsert({ db: deps.KyselyPg, ...input });
         // `users_and_favorite_rules.rule_id` has a FK to `public.rules`, so
-        // we need a real rule row. Reuse the existing Sequelize fixture until
-        // rule fixtures are themselves Kysely-backed.
-        const rule = await createRule(deps.Sequelize, org.id, {
+        // we need a real rule row.
+        const rule = await createRule(deps.KyselyPg, org.id, {
           creatorId: input.id,
         });
         try {

--- a/server/graphql/datasources/userKyselyPersistence.ts
+++ b/server/graphql/datasources/userKyselyPersistence.ts
@@ -1,14 +1,12 @@
-import { type Kysely, sql } from 'kysely';
+import { sql, type Kysely } from 'kysely';
 
 import {
   getPermissionsForRole,
   type UserPermission,
   type UserRole,
 } from '../../models/types/permissioning.js';
-import {
-  type CoreAppTablesPg,
-  type LoginMethod,
-} from '../../services/coreAppTables.js';
+import { type CombinedPg } from '../../services/combinedDbTypes.js';
+import { type LoginMethod } from '../../services/coreAppTables.js';
 import {
   validateUserCreateInput,
   validateUserUpdatePatch,
@@ -39,7 +37,10 @@ export type GraphQLUserParent = {
   getPermissions(): UserPermission[];
 };
 
-type UsersDb = Kysely<CoreAppTablesPg>;
+// Aligns with `ruleKyselyPersistence.ts`: persistence helpers operate on the
+// full app schema. Lets fixtures and `kyselyCreateRule` callers share a single
+// `Kysely<CombinedPg>` handle without running into Kysely's invariant generic.
+type UsersDb = Kysely<CombinedPg>;
 
 type UserRow = {
   id: string;

--- a/server/graphql/datasources/userValidation.test.ts
+++ b/server/graphql/datasources/userValidation.test.ts
@@ -79,7 +79,7 @@ describe('userValidation', () => {
     test('rejects unknown loginMethods entry', () => {
       const result = validateUserCreateInput({
         ...validInput,
-        loginMethods: ['saml', 'oauth' as never],
+        loginMethods: ['saml', 'oauth'],
       });
       expect(result.ok).toBe(false);
       if (!result.ok) {

--- a/server/graphql/modules/action.ts
+++ b/server/graphql/modules/action.ts
@@ -1,3 +1,4 @@
+import { parseStoredParameters } from '../../services/moderationConfigService/index.js';
 import { isCoopErrorOfType } from '../../utils/errors.js';
 import { assertUnreachable } from '../../utils/misc.js';
 import {
@@ -11,9 +12,8 @@ import {
   type GQLMutationResolvers,
   type GQLQueryResolvers,
 } from '../generated.js';
-import { gqlErrorResult, gqlSuccessResult } from '../utils/gqlResult.js';
 import { unauthenticatedError } from '../utils/errors.js';
-import { parseStoredParameters } from '../../services/moderationConfigService/index.js';
+import { gqlErrorResult, gqlSuccessResult } from '../utils/gqlResult.js';
 
 const typeDefs = /* GraphQL */ `
   interface ActionBase {
@@ -51,20 +51,30 @@ const typeDefs = /* GraphQL */ `
   webhook payload under the parameter's \`name\`.
   """
   type ActionParameter {
-    """Key under which the value is sent in the webhook payload."""
+    """
+    Key under which the value is sent in the webhook payload.
+    """
     name: String!
     displayName: String!
     description: String
     type: ActionParameterType!
     required: Boolean!
     options: [ActionParameterOption!]
-    """NUMBER only: inclusive minimum."""
+    """
+    NUMBER only: inclusive minimum.
+    """
     min: Float
-    """NUMBER only: inclusive maximum."""
+    """
+    NUMBER only: inclusive maximum.
+    """
     max: Float
-    """STRING only: inclusive maximum length in characters."""
+    """
+    STRING only: inclusive maximum length in characters.
+    """
     maxLength: Int
-    """Pre-filled value shown to the moderator. Shape matches \`type\`."""
+    """
+    Pre-filled value shown to the moderator. Shape matches \`type\`.
+    """
     defaultValue: JSON
   }
 
@@ -142,7 +152,7 @@ const typeDefs = /* GraphQL */ `
   }
 
   union Action =
-      EnqueueToMrtAction
+    | EnqueueToMrtAction
     | EnqueueToNcmecAction
     | CustomAction
     | EnqueueAuthorToMrtAction
@@ -183,7 +193,7 @@ const typeDefs = /* GraphQL */ `
   }
 
   union MutateActionResponse =
-      MutateActionSuccessResponse
+    | MutateActionSuccessResponse
     | ActionNameExistsError
 
   type MutateActionSuccessResponse {
@@ -272,9 +282,11 @@ function projectParameters(value: unknown): GQLActionParameter[] {
     name: p.name,
     displayName: p.displayName,
     description: p.description ?? null,
-    type: p.type as GQLActionParameter['type'],
+    type: p.type,
     required: p.required,
-    options: p.options ? p.options.map((o) => ({ value: o.value, label: o.label })) : null,
+    options: p.options
+      ? p.options.map((o) => ({ value: o.value, label: o.label }))
+      : null,
     min: p.min ?? null,
     max: p.max ?? null,
     maxLength: p.maxLength ?? null,
@@ -290,7 +302,9 @@ function projectParameters(value: unknown): GQLActionParameter[] {
 // defensively so the GraphQL projection works for all four action types.
 function readRawParameters(parent: unknown): unknown {
   if (typeof parent !== 'object' || parent === null) return null;
-  return (parent as { customMrtApiParams?: unknown }).customMrtApiParams ?? null;
+  return (
+    (parent as { customMrtApiParams?: unknown }).customMrtApiParams ?? null
+  );
 }
 
 const CustomAction: GQLCustomActionResolvers = {
@@ -443,11 +457,10 @@ const Mutation: GQLMutationResolvers = {
         actorEmail: email,
         // GraphQL `JSONObject` arrives as a plain object; the datasource
         // narrows + validates per-action against each spec.
-        actionIdToParameters:
-          (params.input.parameters ?? null) as Record<
-            string,
-            Record<string, unknown>
-          > | null,
+        actionIdToParameters: (params.input.parameters ?? null) as Record<
+          string,
+          Record<string, unknown>
+        > | null,
         actorNote: params.input.note ?? null,
       });
 

--- a/server/graphql/modules/actionStatistics.ts
+++ b/server/graphql/modules/actionStatistics.ts
@@ -1,7 +1,4 @@
-/* eslint-disable max-lines */
-
 import { type GQLQueryResolvers } from '../generated.js';
-
 import { unauthenticatedError } from '../utils/errors.js';
 
 const typeDefs = /* GraphQL */ `

--- a/server/graphql/modules/integration.ts
+++ b/server/graphql/modules/integration.ts
@@ -3,17 +3,16 @@ import { Integration } from '../../services/signalsService/index.js';
 import { isCoopErrorOfType } from '../../utils/errors.js';
 import {
   makeIntegrationConfigUnsupportedIntegrationError,
+  type TIntegrationConfigWithMetadata,
 } from '../datasources/IntegrationApi.js';
-import type { TIntegrationConfigWithMetadata } from '../datasources/IntegrationApi.js';
 import {
   type GQLIntegrationConfig,
-  type GQLIntegrationMetadata,
   type GQLMutationResolvers,
   type GQLQueryResolvers,
 } from '../generated.js';
 import { type ResolverMap } from '../resolvers.js';
-import { gqlErrorResult, gqlSuccessResult } from '../utils/gqlResult.js';
 import { unauthenticatedError } from '../utils/errors.js';
+import { gqlErrorResult, gqlSuccessResult } from '../utils/gqlResult.js';
 
 const typeDefs = /* GraphQL */ `
   enum Integration {
@@ -41,7 +40,7 @@ const typeDefs = /* GraphQL */ `
   }
 
   union IntegrationApiCredential =
-      GoogleContentSafetyApiIntegrationApiCredential
+    | GoogleContentSafetyApiIntegrationApiCredential
     | OpenAiIntegrationApiCredential
     | ZentropiIntegrationApiCredential
     | PluginIntegrationApiCredential
@@ -155,7 +154,7 @@ const typeDefs = /* GraphQL */ `
   }
 
   union SetIntegrationConfigResponse =
-      SetIntegrationConfigSuccessResponse
+    | SetIntegrationConfigSuccessResponse
     | IntegrationConfigTooManyCredentialsError
     | IntegrationNoInputCredentialsError
     | IntegrationEmptyInputCredentialsError
@@ -174,7 +173,7 @@ const typeDefs = /* GraphQL */ `
   }
 
   union IntegrationConfigQueryResponse =
-      IntegrationConfigSuccessResult
+    | IntegrationConfigSuccessResult
     | IntegrationConfigUnsupportedIntegrationError
 
   type Query {
@@ -197,7 +196,9 @@ const typeDefs = /* GraphQL */ `
   }
 `;
 
-const IntegrationApiCredential: ResolverMap<TIntegrationConfigWithMetadata['apiCredential']> = {
+const IntegrationApiCredential: ResolverMap<
+  TIntegrationConfigWithMetadata['apiCredential']
+> = {
   __resolveType(it) {
     const integrationName = (it as { name?: string }).name ?? '';
     switch (integrationName) {
@@ -252,13 +253,13 @@ const Query: GQLQueryResolvers = {
     if (user == null) {
       throw unauthenticatedError('Unauthenticated User');
     }
-    return context.dataSources.integrationAPI.getAvailableIntegrations() as GQLIntegrationMetadata[];
+    return context.dataSources.integrationAPI.getAvailableIntegrations();
   },
 };
 
 const PluginIntegrationApiCredential = {
   credential(it: TIntegrationConfigWithMetadata['apiCredential']) {
-    return it as Record<string, unknown>;
+    return it;
   },
 };
 
@@ -301,7 +302,7 @@ const Mutation: GQLMutationResolvers = {
       const newConfig =
         await context.dataSources.integrationAPI.setConfigByIntegrationId(
           params.input.integrationId,
-          params.input.credential as Record<string, unknown>,
+          params.input.credential,
           user.orgId,
         );
 

--- a/server/graphql/modules/investigation.ts
+++ b/server/graphql/modules/investigation.ts
@@ -1,13 +1,12 @@
 /* eslint-disable max-lines */
 import { type DateString } from '@roostorg/types';
-
 import _ from 'lodash';
 
-import { type ConditionSetWithResult } from '../../services/moderationConfigService/index.js';
 import {
   getFieldValueForRole,
   type ItemSubmission,
 } from '../../services/itemProcessingService/index.js';
+import { type ConditionSetWithResult } from '../../services/moderationConfigService/index.js';
 import {
   asyncIterableToArray,
   asyncIterableToArrayWithTimeout,
@@ -19,13 +18,12 @@ import { isCoopErrorOfType, makeNotFoundError } from '../../utils/errors.js';
 import { MONTH_MS } from '../../utils/time.js';
 import {
   type GQLQueryResolvers,
-  type GQLResolversTypes,
   type GQLRuleEnvironment,
   type GQLUserHistoryResolvers,
 } from '../generated.js';
 import { formatItemSubmissionForGQL } from '../types.js';
-import { gqlErrorResult, gqlSuccessResult } from '../utils/gqlResult.js';
 import { unauthenticatedError } from '../utils/errors.js';
+import { gqlErrorResult, gqlSuccessResult } from '../utils/gqlResult.js';
 
 const typeDefs = /* GraphQL */ `
   type Query {
@@ -366,9 +364,7 @@ const Query: GQLQueryResolvers = {
       {
         item: formatItemSubmissionForGQL(item.latestSubmission),
         // TODO: Fix casting here
-        executions: itemExecutionHistory as ReadonlyArray<
-          GQLResolversTypes['RuleExecutionResult']
-        >,
+        executions: itemExecutionHistory,
       },
       'ItemHistoryResult',
     );

--- a/server/iocContainer/index.ts
+++ b/server/iocContainer/index.ts
@@ -3,13 +3,12 @@ import { createRequire } from 'module';
 import Bottle from '@ethanresnick/bottlejs';
 import opentelemetry from '@opentelemetry/api';
 import { makeDateString, type ItemIdentifier } from '@roostorg/types';
-import { types as scyllaTypes, type Host as ScyllaHost } from 'cassandra-driver';
-import IORedis, { type Cluster } from 'ioredis';
 import {
-  Kysely,
-  PostgresDialect,
-  type PostgresCursorConstructor,
-} from 'kysely';
+  types as scyllaTypes,
+  type Host as ScyllaHost,
+} from 'cassandra-driver';
+import IORedis, { type Cluster } from 'ioredis';
+import { Kysely, PostgresDialect } from 'kysely';
 import _ from 'lodash';
 import { DynamicPool } from 'node-worker-threads-pool';
 import pg from 'pg';
@@ -36,10 +35,6 @@ import {
   makeItemSubmissionBulkWrite,
   type ItemSubmissionBulkWrite,
 } from '../queues/itemSubmissionQueue.js';
-import {
-  getPolicyActionPenaltiesForOrg,
-  type PolicyActionPenalties,
-} from '../services/policyActionPenalties.js';
 import makeActionPublisher, {
   type ActionPublisher,
   type ActionTargetItem,
@@ -173,6 +168,10 @@ import {
   makePlacesApiService,
   type PlacesApiService,
 } from '../services/placesApiService/index.js';
+import {
+  getPolicyActionPenaltiesForOrg,
+  type PolicyActionPenalties,
+} from '../services/policyActionPenalties.js';
 import {
   makeReportingService,
   type ReportingService,
@@ -481,7 +480,7 @@ export default async function getBottle() {
       new Kysely<CombinedPg>({
         dialect: new PostgresDialect({
           pool: new pg.Pool(getPgMasterConnectionInfo()),
-          cursor: Cursor as unknown as PostgresCursorConstructor,
+          cursor: Cursor,
         }),
       }),
   );
@@ -496,7 +495,7 @@ export default async function getBottle() {
             max: parseInt(process.env.DATABASE_READ_POOL_MAX ?? '150'),
             host: safeGetEnvVar('DATABASE_READ_ONLY_HOST'),
           }),
-          cursor: Cursor as unknown as PostgresCursorConstructor,
+          cursor: Cursor,
         }),
       }),
   );
@@ -691,8 +690,7 @@ export default async function getBottle() {
     // server cert. Prefer an explicit `SCYLLA_SSL_SERVERNAME` (e.g., the
     // Keyspaces regional endpoint) over inferring one from `SCYLLA_HOSTS`,
     // which may contain multiple contact points with different cert names.
-    const sslServerName =
-      process.env.SCYLLA_SSL_SERVERNAME ?? contactPoints[0];
+    const sslServerName = process.env.SCYLLA_SSL_SERVERNAME ?? contactPoints[0];
     const scyllaDriver = new ScyllaClient({
       contactPoints,
       credentials: {
@@ -768,7 +766,9 @@ export default async function getBottle() {
     // but keep it bounded so a true runaway is still noticeable.
     const controlConnection = (
       scyllaDriver as unknown as {
-        controlConnection?: { hosts?: { setMaxListeners?: (n: number) => void } };
+        controlConnection?: {
+          hosts?: { setMaxListeners?: (n: number) => void };
+        };
       }
     ).controlConnection;
     controlConnection?.hosts?.setMaxListeners?.(15);
@@ -1270,7 +1270,7 @@ export default async function getBottle() {
                     ...{
                       reportIds:
                         'reportIds' in job.payload
-                          ? job.payload.reportIds ?? []
+                          ? (job.payload.reportIds ?? [])
                           : [],
                     },
                     ...('reportedForReason' in job.payload
@@ -1410,10 +1410,7 @@ export default async function getBottle() {
 
       return cached({
         async producer(orgId) {
-          return getPolicyActionPenaltiesForOrg(
-            moderationConfigService,
-            orgId,
-          );
+          return getPolicyActionPenaltiesForOrg(moderationConfigService, orgId);
         },
         directives: { freshUntilAge: 60 },
       });

--- a/server/plugins/warehouse/utils/clickhouseSql.ts
+++ b/server/plugins/warehouse/utils/clickhouseSql.ts
@@ -23,7 +23,7 @@ function formatValue(value: unknown): string {
 
   const type = typeof value;
   if (type === 'number') {
-    if (!Number.isFinite(value as number)) {
+    if (!Number.isFinite(value)) {
       throw new Error('ClickHouse adapter does not support non-finite numbers');
     }
     return String(value);
@@ -89,4 +89,3 @@ function translateFunctions(statement: string): string {
     .replace(/\bDATE_TRUNC\b/gi, 'date_trunc')
     .replace(/\bDATE\(/gi, 'toDate(');
 }
-

--- a/server/plugins/warehouse/utils/clickhouseSql.ts
+++ b/server/plugins/warehouse/utils/clickhouseSql.ts
@@ -21,23 +21,22 @@ function formatValue(value: unknown): string {
     return `unhex('${value.toString('hex')}')`;
   }
 
-  const type = typeof value;
-  if (type === 'number') {
+  if (typeof value === 'number') {
     if (!Number.isFinite(value)) {
       throw new Error('ClickHouse adapter does not support non-finite numbers');
     }
     return String(value);
   }
 
-  if (type === 'bigint') {
+  if (typeof value === 'bigint') {
     return value.toString();
   }
 
-  if (type === 'boolean') {
-    return (value as boolean) ? '1' : '0';
+  if (typeof value === 'boolean') {
+    return value ? '1' : '0';
   }
 
-  if (type === 'object') {
+  if (typeof value === 'object') {
     const json = safeStableStringify(value);
     return `'${escapeString(json)}'`;
   }

--- a/server/routes/action/submitAction.test.ts
+++ b/server/routes/action/submitAction.test.ts
@@ -2,8 +2,6 @@ import { type Request, type Response } from 'express';
 
 import submitAction from './submitAction.js';
 
-type Handler = ReturnType<typeof submitAction>;
-
 function makeDeps(
   overrides?: Partial<{
     action: Record<string, unknown>;
@@ -48,7 +46,7 @@ function makeDeps(
     ModerationConfigService: { getActions, getPolicies },
     getItemTypeEventuallyConsistent,
     UserAPIDataSource: { getGraphQLUserFromId },
-  } as never) as Handler;
+  } as never);
 
   return { handler, publishActions, getActions };
 }
@@ -100,11 +98,7 @@ describe('submitAction (REST handler)', () => {
     const res = makeRes();
     const next = jest.fn();
 
-    await handler(
-      makeReq({ ...validBody, parameters: {} }),
-      res,
-      next,
-    );
+    await handler(makeReq({ ...validBody, parameters: {} }), res, next);
 
     expect(publishActions).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalledTimes(1);

--- a/server/routes/content/ContentRoutes.test.ts
+++ b/server/routes/content/ContentRoutes.test.ts
@@ -7,6 +7,7 @@ import { type Dependencies } from '../../iocContainer/index.js';
 import { serializeDerivedFieldSpec } from '../../services/derivedFieldsService/index.js';
 import { type ContentItemType } from '../../services/moderationConfigService/index.js';
 import createOrg from '../../test/fixtureHelpers/createOrg.js';
+import createUser from '../../test/fixtureHelpers/createUser.js';
 import { makeMockedServer } from '../../test/setupMockedServer.js';
 
 const { omit } = _;
@@ -21,7 +22,7 @@ describe('POST Content', () => {
     shutdown: Awaited<ReturnType<typeof makeMockedServer>>['shutdown'],
     apiKey: Awaited<ReturnType<typeof createOrg>>['apiKey'],
     orgCleanup: Awaited<ReturnType<typeof createOrg>>['cleanup'],
-    models: Dependencies['Sequelize'],
+    userCleanup: Awaited<ReturnType<typeof createUser>>['cleanup'],
     ModerationConfigService: Dependencies['ModerationConfigService'],
     ApiKeyService: Dependencies['ApiKeyService'],
     analytics: Dependencies['DataWarehouseAnalytics'],
@@ -32,15 +33,12 @@ describe('POST Content', () => {
       request,
       shutdown,
       deps: {
-        Sequelize: models,
         DataWarehouseAnalytics: analytics,
         ModerationConfigService,
         ApiKeyService,
         KyselyPg,
       },
     } = await makeMockedServer());
-
-    const { User } = models;
 
     ({ apiKey, cleanup: orgCleanup } = await createOrg(
       { KyselyPg, ModerationConfigService, ApiKeyService },
@@ -81,19 +79,12 @@ describe('POST Content', () => {
       schemaFieldRoles: {},
     });
 
-    await User.create({
+    ({ cleanup: userCleanup } = await createUser(KyselyPg, orgId, {
       id: userId,
-      orgId,
-      password: faker.random.alphaNumeric(),
-      firstName: faker.name.firstName(),
-      lastName: faker.name.lastName(),
-      email: faker.internet.email(),
-      loginMethods: ['password'],
-    });
+    }));
   });
 
   afterAll(async () => {
-    const { User } = models;
     await orgCleanup();
     await ModerationConfigService.deleteItemType({
       orgId,
@@ -103,7 +94,7 @@ describe('POST Content', () => {
       orgId,
       itemTypeId: contentType2.id,
     });
-    await User.destroy({ where: { id: userId } });
+    await userCleanup();
     await shutdown();
   });
 
@@ -187,26 +178,29 @@ describe('POST Content', () => {
   // But I ran it manually once and it works.
   test.skip('should return the requested derived fields', async () => {
     const seedOrgId = 'e7c89ce7729';
-    const contentTypeId = uid();
+    const contentType = await ModerationConfigService.createContentType(
+      seedOrgId,
+      {
+        name: 'tes333t',
+        description: faker.datatype.string(),
+        schema: [
+          {
+            name: 'video',
+            type: 'VIDEO',
+            required: false,
+            container: null,
+          },
+        ],
+        schemaFieldRoles: {},
+      },
+    );
     const fieldId = serializeDerivedFieldSpec({
-      source: { type: 'CONTENT_FIELD', name: 'video', contentTypeId },
+      source: {
+        type: 'CONTENT_FIELD',
+        name: 'video',
+        contentTypeId: contentType.id,
+      },
       derivationType: 'VIDEO_TRANSCRIPTION',
-    });
-
-    const contentType = await models.ItemType.create({
-      id: contentTypeId,
-      name: 'tes333t',
-      description: faker.datatype.string(),
-      orgId: seedOrgId,
-      fields: [
-        {
-          name: 'video',
-          type: 'VIDEO',
-          required: false,
-          container: null,
-        },
-      ],
-      kind: 'CONTENT',
     });
 
     try {
@@ -226,7 +220,7 @@ describe('POST Content', () => {
         .expect(200)
         .expect(({ body }) => {
           expect(body.derivedFields[fieldId].field.source.contentTypeId).toBe(
-            contentTypeId,
+            contentType.id,
           );
 
           expect(body.derivedFields[fieldId].value).toMatchInlineSnapshot(
@@ -249,7 +243,10 @@ describe('POST Content', () => {
           throw e;
         });
     } finally {
-      await contentType.destroy();
+      await ModerationConfigService.deleteItemType({
+        orgId: seedOrgId,
+        itemTypeId: contentType.id,
+      });
     }
   });
 

--- a/server/routes/items/ItemRoutes.test.ts
+++ b/server/routes/items/ItemRoutes.test.ts
@@ -5,6 +5,7 @@ import { uid } from 'uid';
 import { type Dependencies } from '../../iocContainer/index.js';
 import { type ContentItemType } from '../../services/moderationConfigService/index.js';
 import createOrg from '../../test/fixtureHelpers/createOrg.js';
+import createUser from '../../test/fixtureHelpers/createUser.js';
 import { makeMockedServer } from '../../test/setupMockedServer.js';
 
 describe('POST Items', () => {
@@ -16,7 +17,7 @@ describe('POST Items', () => {
     shutdown: Awaited<ReturnType<typeof makeMockedServer>>['shutdown'],
     apiKey: Awaited<ReturnType<typeof createOrg>>['apiKey'],
     orgCleanup: Awaited<ReturnType<typeof createOrg>>['cleanup'],
-    models: Dependencies['Sequelize'],
+    userCleanup: Awaited<ReturnType<typeof createUser>>['cleanup'],
     ModerationConfigService: Dependencies['ModerationConfigService'],
     ApiKeyService: Dependencies['ApiKeyService'],
     analytics: Dependencies['DataWarehouseAnalytics'],
@@ -27,15 +28,12 @@ describe('POST Items', () => {
       request,
       shutdown,
       deps: {
-        Sequelize: models,
         DataWarehouseAnalytics: analytics,
         ModerationConfigService,
         ApiKeyService,
         KyselyPg,
       },
     } = await makeMockedServer());
-
-    const { User } = models;
 
     ({ apiKey, cleanup: orgCleanup } = await createOrg(
       { KyselyPg, ModerationConfigService, ApiKeyService },
@@ -62,25 +60,18 @@ describe('POST Items', () => {
       schemaFieldRoles: {},
     });
 
-    await User.create({
+    ({ cleanup: userCleanup } = await createUser(KyselyPg, orgId, {
       id: userId,
-      orgId,
-      password: faker.random.alphaNumeric(),
-      firstName: faker.name.firstName(),
-      lastName: faker.name.lastName(),
-      email: faker.internet.email(),
-      loginMethods: ['password'],
-    });
+    }));
   });
 
   afterAll(async () => {
-    const { User } = models;
     await orgCleanup();
     await ModerationConfigService.deleteItemType({
       orgId,
       itemTypeId: contentType.id,
     });
-    await User.destroy({ where: { id: userId } });
+    await userCleanup();
     await shutdown();
   });
 

--- a/server/routes/policies/PoliciesRoutes.test.ts
+++ b/server/routes/policies/PoliciesRoutes.test.ts
@@ -6,15 +6,12 @@ import createPolicy from '../../test/fixtureHelpers/createPolicy.js';
 import { makeMockedServer } from '../../test/setupMockedServer.js';
 
 describe('GET policies', () => {
-  const orgId = uid(),
-    policyId1 = uid(),
-    policyId2 = uid();
+  const orgId = uid();
 
   let request: Awaited<ReturnType<typeof makeMockedServer>>['request'],
     shutdown: Awaited<ReturnType<typeof makeMockedServer>>['shutdown'],
     apiKey: Awaited<ReturnType<typeof createOrg>>['apiKey'],
     orgCleanup: Awaited<ReturnType<typeof createOrg>>['cleanup'],
-    models: Dependencies['Sequelize'],
     ModerationConfigService: Dependencies['ModerationConfigService'],
     ApiKeyService: Dependencies['ApiKeyService'],
     KyselyPg: Dependencies['KyselyPg'];
@@ -23,12 +20,7 @@ describe('GET policies', () => {
     ({
       request,
       shutdown,
-      deps: {
-        Sequelize: models,
-        ModerationConfigService,
-        ApiKeyService,
-        KyselyPg,
-      },
+      deps: { ModerationConfigService, ApiKeyService, KyselyPg },
     } = await makeMockedServer());
 
     ({ apiKey, cleanup: orgCleanup } = await createOrg(
@@ -38,9 +30,6 @@ describe('GET policies', () => {
   });
 
   afterAll(async () => {
-    const { Policy } = models;
-    await Policy.destroy({ where: { id: policyId1 } });
-    await Policy.destroy({ where: { id: policyId2 } });
     await orgCleanup();
     await shutdown();
   });

--- a/server/routes/reporting/ReportingRoutes.test.ts
+++ b/server/routes/reporting/ReportingRoutes.test.ts
@@ -1,8 +1,8 @@
 /* eslint-disable max-lines */
 import { faker } from '@faker-js/faker';
 
-import { type Dependencies } from '../../iocContainer/index.js';
 import createOrg from '../../test/fixtureHelpers/createOrg.js';
+import createUser from '../../test/fixtureHelpers/createUser.js';
 import { makeMockedServer } from '../../test/setupMockedServer.js';
 
 describe('POST Report', () => {
@@ -13,22 +13,17 @@ describe('POST Report', () => {
   let userTypeId: string;
   let threadTypeId: string;
 
-  let models: Dependencies['Sequelize'],
-    deps: Awaited<ReturnType<typeof makeMockedServer>>['deps'],
+  let deps: Awaited<ReturnType<typeof makeMockedServer>>['deps'],
     request: Awaited<ReturnType<typeof makeMockedServer>>['request'],
     shutdown: Awaited<ReturnType<typeof makeMockedServer>>['shutdown'],
     apiKey: Awaited<ReturnType<typeof createOrg>>['apiKey'],
-    orgCleanup: Awaited<ReturnType<typeof createOrg>>['cleanup'];
+    orgCleanup: Awaited<ReturnType<typeof createOrg>>['cleanup'],
+    userCleanup: Awaited<ReturnType<typeof createUser>>['cleanup'];
 
-  const getBulkWriteMock = () =>
-    deps.DataWarehouseAnalytics.bulkWrite as jest.MockedFunction<
-      Dependencies['DataWarehouseAnalytics']['bulkWrite']
-    >;
+  const getBulkWriteMock = () => deps.DataWarehouseAnalytics.bulkWrite;
 
   beforeAll(async () => {
     ({ deps, request, shutdown } = await makeMockedServer());
-
-    models = deps.Sequelize;
 
     ({ apiKey, cleanup: orgCleanup } = await createOrg(
       {
@@ -110,24 +105,28 @@ describe('POST Report', () => {
 
     threadTypeId = threadType.id;
 
-    await models.User.create({
+    ({ cleanup: userCleanup } = await createUser(deps.KyselyPg, orgId, {
       id: userId,
-      orgId,
-      password: faker.random.alphaNumeric(),
-      firstName: faker.name.firstName(),
-      lastName: faker.name.lastName(),
-      email: faker.internet.email(),
-      loginMethods: ['password'],
-    });
+    }));
   });
 
   afterAll(async () => {
-    const { User, ItemType } = models;
     await orgCleanup();
-    await ItemType.destroy({ where: { id: contentTypeId } });
-    await ItemType.destroy({ where: { id: userTypeId } });
-    await ItemType.destroy({ where: { id: threadTypeId } });
-    await User.destroy({ where: { id: userId } });
+    await Promise.all([
+      deps.ModerationConfigService.deleteItemType({
+        orgId,
+        itemTypeId: contentTypeId,
+      }),
+      deps.ModerationConfigService.deleteItemType({
+        orgId,
+        itemTypeId: userTypeId,
+      }),
+      deps.ModerationConfigService.deleteItemType({
+        orgId,
+        itemTypeId: threadTypeId,
+      }),
+    ]);
+    await userCleanup();
     await shutdown();
   });
 

--- a/server/rule_engine/ActionPublisher.ts
+++ b/server/rule_engine/ActionPublisher.ts
@@ -77,8 +77,8 @@ export function getUserFromActionTarget(it: ActionTargetItem) {
   return it.itemType.kind === 'USER'
     ? { id: it.itemId, typeId: it.itemType.id }
     : isFullSubmission(it)
-    ? it.creator
-    : undefined;
+      ? it.creator
+      : undefined;
 }
 
 /**
@@ -100,8 +100,8 @@ export function getUserFromActionTargetItem(it: ActionTargetItem) {
   return it.itemType.kind === 'USER'
     ? { id: it.itemId, typeId: it.itemType.id }
     : isFullSubmission(it)
-    ? it.creator
-    : undefined;
+      ? it.creator
+      : undefined;
 }
 
 /**
@@ -267,9 +267,7 @@ class ActionPublisher {
                 // Audit-trail context: persist what the moderator supplied
                 // alongside the action itself so reviewers can see why and
                 // with what values it ran (PR 3 for #377).
-                parameterValues: customMrtApiParamDecisionPayload as
-                  | Record<string, unknown>
-                  | undefined,
+                parameterValues: customMrtApiParamDecisionPayload,
                 actorNote,
               },
             ],

--- a/server/services/itemProcessingService/fieldTypeHandlers.test.ts
+++ b/server/services/itemProcessingService/fieldTypeHandlers.test.ts
@@ -31,7 +31,7 @@ describe('Content type schemas', () => {
             fc.property(dummyContainerFieldArb, (containerField) => {
               expect(
                 (handlers as (typeof fieldTypeHandlers)[ContainerType]).coerce(
-                  null as never,
+                  null,
                   [],
                   containerField.container as never,
                 ),

--- a/server/services/manualReviewToolService/manualReviewToolQueries.ts
+++ b/server/services/manualReviewToolService/manualReviewToolQueries.ts
@@ -23,7 +23,7 @@ export const makeGetActionsByIdEventuallyConsistent = inject(
           orgId: actionIds.orgId,
           ids: actionIds.ids,
           readFromReplica: true,
-        }) as Promise<CollapseCases<Action>[]>;
+        });
       },
       directives: { freshUntilAge: 10, maxStale: [0, 2, 2] },
     }),

--- a/server/services/manualReviewToolService/modules/CommentOperations.test.ts
+++ b/server/services/manualReviewToolService/modules/CommentOperations.test.ts
@@ -26,23 +26,24 @@ describe('CommentOperations', () => {
 
     // Create test user
     const { user, cleanup: userCleanup } = await createUser(
-      container.Sequelize,
+      container.KyselyPg,
       orgId,
     );
 
     // Create a queue (required for job_creations foreign key)
-    const queue = await container.ManualReviewToolService.createManualReviewQueue({
-      name: 'Test Queue',
-      description: null,
-      userIds: [user.id],
-      hiddenActionIds: [],
-      isAppealsQueue: false,
-      invokedBy: {
-        userId: user.id,
-        permissions: [UserPermission.EDIT_MRT_QUEUES],
-        orgId,
-      },
-    });
+    const queue =
+      await container.ManualReviewToolService.createManualReviewQueue({
+        name: 'Test Queue',
+        description: null,
+        userIds: [user.id],
+        hiddenActionIds: [],
+        isAppealsQueue: false,
+        invokedBy: {
+          userId: user.id,
+          permissions: [UserPermission.EDIT_MRT_QUEUES],
+          orgId,
+        },
+      });
 
     // Create test item identifiers and jobs
     const itemId = uuidv1();
@@ -164,7 +165,10 @@ describe('CommentOperations', () => {
           })
           .execute();
 
-        const result = await commentOps.getComments({ orgId, jobId: singleJobId });
+        const result = await commentOps.getComments({
+          orgId,
+          jobId: singleJobId,
+        });
 
         expect(result).toHaveLength(1);
         expect(result[0].commentText).toBe('Test comment');
@@ -262,7 +266,10 @@ describe('CommentOperations', () => {
     testWithFixtures(
       'should return 0 when no comments found',
       async ({ commentOps, orgId, jobId1 }) => {
-        const result = await commentOps.getCommentCount({ orgId, jobId: jobId1 });
+        const result = await commentOps.getCommentCount({
+          orgId,
+          jobId: jobId1,
+        });
 
         expect(result).toBe(0);
       },
@@ -302,7 +309,10 @@ describe('CommentOperations', () => {
           ])
           .execute();
 
-        const result = await commentOps.getCommentCount({ orgId, jobId: jobId1 });
+        const result = await commentOps.getCommentCount({
+          orgId,
+          jobId: jobId1,
+        });
 
         expect(result).toBe(3);
       },
@@ -461,7 +471,10 @@ describe('CommentOperations', () => {
           authorId: userId,
         });
 
-        const result = await commentOps.getCommentCount({ orgId, jobId: jobId2 });
+        const result = await commentOps.getCommentCount({
+          orgId,
+          jobId: jobId2,
+        });
 
         expect(result).toBe(3);
       },

--- a/server/services/manualReviewToolService/modules/QueueOperations.test.ts
+++ b/server/services/manualReviewToolService/modules/QueueOperations.test.ts
@@ -45,7 +45,7 @@ describe('QueueOperations', () => {
       );
 
       const { user, cleanup: userCleanup } = await createUser(
-        container.Sequelize,
+        container.KyselyPg,
         org.id,
       );
       const { itemTypes, cleanup: itemTypesCleanup } =

--- a/server/services/moderationConfigService/moderationConfigService.test.ts
+++ b/server/services/moderationConfigService/moderationConfigService.test.ts
@@ -17,12 +17,11 @@ import { ErrorType } from '../../utils/errors.js';
 import { type Satisfies } from '../../utils/typescript-types.js';
 import { type ModerationConfigServicePg } from './dbTypes.js';
 import {
+  RuleStatus,
+  RuleType,
   type Action,
   type ConditionSet,
   type ItemType,
-  RuleAlarmStatus,
-  RuleStatus,
-  RuleType,
   type Policy,
   type UserItemType,
 } from './index.js';
@@ -133,13 +132,11 @@ describe('ModerationConfigService', () => {
   });
 
   afterAll(async () => {
-    const { Sequelize: models } = (await getBottle()).container;
     await dummyOrgCleanup();
 
     await Promise.all([
       container.KyselyPg.destroy(),
       container.KyselyPgReadReplica.destroy(),
-      await models.close(),
     ]);
   });
 
@@ -205,33 +202,23 @@ describe('ModerationConfigService', () => {
         uid(),
       );
       const { user, cleanup: userCleanup } = await createUser(
-        container.Sequelize,
+        container.KyselyPg,
         org.id,
       );
-      const ruleId = uid();
-      await container.Sequelize.Rule.create({
-        id: ruleId,
-        orgId: org.id,
-        creatorId: user.id,
+      const rule = await createRule(container.KyselyPg, org.id, {
+        creator: user,
         name: 'getRuleByIdAndOrg fixture rule',
-        description: null,
-        status: RuleStatus.DRAFT,
-        statusIfUnexpired: RuleStatus.DRAFT,
-        tags: [],
-        conditionSet: minimalRuleConditionSet,
         ruleType: RuleType.USER,
-        alarmStatus: RuleAlarmStatus.INSUFFICIENT_DATA,
+        status: RuleStatus.DRAFT,
+        conditionSet: minimalRuleConditionSet,
       });
 
       return {
         org,
         user,
-        ruleId,
+        ruleId: rule.id,
         async cleanup() {
-          await container.Sequelize.Rule.destroy({
-            where: { id: ruleId },
-            force: true,
-          });
+          await rule.destroy();
           await userCleanup();
           await orgCleanup();
         },
@@ -572,31 +559,31 @@ describe('ModerationConfigService', () => {
             uid(),
           );
           try {
-            const contentType =
-              await sutWithPrimary.createContentType(fresh.org.id, {
+            const contentType = await sutWithPrimary.createContentType(
+              fresh.org.id,
+              {
                 schema: dummySchema,
                 description: null,
                 name: faker.random.alphaNumeric(16),
                 schemaFieldRoles: { displayName: 'fakeField' },
-              });
+              },
+            );
 
             const forUser = await sutWithPrimary.getActionsForItemType({
               orgId: fresh.org.id,
               itemTypeId: fresh.defaultUserItemType.id,
               itemTypeKind: 'USER',
             });
-            expect(
-              forUser.map((it) => it.actionType).sort(),
-            ).toEqual(['ENQUEUE_TO_MRT', 'ENQUEUE_TO_NCMEC'].sort());
+            expect(forUser.map((it) => it.actionType).sort()).toEqual(
+              ['ENQUEUE_TO_MRT', 'ENQUEUE_TO_NCMEC'].sort(),
+            );
 
             const forContent = await sutWithPrimary.getActionsForItemType({
               orgId: fresh.org.id,
               itemTypeId: contentType.id,
               itemTypeKind: 'CONTENT',
             });
-            expect(
-              forContent.map((it) => it.actionType).sort(),
-            ).toEqual(
+            expect(forContent.map((it) => it.actionType).sort()).toEqual(
               [
                 'ENQUEUE_AUTHOR_TO_MRT',
                 'ENQUEUE_TO_MRT',
@@ -663,9 +650,7 @@ describe('ModerationConfigService', () => {
             (it) => it.actionType === 'CUSTOM_ACTION',
           );
           expect(customActions).toHaveLength(createdActions.length);
-          expect(customActions).toEqual(
-            expect.arrayContaining(createdActions),
-          );
+          expect(customActions).toEqual(expect.arrayContaining(createdActions));
         });
 
         it('should round-trip a non-null customMrtApiParams value', async () => {
@@ -862,16 +847,18 @@ describe('ModerationConfigService', () => {
 
             await new Promise((resolve) => setTimeout(resolve, 5));
 
-            const result = await sutWithPrimary.updateCustomAction(
-              dummyOrgId,
-              { actionId: action.id, patch: {} },
-            );
+            const result = await sutWithPrimary.updateCustomAction(dummyOrgId, {
+              actionId: action.id,
+              patch: {},
+            });
 
             const after = await container.KyselyPg.selectFrom('public.actions')
               .select(['updated_at'])
               .where('id', '=', action.id)
               .executeTakeFirstOrThrow();
-            expect(after.updated_at.getTime()).toBe(before.updated_at.getTime());
+            expect(after.updated_at.getTime()).toBe(
+              before.updated_at.getTime(),
+            );
             expect(result.id).toBe(action.id);
           },
         );
@@ -1196,11 +1183,9 @@ describe('ModerationConfigService', () => {
                 schemaFieldRoles: { displayName: 'fakeField' },
               },
             );
-            const rule = await createRule(container.Sequelize, dummyOrgId);
+            const rule = await createRule(container.KyselyPg, dummyOrgId);
 
-            await container.KyselyPg.insertInto(
-              'public.actions_and_item_types',
-            )
+            await container.KyselyPg.insertInto('public.actions_and_item_types')
               .values({ action_id: action.id, item_type_id: itemType.id })
               .execute();
             await container.KyselyPg.insertInto('public.rules_and_actions')
@@ -1375,7 +1360,7 @@ describe('ModerationConfigService', () => {
 
     describe('#getActionsForRuleId', () => {
       const testWithRuleAndAction = makeTestWithFixture(async () => {
-        const rule = await createRule(container.Sequelize, dummyOrgId);
+        const rule = await createRule(container.KyselyPg, dummyOrgId);
         const action = await sutWithPrimary.createAction(dummyOrgId, {
           name: faker.random.alphaNumeric(16),
           description: null,
@@ -1463,7 +1448,7 @@ describe('ModerationConfigService', () => {
         );
 
         const { user, cleanup: userCleanup } = await createUser(
-          container.Sequelize,
+          container.KyselyPg,
           org.id,
         );
 

--- a/server/services/moderationConfigService/modules/PolicyOperations.ts
+++ b/server/services/moderationConfigService/modules/PolicyOperations.ts
@@ -15,7 +15,6 @@ import {
 import {
   isUniqueViolationError,
   type FixKyselyRowCorrelation,
-
 } from '../../../utils/kysely.js';
 import { removeUndefinedKeys } from '../../../utils/misc.js';
 import { type ModerationConfigServicePg } from '../dbTypes.js';
@@ -124,7 +123,7 @@ export default class PolicyOperations {
     const out: Record<string, Policy[]> = {};
     for (const row of rows) {
       const { ruleId, ...policyFields } = row;
-      const policy = this.#dbResultToPolicy(policyFields as PolicyDbResult);
+      const policy = this.#dbResultToPolicy(policyFields);
       (out[ruleId] ??= []).push(policy);
     }
     return out;
@@ -142,8 +141,7 @@ export default class PolicyOperations {
       .select(policyDbSelection)
       .where('org_id', '=', orgId)
       .where('id', '=', policyId);
-    const result =
-      (await query.executeTakeFirst()) as PolicyDbResult;
+    const result = (await query.executeTakeFirst()) as PolicyDbResult;
 
     return this.#dbResultToPolicy(result);
   }

--- a/server/services/reportingService/ReportingRules.ts
+++ b/server/services/reportingService/ReportingRules.ts
@@ -1,9 +1,9 @@
-import { type ConsumerDirectives } from '../../lib/cache/index.js';
 import { makeEnumLike } from '@roostorg/types';
 import { sql, type Kysely, type Transaction } from 'kysely';
 import { type ReadonlyDeep } from 'type-fest';
 import { v1 as uuidv1 } from 'uuid';
 
+import { type ConsumerDirectives } from '../../lib/cache/index.js';
 import { cached } from '../../utils/caching.js';
 import { filterNullOrUndefined } from '../../utils/collections.js';
 import {
@@ -162,7 +162,7 @@ export default class ReportingRules {
 
         return {
           ...reportingRule,
-          itemTypeIds: itemTypeIds as string[],
+          itemTypeIds,
           actionIds,
           policyIds,
         };

--- a/server/services/ruleAnomalyDetectionService/detectRulePassRateAnomaliesJob.test.ts
+++ b/server/services/ruleAnomalyDetectionService/detectRulePassRateAnomaliesJob.test.ts
@@ -86,12 +86,9 @@ describe('Detect Rule Anomalies', () => {
 
     beforeAll(async () => {
       /* eslint-disable functional/immutable-data */
-      const {
-        Sequelize: models,
-        ModerationConfigService,
-        ApiKeyService,
-        KyselyPg,
-      } = (await getBottle()).container;
+      const { ModerationConfigService, ApiKeyService, KyselyPg } = (
+        await getBottle()
+      ).container;
 
       // make some fake rules (w/ stable ids so we can match them in a snapshot)
       // in different initial alarm statuses, to test all 9 combinations [i.e.,
@@ -111,56 +108,60 @@ describe('Detect Rule Anomalies', () => {
         undefined,
         { onCallAlertEmail: 'test@gmail.com' },
       );
-      const { user: ruleOwner } = await createUser(models, org.id, {
-        id: 'cb34377bcc3',
-      });
-      const { user: ruleOwner2 } = await createUser(models, org.id, {
-        id: 'cb34377bcc4',
-      });
+      const { user: ruleOwner, cleanup: ruleOwnerCleanup } = await createUser(
+        KyselyPg,
+        org.id,
+        { id: 'cb34377bcc3' },
+      );
+      const { user: ruleOwner2, cleanup: ruleOwner2Cleanup } = await createUser(
+        KyselyPg,
+        org.id,
+        { id: 'cb34377bcc4' },
+      );
       const fakeRules = await Promise.all([
-        createRule(models, org.id, {
+        createRule(KyselyPg, org.id, {
           alarmStatus: RuleAlarmStatus.ALARM,
           id: '9d237a650c1',
           creator: ruleOwner,
         }),
-        createRule(models, org.id, {
+        createRule(KyselyPg, org.id, {
           alarmStatus: RuleAlarmStatus.ALARM,
           id: '386da8abc3b',
           creator: ruleOwner,
         }),
-        createRule(models, org.id, {
+        createRule(KyselyPg, org.id, {
           alarmStatus: RuleAlarmStatus.ALARM,
           id: 'd237a650c13',
           creator: ruleOwner,
         }),
 
-        createRule(models, org.id, {
+        createRule(KyselyPg, org.id, {
           alarmStatus: RuleAlarmStatus.OK,
           id: '86da8abc3b6',
           creator: ruleOwner,
         }),
-        createRule(models, org.id, {
+        createRule(KyselyPg, org.id, {
           alarmStatus: RuleAlarmStatus.OK,
           id: 'fdb4ee86f93',
           creator: ruleOwner,
         }),
-        createRule(models, org.id, {
+        createRule(KyselyPg, org.id, {
           alarmStatus: RuleAlarmStatus.OK,
           id: '237a650c134',
           creator: ruleOwner,
         }),
 
-        createRule(models, org2.id, {
+        createRule(KyselyPg, org2.id, {
           alarmStatus: RuleAlarmStatus.INSUFFICIENT_DATA,
           id: 'db4ee86f938',
           creator: ruleOwner2,
         }),
-        createRule(models, org2.id, {
+        createRule(KyselyPg, org2.id, {
           alarmStatus: RuleAlarmStatus.INSUFFICIENT_DATA,
           id: '37a650c1342',
           creator: ruleOwner2,
         }),
-        createRule(models, org2.id, {
+        createRule(KyselyPg, org2.id, {
           alarmStatus: RuleAlarmStatus.INSUFFICIENT_DATA,
           id: 'b4ee86f9386',
           creator: ruleOwner2,
@@ -210,10 +211,9 @@ describe('Detect Rule Anomalies', () => {
 
       deleteMockData = async () => {
         await Promise.all(fakeRules.map(async (it) => it.destroy()));
-        await Promise.all([ruleOwner.destroy(), ruleOwner2.destroy()]);
+        await Promise.all([ruleOwnerCleanup(), ruleOwner2Cleanup()]);
         await orgCleanup();
         await org2Cleanup();
-        await models.sequelize.close();
       };
       /* eslint-enable functional/immutable-data */
     });

--- a/server/services/signalsService/SignalsService.ts
+++ b/server/services/signalsService/SignalsService.ts
@@ -294,8 +294,8 @@ export class SignalsService {
       'value' in input.value
         ? input.value.type
         : isTaggedItemData(input.value)
-        ? 'FULL_ITEM'
-        : assertUnreachable(input.value, 'Unknown signal input...');
+          ? 'FULL_ITEM'
+          : assertUnreachable(input.value, 'Unknown signal input...');
 
     if (!signal.eligibleInputs.includes(signalInputType)) {
       throw new CoopError({
@@ -320,7 +320,7 @@ export class SignalsService {
     // and some demand an image reference), so it'll only let us make this call
     // if we cast the input to `never` (which is the intersection of every
     // signal's input type).
-    return signal.run(input as never) as Promise<
+    return signal.run(input) as Promise<
       Awaited<SignalTypesToRunOutputTypes[T]>
     >;
   }

--- a/server/services/signalsService/SignalsService.ts
+++ b/server/services/signalsService/SignalsService.ts
@@ -311,15 +311,12 @@ export class SignalsService {
       });
     }
 
-    // When we look up the signal with `#getSignalInstance` above, TS thinks
-    // (correctly) that we could get any signal back, but it loses track of the
-    // relationship between the signal we get back and the type of the `input`.
-    // So, when we call `signal.run()` it tries to check that the `input` is a
-    // type that _any_ signal would accept. However, there is no type that'll
-    // work as every signal's input (e.g, because some signals demand text input
-    // and some demand an image reference), so it'll only let us make this call
-    // if we cast the input to `never` (which is the intersection of every
-    // signal's input type).
+    // `#getSignalInstance` returns a signal whose input type is the union of
+    // every signal's input, so TS loses the relationship between the looked-up
+    // signal and the caller's `input`. The cast on the return value restores
+    // the expected output type for this signal type `T`; the runtime call is
+    // sound because we already validated `signalInputType` against
+    // `signal.eligibleInputs` above.
     return signal.run(input) as Promise<
       Awaited<SignalTypesToRunOutputTypes[T]>
     >;

--- a/server/services/signalsService/signals/aggregation/AggregationSignal.test.ts
+++ b/server/services/signalsService/signals/aggregation/AggregationSignal.test.ts
@@ -21,7 +21,6 @@ describe('AggregationSignal', () => {
     const { server, deps, shutdown } = await makeMockedServer();
 
     const {
-      Sequelize: models,
       ModerationConfigService,
       AggregationsService,
       RuleAPIDataSource,
@@ -35,7 +34,7 @@ describe('AggregationSignal', () => {
       uid(),
     );
 
-    const { user, cleanup: userCleanup } = await createUser(models, org.id, {});
+    const { user, cleanup: userCleanup } = await createUser(KyselyPg, org.id);
 
     const { itemTypes, cleanup: itemTypesCleanup } =
       await createContentItemTypes({

--- a/server/services/signalsService/types/SignalId.ts
+++ b/server/services/signalsService/types/SignalId.ts
@@ -78,7 +78,7 @@ export function isSignalId(it: unknown): it is SignalId {
     typeof it === 'object' &&
     it !== null &&
     'type' in it &&
-    typeof (it as { type: unknown }).type === 'string' &&
+    typeof it.type === 'string' &&
     (it.type === SignalType.CUSTOM
       ? 'id' in it && isNonEmptyString(it.id)
       : true)

--- a/server/services/signingKeyPairService/postgresSigningKeyPairStorage.ts
+++ b/server/services/signingKeyPairService/postgresSigningKeyPairStorage.ts
@@ -52,11 +52,10 @@ export class PostgresSigningKeyPairStorage implements SigningKeyPairStorage {
         org_id: keyId.orgId,
         key_data: jsonStringify(keyData),
       })
-      .onConflict((oc) => oc
-        .column('org_id')
-        .doUpdateSet({
+      .onConflict((oc) =>
+        oc.column('org_id').doUpdateSet({
           key_data: jsonStringify(keyData),
-        })
+        }),
       )
       .execute();
   }
@@ -81,10 +80,8 @@ export class PostgresSigningKeyPairStorage implements SigningKeyPairStorage {
 
     const keyData: JWTCryptoKeyPairWithAlgorithm =
       typeof result.key_data === 'string'
-        ? jsonParse(
-            result.key_data as JsonOf<JWTCryptoKeyPairWithAlgorithm>,
-          )
-        : (result.key_data as JWTCryptoKeyPairWithAlgorithm);
+        ? jsonParse(result.key_data as JsonOf<JWTCryptoKeyPairWithAlgorithm>)
+        : result.key_data;
     const { privateKeyWithAlgorithm, publicKeyWithAlgorithm } = keyData;
 
     return {

--- a/server/storage/dataWarehouse/DataWarehouseFactory.ts
+++ b/server/storage/dataWarehouse/DataWarehouseFactory.ts
@@ -3,10 +3,11 @@
  */
 
 /* eslint-disable max-classes-per-file */
+import { type Kysely } from 'kysely';
+
 import {
   ClickhouseAnalyticsAdapter as ClickhouseAnalyticsPlugin,
   NoOpAnalyticsAdapter,
-  type AnalyticsEventInput,
   type IAnalyticsAdapter,
 } from '../../plugins/analytics/index.js';
 import {
@@ -27,7 +28,6 @@ import {
   type DataWarehouseProvider as IDataWarehouseProvider,
   type TransactionFunction,
 } from './IDataWarehouse.js';
-import { type Kysely } from 'kysely';
 import type {
   AnalyticsSchema,
   BulkWriteConfig,
@@ -119,7 +119,7 @@ class WarehouseAdapterBridge implements IDataWarehouse {
     return this.adapter.transaction(async (warehouseQuery) => {
       return fn(async (statement, parameters = []) => {
         const rows = await warehouseQuery(statement, parameters);
-        return Array.from(rows) as unknown[];
+        return Array.from(rows);
       });
     });
   }
@@ -154,7 +154,7 @@ class AnalyticsAdapterBridge implements IDataWarehouseAnalytics {
   ): Promise<void> {
     await this.adapter.writeEvents(
       tableName,
-      rows as readonly AnalyticsEventInput[],
+      rows,
       config?.batchTimeout !== undefined
         ? { batchTimeout: config.batchTimeout }
         : undefined,
@@ -263,8 +263,7 @@ export class DataWarehouseFactory {
     config: DataWarehouseConfig,
     dialect?: IDataWarehouseDialect,
   ): IDataWarehouseAnalytics {
-    const analyticsProvider =
-      config.analyticsProvider ?? (config.provider as AnalyticsProvider);
+    const analyticsProvider = config.analyticsProvider ?? config.provider;
 
     switch (analyticsProvider) {
       case 'noop':

--- a/server/test/fixtureHelpers/createRule.ts
+++ b/server/test/fixtureHelpers/createRule.ts
@@ -1,57 +1,103 @@
+import { type Kysely } from 'kysely';
 import { uid } from 'uid';
 
-import { type Dependencies } from '../../iocContainer/index.js';
-import { type User } from '../../models/UserModel.js';
+import {
+  kyselyCreateRule,
+  kyselyDeleteRule,
+} from '../../graphql/datasources/ruleKyselyPersistence.js';
+import { type CombinedPg } from '../../services/combinedDbTypes.js';
 import {
   ConditionConjunction,
+  RuleAlarmStatus,
   RuleStatus,
-  type RuleAlarmStatus,
+  RuleType,
+  type ConditionSet,
 } from '../../services/moderationConfigService/index.js';
 import { SignalType } from '../../services/signalsService/index.js';
 import { jsonStringify } from '../../utils/encoding.js';
 import { logErrorAndThrow } from '../utils.js';
 import createUser from './createUser.js';
 
-export default async function (
-  models: Dependencies['Sequelize'],
+const DEFAULT_CONDITION_SET: ConditionSet = {
+  conditions: [
+    {
+      input: {
+        type: 'CONTENT_FIELD',
+        name: 'text',
+        contentTypeId: '6f8f8612205',
+      },
+      signal: {
+        id: jsonStringify({ type: SignalType.TEXT_MATCHING_CONTAINS_TEXT }),
+        type: SignalType.TEXT_MATCHING_CONTAINS_TEXT,
+      },
+      matchingValues: { strings: ['test'] },
+    },
+  ],
+  conjunction: ConditionConjunction.AND,
+};
+
+export default async function createRule(
+  db: Kysely<CombinedPg>,
   orgId: string,
   extra: {
     creatorId?: string;
-    creator?: User;
+    creator?: { id: string };
     id?: string;
     alarmStatus?: RuleAlarmStatus;
     name?: string;
+    ruleType?: RuleType;
+    status?: RuleStatus;
+    conditionSet?: ConditionSet;
   } = {},
 ) {
-  const finalId = extra.id ?? uid();
-  return models.Rule.create({
-    id: finalId,
-    name: extra.name ?? `Dummy_Rule_Name_${finalId}`,
-    status: RuleStatus.LIVE,
-    alarmStatus: extra.alarmStatus,
+  const ruleId = extra.id ?? uid();
+  const name = extra.name ?? `Dummy_Rule_Name_${ruleId}`;
+  const ruleType = extra.ruleType ?? RuleType.CONTENT;
+  const status = extra.status ?? RuleStatus.LIVE;
+  const creatorId =
+    extra.creator?.id ??
+    extra.creatorId ??
+    (await createUser(db, orgId)).user.id;
+
+  await kyselyCreateRule(db, {
+    id: ruleId,
+    name,
+    description: null,
+    status,
+    conditionSet: extra.conditionSet ?? DEFAULT_CONDITION_SET,
     tags: [],
+    maxDailyActions: null,
+    expirationTime: null,
+    creatorId,
     orgId,
-    ruleType: 'CONTENT',
-    creatorId:
-      extra.creator?.id ??
-      extra.creatorId ??
-      (await createUser(models, orgId)).user.id,
-    conditionSet: {
-      conditions: [
-        {
-          input: {
-            type: 'CONTENT_FIELD',
-            name: 'text',
-            contentTypeId: '6f8f8612205',
-          },
-          signal: {
-            id: jsonStringify({ type: SignalType.TEXT_MATCHING_CONTAINS_TEXT }),
-            type: SignalType.TEXT_MATCHING_CONTAINS_TEXT,
-          },
-          matchingValues: { strings: ['test'] },
-        },
-      ],
-      conjunction: ConditionConjunction.AND,
-    },
+    ruleType,
+    parentId: null,
+    actionIds: [],
+    policyIds: [],
+    contentTypeIds: [],
   }).catch(logErrorAndThrow);
+
+  // `kyselyCreateRule` always seeds `INSUFFICIENT_DATA`; patch when callers
+  // seed a different alarm status (e.g. anomaly-detection snapshot fixtures).
+  const alarmStatus = extra.alarmStatus ?? RuleAlarmStatus.INSUFFICIENT_DATA;
+  if (alarmStatus !== RuleAlarmStatus.INSUFFICIENT_DATA) {
+    await db
+      .updateTable('public.rules')
+      .set({ alarm_status: alarmStatus, alarm_status_set_at: new Date() })
+      .where('id', '=', ruleId)
+      .where('org_id', '=', orgId)
+      .execute();
+  }
+
+  return {
+    id: ruleId,
+    orgId,
+    creatorId,
+    name,
+    alarmStatus,
+    statusIfUnexpired: status,
+    async destroy() {
+      await kyselyDeleteRule(db, ruleId, orgId);
+    },
+  };
 }

--- a/server/test/fixtureHelpers/createUser.ts
+++ b/server/test/fixtureHelpers/createUser.ts
@@ -1,28 +1,50 @@
 import { faker } from '@faker-js/faker';
+import { type Kysely } from 'kysely';
 import { uid } from 'uid';
 
-import { type Dependencies } from '../../iocContainer/index.js';
+import {
+  kyselyUserDeleteById,
+  kyselyUserInsert,
+} from '../../graphql/datasources/userKyselyPersistence.js';
+import { UserRole } from '../../models/types/permissioning.js';
+import { type CombinedPg } from '../../services/combinedDbTypes.js';
+import { type LoginMethod } from '../../services/coreAppTables.js';
 import { logErrorAndThrow } from '../utils.js';
 
-export default async function (
-  models: Dependencies['Sequelize'],
+// SAML-only by default keeps the `password_null_when_not_present` CHECK
+// satisfied without a placeholder password.
+const DEFAULT_LOGIN_METHODS: readonly LoginMethod[] = ['saml'];
+
+export default async function createUser(
+  db: Kysely<CombinedPg>,
   orgId: string,
-  extra: { id?: string } = {},
+  extra: {
+    id?: string;
+    role?: UserRole;
+    loginMethods?: readonly LoginMethod[];
+    password?: string | null;
+  } = {},
 ) {
-  const user = await models.User.create({
+  const userId = extra.id ?? uid();
+  const loginMethods = extra.loginMethods ?? DEFAULT_LOGIN_METHODS;
+  const password = extra.password ?? null;
+
+  const user = await kyselyUserInsert({
+    db,
+    id: userId,
     orgId,
-    id: extra.id ?? uid(),
     email: faker.internet.email(),
-    password: '',
+    password,
     firstName: faker.name.firstName(),
     lastName: faker.name.lastName(),
-    loginMethods: ['password'],
+    role: extra.role ?? UserRole.ADMIN,
+    loginMethods,
   }).catch(logErrorAndThrow);
 
   return {
     user,
     async cleanup() {
-      await user.destroy();
+      await kyselyUserDeleteById(db, userId);
     },
   };
 }

--- a/server/test/fixtureHelpers/fixtureHelpers.test.ts
+++ b/server/test/fixtureHelpers/fixtureHelpers.test.ts
@@ -1,0 +1,178 @@
+import { uid } from 'uid';
+
+import { kyselyUserFindById } from '../../graphql/datasources/userKyselyPersistence.js';
+import { UserRole } from '../../models/types/permissioning.js';
+import {
+  RuleAlarmStatus,
+  RuleStatus,
+  RuleType,
+} from '../../services/moderationConfigService/index.js';
+import { makeMockedServer } from '../setupMockedServer.js';
+import { makeTestWithFixture } from '../utils.js';
+import createOrg from './createOrg.js';
+import createRule from './createRule.js';
+import createUser from './createUser.js';
+
+describe('fixtureHelpers', () => {
+  const testWithOrg = makeTestWithFixture(async () => {
+    const { deps, shutdown } = await makeMockedServer();
+    const { org, cleanup: orgCleanup } = await createOrg(
+      {
+        KyselyPg: deps.KyselyPg,
+        ModerationConfigService: deps.ModerationConfigService,
+        ApiKeyService: deps.ApiKeyService,
+      },
+      uid(),
+    );
+    return {
+      deps,
+      org,
+      async cleanup() {
+        await orgCleanup();
+        await shutdown();
+      },
+    };
+  });
+
+  describe('createUser', () => {
+    testWithOrg(
+      'defaults: SAML-only loginMethods, ADMIN role, null password, override id honored',
+      async ({ deps, org }) => {
+        const overrideId = uid();
+        const { user, cleanup } = await createUser(deps.KyselyPg, org.id, {
+          id: overrideId,
+        });
+        try {
+          expect(user).toMatchObject({
+            id: overrideId,
+            orgId: org.id,
+            role: UserRole.ADMIN,
+            loginMethods: ['saml'],
+            password: null,
+          });
+        } finally {
+          await cleanup();
+        }
+      },
+    );
+
+    testWithOrg('cleanup() actually deletes the row', async ({ deps, org }) => {
+      const { user, cleanup } = await createUser(deps.KyselyPg, org.id);
+      expect(await kyselyUserFindById(deps.KyselyPg, user.id)).toBeDefined();
+      await cleanup();
+      expect(await kyselyUserFindById(deps.KyselyPg, user.id)).toBeUndefined();
+    });
+  });
+
+  describe('createRule', () => {
+    testWithOrg(
+      'defaults: CONTENT type, LIVE status, INSUFFICIENT_DATA alarm, override id/name honored',
+      async ({ deps, org }) => {
+        const overrideId = uid();
+        const overrideName = `RuleFixture_${overrideId}`;
+        const rule = await createRule(deps.KyselyPg, org.id, {
+          id: overrideId,
+          name: overrideName,
+        });
+        try {
+          expect(rule).toMatchObject({
+            id: overrideId,
+            orgId: org.id,
+            name: overrideName,
+            alarmStatus: RuleAlarmStatus.INSUFFICIENT_DATA,
+            statusIfUnexpired: RuleStatus.LIVE,
+          });
+
+          const row = await deps.KyselyPg.selectFrom('public.rules')
+            .select(['rule_type', 'status_if_unexpired', 'alarm_status'])
+            .where('id', '=', overrideId)
+            .executeTakeFirstOrThrow();
+          expect(row.rule_type).toBe(RuleType.CONTENT);
+          expect(row.status_if_unexpired).toBe(RuleStatus.LIVE);
+          expect(row.alarm_status).toBe(RuleAlarmStatus.INSUFFICIENT_DATA);
+        } finally {
+          await rule.destroy();
+        }
+      },
+    );
+
+    testWithOrg(
+      'extra.alarmStatus !== INSUFFICIENT_DATA triggers the follow-up UPDATE',
+      async ({ deps, org }) => {
+        const rule = await createRule(deps.KyselyPg, org.id, {
+          alarmStatus: RuleAlarmStatus.ALARM,
+        });
+        try {
+          expect(rule.alarmStatus).toBe(RuleAlarmStatus.ALARM);
+          const row = await deps.KyselyPg.selectFrom('public.rules')
+            .select('alarm_status')
+            .where('id', '=', rule.id)
+            .executeTakeFirstOrThrow();
+          expect(row.alarm_status).toBe(RuleAlarmStatus.ALARM);
+        } finally {
+          await rule.destroy();
+        }
+      },
+    );
+
+    testWithOrg(
+      'extra.ruleType: USER persists rule_type=USER (and skips item-type junctions)',
+      async ({ deps, org }) => {
+        const rule = await createRule(deps.KyselyPg, org.id, {
+          ruleType: RuleType.USER,
+        });
+        try {
+          const row = await deps.KyselyPg.selectFrom('public.rules')
+            .select('rule_type')
+            .where('id', '=', rule.id)
+            .executeTakeFirstOrThrow();
+          expect(row.rule_type).toBe(RuleType.USER);
+
+          const junctions = await deps.KyselyPg.selectFrom(
+            'public.rules_and_item_types',
+          )
+            .select('item_type_id')
+            .where('rule_id', '=', rule.id)
+            .execute();
+          expect(junctions).toEqual([]);
+        } finally {
+          await rule.destroy();
+        }
+      },
+    );
+
+    testWithOrg('destroy() removes the row', async ({ deps, org }) => {
+      const rule = await createRule(deps.KyselyPg, org.id);
+      const before = await deps.KyselyPg.selectFrom('public.rules')
+        .select('id')
+        .where('id', '=', rule.id)
+        .executeTakeFirst();
+      expect(before).toBeDefined();
+
+      await rule.destroy();
+
+      const after = await deps.KyselyPg.selectFrom('public.rules')
+        .select('id')
+        .where('id', '=', rule.id)
+        .executeTakeFirst();
+      expect(after).toBeUndefined();
+    });
+
+    testWithOrg(
+      'auto-creates a creator user when none is supplied',
+      async ({ deps, org }) => {
+        const rule = await createRule(deps.KyselyPg, org.id);
+        try {
+          const creator = await kyselyUserFindById(
+            deps.KyselyPg,
+            rule.creatorId,
+          );
+          expect(creator).toBeDefined();
+          expect(creator?.orgId).toBe(org.id);
+        } finally {
+          await rule.destroy();
+        }
+      },
+    );
+  });
+});

--- a/server/test/setupMockedServer.ts
+++ b/server/test/setupMockedServer.ts
@@ -51,9 +51,7 @@ export async function getBottleContainerWithIOMocks() {
   ) as jest.MockedFunction<IDataWarehouse['query']>;
 
   const transactionImpl: IDataWarehouse['transaction'] = async (fn) =>
-    fn(async (sql, binds) =>
-      queryMock(sql, tracer, binds as readonly unknown[] | undefined),
-    );
+    fn(async (sql, binds) => queryMock(sql, tracer, binds));
 
   const startMock = jest.fn(() => {}) as IDataWarehouse['start'];
   const closeMock = jest.fn(async () => {}) as IDataWarehouse['close'];

--- a/server/utils/apiKeyMiddleware.ts
+++ b/server/utils/apiKeyMiddleware.ts
@@ -43,7 +43,7 @@ export function createApiKeyMiddleware<
     }
 
     if (!orgId) {
-      // Invalid API key is a client-side error, so return a 400.
+      // A missing or invalid API key is an authentication failure, so return 401.
       const requestId = toCorrelationId({
         type: 'api-key-validation',
         id: uuidv1(),

--- a/server/utils/apiKeyMiddleware.ts
+++ b/server/utils/apiKeyMiddleware.ts
@@ -2,11 +2,8 @@ import { type JsonObject, type JsonValue, type ReadonlyDeep } from 'type-fest';
 import { v1 as uuidv1 } from 'uuid';
 
 import { type Dependencies } from '../iocContainer/index.js';
-import {
-  fromCorrelationId,
-  toCorrelationId,
-} from './correlationIds.js';
-import { ErrorType, CoopError } from './errors.js';
+import { fromCorrelationId, toCorrelationId } from './correlationIds.js';
+import { CoopError, ErrorType } from './errors.js';
 import { type RequestHandlerWithBodies } from './route-helpers.js';
 
 /**
@@ -22,18 +19,24 @@ export interface RequestWithOrgId {
  */
 export function createApiKeyMiddleware<
   ReqBody extends JsonObject = JsonObject,
-  ResBody extends ReadonlyDeep<JsonValue> | undefined = ReadonlyDeep<JsonValue> | undefined
+  ResBody extends ReadonlyDeep<JsonValue> | undefined =
+    | ReadonlyDeep<JsonValue>
+    | undefined,
 >({
   ApiKeyService,
-}: Pick<Dependencies, 'ApiKeyService'>): RequestHandlerWithBodies<ReqBody, ResBody> {
+}: Pick<Dependencies, 'ApiKeyService'>): RequestHandlerWithBodies<
+  ReqBody,
+  ResBody
+> {
   return async (req, _res, next) => {
     const providedKey = req.header('x-api-key');
     let orgId: string | null;
-    
+
     try {
-      orgId = providedKey && !Array.isArray(providedKey) 
-        ? await ApiKeyService.validateApiKey(providedKey) 
-        : null;
+      orgId =
+        providedKey && !Array.isArray(providedKey)
+          ? await ApiKeyService.validateApiKey(providedKey)
+          : null;
     } catch (_error) {
       // If API key validation throws an error, treat it as invalid
       orgId = null;
@@ -41,22 +44,24 @@ export function createApiKeyMiddleware<
 
     if (!orgId) {
       // Invalid API key is a client-side error, so return a 400.
-      const requestId = toCorrelationId({ 
-        type: 'api-key-validation', 
-        id: uuidv1() 
+      const requestId = toCorrelationId({
+        type: 'api-key-validation',
+        id: uuidv1(),
       });
-      
-      return next(new CoopError({
-        status: 401,
-        type: [ErrorType.Unauthorized],
-        title: 'Invalid API Key',
-        detail:
-          'Something went wrong finding or validating your API key. ' +
-          'Make sure the proper key is provided in the x-api-key header.',
-        requestId: fromCorrelationId(requestId),
-        name: 'UnauthorizedError',
-        shouldErrorSpan: true,
-      }));
+
+      return next(
+        new CoopError({
+          status: 401,
+          type: [ErrorType.Unauthorized],
+          title: 'Invalid API Key',
+          detail:
+            'Something went wrong finding or validating your API key. ' +
+            'Make sure the proper key is provided in the x-api-key header.',
+          requestId: fromCorrelationId(requestId),
+          name: 'UnauthorizedError',
+          shouldErrorSpan: true,
+        }),
+      );
     }
 
     // Store orgId on the request for use by route handlers
@@ -69,5 +74,10 @@ export function createApiKeyMiddleware<
  * Type guard to check if request has orgId set by the API key middleware
  */
 export function hasOrgId(req: unknown): req is RequestWithOrgId {
-  return typeof req === 'object' && req !== null && 'orgId' in req && typeof (req as { orgId: unknown }).orgId === 'string';
+  return (
+    typeof req === 'object' &&
+    req !== null &&
+    'orgId' in req &&
+    typeof req.orgId === 'string'
+  );
 }

--- a/server/utils/sql.test.ts
+++ b/server/utils/sql.test.ts
@@ -1,8 +1,10 @@
-import { Kysely, PostgresDialect, type PostgresQueryResult } from 'kysely';
+import { Kysely, PostgresDialect } from 'kysely';
 
 import { takeLast } from './sql.js';
 
-function makeCompileOnlyDb<T extends Record<string, Record<string, unknown>>>() {
+function makeCompileOnlyDb<
+  T extends Record<string, Record<string, unknown>>,
+>() {
   return new Kysely<T>({
     dialect: new PostgresDialect({
       pool: {
@@ -12,7 +14,7 @@ function makeCompileOnlyDb<T extends Record<string, Record<string, unknown>>>() 
               rows: [],
               command: 'SELECT',
               rowCount: 0,
-            } as PostgresQueryResult<unknown>),
+            }),
             async release() {},
           };
         },

--- a/server/utils/sql.ts
+++ b/server/utils/sql.ts
@@ -47,22 +47,21 @@ export function takeLast<
 ) {
   let inner = unsortedSelectQuery.clearOrderBy();
   for (const it of sortCriteria) {
-    inner = inner.orderBy(
-      it.column,
-      it.order === 'desc' ? 'asc' : 'desc',
-    );
+    inner = inner.orderBy(it.column, it.order === 'desc' ? 'asc' : 'desc');
   }
   inner = inner.limit(size);
 
   // Chaining `orderBy` in a loop widens `outer` to an incompatible union; the
   // builder is still the same concrete Kysely select at runtime.
-  let outer = db.selectFrom(inner.as(SUBQUERY_ALIAS)).selectAll() as SelectQueryBuilder<
+  let outer = db
+    .selectFrom(inner.as(SUBQUERY_ALIAS))
+    .selectAll() as SelectQueryBuilder<
     DB & { [K in typeof SUBQUERY_ALIAS]: O },
     typeof SUBQUERY_ALIAS,
     O
   >;
   for (const it of sortCriteria) {
-    outer = outer.orderBy(it.column, it.order) as typeof outer;
+    outer = outer.orderBy(it.column, it.order);
   }
   return outer as SelectQueryBuilder<
     DB & { [K in typeof SUBQUERY_ALIAS]: O },

--- a/server/utils/sql.ts
+++ b/server/utils/sql.ts
@@ -51,8 +51,10 @@ export function takeLast<
   }
   inner = inner.limit(size);
 
-  // Chaining `orderBy` in a loop widens `outer` to an incompatible union; the
-  // builder is still the same concrete Kysely select at runtime.
+  // The initial cast pins `outer` to the concrete `SelectQueryBuilder` shape
+  // we want to return; chaining `orderBy` in the loop below otherwise widens
+  // it to an incompatible union, and the final cast restores that shape for
+  // callers. The builder is the same concrete Kysely select at runtime.
   let outer = db
     .selectFrom(inner.as(SUBQUERY_ALIAS))
     .selectAll() as SelectQueryBuilder<


### PR DESCRIPTION
## Context & Requests for Reviewers

Removes the last remaining consumers of the `Sequelize` IoC factory by migrating the two test-fixture helpers, the `create-org-and-user` bin script, and the route/service tests that injected `Sequelize` directly. After this PR merges, the `Sequelize` factory in `iocContainer/index.ts` has zero callers, which unblocks the final demolition PR (delete `server/models/`, drop the IoC bindings, drop `sequelize` + `clshooked` from `server/package.json`).

Had to change some more files due to husky errors 😓 

After merge, the next (final) PR will do the final cleanup into one demolition pr 💥 
