### PR TITLE
bugfix: make CoopButton links respect disabled state

### DIFF
--- a/client/src/webpages/dashboard/components/CoopButton.tsx
+++ b/client/src/webpages/dashboard/components/CoopButton.tsx
@@ -57,7 +57,7 @@ export default function CoopButton(
     fontWeight = 'semibold',
     iconPosition = 'left',
   } = props;
-  const size = 'size' in props ? props.size ?? 'middle' : 'middle';
+  const size = 'size' in props ? (props.size ?? 'middle') : 'middle';
 
   const sizeProps = (() => {
     if (type === 'link') {
@@ -131,7 +131,11 @@ export default function CoopButton(
   );
 
   const buttonPossiblyWithLinkWrapper =
-    destination != null ? <Link to={destination}>{button}</Link> : button;
+    destination != null && !buttonIsDisabled ? (
+      <Link to={destination}>{button}</Link>
+    ) : (
+      button
+    );
 
   const finalButtonPossiblyWithTooltip =
     Boolean(disabled) && disabledTooltipTitle ? (


### PR DESCRIPTION
Fixes #467

## Summary
Updates `CoopButton` so link-style buttons also respect the `disabled` prop. Previously, disabled-looking buttons could still navigate when rendered as links.

## Testing
- Confirmed a moderator cannot open the Create Action form from the disabled Create Action button
- Confirmed enabled `CoopButton` links still navigate normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved button sizing logic to consistently apply default size when unspecified
  * Corrected button behavior to prevent disabled buttons from acting as navigation links

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/472)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->