### PR TITLE
fix: Move NCMEC routing of reports to env config

### DIFF
--- a/docs/NCMEC.md
+++ b/docs/NCMEC.md
@@ -29,7 +29,7 @@ Both sets of credentials must be obtained from NCMEC by [registering as an ESP](
 
 3. **NCMEC org settings configured**: set via **Settings → NCMEC** (Admin only). See [NCMEC Settings](#ncmec-settings) below.
 
-4. **A dedicated NCMEC manual review queue named "NCMEC Review**: Coop routes NCMEC jobs to the queue specified in your NCMEC settings. Whether decisions made from this queue submit real CyberTips or go to NCMEC's sandbox is controlled by the `NCMEC_ENV` environment variable on the Coop server — see [Test vs. Production Submissions](#test-vs-production-submissions).
+4. **A dedicated NCMEC manual review queue named "NCMEC Review"**: Coop routes NCMEC jobs to the queue specified in your NCMEC settings. Whether decisions made from this queue submit real CyberTips or go to NCMEC's sandbox is controlled by the `NCMEC_ENV` environment variable on the Coop server — see [Test vs. Production Submissions](#test-vs-production-submissions).
 
 5. **An Additional Info endpoint** (optional, but strongly recommended): a webhook Coop calls before submitting a CyberTip to fetch enriched metadata: email addresses, screen names, IP capture events, and per-media details. Without this, Coop submits the CyberTip with only the user ID and basic information from the Item data.
 

--- a/docs/NCMEC.md
+++ b/docs/NCMEC.md
@@ -17,11 +17,11 @@ Before you can review and report content to NCMEC, you must have the following c
 
 Coop's NCMEC integration uses two different NCMEC APIs, each requiring its own credentials:
 
-| | [Hash Sharing API](https://report.cybertip.org/ws-hashsharing/v2/documentation/) | [CyberTipline Reporting API](https://report.cybertip.org/ispws/documentation/index.html) |
-|---|---|---|
-| **Purpose** | Pull known CSAM hashes for matching | Submit CyberTip reports |
-| **URL** | `report.cybertip.org/ws-hashsharing` | `report.cybertip.org/ispws` |
-| **How to configure credentials** | In HMA's curator UI or via `TX_NCMEC_CREDENTIALS` env var on the HMA service | In Coop under **Settings → NCMEC** |
+|                                  | [Hash Sharing API](https://report.cybertip.org/ws-hashsharing/v2/documentation/) | [CyberTipline Reporting API](https://report.cybertip.org/ispws/documentation/index.html) |
+| -------------------------------- | -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| **Purpose**                      | Pull known CSAM hashes for matching                                              | Submit CyberTip reports                                                                  |
+| **URL**                          | `report.cybertip.org/ws-hashsharing`                                             | `report.cybertip.org/ispws`                                                              |
+| **How to configure credentials** | In HMA's curator UI or via `TX_NCMEC_CREDENTIALS` env var on the HMA service     | In Coop under **Settings → NCMEC**                                                       |
 
 Both sets of credentials must be obtained from NCMEC by [registering as an ESP](https://esp.ncmec.org/registration). They may be the same account or different accounts depending on how NCMEC provisions access for your organization.
 
@@ -29,7 +29,7 @@ Both sets of credentials must be obtained from NCMEC by [registering as an ESP](
 
 3. **NCMEC org settings configured**: set via **Settings → NCMEC** (Admin only). See [NCMEC Settings](#ncmec-settings) below.
 
-4. **A dedicated NCMEC manual review queue named "NCMEC Review**: Coop routes NCMEC jobs to the queue specified in your NCMEC settings. Queue IDs that are registered as production queues with Coop support will submit real CyberTips; all others use the NCMEC test environment.
+4. **A dedicated NCMEC manual review queue named "NCMEC Review**: Coop routes NCMEC jobs to the queue specified in your NCMEC settings. Whether decisions made from this queue submit real CyberTips or go to NCMEC's sandbox is controlled by the `NCMEC_ENV` environment variable on the Coop server — see [Test vs. Production Submissions](#test-vs-production-submissions).
 
 5. **An Additional Info endpoint** (optional, but strongly recommended): a webhook Coop calls before submitting a CyberTip to fetch enriched metadata: email addresses, screen names, IP capture events, and per-media details. Without this, Coop submits the CyberTip with only the user ID and basic information from the Item data.
 
@@ -45,20 +45,20 @@ Configure NCMEC reporting under **Settings → NCMEC** (`/dashboard/settings/ncm
 
 ![Setting up NCMEC reporting on Coop: add the required information for the reports submitted to NCMEC for content violating your company policies](./images/coop-ncmec-settings.png)
 
-| Setting | Description |
-|--------|-------------|
-| **Username** | Your NCMEC CyberTipline API username. |
-| **Password** | Your NCMEC CyberTipline API password. |
-| **Company Report Name** | Your organization name as it appears in NCMEC reports. This value is also sent as the ESP service name for the reported user in each CyberTip. |
-| **Legal URL** | URL to your Terms of Service or legal policies (e.g. `https://yourcompany.com/terms`). |
-| **Contact Email** | Email for the reporting person on the CyberTip. The XML receipt from NCMEC can serve as the ESP notification. |
-| **Terms of Service** | TOS text or URL to an acceptable use policy relevant to the incident being reported. Maximum 3000 characters. |
-| **Contact Person (for law enforcement)** | A contact person law enforcement can reach (other than the reporting contact email): first name, last name, email, phone. |
-| **More Info URL** | URL for additional information about your reporting process (e.g. `https://yourcompany.com/ncmec-info`). Used as the web page URL when "Default internet detail type" is set to "Web page." |
-| **Default NCMEC Queue** | When reviewers click "Enqueue to NCMEC," jobs are sent to this queue. Leave as "Use org default queue" to fall back to the organization's default queue. |
-| **Default Internet Detail Type** | The incident context (channel/medium) included in every CyberTip: Web page, Email, Newsgroup, Chat/IM, Online gaming, Cell phone, Non-internet, or Peer-to-peer. |
-| **NCMEC Additional Info Endpoint** | Webhook URL Coop calls before submitting a CyberTip to fetch enriched user and media metadata. See [Additional Info Endpoint](#additional-info-endpoint) below. Strongly recommended as without it, CyberTips are submitted with minimal user data. |
-| **NCMEC Preservation Endpoint** | Webhook URL Coop calls after a successful CyberTip submission with the report ID. See [Preservation Endpoint](#preservation-endpoint) below. |
+| Setting                                  | Description                                                                                                                                                                                                                                         |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Username**                             | Your NCMEC CyberTipline API username.                                                                                                                                                                                                               |
+| **Password**                             | Your NCMEC CyberTipline API password.                                                                                                                                                                                                               |
+| **Company Report Name**                  | Your organization name as it appears in NCMEC reports. This value is also sent as the ESP service name for the reported user in each CyberTip.                                                                                                      |
+| **Legal URL**                            | URL to your Terms of Service or legal policies (e.g. `https://yourcompany.com/terms`).                                                                                                                                                              |
+| **Contact Email**                        | Email for the reporting person on the CyberTip. The XML receipt from NCMEC can serve as the ESP notification.                                                                                                                                       |
+| **Terms of Service**                     | TOS text or URL to an acceptable use policy relevant to the incident being reported. Maximum 3000 characters.                                                                                                                                       |
+| **Contact Person (for law enforcement)** | A contact person law enforcement can reach (other than the reporting contact email): first name, last name, email, phone.                                                                                                                           |
+| **More Info URL**                        | URL for additional information about your reporting process (e.g. `https://yourcompany.com/ncmec-info`). Used as the web page URL when "Default internet detail type" is set to "Web page."                                                         |
+| **Default NCMEC Queue**                  | When reviewers click "Enqueue to NCMEC," jobs are sent to this queue. Leave as "Use org default queue" to fall back to the organization's default queue.                                                                                            |
+| **Default Internet Detail Type**         | The incident context (channel/medium) included in every CyberTip: Web page, Email, Newsgroup, Chat/IM, Online gaming, Cell phone, Non-internet, or Peer-to-peer.                                                                                    |
+| **NCMEC Additional Info Endpoint**       | Webhook URL Coop calls before submitting a CyberTip to fetch enriched user and media metadata. See [Additional Info Endpoint](#additional-info-endpoint) below. Strongly recommended as without it, CyberTips are submitted with minimal user data. |
+| **NCMEC Preservation Endpoint**          | Webhook URL Coop calls after a successful CyberTip submission with the report ID. See [Preservation Endpoint](#preservation-endpoint) below.                                                                                                        |
 
 Saving credentials, Company Report Name, and Legal URL enables NCMEC reporting for the organization. The remaining fields are not required to submit a CyberTip, but filling them out makes reports significantly more actionable for NCMEC investigators.
 
@@ -66,14 +66,14 @@ Saving credentials, Company Report Name, and Legal URL enables NCMEC reporting f
 
 NCMEC data is sensitive. Coop restricts access based on user roles:
 
-| Role | Can Access NCMEC Jobs | Can Submit CyberTips | Can Configure NCMEC Settings |
-|---|---|---|---|
-| Admin | Yes | Yes | Yes |
-| Moderator Manager | Yes | Yes | No |
-| Child Safety Moderator | Yes | Yes | No |
-| Moderator | No | No | No |
-| Analyst / Rules Manager | No | No | No |
-| External Moderator | No | No | No |
+| Role                    | Can Access NCMEC Jobs | Can Submit CyberTips | Can Configure NCMEC Settings |
+| ----------------------- | --------------------- | -------------------- | ---------------------------- |
+| Admin                   | Yes                   | Yes                  | Yes                          |
+| Moderator Manager       | Yes                   | Yes                  | No                           |
+| Child Safety Moderator  | Yes                   | Yes                  | No                           |
+| Moderator               | No                    | No                   | No                           |
+| Analyst / Rules Manager | No                    | No                   | No                           |
+| External Moderator      | No                    | No                   | No                           |
 
 ## How Content Gets Routed to the NCMEC Queue
 
@@ -97,11 +97,10 @@ HMA syncs hashes from NCMEC via NCMEC's [Hash Sharing API](https://report.cybert
 4. In Coop's **Matching Banks**, the NCMEC-sourced bank will be available to reference in rules.
 5. How you set things up depends on your use case:
 
-* If items are submitted by user reports (`POST /api/v1/report`): create a routing rule with the NCMEC hash match logic and assign it to the NCMEC queue.
+- If items are submitted by user reports (`POST /api/v1/report`): create a routing rule with the NCMEC hash match logic and assign it to the NCMEC queue.
 
-* If items are submitted via the items API `(POST /api/v1/items/async/)` and you want Coop to proactively flag matches without a user report: you need an automated enforcement rule with the image hash condition and a "Enqueue to NCMEC" action. 
+- If items are submitted via the items API `(POST /api/v1/items/async/)` and you want Coop to proactively flag matches without a user report: you need an automated enforcement rule with the image hash condition and a "Enqueue to NCMEC" action.
 
- 
 ### 2. Novel CSAM Detection (Content Safety API)
 
 For content that hasn't been seen before and therefore has no known hash, Coop integrates with Google's Content Safety API that classifies images for potential CSAM. You can configure a Routing Rule using a Content Safety signal to route high-confidence detections directly to the NCMEC queue, or to a triage queue for human review before escalation.
@@ -141,7 +140,6 @@ When any of the three triggers above fire, Coop:
 
 This user-centric aggregation means that even if a user has uploaded many pieces of CSAM, a single NCMEC review job is created for the reviewer, and a single CyberTip is submitted to NCMEC rather than separate reports per piece of content.
 
-
 ## Reviewing an NCMEC Job
 
 The NCMEC job UI is distinct from standard review tasks. It is designed around the user and all of their associated media.
@@ -165,12 +163,12 @@ Select the applicable incident type from the NCMEC CyberTipline's defined catego
 
 Apply an [ESP-designated industry classification](https://technologycoalition.org/wp-content/uploads/Tech_Coalition_Industry_Classification_System.pdf) to each media item being reported:
 
-| Classification | Description |
-|---|---|
-| **A1** | Prepubescent minor, explicit sexual activity |
-| **A2** | Prepubescent minor, non-explicit nudity or sexual posing |
-| **B1** | Pubescent minor, explicit sexual activity |
-| **B2** | Pubescent minor, non-explicit nudity or sexual posing |
+| Classification | Description                                              |
+| -------------- | -------------------------------------------------------- |
+| **A1**         | Prepubescent minor, explicit sexual activity             |
+| **A2**         | Prepubescent minor, non-explicit nudity or sexual posing |
+| **B1**         | Pubescent minor, explicit sexual activity                |
+| **B2**         | Pubescent minor, non-explicit nudity or sexual posing    |
 
 Keyboard shortcuts are available in the review UI to speed up classification.
 
@@ -178,23 +176,22 @@ Keyboard shortcuts are available in the review UI to speed up classification.
 
 Apply one or more labels to individual media items to provide NCMEC with additional context:
 
-| Label | Description |
-|---|---|
-| `animeDrawingVirtualHentai` | The file depicts anime, cartoon, virtual, or hentai content. |
-| `potentialMeme` | The file appears to be shared out of mimicry or other seemingly non-malicious intent. |
-| `viral` | The file is circulating rapidly from user to user. |
-| `possibleSelfProduction` | The file is believed to be self-produced. |
-| `physicalHarm` | The file depicts an intentional act of causing physical injury or trauma. |
-| `violenceGore` | The file depicts graphic violence or brutality. |
-| `bestiality` | The file involves an animal. |
-| `liveStreaming` | The content was streamed live at the time it was uploaded. |
-| `infant` | The file depicts an infant. |
-| `generativeAi` | The file is believed to be generated by AI. |
+| Label                       | Description                                                                           |
+| --------------------------- | ------------------------------------------------------------------------------------- |
+| `animeDrawingVirtualHentai` | The file depicts anime, cartoon, virtual, or hentai content.                          |
+| `potentialMeme`             | The file appears to be shared out of mimicry or other seemingly non-malicious intent. |
+| `viral`                     | The file is circulating rapidly from user to user.                                    |
+| `possibleSelfProduction`    | The file is believed to be self-produced.                                             |
+| `physicalHarm`              | The file depicts an intentional act of causing physical injury or trauma.             |
+| `violenceGore`              | The file depicts graphic violence or brutality.                                       |
+| `bestiality`                | The file involves an animal.                                                          |
+| `liveStreaming`             | The content was streamed live at the time it was uploaded.                            |
+| `infant`                    | The file depicts an infant.                                                           |
+| `generativeAi`              | The file is believed to be generated by AI.                                           |
 
 ### Submitting the CyberTip
 
 Once the reviewer has classified all media and selected the incident type, they click **Submit to NCMEC**. Coop then builds and submits the CyberTip automatically. See [CyberTip Submission Flow](#cybertip-submission-flow) below.
-
 
 ## CyberTip Submission Flow
 
@@ -203,8 +200,7 @@ When a reviewer submits a CyberTip, Coop performs the following steps:
 1. **Fetch additional info** — Coop calls your [Additional Info endpoint](#additional-info-endpoint) to retrieve enriched metadata: user email, screen name, IP capture events, and per-media details.
 
 2. **Build the CyberTip XML** — Coop assembles the full report:
-
-   - **escalateToHighPriority**: this is a boolean that marks the report as high priority (ie. there is abuse happening now) that NCMEC prioritizes when triaging. 
+   - **escalateToHighPriority**: this is a boolean that marks the report as high priority (ie. there is abuse happening now) that NCMEC prioritizes when triaging.
    - **Incident summary**: the incident type selected by the reviewer, and the timestamp of the most recently created media item as the `incidentDateTime`.
 
    - **Internet details**: the channel or medium of the incident (e.g. Web page, Chat/IM, Email), set via the "Default Internet Detail Type" in NCMEC org settings.
@@ -243,8 +239,21 @@ When a reviewer submits a CyberTip, Coop performs the following steps:
 
 ### Test vs. Production Submissions
 
-Coop determines whether to submit to the NCMEC test environment or production based on whether the NCMEC queue is registered as a production queue with Coop support. Test submissions go to `exttest.cybertip.org`; production submissions go to `report.cybertip.org`.
+Coop routes every CyberTip submission to one of two NCMEC endpoints:
 
+| Endpoint           | URL                    | What happens to reports                           |
+| ------------------ | ---------------------- | ------------------------------------------------- |
+| **Test (default)** | `exttest.cybertip.org` | Discarded by NCMEC. Used for integration testing. |
+| **Production**     | `report.cybertip.org`  | Real reports routed to law enforcement.           |
+
+The endpoint is selected by the `NCMEC_ENV` environment variable on the Coop server:
+
+- **Unset, or any value other than `production`** → test endpoint. This is the safe default.
+- **`NCMEC_ENV=production`** → production endpoint.
+
+Operators are responsible for ensuring `NCMEC_ENV` matches the credentials they have configured in **Settings → NCMEC**. NCMEC issues separate test and production credentials, and submitting from an unapproved integration to the production endpoint can result in your credentials being revoked.
+
+Reports submitted against the test endpoint are stored in Coop's database with an `is_test` flag and are only visible in the NCMEC Reports dashboard to the reviewer who submitted them. Production reports are visible to anyone in the org with the `VIEW_CHILD_SAFETY_DATA` permission.
 
 ## Webhooks
 
@@ -258,12 +267,8 @@ Coop signs every request with your org's signing key. Verify the signature befor
 
 ```json
 {
-  "users": [
-    { "id": "string", "typeId": "string" }
-  ],
-  "media": [
-    { "id": "string", "typeId": "string" }
-  ]
+  "users": [{ "id": "string", "typeId": "string" }],
+  "media": [{ "id": "string", "typeId": "string" }]
 }
 ```
 
@@ -335,84 +340,79 @@ Coop signs every request with your org's signing key. Verify the signature befor
 
 #### Response Fields
 
-| Field | Type | Description |
-|---|---|---|
-| `users` | Array | Must include an entry for every user in the request. |
-| `users.id` | String | Must match the `id` from the request. |
-| `users.typeId` | String | Must match the `typeId` from the request. |
-| `users.screenName` | String | The user's screen name or username on your platform. |
-| `users.email` | Array | Known email addresses for the user. `type` may be `Business`, `Home`, or `Work`. |
-| `users.ipCaptureEvent` | Array | IP events associated with the user (e.g. logins, registrations). `eventName` may be `Login`, `Registration`, `Purchase`, `Upload`, `Other`, or `Unknown`. |
-| `users.data` | Object | Raw item data for the user. |
-| `media` | Array | Must include an entry for every media item in the request if present. |
-| `media.id` | String | Must match the `id` from the request. |
-| `media.typeId` | String | Must match the `typeId` from the request. |
-| `media.missing` | Boolean | Set to `true` if the media is no longer available. If **all** media items are `missing: true`, no CyberTip is filed. |
-| `media.publiclyAvailable` | Boolean | Whether the media was publicly accessible on your platform at the time of reporting. |
-| `media.fileName` | String | Original filename of the media. |
-| `media.additionalInfo` | Array\<String\> | Additional context about the media to include in the NCMEC file details. |
-| `media.ipCaptureEvent` | Array | IP events associated with this media item (e.g. the upload event). |
-| `media.fileDetails` | Object | Hash information for the file: `{ hash, hashType }`. |
-| `additionalFiles` | Array | Extra files to upload to NCMEC as supplemental evidence (e.g. screenshots). |
-| `messages` | Array | Message-level IP address data for conversation thread context. |
-| `additionalInfo` | String | Top-level freeform additional information to include in the report. |
+| Field                     | Type            | Description                                                                                                                                               |
+| ------------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `users`                   | Array           | Must include an entry for every user in the request.                                                                                                      |
+| `users.id`                | String          | Must match the `id` from the request.                                                                                                                     |
+| `users.typeId`            | String          | Must match the `typeId` from the request.                                                                                                                 |
+| `users.screenName`        | String          | The user's screen name or username on your platform.                                                                                                      |
+| `users.email`             | Array           | Known email addresses for the user. `type` may be `Business`, `Home`, or `Work`.                                                                          |
+| `users.ipCaptureEvent`    | Array           | IP events associated with the user (e.g. logins, registrations). `eventName` may be `Login`, `Registration`, `Purchase`, `Upload`, `Other`, or `Unknown`. |
+| `users.data`              | Object          | Raw item data for the user.                                                                                                                               |
+| `media`                   | Array           | Must include an entry for every media item in the request if present.                                                                                     |
+| `media.id`                | String          | Must match the `id` from the request.                                                                                                                     |
+| `media.typeId`            | String          | Must match the `typeId` from the request.                                                                                                                 |
+| `media.missing`           | Boolean         | Set to `true` if the media is no longer available. If **all** media items are `missing: true`, no CyberTip is filed.                                      |
+| `media.publiclyAvailable` | Boolean         | Whether the media was publicly accessible on your platform at the time of reporting.                                                                      |
+| `media.fileName`          | String          | Original filename of the media.                                                                                                                           |
+| `media.additionalInfo`    | Array\<String\> | Additional context about the media to include in the NCMEC file details.                                                                                  |
+| `media.ipCaptureEvent`    | Array           | IP events associated with this media item (e.g. the upload event).                                                                                        |
+| `media.fileDetails`       | Object          | Hash information for the file: `{ hash, hashType }`.                                                                                                      |
+| `additionalFiles`         | Array           | Extra files to upload to NCMEC as supplemental evidence (e.g. screenshots).                                                                               |
+| `messages`                | Array           | Message-level IP address data for conversation thread context.                                                                                            |
+| `additionalInfo`          | String          | Top-level freeform additional information to include in the report.                                                                                       |
 
 > [!IMPORTANT]
-> If the response does not include an entry for every user and media item in the request, Coop will throw an error and not submit the CyberTip. Your endpoint must return a response entry for each requested user and media item. 
+> If the response does not include an entry for every user and media item in the request, Coop will throw an error and not submit the CyberTip. Your endpoint must return a response entry for each requested user and media item.
 > If all media items have `missing: true`, Coop will not file the CyberTip. The job will be marked as a permanent error and will not be retried.
-
 
 ### Preservation Endpoint
 
-Platforms that submit CyberTips may have data preservation obligations under laws like [18 U.S.C. § 
-  2258A](https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title18-section2258A) and the [REPORT Act 
-  (2024)](https://www.missingkids.org/blog/2024/first-line-of-defense-guidelines-to-help-online-platforms-detect-sexually-exploited-kids), which extended content retention
-  requirements to one year. Talk to your legal team to understand your organization's specific obligations.
+Platforms that submit CyberTips may have data preservation obligations under laws like [18 U.S.C. §
+2258A](https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title18-section2258A) and the [REPORT Act
+(2024)](https://www.missingkids.org/blog/2024/first-line-of-defense-guidelines-to-help-online-platforms-detect-sexually-exploited-kids), which extended content retention
+requirements to one year. Talk to your legal team to understand your organization's specific obligations.
 
-  Coop calls a preservation endpoint you build and host immediately after a CyberTip is successfully submitted. Your endpoint should trigger whatever internal workflow
-  handles data retention — for example, flagging the account for legal hold, snapshotting relevant records, or notifying your legal team. Coop passes the reported user, the
-  media included in the CyberTip, and the NCMEC-assigned report ID so you have everything you need to identify what to retain.
-  Coop signs every request with your org's signing key. Verify the signature before processing.
+Coop calls a preservation endpoint you build and host immediately after a CyberTip is successfully submitted. Your endpoint should trigger whatever internal workflow
+handles data retention — for example, flagging the account for legal hold, snapshotting relevant records, or notifying your legal team. Coop passes the reported user, the
+media included in the CyberTip, and the NCMEC-assigned report ID so you have everything you need to identify what to retain.
+Coop signs every request with your org's signing key. Verify the signature before processing.
 
 #### Request
 
 ```json
 {
   "user": { "id": "string", "typeId": "string" },
-  "reportedMedia": [
-    { "id": "string", "typeId": "string" }
-  ],
+  "reportedMedia": [{ "id": "string", "typeId": "string" }],
   "reportId": "string"
 }
 ```
 
-| Field | Description |
-|---|---|
-| `user` | The user who was reported to NCMEC. |
+| Field           | Description                                         |
+| --------------- | --------------------------------------------------- |
+| `user`          | The user who was reported to NCMEC.                 |
 | `reportedMedia` | All media items that were included in the CyberTip. |
-| `reportId` | The NCMEC-assigned CyberTip report ID. |
+| `reportId`      | The NCMEC-assigned CyberTip report ID.              |
 
 Coop only checks for a successful HTTP status code. The response body is ignored. This webhook is only called for production (non-test) CyberTip submissions.
-
 
 ## Retry Behavior
 
 If a CyberTip submission fails (e.g. due to a transient network error or NCMEC API outage), Coop automatically retries the submission. A background job runs periodically and retries any failed NCMEC decisions that:
 
-* Have not already been successfully submitted (no matching report in the database)
-* Have fewer than 10 prior retry attempts
-* Are not marked as a permanent error (e.g. all media missing)
-* Were decided within the past 30 days
-
+- Have not already been successfully submitted (no matching report in the database)
+- Have fewer than 10 prior retry attempts
+- Are not marked as a permanent error (e.g. all media missing)
+- Were decided within the past 30 days
 
 ## Viewing Submitted Reports
 
 After a CyberTip is submitted, the report is stored in Coop and accessible from the NCMEC Reports dashboard. The report record includes:
 
-* The NCMEC-assigned report ID
-* The reported user
-* All media included in the report
-* The full CyberTip XML
-* Any supplemental files uploaded
-* Any conversation thread CSVs uploaded
-* Whether the submission was a test or production report
+- The NCMEC-assigned report ID
+- The reported user
+- All media included in the report
+- The full CyberTip XML
+- Any supplemental files uploaded
+- Any conversation thread CSVs uploaded
+- Whether the submission was a test or production report

--- a/server/.env.example
+++ b/server/.env.example
@@ -87,6 +87,15 @@ TEAM_EMAIL=team@example.com
 # Set to 'true' to enable the public demo request endpoint
 ENABLE_DEMO_REQUEST=false
 
+# Selects the NCMEC CyberTipline endpoint that "Submit to NCMEC" decisions are
+# routed to. Anything other than the literal string `production` (including
+# being unset) sends submissions to https://exttest.cybertip.org (the NCMEC
+# sandbox, reports are discarded). Set to `production` only when the
+# CyberTipline credentials configured in Settings → NCMEC are production
+# credentials issued by NCMEC and your integration has been approved for live
+# reporting.
+NCMEC_ENV=test
+
 # Other API Keys
 SENDGRID_API_KEY=SG.REAL_API_KEY_HERE
 GOOGLE_PLACES_API_KEY=

--- a/server/decs.d.ts
+++ b/server/decs.d.ts
@@ -242,6 +242,7 @@ namespace NodeJS {
     WAREHOUSE_ADAPTER?: string;
     ANALYTICS_ADAPTER?: string;
     DATA_WAREHOUSE_PROVIDER?: string;
+    NCMEC_ENV?: string;
     NODE_ENV?: string;
     EXPOSE_SENSITIVE_IMPLEMENTATION_DETAILS_IN_ERRORS?: string;
     ALLOW_USER_INPUT_LOCALHOST_URIS?: string;

--- a/server/iocContainer/index.ts
+++ b/server/iocContainer/index.ts
@@ -141,7 +141,6 @@ import {
 } from '../services/moderationConfigService/moderationConfigServiceQueries.js';
 import {
   makeNcmecService,
-  ncmecProdQueues,
   type NcmecService,
 } from '../services/ncmecService/index.js';
 import {
@@ -833,7 +832,6 @@ export default async function getBottle() {
         decisionComponents,
         relatedActions,
         job,
-        queueId,
         reviewerId,
         reviewerEmail,
         decisionReason,
@@ -1198,7 +1196,13 @@ export default async function getBottle() {
                     };
                   }),
                 );
-                const isTest = !ncmecProdQueues.includes(queueId);
+                // Submissions go to the NCMEC test endpoint
+                // (exttest.cybertip.org) unless the deployment is explicitly
+                // configured for production via NCMEC_ENV=production. Operators
+                // are responsible for matching this to whether the credentials
+                // configured in Settings → NCMEC are production or test
+                // credentials issued by NCMEC.
+                const isTest = process.env.NCMEC_ENV !== 'production';
                 await container.NcmecService.submitReport(
                   {
                     reportedUser: {

--- a/server/services/ncmecService/index.ts
+++ b/server/services/ncmecService/index.ts
@@ -1,7 +1,6 @@
 export {
   type NcmecService,
   default as makeNcmecService,
-  ncmecProdQueues,
 } from './ncmecService.js';
 
 export { NCMECIncidentType } from './ncmecReporting.js';

--- a/server/services/ncmecService/ncmecService.ts
+++ b/server/services/ncmecService/ncmecService.ts
@@ -19,14 +19,6 @@ import { type NcmecReportingServicePg } from './dbTypes.js';
 import NcmecEnqueueToMrt from './ncmecEnqueueToMrt.js';
 import NcmecReporting, { type NCMECReportParams } from './ncmecReporting.js';
 
-export const ncmecProdQueues = [
-  '08d99d80-fda3-11ee-93c7-2de73bc8984f',
-  '63d2e0d0-ea93-11ed-800c-990ec859ff6d',
-  'c97f8120-f1e7-11ee-b69a-8b0608a5cb1c',
-  '4e4d04a0-dcac-11ee-a507-bd7289da2601',
-  '0d2811b0-21e2-11ef-b6ce-43fd0fde2b7f',
-];
-
 export class NcmecService {
   private readonly ncmecReporting: NcmecReporting;
   private readonly ncmecEnqueueToMrt: NcmecEnqueueToMrt;
@@ -234,8 +226,7 @@ export class NcmecService {
         ncmec_additional_info_endpoint:
           params.ncmecAdditionalInfoEndpoint ?? undefined,
         default_ncmec_queue_id: params.defaultNcmecQueueId ?? null,
-        default_internet_detail_type:
-          params.defaultInternetDetailType ?? null,
+        default_internet_detail_type: params.defaultInternetDetailType ?? null,
         terms_of_service: params.termsOfService ?? null,
         contact_person_email: params.contactPersonEmail ?? null,
         contact_person_first_name: params.contactPersonFirstName ?? null,


### PR DESCRIPTION
## Context & Requests for Reviewers

Fix bug coming from SaaS era. Move NCMEC routing of reports and display to an env variable to determine whether submissions go to NCMEC's sandbox (`exttest.cybertip.org`) or production (`report.cybertip.org`).

Previously, this was gated by a hardcoded allowlist of MRT queue UUIDs in `server/services/ncmecService/ncmecService.ts` (`ncmecProdQueues`). Adding a new tenant required a code change. That doesn't make sense for a self-hosted OSS project each deployment running Coop, not the maintainers, should decide whether their deployment talks to prod.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  - Clarified NCMEC integration setup, credential distinctions, manual review queue configuration, and expanded access/roles and settings tables. Improved examples and response-contract guidance: responses must include entries for every requested user/media; if all media are marked missing the job is treated as a permanent error and will not be retried.

* **Configuration Enhancement**
  - Added NCMEC_ENV to control submission endpoint: set to "production" for live reporting; otherwise uses the sandbox/test endpoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/474)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->