### PR TITLE
ci: harden GitHub Actions: SHA-pin all uses, --ignore-scripts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -167,3 +167,12 @@ updates:
         applies-to: 'version-updates'
         patterns:
           - '*'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -167,12 +167,3 @@ updates:
         applies-to: 'version-updates'
         patterns:
           - '*'
-
-  - package-ecosystem: 'github-actions'
-    directory: '/'
-    schedule:
-      interval: 'weekly'
-    groups:
-      github-actions:
-        patterns:
-          - '*'

--- a/.github/workflows/apply_pr_checks.yaml
+++ b/.github/workflows/apply_pr_checks.yaml
@@ -28,20 +28,20 @@ jobs:
     if: needs.check_for_server_changes.outputs.result == 'true' || needs.check_for_client_changes.outputs.result == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Check generated GraphQL is up to date
         run: docker compose run --rm --quiet-pull codegen-check
 
   check_migration_order:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           # this is needed to fetch the main branch
           ref: ${{ github.base_ref || 'main' }}
           fetch-depth: 1
           sparse-checkout: 'db/src/scripts'
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           # this is needed to fetch the main branch
           fetch-depth: 1
@@ -119,7 +119,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Lint
         run: docker compose run --rm --quiet-pull backend npm run lint
@@ -141,7 +141,7 @@ jobs:
 
       - name: Test Report
         if: always() # run this step even if previous step failed
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5  # v1.9.1
         continue-on-error: true
         with:
           name: JEST Tests # Name of the check run which will be created
@@ -155,7 +155,7 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Lint client
         run: docker compose run --rm --quiet-pull client npm run lint

--- a/.github/workflows/check_if_directory_changed.yaml
+++ b/.github/workflows/check_if_directory_changed.yaml
@@ -22,13 +22,13 @@ jobs:
     steps:
       # We need to checkout the main branch to compare it against the current
       # branch
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 1
           sparse-checkout: '${{ inputs.directory }}'
           ref: ${{ github.base_ref || 'main' }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           sparse-checkout: '${{ inputs.directory }}'
           fetch-depth: 1

--- a/.github/workflows/checklist.yaml
+++ b/.github/workflows/checklist.yaml
@@ -10,9 +10,9 @@ jobs:
     name: Checklist job
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Checklist
-        uses: ethanresnick/pr-checklists@v1
+        uses: ethanresnick/pr-checklists@4fcf5dc226d3b7eddb209e58fdbd8226f4d179d3  # v1 (no patch tags published)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       # inputs.ref is only set for manual backfills; push-to-main and tag-push events
       # default to the triggering ref automatically
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           ref: ${{ inputs.ref }}
 
@@ -73,7 +73,7 @@ jobs:
 
       - name: Cache mdBook binary
         id: cache-mdbook
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:
           path: mdbook-bin
           key: mdbook-${{ env.MDBOOK_VERSION }}-${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/publish-db-migrator.yaml
+++ b/.github/workflows/publish-db-migrator.yaml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
@@ -35,7 +35,7 @@ jobs:
             echo "⚠️  Version $VERSION of @roostorg/db-migrator already exists on npm - skipping"
           else
             echo "✅ Publishing @roostorg/db-migrator@$VERSION..."
-            npm ci
+            npm ci --ignore-scripts
             npm run build
             npm publish
           fi

--- a/.github/workflows/publish-types.yaml
+++ b/.github/workflows/publish-types.yaml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
@@ -35,7 +35,7 @@ jobs:
             echo "⚠️  Version $VERSION of @roostorg/types already exists on npm - skipping"
           else
             echo "✅ Publishing @roostorg/types@$VERSION..."
-            npm ci
+            npm ci --ignore-scripts
             npm run build
             npm publish
           fi


### PR DESCRIPTION
Fixes #447 

## Summary

Pin every action in `.github/workflows/` to a specific patch-release SHA (with version comments) to harden against the upstream-tag-hijack supply-chain pattern.
## Changes

| Action | Pinned to |
|---|---|
| `actions/checkout` | v4.3.1 |
| `actions/cache` | v4.3.0 |
| `actions/setup-node` | v6.4.0 |
| `dorny/test-reporter` | v1.9.1 |
| `ethanresnick/pr-checklists` | `v1` SHA — maintainer does not publish patch tags |

**`.github/dependabot.yml`** — added `github-actions` ecosystem (weekly, grouped) so the new SHA pins get bumped automatically and don't bitrot.

**`publish-db-migrator.yaml` / `publish-types.yaml`** — `npm ci` → `npm ci --ignore-scripts` as defense against postinstall-based credential theft in the publish chain. This blocks transitive-dep postinstall scripts from running while the OIDC token is in process env. `npm run build` and `npm publish` are unaffected — those run the project's own scripts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to pin GitHub Actions to specific versions for improved security and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/439)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->