### PR TITLE
Build and serve client assets from the server container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# This is a fairly-standard multi-stage Dockerfile. We build 
+# This is a fairly-standard multi-stage Dockerfile. We build
 # backend in a Node image, and then we copy the built files
 # (but not the devDependencies [like typescript, etc.] or the raw source
 # files) to final images that we'll actually run. This makes the final image a
@@ -16,6 +16,13 @@ RUN npm ci
 COPY ["server", "./"]
 
 FROM server_base AS build_backend
+RUN npm run build
+
+FROM node:24.14.1-bullseye-slim AS build_client
+WORKDIR /app
+COPY ["client/package.json", "client/package-lock.json", "./"]
+RUN npm ci
+COPY ["client", "./"]
 RUN npm run build
 
 # make a shared layer that can be the base for worker and api images.
@@ -39,6 +46,7 @@ ENV BUILD_ID=$BUILD_ID
 # Expose 8080 because the backend will run on this port absent a
 # process.env.PORT to the contrary.
 FROM backend_base AS build_server
+COPY --from=build_client /app/build ./client-build
 EXPOSE 8080
 CMD ["node", "bin/www.js"]
 

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
 import express from 'express';
 
 import makeApiApp from './api.js';
@@ -49,6 +51,18 @@ export default async function makeWWWServer(deps: Dependencies) {
   });
 
   app.use('/api/v1', apiApp);
+
+  const clientBuildPath = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    'client-build',
+  );
+  app.use(express.static(clientBuildPath));
+  app.get('{*path}', (_req, res, next) => {
+    const indexPath = path.join(clientBuildPath, 'index.html');
+    res.sendFile(indexPath, (err) => {
+      if (err) next();
+    });
+  });
 
   return { app, shutdown };
 }


### PR DESCRIPTION
## Context & Requests for Reviewers
This adds client assets to the server container which makes it easier to deploy coop on ECS or something similar without needing a CDN.

## Tests
Deployed coop to ecs with these changes. Also verified that the app works locally.
