### PR TITLE
[Code simplification] Drop unmaintained graphql-passport server dependency

### DIFF
--- a/server/api.ts
+++ b/server/api.ts
@@ -22,7 +22,7 @@ import { GraphQLError, type GraphQLFormattedError } from 'graphql';
 import helmet from 'helmet';
 import passport from 'passport';
 
-import { makeLoginUserDoesNotExistError } from './graphql/datasources/UserApi.js';
+import { makeLoginUserDoesNotExistError } from './graphql/datasources/userApiErrors.js';
 import {
   kyselyUserFindByEmail,
   kyselyUserFindById,
@@ -382,12 +382,11 @@ export default async function makeApiServer(deps: Dependencies) {
     '/graphql',
     express.json(),
     expressMiddleware(apolloServer, {
-      context: async ({ req, res }) =>
-        ({
-          ...buildPassportContext(req, res),
-          services: makeGqlServices(deps),
-          dataSources: deps.DataSources,
-        }),
+      context: async ({ req, res }) => ({
+        ...buildPassportContext(req, res),
+        services: makeGqlServices(deps),
+        dataSources: deps.DataSources,
+      }),
     }),
   );
 

--- a/server/api.ts
+++ b/server/api.ts
@@ -19,15 +19,10 @@ import cors from 'cors';
 import express, { type ErrorRequestHandler } from 'express';
 import session from 'express-session';
 import { GraphQLError, type GraphQLFormattedError } from 'graphql';
-import { buildContext, GraphQLLocalStrategy } from 'graphql-passport';
 import helmet from 'helmet';
 import passport from 'passport';
 
-import {
-  makeLoginIncorrectPasswordError,
-  makeLoginSsoRequiredError,
-  makeLoginUserDoesNotExistError,
-} from './graphql/datasources/UserApi.js';
+import { makeLoginUserDoesNotExistError } from './graphql/datasources/UserApi.js';
 import {
   kyselyUserFindByEmail,
   kyselyUserFindById,
@@ -35,11 +30,11 @@ import {
 import resolvers, { type Context } from './graphql/resolvers.js';
 import typeDefs from './graphql/schema.js';
 import { authSchemaWrapper } from './graphql/utils/authorization.js';
+import { buildPassportContext } from './graphql/utils/passportContext.js';
 import { safeDepthLimit } from './graphql/utils/safeDepthLimit.js';
 import { type Dependencies } from './iocContainer/index.js';
 import { isEnvTrue, safeGetEnvInt } from './iocContainer/utils.js';
 import controllers from './routes/index.js';
-import { passwordMatchesHash } from './services/userManagementService/index.js';
 import { createBodySchemaValidator } from './utils/bodySchemaValidation.js';
 import { jsonStringify } from './utils/encoding.js';
 import {
@@ -281,65 +276,6 @@ export default async function makeApiServer(deps: Dependencies) {
     },
   );
 
-  passport.use(
-    new GraphQLLocalStrategy(async (email, password, done) => {
-      try {
-        const user = await kyselyUserFindByEmail(KyselyPg, String(email));
-        if (user == null) {
-          return done(
-            makeLoginUserDoesNotExistError({ shouldErrorSpan: true }),
-          );
-        }
-        const samlSettings = await deps.OrgSettingsService.getSamlSettings(
-          user.orgId,
-        );
-
-        if (
-          samlSettings?.saml_enabled &&
-          // We allow Coop users to log in with email/password even if SSO is
-          // enabled
-          // so Coop employees can manage user accounts
-          String(email).split('@')[1] !== 'getcoop.com'
-        ) {
-          return done(
-            makeLoginSsoRequiredError({
-              detail:
-                'SAML is enabled for this organization. Password login is disabled.',
-              shouldErrorSpan: true,
-            }),
-          );
-        }
-
-        if (!user.loginMethods.includes('password')) {
-          return done(
-            makeLoginIncorrectPasswordError({
-              detail: 'Password is not set for user.',
-              shouldErrorSpan: true,
-            }),
-          );
-        }
-
-        // `loginMethods` includes 'password', so the DB CHECK constraint
-        // guarantees `user.password` is non-null here.
-        if (
-          user.password != null &&
-          (await passwordMatchesHash(String(password), user.password))
-        ) {
-          done(null, user);
-        } else {
-          done(makeLoginIncorrectPasswordError({ shouldErrorSpan: true }));
-        }
-      } catch (e) {
-        deps.Tracer.logActiveSpanFailedIfAny(e);
-        return done(
-          makeInternalServerError('Unknown error during login attempt', {
-            shouldErrorSpan: true,
-          }),
-        );
-      }
-    }),
-  );
-
   passport.serializeUser((user: any, done) => {
     done(null, user.id);
   });
@@ -448,10 +384,10 @@ export default async function makeApiServer(deps: Dependencies) {
     expressMiddleware(apolloServer, {
       context: async ({ req, res }) =>
         ({
-          ...buildContext({ req, res }),
+          ...buildPassportContext(req, res),
           services: makeGqlServices(deps),
           dataSources: deps.DataSources,
-        }) as unknown as Context,
+        }),
     }),
   );
 

--- a/server/graphql/datasources/UserApi.ts
+++ b/server/graphql/datasources/UserApi.ts
@@ -1,5 +1,4 @@
 import { type Exception } from '@opentelemetry/api';
-import { type PassportContext } from 'graphql-passport';
 import { uid } from 'uid';
 
 import { inject, type Dependencies } from '../../iocContainer/index.js';
@@ -12,15 +11,16 @@ import {
   CoopError,
   ErrorType,
   makeBadRequestError,
-  makeInternalServerError,
   makeNotFoundError,
   makeUnauthorizedError,
   type ErrorInstanceData,
 } from '../../utils/errors.js';
 import { safePick } from '../../utils/misc.js';
 import { WEEK_MS } from '../../utils/time.js';
+import { type PassportGqlContext } from '../utils/passportContext.js';
 import { buildGraphqlRuleParent } from './buildGraphqlRuleParent.js';
 import { type GraphQLRuleParent } from './ruleKyselyPersistence.js';
+import { verifyEmailPasswordCredentials } from './userApiCredentials.js';
 import {
   kyselyUserAddFavoriteRule,
   kyselyUserFindByEmail,
@@ -48,6 +48,7 @@ class UserAPI {
     private readonly tracer: Dependencies['Tracer'],
     private readonly userManagementService: Dependencies['UserManagementService'],
     private readonly moderationConfigService: Dependencies['ModerationConfigService'],
+    private readonly orgSettingsService: Dependencies['OrgSettingsService'],
   ) {}
 
   async getGraphQLUserFromId(opts: {
@@ -71,26 +72,27 @@ class UserAPI {
     return kyselyUserFindByIds(this.kyselyPg, ids);
   }
 
-  async login(params: any, context: PassportContext<GraphQLUserParent, any>) {
-    const credentials = safePick(params.input, ['email', 'password']);
+  async login(params: any, context: PassportGqlContext) {
+    const { email, password } = safePick(params.input, ['email', 'password']);
 
-    // NB: this will throw for bad credentials; will be handled in the resolver.
-    const { user } = await context.authenticate('graphql-local', credentials);
-
-    if (!user) {
-      throw makeInternalServerError('Unknown error during login attempt', {
-        shouldErrorSpan: true,
-      });
-    }
+    const user = await verifyEmailPasswordCredentials(
+      {
+        kyselyPg: this.kyselyPg,
+        orgSettingsService: this.orgSettingsService,
+        tracer: this.tracer,
+      },
+      String(email),
+      String(password),
+    );
 
     await context.login(user);
 
     return user;
   }
 
-  async logout(context: any) {
+  async logout(context: PassportGqlContext) {
     try {
-      context.logout();
+      await context.logout();
       return true;
     } catch (_) {
       return false;
@@ -387,7 +389,13 @@ function userValidationFailureToBadRequestError(
 }
 
 export default inject(
-  ['KyselyPg', 'Tracer', 'UserManagementService', 'ModerationConfigService'],
+  [
+    'KyselyPg',
+    'Tracer',
+    'UserManagementService',
+    'ModerationConfigService',
+    'OrgSettingsService',
+  ],
   UserAPI,
 );
 export type { UserAPI };

--- a/server/graphql/datasources/UserApi.ts
+++ b/server/graphql/datasources/UserApi.ts
@@ -77,14 +77,26 @@ class UserAPI {
   async login(params: any, context: PassportGqlContext) {
     const { email, password } = safePick(params.input, ['email', 'password']);
 
+    // Reject missing/empty credentials as a bad request before verifying.
+    if (
+      typeof email !== 'string' ||
+      email.length === 0 ||
+      typeof password !== 'string' ||
+      password.length === 0
+    ) {
+      throw makeBadRequestError('Email and password are required.', {
+        shouldErrorSpan: true,
+      });
+    }
+
     const user = await verifyEmailPasswordCredentials(
       {
         kyselyPg: this.kyselyPg,
         orgSettingsService: this.orgSettingsService,
         tracer: this.tracer,
       },
-      String(email),
-      String(password),
+      email,
+      password,
     );
 
     await context.login(user);

--- a/server/graphql/datasources/UserApi.ts
+++ b/server/graphql/datasources/UserApi.ts
@@ -8,12 +8,9 @@ import {
   passwordMatchesHash,
 } from '../../services/userManagementService/index.js';
 import {
-  CoopError,
-  ErrorType,
   makeBadRequestError,
   makeNotFoundError,
   makeUnauthorizedError,
-  type ErrorInstanceData,
 } from '../../utils/errors.js';
 import { safePick } from '../../utils/misc.js';
 import { WEEK_MS } from '../../utils/time.js';
@@ -21,6 +18,11 @@ import { type PassportGqlContext } from '../utils/passportContext.js';
 import { buildGraphqlRuleParent } from './buildGraphqlRuleParent.js';
 import { type GraphQLRuleParent } from './ruleKyselyPersistence.js';
 import { verifyEmailPasswordCredentials } from './userApiCredentials.js';
+import {
+  makeChangePasswordIncorrectPasswordError,
+  makeChangePasswordNotAllowedError,
+  makeSignUpUserExistsError,
+} from './userApiErrors.js';
 import {
   kyselyUserAddFavoriteRule,
   kyselyUserFindByEmail,
@@ -94,7 +96,12 @@ class UserAPI {
     try {
       await context.logout();
       return true;
-    } catch (_) {
+    } catch (e) {
+      // Session teardown is best-effort: surface the failure to the active
+      // tracing span (mirrors the pattern used elsewhere in this file and in
+      // `verifyEmailPasswordCredentials`) but still report `false` to the
+      // client so a stale session doesn't block the logout response.
+      this.tracer.logActiveSpanFailedIfAny(e);
       return false;
     }
   }
@@ -400,68 +407,16 @@ export default inject(
 );
 export type { UserAPI };
 
-export type UserErrorType =
-  | 'LoginUserDoesNotExistError'
-  | 'LoginIncorrectPasswordError'
-  | 'LoginSsoRequiredError'
-  | 'CannotDeleteDefaultUserError'
-  | 'ChangePasswordIncorrectPasswordError'
-  | 'ChangePasswordNotAllowedError';
-
-export const makeLoginUserDoesNotExistError = (data: ErrorInstanceData) =>
-  new CoopError({
-    status: 401,
-    type: [ErrorType.Unauthenticated],
-    title: 'User with this email does not exist.',
-    name: 'LoginUserDoesNotExistError',
-    ...data,
-  });
-
-export const makeLoginIncorrectPasswordError = (data: ErrorInstanceData) =>
-  new CoopError({
-    status: 401,
-    type: [ErrorType.Unauthenticated],
-    title: 'Incorrect password.',
-    name: 'LoginIncorrectPasswordError',
-    ...data,
-  });
-
-export const makeLoginSsoRequiredError = (data: ErrorInstanceData) =>
-  new CoopError({
-    status: 401,
-    type: [ErrorType.Unauthenticated],
-    title: 'SSO Login is Required',
-    name: 'LoginSsoRequiredError',
-    ...data,
-  });
-
-export type SignUpErrorType = 'SignUpUserExistsError';
-
-export const makeSignUpUserExistsError = (data: ErrorInstanceData) =>
-  new CoopError({
-    status: 409,
-    type: [ErrorType.UniqueViolation],
-    title: 'User with this email already exists.',
-    name: 'SignUpUserExistsError',
-    ...data,
-  });
-
-export const makeChangePasswordIncorrectPasswordError = (
-  data: ErrorInstanceData,
-) =>
-  new CoopError({
-    status: 401,
-    type: [ErrorType.Unauthenticated],
-    title: 'Current password is incorrect.',
-    name: 'ChangePasswordIncorrectPasswordError',
-    ...data,
-  });
-
-export const makeChangePasswordNotAllowedError = (data: ErrorInstanceData) =>
-  new CoopError({
-    status: 403,
-    type: [ErrorType.Unauthorized],
-    title: 'Password change is not allowed for this user.',
-    name: 'ChangePasswordNotAllowedError',
-    ...data,
-  });
+// Re-export for backward compatibility with other modules that historically
+// imported these from `UserApi`. New code should import directly from
+// `./userApiErrors`.
+export {
+  makeChangePasswordIncorrectPasswordError,
+  makeChangePasswordNotAllowedError,
+  makeLoginIncorrectPasswordError,
+  makeLoginSsoRequiredError,
+  makeLoginUserDoesNotExistError,
+  makeSignUpUserExistsError,
+  type SignUpErrorType,
+  type UserErrorType,
+} from './userApiErrors.js';

--- a/server/graphql/datasources/userApiCredentials.ts
+++ b/server/graphql/datasources/userApiCredentials.ts
@@ -1,0 +1,85 @@
+import { type Dependencies } from '../../iocContainer/index.js';
+import { passwordMatchesHash } from '../../services/userManagementService/index.js';
+import { CoopError, makeInternalServerError } from '../../utils/errors.js';
+import {
+  makeLoginIncorrectPasswordError,
+  makeLoginSsoRequiredError,
+  makeLoginUserDoesNotExistError,
+} from './UserApi.js';
+import {
+  kyselyUserFindByEmail,
+  type GraphQLUserParent,
+} from './userKyselyPersistence.js';
+
+/**
+ * Look up a user by email and verify their password, applying the same
+ * SAML-required and password-login-enabled gates the previous
+ * `GraphQLLocalStrategy` callback enforced. Throws a typed `CoopError` on
+ * failure so the resolver can classify the error type and return the
+ * appropriate GraphQL union member.
+ *
+ * Pulled out of the previous `passport.authenticate('graphql-local', ...)`
+ * flow when the unmaintained `graphql-passport` dependency was dropped (it
+ * also pulled in deprecated `subscriptions-transport-ws`). The verification
+ * now runs inline and the session is established via the standard
+ * `req.login` (wrapped by `PassportGqlContext.login`).
+ */
+export async function verifyEmailPasswordCredentials(
+  deps: {
+    kyselyPg: Dependencies['KyselyPg'];
+    orgSettingsService: Dependencies['OrgSettingsService'];
+    tracer: Dependencies['Tracer'];
+  },
+  email: string,
+  password: string,
+): Promise<GraphQLUserParent> {
+  try {
+    const user = await kyselyUserFindByEmail(deps.kyselyPg, email);
+    if (user == null) {
+      throw makeLoginUserDoesNotExistError({ shouldErrorSpan: true });
+    }
+
+    const samlSettings = await deps.orgSettingsService.getSamlSettings(
+      user.orgId,
+    );
+
+    if (
+      samlSettings?.saml_enabled &&
+      // We allow Coop users to log in with email/password even if SSO is
+      // enabled so Coop employees can manage user accounts.
+      email.split('@')[1] !== 'getcoop.com'
+    ) {
+      throw makeLoginSsoRequiredError({
+        detail:
+          'SAML is enabled for this organization. Password login is disabled.',
+        shouldErrorSpan: true,
+      });
+    }
+
+    if (!user.loginMethods.includes('password')) {
+      throw makeLoginIncorrectPasswordError({
+        detail: 'Password is not set for user.',
+        shouldErrorSpan: true,
+      });
+    }
+
+    // `loginMethods` includes 'password', so the DB CHECK constraint
+    // guarantees `user.password` is non-null here.
+    if (
+      user.password == null ||
+      !(await passwordMatchesHash(password, user.password))
+    ) {
+      throw makeLoginIncorrectPasswordError({ shouldErrorSpan: true });
+    }
+
+    return user;
+  } catch (e) {
+    if (e instanceof CoopError) {
+      throw e;
+    }
+    deps.tracer.logActiveSpanFailedIfAny(e);
+    throw makeInternalServerError('Unknown error during login attempt', {
+      shouldErrorSpan: true,
+    });
+  }
+}

--- a/server/graphql/datasources/userApiCredentials.ts
+++ b/server/graphql/datasources/userApiCredentials.ts
@@ -43,12 +43,7 @@ export async function verifyEmailPasswordCredentials(
       user.orgId,
     );
 
-    if (
-      samlSettings?.saml_enabled &&
-      // We allow Coop users to log in with email/password even if SSO is
-      // enabled so Coop employees can manage user accounts.
-      email.split('@')[1] !== 'getcoop.com'
-    ) {
+    if (samlSettings?.saml_enabled) {
       throw makeLoginSsoRequiredError({
         detail:
           'SAML is enabled for this organization. Password login is disabled.',

--- a/server/graphql/datasources/userApiCredentials.ts
+++ b/server/graphql/datasources/userApiCredentials.ts
@@ -5,7 +5,7 @@ import {
   makeLoginIncorrectPasswordError,
   makeLoginSsoRequiredError,
   makeLoginUserDoesNotExistError,
-} from './UserApi.js';
+} from './userApiErrors.js';
 import {
   kyselyUserFindByEmail,
   type GraphQLUserParent,

--- a/server/graphql/datasources/userApiErrors.ts
+++ b/server/graphql/datasources/userApiErrors.ts
@@ -1,0 +1,78 @@
+import {
+  CoopError,
+  ErrorType,
+  type ErrorInstanceData,
+} from '../../utils/errors.js';
+
+/**
+ * Auth-related typed error factories used by `UserAPI` and the
+ * `verifyEmailPasswordCredentials` helper. Lives in its own module so that
+ * `userApiCredentials.ts` can import them without creating a circular
+ * dependency with `UserApi.ts` (which imports the credentials helper).
+ */
+
+export type UserErrorType =
+  | 'LoginUserDoesNotExistError'
+  | 'LoginIncorrectPasswordError'
+  | 'LoginSsoRequiredError'
+  | 'CannotDeleteDefaultUserError'
+  | 'ChangePasswordIncorrectPasswordError'
+  | 'ChangePasswordNotAllowedError';
+
+export const makeLoginUserDoesNotExistError = (data: ErrorInstanceData) =>
+  new CoopError({
+    status: 401,
+    type: [ErrorType.Unauthenticated],
+    title: 'User with this email does not exist.',
+    name: 'LoginUserDoesNotExistError',
+    ...data,
+  });
+
+export const makeLoginIncorrectPasswordError = (data: ErrorInstanceData) =>
+  new CoopError({
+    status: 401,
+    type: [ErrorType.Unauthenticated],
+    title: 'Incorrect password.',
+    name: 'LoginIncorrectPasswordError',
+    ...data,
+  });
+
+export const makeLoginSsoRequiredError = (data: ErrorInstanceData) =>
+  new CoopError({
+    status: 401,
+    type: [ErrorType.Unauthenticated],
+    title: 'SSO Login is Required',
+    name: 'LoginSsoRequiredError',
+    ...data,
+  });
+
+export type SignUpErrorType = 'SignUpUserExistsError';
+
+export const makeSignUpUserExistsError = (data: ErrorInstanceData) =>
+  new CoopError({
+    status: 409,
+    type: [ErrorType.UniqueViolation],
+    title: 'User with this email already exists.',
+    name: 'SignUpUserExistsError',
+    ...data,
+  });
+
+export const makeChangePasswordIncorrectPasswordError = (
+  data: ErrorInstanceData,
+) =>
+  new CoopError({
+    status: 401,
+    type: [ErrorType.Unauthenticated],
+    title: 'Current password is incorrect.',
+    name: 'ChangePasswordIncorrectPasswordError',
+    ...data,
+  });
+
+export const makeChangePasswordNotAllowedError = (data: ErrorInstanceData) =>
+  new CoopError({
+    status: 403,
+    type: [ErrorType.Unauthorized],
+    title: 'Password change is not allowed for this user.',
+    name: 'ChangePasswordNotAllowedError',
+    ...data,
+  });

--- a/server/graphql/resolvers.ts
+++ b/server/graphql/resolvers.ts
@@ -1,11 +1,10 @@
 import { mergeResolvers } from '@graphql-tools/merge';
 import { type GraphQLFieldResolver } from 'graphql';
-import { type PassportContext } from 'graphql-passport';
 
 import { type GQLServices } from '../api.js';
 import { type DataSources } from '../iocContainer/index.js';
-import { type GraphQLUserParent } from './datasources/userKyselyPersistence.js';
 import { CoopError, isCoopErrorOfType } from '../utils/errors.js';
+import { type GraphQLUserParent } from './datasources/userKyselyPersistence.js';
 import {
   type GQLInviteUserToken,
   type GQLMutationResolvers,
@@ -18,13 +17,13 @@ import { resolvers as authenticationResolvers } from './modules/authentication.j
 import { resolvers as backtestResolvers } from './modules/backtest.js';
 import { resolvers as contentTypeResolvers } from './modules/contentType.js';
 import { resolvers as genericResolvers } from './modules/generic.js';
+import { resolvers as hashBankResolvers } from './modules/hashBanks/resolvers.js';
 import { resolvers as insightsResolvers } from './modules/insights.js';
 import { resolvers as integrationResolvers } from './modules/integration.js';
 import { resolvers as investigationResolvers } from './modules/investigation.js';
 import { resolvers as itemTypeResolvers } from './modules/itemType.js';
 import { resolvers as locationBankResolvers } from './modules/locationBank.js';
 import { resolvers as manualReviewToolResolvers } from './modules/manualReviewTool.js';
-import { resolvers as hashBankResolvers } from './modules/hashBanks/resolvers.js';
 import { resolvers as ncmecResolvers } from './modules/ncmec.js';
 import { resolvers as orgResolvers } from './modules/org.js';
 import { resolvers as policyResolvers } from './modules/policy.js';
@@ -37,11 +36,11 @@ import { resolvers as signalResolvers } from './modules/signal.js';
 import { resolvers as spotTestResolvers } from './modules/spotTest.js';
 import { resolvers as textBankResolvers } from './modules/textBank.js';
 import { resolvers as userResolvers } from './modules/user.js';
-import { gqlErrorResult, gqlSuccessResult } from './utils/gqlResult.js';
 import { forbiddenError, unauthenticatedError } from './utils/errors.js';
+import { gqlErrorResult, gqlSuccessResult } from './utils/gqlResult.js';
+import { type PassportGqlContext } from './utils/passportContext.js';
 
-// eslint-disable-next-line @typescript-eslint/no-restricted-types
-export type Context = PassportContext<GraphQLUserParent, {}> & {
+export type Context = PassportGqlContext & {
   dataSources: DataSources;
   services: GQLServices;
 };
@@ -72,9 +71,8 @@ const Query: GQLQueryResolvers = {
   },
   async inviteUserToken(_, { token }, { dataSources }) {
     try {
-      const inviteUserToken = await dataSources.orgAPI.getInviteUserToken(
-        token,
-      );
+      const inviteUserToken =
+        await dataSources.orgAPI.getInviteUserToken(token);
       return gqlSuccessResult(
         { tokenData: inviteUserToken as unknown as GQLInviteUserToken },
         'InviteUserTokenSuccessResponse',
@@ -105,7 +103,10 @@ const Query: GQLQueryResolvers = {
       )) as any;
     } catch (e) {
       // eslint-disable-next-line no-console
-      console.error('allRuleInsights: warehouse query failed:', (e as Error).message);
+      console.error(
+        'allRuleInsights: warehouse query failed:',
+        (e as Error).message,
+      );
       return null;
     }
   },
@@ -118,7 +119,10 @@ const Query: GQLQueryResolvers = {
       return true;
     } catch (e) {
       // eslint-disable-next-line no-console
-      console.error('isWarehouseAvailable: warehouse health check failed:', (e as Error).message);
+      console.error(
+        'isWarehouseAvailable: warehouse health check failed:',
+        (e as Error).message,
+      );
       return false;
     }
   },
@@ -170,7 +174,9 @@ const Mutation: GQLMutationResolvers = {
     }
 
     if (!user.getPermissions().includes('MANAGE_ORG')) {
-      throw forbiddenError('User does not have permission to generate password reset tokens');
+      throw forbiddenError(
+        'User does not have permission to generate password reset tokens',
+      );
     }
 
     const token =

--- a/server/graphql/utils/passportContext.ts
+++ b/server/graphql/utils/passportContext.ts
@@ -1,0 +1,58 @@
+import { type Request, type Response } from 'express';
+
+import { type GraphQLUserParent } from '../datasources/userKyselyPersistence.js';
+
+/**
+ * Context fields that mimic the subset of `graphql-passport`'s `PassportContext`
+ * that Coop actually uses (getUser/login/logout, plus `req`/`res`).
+ *
+ * The package itself was unmaintained and pulled in the deprecated
+ * `subscriptions-transport-ws` as an optional peer; since Coop doesn't use
+ * GraphQL subscriptions, we replicate the small surface area we need here.
+ */
+export type PassportGqlContext = {
+  req: Request;
+  res: Response;
+  getUser: () => GraphQLUserParent | undefined;
+  login: (user: GraphQLUserParent) => Promise<void>;
+  logout: () => Promise<void>;
+};
+
+/**
+ * Build the passport-flavored slice of the Apollo resolver context.
+ *
+ * - `getUser()` reads `req.user`, populated by passport's session middleware
+ *   via `passport.deserializeUser` (wired in `server/api.ts`).
+ * - `login` / `logout` promisify the standard `req.login` / `req.logout` calls
+ *   that `app.use(passport.session())` attaches to every request.
+ */
+export function buildPassportContext(
+  req: Request,
+  res: Response,
+): PassportGqlContext {
+  return {
+    req,
+    res,
+    getUser: () => req.user as GraphQLUserParent | undefined,
+    login: async (user) =>
+      new Promise<void>((resolve, reject) => {
+        req.login(user, (err) => {
+          if (err) {
+            reject(err instanceof Error ? err : new Error(String(err)));
+          } else {
+            resolve();
+          }
+        });
+      }),
+    logout: async () =>
+      new Promise<void>((resolve, reject) => {
+        req.logout((err) => {
+          if (err) {
+            reject(err instanceof Error ? err : new Error(String(err)));
+          } else {
+            resolve();
+          }
+        });
+      }),
+  };
+}

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -64,7 +64,6 @@
         "generic-pool": "^3.8.2",
         "graphql": "^16.13.2",
         "graphql-depth-limit": "^1.1.0",
-        "graphql-passport": "^0.6.4",
         "graphql-scalars": "^1.19.0",
         "helmet": "^8.1.0",
         "ioredis": "^5.2.4",
@@ -11027,15 +11026,6 @@
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.9.0.tgz",
       "integrity": "sha512-NclP0IbzHj/4tJZKFqKh8E7kZdgss+MCUYV9G+TLltFfDA4lFgE4PKPpDIyS2FlcdANIfSx273emkupvChigbw=="
     },
-    "node_modules/@types/ws": {
-      "version": "7.4.7",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
-      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/xml-encryption": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/xml-encryption/-/xml-encryption-1.2.4.tgz",
@@ -12217,13 +12207,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/array-includes": {
       "version": "3.1.9",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
@@ -12505,12 +12488,6 @@
       "peerDependencies": {
         "@babel/core": "^7.0.0"
       }
-    },
-    "node_modules/backo2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA==",
-      "optional": true
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -13400,17 +13377,6 @@
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/destroy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/detect-libc": {
@@ -14425,12 +14391,6 @@
       "resolved": "https://registry.npmjs.org/eventemitter-asyncresource/-/eventemitter-asyncresource-1.0.0.tgz",
       "integrity": "sha512-39F7TBIV0G7gTelxwbEqnwhp90eqCPON1k0NwNfwhgKn4Co4ybUbj2pECcXT0B3ztRKZ7Pw1JujUUgmQJHcVAQ==",
       "dev": true
-    },
-    "node_modules/eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-      "optional": true
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -15469,305 +15429,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/graphql-passport": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/graphql-passport/-/graphql-passport-0.6.7.tgz",
-      "integrity": "sha512-+Y5p8tqPAKrOogcgueYPYspl2E5u0Xr7dcYHska3elhw104PzB1pkVihByM1DwWArK7CVcf5+zw+U7Z2uvq1Fg==",
-      "dependencies": {
-        "passport-strategy": "^1.0.0"
-      },
-      "optionalDependencies": {
-        "@types/express": "^4.17.13",
-        "@types/passport": "^1.0.9",
-        "@types/passport-strategy": "^0.2.35",
-        "@types/ws": "^7.4.7",
-        "express": "^4.17.1",
-        "graphql": "^15.5.3",
-        "subscriptions-transport-ws": "^0.11.0",
-        "ws": "7.x || 8.x"
-      },
-      "peerDependencies": {
-        "express": "4.x",
-        "passport": "0.x",
-        "subscriptions-transport-ws": "0.x",
-        "ws": "7.x || 8.x"
-      }
-    },
-    "node_modules/graphql-passport/node_modules/accepts": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/graphql-passport/node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "~1.2.0",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
-        "raw-body": "~2.5.3",
-        "type-is": "~1.6.18",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/graphql-passport/node_modules/content-disposition": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/graphql-passport/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/graphql-passport/node_modules/debug/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/graphql-passport/node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "accepts": "~1.3.8",
-        "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
-        "content-disposition": "~0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "~0.7.1",
-        "cookie-signature": "~1.0.6",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "~1.3.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.0",
-        "merge-descriptors": "1.0.3",
-        "methods": "~1.1.2",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "~0.1.12",
-        "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.2.1",
-        "send": "~0.19.0",
-        "serve-static": "~1.16.2",
-        "setprototypeof": "1.2.0",
-        "statuses": "~2.0.1",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/graphql-passport/node_modules/finalhandler": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
-      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "~2.0.2",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/graphql-passport/node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/graphql-passport/node_modules/graphql": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
-      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
-      "optional": true,
-      "engines": {
-        "node": ">= 10.x"
-      }
-    },
-    "node_modules/graphql-passport/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/graphql-passport/node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/graphql-passport/node_modules/merge-descriptors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/graphql-passport/node_modules/negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/graphql-passport/node_modules/path-to-regexp": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/graphql-passport/node_modules/raw-body": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
-      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/graphql-passport/node_modules/send": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
-      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.1",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "~2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "~2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/graphql-passport/node_modules/serve-static": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
-      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "~0.19.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/graphql-passport/node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/graphql-scalars": {
       "version": "1.22.2",
       "resolved": "https://registry.npmjs.org/graphql-scalars/-/graphql-scalars-1.22.2.tgz",
@@ -16696,7 +16357,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
       "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -17872,7 +17533,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -17900,19 +17561,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/mime-db": {
@@ -20388,44 +20036,6 @@
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw=="
     },
-    "node_modules/subscriptions-transport-ws": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.11.0.tgz",
-      "integrity": "sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==",
-      "deprecated": "The `subscriptions-transport-ws` package is no longer maintained. We recommend you use `graphql-ws` instead. For help migrating Apollo software to `graphql-ws`, see https://www.apollographql.com/docs/apollo-server/data/subscriptions/#switching-from-subscriptions-transport-ws    For general help using `graphql-ws`, see https://github.com/enisdenjo/graphql-ws/blob/master/README.md",
-      "optional": true,
-      "dependencies": {
-        "backo2": "^1.0.2",
-        "eventemitter3": "^3.1.0",
-        "iterall": "^1.2.1",
-        "symbol-observable": "^1.0.4",
-        "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^15.7.2 || ^16.0.0"
-      }
-    },
-    "node_modules/subscriptions-transport-ws/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "optional": true,
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/superagent": {
       "version": "8.0.9",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.0.9.tgz",
@@ -20492,15 +20102,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/tapable": {
@@ -21687,27 +21288,6 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "optional": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/xml": {

--- a/server/package.json
+++ b/server/package.json
@@ -78,7 +78,6 @@
     "generic-pool": "^3.8.2",
     "graphql": "^16.13.2",
     "graphql-depth-limit": "^1.1.0",
-    "graphql-passport": "^0.6.4",
     "graphql-scalars": "^1.19.0",
     "helmet": "^8.1.0",
     "ioredis": "^5.2.4",


### PR DESCRIPTION
- Fixes #66
- Fixes #490 

## Context & Requests for Reviewers

`graphql-passport` is unmaintained (last release Jan 2024) and pulls in the deprecated `subscriptions-transport-ws` as an optional peer, which surfaces a deprecation warning on every `npm install` in `server/`. Coop doesn't use GraphQL subscriptions, and the package's actual surface area in our code is tiny enough to inline rather than carry an unmaintained dep.

## Tests

Tested locally and all works as expected. There was no real client errors. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified server authentication wiring to standardize session, login, and logout behavior.
  * Removed an unused authentication dependency.

* **New Features**
  * Centralized credential verification with a clear SSO vs. password enforcement path.

* **Bug Fixes**
  * Improved and standardized authentication error responses and logging for clearer failure messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/462?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->