### PR TITLE
[Bug Fix] Fix Submit button getting cut off in MRT and Investigation when content overflows

### DIFF
--- a/client/src/components/ItemAction.tsx
+++ b/client/src/components/ItemAction.tsx
@@ -241,11 +241,11 @@ export default function ItemAction(props: {
       <div className="flex flex-col items-start mb-2">
         <div className="text-base font-semibold">{title}</div>
       </div>
-      <div className="flex flex-row gap-4">
+      <div className="flex flex-row flex-wrap items-end gap-4">
         <div className="flex flex-col items-start">
           <div>
             <Select
-              className="w-80"
+              className="w-80 max-w-full"
               mode="multiple"
               maxTagCount={1}
               placeholder="Select action"
@@ -266,7 +266,7 @@ export default function ItemAction(props: {
         <div className="flex flex-col items-start">
           <div>
             <PolicyDropdown
-              className="w-80"
+              className="w-80 max-w-full"
               policies={policiesMemo}
               maxTagCount={1}
               onChange={policiesDropdownOnChange}

--- a/client/src/components/common/CopyTextComponent.tsx
+++ b/client/src/components/common/CopyTextComponent.tsx
@@ -58,7 +58,7 @@ export default function CopyTextComponent(props: {
             <span
               className={`font-normal ${
                 isError ? 'text-red-400' : 'text-slate-400'
-              } ${wrapText ? '' : 'whitespace-nowrap'}`}
+              } ${wrapText ? 'break-all min-w-0' : 'whitespace-nowrap'}`}
             >
               {displayValue}
             </span>

--- a/client/src/webpages/dashboard/investigation/ItemInvestigation.tsx
+++ b/client/src/webpages/dashboard/investigation/ItemInvestigation.tsx
@@ -438,8 +438,8 @@ export default function ItemInvestigation(props: {
         Input an Item ID to see which Coop rules it matched against, why they
         matched, and what actions those rules applied to the item.
       </div>
-      <div className="flex items-start justify-between w-full gap-4">
-        <div className="flex flex-row items-end mb-6">
+      <div className="flex flex-wrap items-start justify-between w-full gap-4">
+        <div className="flex flex-row flex-wrap items-end mb-6">
           <div className="flex flex-col items-start mr-2">
             <div className="mb-2 font-bold">Item ID</div>
             <Input

--- a/client/src/webpages/dashboard/mrt/manual_review_job/ManualReviewJobReview.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/ManualReviewJobReview.tsx
@@ -1451,7 +1451,7 @@ function ManualReviewJobReviewImpl(props: {
         // dashboard a few levels up
         className="flex flex-row w-full pl-12 -ml-12"
       >
-        <div className="flex flex-col flex-1 pb-12 pr-8 overflow-y-auto">
+        <div className="flex flex-col flex-1 min-w-0 pb-12 pr-8 overflow-y-auto">
           {!closedJob && queue ? (
             <div className="flex flex-col items-start mb-8">
               <div className="flex flex-row self-stretch justify-between">
@@ -1481,15 +1481,18 @@ function ManualReviewJobReviewImpl(props: {
             : null}
           <div
             ref={reportedUserRef}
-            className="flex flex-row justify-between mt-8"
+            className="flex flex-row flex-wrap items-baseline justify-between gap-x-4 gap-y-1 min-w-0 mt-8"
           >
-            <div className="self-start text-lg font-bold">
+            <div className="self-start text-lg font-bold whitespace-nowrap">
               {isAppeal ? 'Appealed ' : 'Reported '} {reportedItem.type.name}
             </div>
-            <CopyTextComponent
-              value={reportedItem.id}
-              displayValue={`ID: ${reportedItem.id}`}
-            />
+            <div className="min-w-0 max-w-full">
+              <CopyTextComponent
+                value={reportedItem.id}
+                displayValue={`ID: ${reportedItem.id}`}
+                wrapText
+              />
+            </div>
           </div>
           <div className="my-2 divider" />
           {contentArea()}

--- a/client/src/webpages/dashboard/mrt/manual_review_job/ReportInfoComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/ReportInfoComponent.tsx
@@ -151,15 +151,17 @@ export default function ReportInfoComponent(props: {
                 <th className="py-1 mr-4 font-bold align-top text-start whitespace-nowrap">
                   {isAppeal ? 'Actioned ' : 'Reported '}Item
                 </th>
-                <td className="flex flex-wrap py-1 align-top gap-x-2 gap-y-0 text-start text-slate-500 break-all">
-                  <span className="whitespace-nowrap">
-                    {reportedItem.type.name}:
-                  </span>
-                  <CopyTextComponent
-                    value={reportedItem.id}
-                    displayValue={reportedItem.id}
-                    wrapText
-                  />
+                <td className="py-1 align-top text-start text-slate-500">
+                  <div className="flex flex-wrap gap-x-2 gap-y-0 break-all">
+                    <span className="whitespace-nowrap">
+                      {reportedItem.type.name}:
+                    </span>
+                    <CopyTextComponent
+                      value={reportedItem.id}
+                      displayValue={reportedItem.id}
+                      wrapText
+                    />
+                  </div>
                 </td>
               </tr>
               {payload.enqueueSourceInfo && (

--- a/client/src/webpages/dashboard/mrt/manual_review_job/ReportInfoComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/ReportInfoComponent.tsx
@@ -151,11 +151,14 @@ export default function ReportInfoComponent(props: {
                 <th className="py-1 mr-4 font-bold align-top text-start whitespace-nowrap">
                   {isAppeal ? 'Actioned ' : 'Reported '}Item
                 </th>
-                <td className="flex py-1 align-top gap-2 text-start text-slate-500">
-                  {reportedItem.type.name}:{' '}
+                <td className="flex flex-wrap py-1 align-top gap-x-2 gap-y-0 text-start text-slate-500 break-all">
+                  <span className="whitespace-nowrap">
+                    {reportedItem.type.name}:
+                  </span>
                   <CopyTextComponent
                     value={reportedItem.id}
                     displayValue={reportedItem.id}
+                    wrapText
                   />
                 </td>
               </tr>

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobFieldsComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobFieldsComponent.tsx
@@ -159,10 +159,10 @@ function TableRowComponent(props: {
     }
     case 'USER_ID': {
       return (
-        <div className="align-top text-start">
+        <div className="align-top text-start min-w-0">
           {label ? <div className="pr-3 font-bold">{label}</div> : null}
           <Link
-            className="cursor-pointer shrink-0"
+            className="cursor-pointer break-all"
             to={`/dashboard/manual_review/investigation?id=${value.id}&typeId=${value.typeId}`}
             target="_blank"
           >

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/related_actions/ManualReviewJobEnqueuedRelatedActionEntry.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/related_actions/ManualReviewJobEnqueuedRelatedActionEntry.tsx
@@ -34,7 +34,7 @@ export default function ManualReviewJobEnqueuedRelatedActionEntry(props: {
   } = props;
 
   return (
-    <div className="flex flex-col items-start max-w-[240px]">
+    <div className="flex flex-col items-start w-full min-w-0">
       <div className="flex flex-row items-center w-full pr-2 gap-3">
         <ManualReviewJobMagnifyImageComponent
           itemIdentifier={itemIdentifier}

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/related_actions/ManualReviewJobEnqueuedRelatedActions.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/related_actions/ManualReviewJobEnqueuedRelatedActions.tsx
@@ -56,7 +56,7 @@ export default function ManualReviewJobEnqueuedRelatedActions(props: {
     <div className="flex flex-col mb-4 text-start">
       <div className="self-start mb-2 text-base font-medium">Other Actions</div>
       <div
-        className={`flex flex-col max-h-[360px] max-w-[240px] border border-solid p-4 rounded-md border-gray-200 bg-white overflow-auto`}
+        className={`flex flex-col w-full max-h-[360px] border border-solid p-4 rounded-md border-gray-200 bg-white overflow-auto`}
       >
         {groupedActions.map((groupedAction, i) => (
           <div className="flex flex-col" key={groupedAction.action.id}>


### PR DESCRIPTION
Fixes #431

## Context & Requests for Reviewers

The "Submit" button in the action sidebar can get pushed off-screen on the Manual Review job page and on the Investigation page when:
- a reported/owner item id is unusually long, or
- many actions / policies are selected.

Both surfaces share the same root cause: a `flex` row whose right-hand action panel can't stay in view because a sibling flex item refuses to shrink. 

Fixed:

<img width="1010" height="634" alt="Screenshot 2026-05-13 at 10 53 59 PM" src="https://github.com/user-attachments/assets/f6fa4eae-25b3-4562-b0c8-dbfebbc10989" />
<img width="992" height="907" alt="Screenshot 2026-05-13 at 10 53 43 PM" src="https://github.com/user-attachments/assets/c61abe13-ec51-4cb7-97ea-013e6a681331" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved responsive layout across dashboard pages and header/search controls to better support smaller widths and prevent wrapping issues.
  * Enhanced text wrapping and overflow handling in data display components for improved readability and to prevent content overflow.
  * Adjusted spacing, alignment, and width constraints in action menus, review rows, and related-item entries to optimize space usage and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/463)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->