### PR TITLE
mdbook: use versioned subdirectories for GitHub Pages

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -42,6 +42,8 @@ jobs:
     env:
       MDBOOK_VERSION: 0.5.2
     steps:
+      # inputs.ref is only set for manual backfills; push-to-main and tag-push events
+      # default to the triggering ref automatically
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -33,7 +33,7 @@ permissions:
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: 'pages'
+  group: 'mdbook'
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -62,26 +62,37 @@ jobs:
         run: ${{ github.workspace }}/mdbook-bin/mdbook build docs
 
       - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: docs/book
-          target-folder: ${{ steps.deploy-path.outputs.path }}
-
-      - name: Checkout gh-pages for index generation
-        uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-          path: gh-pages-content
-
-      - name: Generate version index
-        working-directory: gh-pages-content
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          mkdir -p ../index-deploy
-          tree -d -L 1 -H . -T "Coop Documentation" -o ../index-deploy/index.html --noreport
+          DEPLOY_PATH="${{ steps.deploy-path.outputs.path }}"
 
-      - name: Deploy root index
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: index-deploy
-          target-folder: .
-          clean: false
+          # Clone the gh-pages branch, or initialize it if this is the first deployment
+          if git ls-remote --exit-code --heads origin gh-pages > /dev/null 2>&1; then
+            git clone --depth=1 --single-branch --branch gh-pages \
+              "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+              _gh-pages
+          else
+            mkdir _gh-pages
+            git -C _gh-pages init
+            git -C _gh-pages checkout --orphan gh-pages
+            git -C _gh-pages remote add origin \
+              "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          fi
+
+          touch _gh-pages/.nojekyll
+
+          # Deploy the versioned docs
+          rm -rf "_gh-pages/${DEPLOY_PATH}"
+          cp -r docs/book "_gh-pages/${DEPLOY_PATH}"
+
+          # Regenerate the root version index
+          (cd _gh-pages && tree -d -L 1 -H . -T "Coop Documentation" -o index.html --noreport)
+
+          # Commit and push
+          git -C _gh-pages config user.name "github-actions[bot]"
+          git -C _gh-pages config user.email "github-actions[bot]@users.noreply.github.com"
+          git -C _gh-pages add --all
+          git -C _gh-pages diff --staged --quiet || \
+            git -C _gh-pages commit --message "Deploy docs: ${DEPLOY_PATH}"
+          git -C _gh-pages push origin gh-pages

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -3,34 +3,42 @@ name: Deploy mdBook site to Pages
 on:
   # Runs on pushes targeting the default branch, only when docs or this workflow change
   push:
-    branches: ["main"]
+    branches: ['main']
     paths:
-      - "docs/**"
-      - ".github/workflows/mdbook.yml"
+      - 'docs/**'
+      - '.github/workflows/mdbook.yml'
+    tags:
+      - '[0-9]*'
 
-  # Allows you to run this workflow manually from the Actions tab
+  # Allows you to run this workflow manually from the Actions tab (supports --ref for backfilling tags)
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+# Write access needed to push to the gh-pages branch
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: "pages"
+  group: 'pages'
   cancel-in-progress: false
 
 jobs:
-  # Build job
   build:
     runs-on: ubuntu-latest
     env:
       MDBOOK_VERSION: 0.5.2
     steps:
       - uses: actions/checkout@v4
+
+      - name: Determine deployment path
+        id: deploy-path
+        run: |
+          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+            echo "path=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
+          else
+            echo "path=latest" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Cache mdBook binary
         id: cache-mdbook
@@ -50,24 +58,30 @@ jobs:
           tar -xzf mdbook.tar.gz -C mdbook-bin
           rm mdbook.tar.gz
 
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v5
       - name: Build with mdBook
         run: ${{ github.workspace }}/mdbook-bin/mdbook build docs
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./docs/book
 
-  # Deployment job
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
       - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: docs/book
+          target-folder: ${{ steps.deploy-path.outputs.path }}
+
+      - name: Checkout gh-pages for index generation
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages-content
+
+      - name: Generate version index
+        working-directory: gh-pages-content
+        run: |
+          mkdir -p ../index-deploy
+          tree -d -L 1 -H . -T "Coop Documentation" -o ../index-deploy/index.html --noreport
+
+      - name: Deploy root index
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: index-deploy
+          target-folder: .
+          clean: false

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -39,6 +39,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'roostorg/coop' }}
     env:
       MDBOOK_VERSION: 0.5.2
     steps:

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -1,8 +1,8 @@
-# docs in `main` get built into `/latest`, docs from tags get build into a subdirectory
+# docs in `main` get built into `/latest`, docs from tags get built into a subdirectory
 # matching the tag name (e.g. `/0.1`). Automatically runs when updating the docs, editing
 # this workflow, or pushing a new tag.
 #
