### PR TITLE
client: always use relative GraphQL URL

### DIFF
--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -44,10 +44,7 @@ gql`
 `;
 
 const httpLink = new HttpLink({
-  uri:
-    import.meta.env.MODE === 'production'
-      ? '/api/v1/graphql'
-      : 'http://localhost:3000/api/v1/graphql',
+  uri: '/api/v1/graphql',
 });
 
 const retryLink = new RetryLink({


### PR DESCRIPTION
The hardcoded localhost fallback breaks environments like Codespaces where the app isn't served from localhost. The relative path works in all environments.

Fixes #452

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved inconsistent API endpoint configuration to ensure reliable connectivity across all environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/455)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->