### PR TITLE
[fix] Display report information on other reports table

### DIFF
--- a/client/src/webpages/dashboard/mrt/manual_review_job/ManualReviewJobReview.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/ManualReviewJobReview.tsx
@@ -831,7 +831,7 @@ function ManualReviewJobReviewImpl(props: {
   const otherReports =
     reportHistory.length > 1 ? (
       <MergedReportsComponent
-        primaryReportedAt={job.createdAt}
+        primaryReportId={reportHistory[0]?.reportId}
         reportHistory={reportHistory}
       />
     ) : null;

--- a/client/src/webpages/dashboard/mrt/manual_review_job/MergedReportsComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/MergedReportsComponent.tsx
@@ -163,7 +163,7 @@ export default function MergedReportsComponent(props: {
           ) : (
             '—'
           ),
-          reason: report.reason ?? '—',
+          reason: report.reason?.trim() ? report.reason : '—',
           reportTime: parseDatetimeToReadableStringInCurrentTimeZone(
             report.reportedAt,
           ),

--- a/client/src/webpages/dashboard/mrt/manual_review_job/MergedReportsComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/MergedReportsComponent.tsx
@@ -13,7 +13,7 @@ import { Link } from 'react-router-dom';
 import Table from '../../components/table/Table';
 
 export default function MergedReportsComponent(props: {
-  primaryReportedAt: Date | string;
+  primaryReportId?: string | null;
   reportHistory: ReadonlyArray<{
     reportId: string;
     reportedAt: Date | string;
@@ -25,15 +25,35 @@ export default function MergedReportsComponent(props: {
     } | null;
   }>;
 }) {
-  const { primaryReportedAt, reportHistory } = props;
-  const numOtherReports = reportHistory.length - 1;
+  const { primaryReportId, reportHistory } = props;
+  // The primary report is shown separately above this component. If we know
+  // its reportId, exclude it from the merged list; otherwise fall back to
+  // dropping the first entry (newest, which corresponds to the displayed
+  // primary report after a job merge). Filtering by `reportId` is stable
+  // across reports that happen to share the same `reportedAt` timestamp.
+  const otherReports = useMemo(() => {
+    if (primaryReportId != null) {
+      const matchIdx = reportHistory.findIndex(
+        (it) => it.reportId === primaryReportId,
+      );
+      if (matchIdx >= 0) {
+        return [
+          ...reportHistory.slice(0, matchIdx),
+          ...reportHistory.slice(matchIdx + 1),
+        ];
+      }
+      return reportHistory;
+    }
+    return reportHistory.slice(1);
+  }, [primaryReportId, reportHistory]);
+  const numOtherReports = otherReports.length;
   const [collapsed, setCollapsed] = useState(true);
   const { data } = useGQLPoliciesQuery();
 
   const { data: reporterInfo } = useGQLGetUserItemsQuery({
     variables: {
       itemIdentifiers: filterNullOrUndefined(
-        reportHistory.map((it) =>
+        otherReports.map((it) =>
           it.reporterId
             ? { id: it.reporterId.id, typeId: it.reporterId.typeId }
             : null,
@@ -59,7 +79,7 @@ export default function MergedReportsComponent(props: {
     [reporterData],
   );
   const reportHistoryWithDisplayInfo = useMemo(() => {
-    return reportHistory.map((report) => {
+    return otherReports.map((report) => {
       const displayInfo = reporterDisplayInfo.find(
         (it) =>
           it.id === report.reporterId?.id &&
@@ -70,7 +90,7 @@ export default function MergedReportsComponent(props: {
         ...(displayInfo ? { displayInfo } : {}),
       };
     });
-  }, [reporterDisplayInfo, reportHistory]);
+  }, [reporterDisplayInfo, otherReports]);
 
   const columns = useMemo(
     () => [
@@ -84,17 +104,50 @@ export default function MergedReportsComponent(props: {
 
   const tableData = useMemo(
     () =>
-      reportHistoryWithDisplayInfo
-        .filter((it) => it.reportedAt !== primaryReportedAt)
-        .map((report) => ({
+      reportHistoryWithDisplayInfo.map((report) => {
+        const policy = data?.myOrg?.policies.find(
+          (p) => p.id === report.policyId,
+        );
+        const hasReporter = report.reporterId != null;
+        // Distinguish "no reporter on the report" (e.g. rule-engine, NCMEC,
+        // or other system-generated enqueues) from "we couldn't resolve the
+        // user item" so reviewers don't see a misleading "Unknown".
+        const reportedByLabel = !hasReporter
+          ? 'System'
+          : report.displayInfo?.displayName ??
+            report.reporterId?.id ??
+            'Unknown reporter';
+        const reportedByPrefix =
+          hasReporter && report.displayInfo?.typeName
+            ? `${report.displayInfo.typeName}: `
+            : '';
+        return {
           reportedBy: (
             <div>
-              {report.displayInfo?.typeName
-                ? `${report.displayInfo.typeName}: `
-                : ''}
-              {report.displayInfo?.displayName ?? 'Unknown'}
+              {reportedByPrefix}
+              {reportedByLabel}
+              {hasReporter && report.reporterId ? (
+                <Link
+                  to={`/dashboard/manual_review/investigation?id=${report.reporterId.id}&typeId=${report.reporterId.typeId}`}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  <Button
+                    className="!fill-none !p-0 !pl-1"
+                    size="icon"
+                    variant="link"
+                    endIcon={ExternalLink}
+                    aria-label="Open reporter investigation page"
+                  ></Button>
+                </Link>
+              ) : null}
+            </div>
+          ),
+          reportedFor: policy ? (
+            <div>
+              {policy.name}
               <Link
-                to={`/dashboard/manual_review/investigation?id=${report.reporterId?.id}&typeId=${report.reporterId?.typeId}`}
+                to={`/dashboard/policies/form/${policy.id}`}
                 target="_blank"
                 rel="noreferrer"
               >
@@ -103,29 +156,31 @@ export default function MergedReportsComponent(props: {
                   size="icon"
                   variant="link"
                   endIcon={ExternalLink}
-                  aria-label="Open reporter investigation page"
+                  aria-label={`Open policy ${policy.name}`}
                 ></Button>
               </Link>
             </div>
+          ) : (
+            '—'
           ),
-          reportedFor: data?.myOrg?.policies.find(
-            (p) => p.id === report.policyId,
-          )?.name,
-          reason: report.reason,
+          reason: report.reason ?? '—',
           reportTime: parseDatetimeToReadableStringInCurrentTimeZone(
             report.reportedAt,
           ),
-        })),
-    [data?.myOrg?.policies, primaryReportedAt, reportHistoryWithDisplayInfo],
+        };
+      }),
+    [data?.myOrg?.policies, reportHistoryWithDisplayInfo],
   );
 
-  const otherReportsTable = <Table columns={columns} data={tableData} />;
+  const otherReportsTable = (
+    <Table columns={columns} data={tableData} containerClassName="w-full" />
+  );
   const toggleCollapsed = useCallback(
     () => setCollapsed(!collapsed),
     [collapsed],
   );
   return (
-    <div className="flex flex-col pl-4 bg-white border border-gray-200 border-solid rounded-lg">
+    <div className="flex flex-col w-full p-4 bg-white border border-gray-200 border-solid rounded-lg">
       <div className="flex flex-row items-center justify-between text-lg">
         {numOtherReports}{' '}
         {numOtherReports === 1 ? 'other report' : 'other reports'}

--- a/client/src/webpages/dashboard/mrt/manual_review_job/MergedReportsComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/MergedReportsComponent.tsx
@@ -42,7 +42,6 @@ export default function MergedReportsComponent(props: {
           ...reportHistory.slice(matchIdx + 1),
         ];
       }
-      return reportHistory;
     }
     return reportHistory.slice(1);
   }, [primaryReportId, reportHistory]);


### PR DESCRIPTION
## Context & Requests for Reviewers

Fixes #450

When a job had multiple merged reports, the "N other reports" table on the manual review screen rendered column headers but no rows, even though the count above said reports existed.

Root cause: `MergedReportsComponent` filtered the merged report list by `reportedAt !== job.createdAt` to drop the primary report (which is shown separately above). That filter is fragile given that several reports share the same `reportedAt` (common in tests, scripted submissions, or bursty real traffic where multiple users report within the same second), every entry whose timestamp matched the original report's reportedAt got filtered out, leaving an empty table.

Some minor improvements:
- "Reported By" now shows System when a report has no reporterId (rule-engine, NCMEC, system enqueues) instead of a misleading Unknown. Falls back to the raw reporter id, then Unknown reporter, only when there was a reporterId we couldn't resolve. The investigation external-link icon is hidden for system reports.
- "Reported For" now renders the policy name as a link to /dashboard/policies/form/<policyId> (same destination PoliciesDashboard uses), opened in a new tab with the same external-link icon pattern as "Reported By".
- Empty Reported For / Reason render as — instead of blank cells.

 
The table now spans the full width of its container and the wrapper has symmetric padding so the Hide button isn't flush against the edge.

After:
<img width="1468" height="876" alt="Screenshot 2026-05-14 at 8 01 08 PM" src="https://github.com/user-attachments/assets/02a03115-954b-40de-9eaa-884c2883969d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved report identification and filtering in the manual review interface by using a specific primary report identifier
  * Enhanced display of report metadata including associated policies with clearer policy links
  * Refined handling of missing reasons and system-generated reports with clearer labeling
  * Fixed reporter investigation link resolution so links appear only when reporter info is present
  * Improved table layout and container styling for more consistent display

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/475?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->