-# Does not handle directly publishing to GitHub Pages; just updates the `gh-pages` branch to 
+# Does not handle directly publishing to GitHub Pages; just updates the `gh-pages` branch to
 # let GitHub build and deploy from that branch.
 
 name: Update docs with mdbook

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -57,6 +57,10 @@ jobs:
             DEPLOY_REF="$GITHUB_REF_NAME"
           fi
           if [[ "$GITHUB_REF_TYPE" == "tag" || "$DEPLOY_REF" =~ ^[0-9] ]]; then
+            if [[ "$DEPLOY_REF" =~ [^A-Za-z0-9._-] ]]; then
+               echo "Refusing unsafe deploy ref: $DEPLOY_REF" >&2
+               exit 1
+            fi
             echo "path=$DEPLOY_REF" >> "$GITHUB_OUTPUT"
           else
             echo "path=latest" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -10,8 +10,15 @@ on:
     tags:
       - '[0-9]*'
 
-  # Allows you to run this workflow manually from the Actions tab (supports --ref for backfilling tags)
+  # Allows you to run this workflow manually from the Actions tab.
+  # To backfill an old version, pass the tag as the `ref` input so the new
+  # workflow file runs from main but checks out docs from the specified tag.
   workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Tag to build and deploy docs from (e.g. 0.1); leave empty for latest main'
+        required: false
+        type: string
 
 # Write access needed to push to the gh-pages branch
 permissions:
@@ -30,12 +37,19 @@ jobs:
       MDBOOK_VERSION: 0.5.2
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Determine deployment path
         id: deploy-path
         run: |
-          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
-            echo "path=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
+          # For manual backfill, use the input ref; otherwise derive from the triggering ref
+          DEPLOY_REF="${{ inputs.ref }}"
+          if [[ -z "$DEPLOY_REF" ]]; then
+            DEPLOY_REF="$GITHUB_REF_NAME"
+          fi
+          if [[ "$GITHUB_REF_TYPE" == "tag" || "$DEPLOY_REF" =~ ^[0-9] ]]; then
+            echo "path=$DEPLOY_REF" >> "$GITHUB_OUTPUT"
           else
             echo "path=latest" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -1,7 +1,13 @@
-name: Deploy mdBook site to Pages
+# docs in `main` get built into `/latest`, docs from tags get build into a subdirectory
+# matching the tag name (e.g. `/0.1`). Automatically runs when updating the docs, editing
+# this workflow, or pushing a new tag.
+#
+# Does not handle directly publishing to GitHub Pages; just updates the `gh-pages` branch to 
+# let GitHub build and deploy from that branch.
+
+name: Update docs with mdbook
 
 on:
-  # Runs on pushes targeting the default branch, only when docs or this workflow change
   push:
     branches: ['main']
     paths:

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -55,6 +55,10 @@ jobs:
           # For manual backfill, use the input ref; otherwise derive from the triggering ref
           DEPLOY_REF="${{ inputs.ref }}"
           if [[ -z "$DEPLOY_REF" ]]; then
+            if [[ "${{ github.event_name }}" == "workflow_dispatch" && "$GITHUB_REF_NAME" != "main" ]]; then
+              echo "Dispatching from a non-main branch requires a ref input (e.g. a tag name)" >&2
+              exit 1
+            fi
             DEPLOY_REF="$GITHUB_REF_NAME"
           fi
           if [[ "$GITHUB_REF_TYPE" == "tag" || "$DEPLOY_REF" =~ ^[0-9] ]]; then


### PR DESCRIPTION
Fixes #415

Switches from the artifact-based deploy-pages approach (which replaces the entire site on each run) to deploy to a `gh-pages` branch scoped to a single target folder.

- Docs in `main` deploy to `/latest/`
- Tagged releases deploy that tag's docs to a matching subdirectory (e.g. `/0.1/`)
- A simple index is regenerated after each deployment to list available versions at `/`

This does bring a one-time break of existing docs URLs on the generated docs site since they'll be under `/latest/` now; however, going forward this should give us more stable URLs since they'll be scoped to the released versions. Links to Markdown files directly in the GitHub web UI will remain the same as before, including browsing the repo by tag or commit to view a snapshot of the docs.

After updating the Pages source setting to serve from the `gh-pages` branch, we'll need to backfill old releases:

```sh
gh workflow run mdbook.yml --repo roostorg/coop --field ref=0.0
gh workflow run mdbook.yml --repo roostorg/coop --field ref=0.1
```

## Non-code follow-up

- [x] switch GitHub Pages setting to deploy from `gh-pages` branch
- [x] backfill old releases
- [x] test and make sure it all looks right!