### PR TITLE
Add additionalInfo to NCMEC reports; fix XML element ordering and Node 24 multipart submission

### DIFF
--- a/client/src/components/ItemAction.tsx
+++ b/client/src/components/ItemAction.tsx
@@ -1,21 +1,21 @@
-import ActionParametersModal, {
-  defaultValuesForParameters,
-} from '@/components/ActionParametersModal';
-import { type ActionParameterValues } from '@/components/ActionParameterInputs';
-import { type JsonObject } from 'type-fest';
 import {
-  type GQLActionParameter,
   namedOperations,
   useGQLBulkActionExecutionMutation,
   useGQLBulkActionsFormDataQuery,
+  type GQLActionParameter,
 } from '@/graphql/generated';
 import { stripTypename } from '@/graphql/inputHelpers';
-import { ItemIdentifier } from '@roostorg/types';
 import Pencil from '@/icons/lni/Education/pencil.svg?react';
+import { ItemIdentifier } from '@roostorg/types';
 import { Button, Input, Select } from 'antd';
 import orderBy from 'lodash/orderBy';
 import { useCallback, useMemo, useState } from 'react';
+import { type JsonObject } from 'type-fest';
 
+import { type ActionParameterValues } from '@/components/ActionParameterInputs';
+import ActionParametersModal, {
+  defaultValuesForParameters,
+} from '@/components/ActionParametersModal';
 import { selectFilterByLabelOption } from '@/webpages/dashboard/components/antDesignUtils';
 import CoopButton from '@/webpages/dashboard/components/CoopButton';
 import CoopModal from '@/webpages/dashboard/components/CoopModal';
@@ -50,7 +50,9 @@ export default function ItemAction(props: {
       const anyFailed = results.some((r) => r.success === false);
       if (anyFailed) {
         setModalBody(
-          'One or more actions failed. The callback URL may have returned an error. If your org requires a policy for decisions, select a policy and try again.',
+          'One or more actions failed. Check server logs for details. ' +
+            'If the action posts to a callback URL, the URL may have returned an error. ' +
+            'If your org requires a policy for decisions, select a policy and try again.',
         );
       } else {
         setModalBody('Actions submitted successfully.');
@@ -76,7 +78,9 @@ export default function ItemAction(props: {
   const [moderatorNote, setModeratorNote] = useState<string>('');
 
   const eligibleActions: EligibleAction[] = (queryData?.myOrg?.actions ?? [])
-    .filter((it) => it.itemTypes.map((t) => t.id).includes(itemIdentifier.typeId))
+    .filter((it) =>
+      it.itemTypes.map((t) => t.id).includes(itemIdentifier.typeId),
+    )
     .map((it) => ({
       id: it.id,
       name: it.name,
@@ -211,7 +215,8 @@ export default function ItemAction(props: {
               Object.keys(parametersByActionId).length > 0
                 ? (parametersByActionId as unknown as JsonObject)
                 : undefined,
-            note: moderatorNote.trim() === '' ? undefined : moderatorNote.trim(),
+            note:
+              moderatorNote.trim() === '' ? undefined : moderatorNote.trim(),
           },
         },
       }),

--- a/client/src/components/common/CoopSelect.tsx
+++ b/client/src/components/common/CoopSelect.tsx
@@ -1,8 +1,7 @@
+import { isTypingInEditableElement } from '@/utils/misc';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import TextToken from '../../webpages/dashboard/components/TextToken';
-
-import { isTypingInEditableElement } from '../../utils/misc';
 
 export default function CoopSelect<T extends string>(props: {
   options: {

--- a/client/src/components/common/CoopSelect.tsx
+++ b/client/src/components/common/CoopSelect.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import TextToken from '../../webpages/dashboard/components/TextToken';
 
+import { isTypingInEditableElement } from '../../utils/misc';
+
 export default function CoopSelect<T extends string>(props: {
   options: {
     value: T;
@@ -148,6 +150,9 @@ export default function CoopSelect<T extends string>(props: {
       if (disabled) {
         return;
       }
+      if (isTypingInEditableElement(event.target)) {
+        return;
+      }
       if (!isMenuVisible) {
         if (event.key === openDropdownKeyBinding) {
           setIsMenuVisible(true);
@@ -272,8 +277,8 @@ export default function CoopSelect<T extends string>(props: {
                   selectedOptions.includes(option.value)
                     ? 'bg-coop-lightblue'
                     : focusedOption === option.value
-                    ? 'bg-slate-100'
-                    : 'bg-white'
+                      ? 'bg-slate-100'
+                      : 'bg-white'
                 } hover:bg-coop-lightblue-hover whitespace-nowrap`}
                 onClick={() => toggleOption(option.value)}
               >

--- a/client/src/graphql/generated.ts
+++ b/client/src/graphql/generated.ts
@@ -4323,6 +4323,7 @@ export type GQLSubmitNcmecReportDecisionComponent =
   };
 
 export type GQLSubmitNcmecReportInput = {
+  readonly additionalInfo?: InputMaybe<Scalars['String']['input']>;
   readonly escalateToHighPriority?: InputMaybe<Scalars['String']['input']>;
   readonly incidentType: GQLNcmecIncidentType;
   readonly reportedMedia: ReadonlyArray<GQLNcmecMediaInput>;

--- a/client/src/graphql/generated.ts
+++ b/client/src/graphql/generated.ts
@@ -2452,6 +2452,12 @@ export type GQLMutation = {
   readonly reorderRoutingRules: GQLReorderRoutingRulesResponse;
   readonly requestDemo?: Maybe<Scalars['Boolean']['output']>;
   readonly resetPassword: Scalars['Boolean']['output'];
+  /**
+   * Retries a previously-failed NCMEC submission. Org-scoped: callers can only
+   * retry decisions that belong to their own org. Returns success on a fresh
+   * successful submission, or an error with a user-safe summary on failure.
+   */
+  readonly retryNcmecSubmission: GQLRetryNcmecSubmissionResponse;
   readonly rotateApiKey: GQLRotateApiKeyResponse;
   readonly rotateWebhookSigningKey: GQLRotateWebhookSigningKeyResponse;
   readonly runRetroaction?: Maybe<GQLRunRetroactionResponse>;
@@ -2683,6 +2689,10 @@ export type GQLMutationResetPasswordArgs = {
   input: GQLResetPasswordInput;
 };
 
+export type GQLMutationRetryNcmecSubmissionArgs = {
+  decisionId: Scalars['ID']['input'];
+};
+
 export type GQLMutationRotateApiKeyArgs = {
   input: GQLRotateApiKeyInput;
 };
@@ -2879,6 +2889,33 @@ export type GQLNcmecContentItem = {
   readonly isReported: Scalars['Boolean']['output'];
 };
 
+/**
+ * An NCMEC submission that was decisioned in the MRT but never produced a
+ * successful CyberTip report. Reused on the NCMEC Reports dashboard so that
+ * reviewers can see and retry failed submissions in the same place as
+ * successful reports. The userId + userItemTypeId pair uniquely identifies
+ * the reported user; decisionId is the stable handle for retrying.
+ */
+export type GQLNcmecFailedSubmission = {
+  readonly __typename: 'NcmecFailedSubmission';
+  readonly decisionId: Scalars['ID']['output'];
+  readonly lastError?: Maybe<Scalars['String']['output']>;
+  readonly retryCount: Scalars['Int']['output'];
+  readonly reviewerId?: Maybe<Scalars['String']['output']>;
+  readonly status: GQLNcmecFailedSubmissionStatus;
+  readonly ts: Scalars['DateTime']['output'];
+  readonly userId: Scalars['String']['output'];
+  readonly userItemType: GQLUserItemType;
+};
+
+export const GQLNcmecFailedSubmissionStatus = {
+  NeverAttempted: 'NEVER_ATTEMPTED',
+  PermanentError: 'PERMANENT_ERROR',
+  RetryableError: 'RETRYABLE_ERROR',
+} as const;
+
+export type GQLNcmecFailedSubmissionStatus =
+  (typeof GQLNcmecFailedSubmissionStatus)[keyof typeof GQLNcmecFailedSubmissionStatus];
 export const GQLNcmecFileAnnotation = {
   AnimeDrawingVirtualHentai: 'ANIME_DRAWING_VIRTUAL_HENTAI',
   Bestiality: 'BESTIALITY',
@@ -3044,6 +3081,12 @@ export type GQLOrg = {
   readonly contentTypes: ReadonlyArray<GQLContentType>;
   readonly defaultInterfacePreferences: GQLUserInterfacePreferences;
   readonly email: Scalars['String']['output'];
+  /**
+   * NCMEC decisions that did not produce a successful CyberTip report. Returned
+   * alongside ncmecReports on the dashboard so reviewers can see the full
+   * submission status (successful + failed) in one place and retry failures.
+   */
+  readonly failedNcmecSubmissions: ReadonlyArray<GQLNcmecFailedSubmission>;
   readonly hasAppealsEnabled: Scalars['Boolean']['output'];
   readonly hasNCMECReportingEnabled: Scalars['Boolean']['output'];
   readonly hasPartialItemsEndpoint: Scalars['Boolean']['output'];
@@ -3802,6 +3845,16 @@ export type GQLResolvedJobCount = {
   readonly queueId?: Maybe<Scalars['String']['output']>;
   readonly reviewerId?: Maybe<Scalars['String']['output']>;
   readonly time: Scalars['String']['output'];
+};
+
+export type GQLRetryNcmecSubmissionResponse = {
+  readonly __typename: 'RetryNcmecSubmissionResponse';
+  /**
+   * Human-readable error summary if the retry failed. Never includes raw
+   * NCMEC response bodies; safe to render in the UI.
+   */
+  readonly error?: Maybe<Scalars['String']['output']>;
+  readonly success: Scalars['Boolean']['output'];
 };
 
 export type GQLRotateApiKeyError = GQLError & {
@@ -18383,6 +18436,21 @@ export type GQLNcmecReportValuesFragment = {
   }>;
 };
 
+export type GQLNcmecFailedSubmissionValuesFragment = {
+  readonly __typename: 'NcmecFailedSubmission';
+  readonly decisionId: string;
+  readonly ts: Date | string;
+  readonly reviewerId?: string | null;
+  readonly userId: string;
+  readonly status: GQLNcmecFailedSubmissionStatus;
+  readonly retryCount: number;
+  readonly lastError?: string | null;
+  readonly userItemType: {
+    readonly __typename: 'UserItemType';
+    readonly name: string;
+  };
+};
+
 export type GQLAllNcmecReportsQueryVariables = Exact<{ [key: string]: never }>;
 
 export type GQLAllNcmecReportsQuery = {
@@ -18419,6 +18487,20 @@ export type GQLAllNcmecReportsQuery = {
         readonly csv: string;
         readonly ncmecFileId: string;
       }>;
+    }>;
+    readonly failedNcmecSubmissions: ReadonlyArray<{
+      readonly __typename: 'NcmecFailedSubmission';
+      readonly decisionId: string;
+      readonly ts: Date | string;
+      readonly reviewerId?: string | null;
+      readonly userId: string;
+      readonly status: GQLNcmecFailedSubmissionStatus;
+      readonly retryCount: number;
+      readonly lastError?: string | null;
+      readonly userItemType: {
+        readonly __typename: 'UserItemType';
+        readonly name: string;
+      };
     }>;
     readonly users: ReadonlyArray<{
       readonly __typename: 'User';
@@ -18475,6 +18557,19 @@ export type GQLGetNcmecReportQuery = {
       readonly ncmecFileId: string;
     }>;
   } | null;
+};
+
+export type GQLRetryNcmecSubmissionMutationVariables = Exact<{
+  decisionId: Scalars['ID']['input'];
+}>;
+
+export type GQLRetryNcmecSubmissionMutation = {
+  readonly __typename: 'Mutation';
+  readonly retryNcmecSubmission: {
+    readonly __typename: 'RetryNcmecSubmissionResponse';
+    readonly success: boolean;
+    readonly error?: string | null;
+  };
 };
 
 export type GQLIsWarehouseAvailableQueryVariables = Exact<{
@@ -24873,6 +24968,20 @@ export const GQLNcmecReportValuesFragmentDoc = gql`
       ncmecFileId
     }
     isTest
+  }
+`;
+export const GQLNcmecFailedSubmissionValuesFragmentDoc = gql`
+  fragment NcmecFailedSubmissionValues on NcmecFailedSubmission {
+    decisionId
+    ts
+    reviewerId
+    userId
+    userItemType {
+      name
+    }
+    status
+    retryCount
+    lastError
   }
 `;
 export const GQLPolicyFieldsFragmentDoc = gql`
@@ -37096,6 +37205,9 @@ export const GQLAllNcmecReportsDocument = gql`
       ncmecReports {
         ...NCMECReportValues
       }
+      failedNcmecSubmissions {
+        ...NcmecFailedSubmissionValues
+      }
       users {
         id
         firstName
@@ -37104,6 +37216,7 @@ export const GQLAllNcmecReportsDocument = gql`
     }
   }
   ${GQLNcmecReportValuesFragmentDoc}
+  ${GQLNcmecFailedSubmissionValuesFragmentDoc}
 `;
 
 /**
@@ -37397,6 +37510,57 @@ export type GQLGetNcmecReportSuspenseQueryHookResult = ReturnType<
 export type GQLGetNcmecReportQueryResult = Apollo.QueryResult<
   GQLGetNcmecReportQuery,
   GQLGetNcmecReportQueryVariables
+>;
+export const GQLRetryNcmecSubmissionDocument = gql`
+  mutation RetryNcmecSubmission($decisionId: ID!) {
+    retryNcmecSubmission(decisionId: $decisionId) {
+      success
+      error
+    }
+  }
+`;
+export type GQLRetryNcmecSubmissionMutationFn = Apollo.MutationFunction<
+  GQLRetryNcmecSubmissionMutation,
+  GQLRetryNcmecSubmissionMutationVariables
+>;
+
+/**
+ * __useGQLRetryNcmecSubmissionMutation__
+ *
+ * To run a mutation, you first call `useGQLRetryNcmecSubmissionMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useGQLRetryNcmecSubmissionMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [gqlRetryNcmecSubmissionMutation, { data, loading, error }] = useGQLRetryNcmecSubmissionMutation({
+ *   variables: {
+ *      decisionId: // value for 'decisionId'
+ *   },
+ * });
+ */
+export function useGQLRetryNcmecSubmissionMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    GQLRetryNcmecSubmissionMutation,
+    GQLRetryNcmecSubmissionMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    GQLRetryNcmecSubmissionMutation,
+    GQLRetryNcmecSubmissionMutationVariables
+  >(GQLRetryNcmecSubmissionDocument, options);
+}
+export type GQLRetryNcmecSubmissionMutationHookResult = ReturnType<
+  typeof useGQLRetryNcmecSubmissionMutation
+>;
+export type GQLRetryNcmecSubmissionMutationResult =
+  Apollo.MutationResult<GQLRetryNcmecSubmissionMutation>;
+export type GQLRetryNcmecSubmissionMutationOptions = Apollo.BaseMutationOptions<
+  GQLRetryNcmecSubmissionMutation,
+  GQLRetryNcmecSubmissionMutationVariables
 >;
 export const GQLIsWarehouseAvailableDocument = gql`
   query IsWarehouseAvailable {
@@ -43402,6 +43566,7 @@ export const namedOperations = {
     UpdateRoutingRule: 'UpdateRoutingRule',
     ReorderRoutingRules: 'ReorderRoutingRules',
     SetMrtChartConfigurationSettings: 'SetMrtChartConfigurationSettings',
+    RetryNcmecSubmission: 'RetryNcmecSubmission',
     AddPolicies: 'AddPolicies',
     UpdatePolicy: 'UpdatePolicy',
     DeletePolicy: 'DeletePolicy',
@@ -43438,6 +43603,7 @@ export const namedOperations = {
     JobFields: 'JobFields',
     ManualReviewJobCommentFields: 'ManualReviewJobCommentFields',
     NCMECReportValues: 'NCMECReportValues',
+    NcmecFailedSubmissionValues: 'NcmecFailedSubmissionValues',
     PolicyFields: 'PolicyFields',
     RulesDashboardRuleFieldsFragment: 'RulesDashboardRuleFieldsFragment',
     SampleReportingRuleExecutionResultFields:

--- a/client/src/utils/misc.ts
+++ b/client/src/utils/misc.ts
@@ -93,3 +93,15 @@ export type OmitRecursively<T extends any, K extends PropertyKey> = Omit<
 export const __throw = (x: unknown): never => {
   throw x;
 };
+
+/** Used by global keyboard handlers to avoid hijacking single-key shortcuts while a form control has focus. */
+export function isTypingInEditableElement(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  const tag = target.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') {
+    return true;
+  }
+  return target.isContentEditable;
+}

--- a/client/src/webpages/dashboard/Dashboard.css
+++ b/client/src/webpages/dashboard/Dashboard.css
@@ -186,3 +186,33 @@ body {
   -ms-overflow-style: none; /* IE and Edge */
   scrollbar-width: none; /* Firefox */
 }
+
+.scrollbar-show {
+  scrollbar-width: thin; /* Firefox */
+  scrollbar-color: rgba(0, 0, 0, 0.25) transparent; /* Firefox */
+}
+
+.scrollbar-show::-webkit-scrollbar {
+  -webkit-appearance: none;
+  width: 10px;
+  height: 10px;
+}
+
+.scrollbar-show::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.scrollbar-show::-webkit-scrollbar-thumb {
+  background-color: rgba(0, 0, 0, 0.25);
+  border-radius: 9999px;
+  border: 2px solid transparent;
+  background-clip: content-box;
+}
+
+.scrollbar-show::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(0, 0, 0, 0.45);
+}
+
+.scrollbar-show::-webkit-scrollbar-corner {
+  background: transparent;
+}

--- a/client/src/webpages/dashboard/Dashboard.tsx
+++ b/client/src/webpages/dashboard/Dashboard.tsx
@@ -739,14 +739,16 @@ export default function Dashboard() {
                   : '/dashboard'
               }
             >
-              <div className="w-full max-w-[1800px]">
+              {/* min-w-0 lets descendants' overflow-x-auto scroll instead of
+                  the whole page when content is wider than the viewport. */}
+              <div className="w-full max-w-[1800px] min-w-0">
                 {isCSSLoaded ? <Outlet /> : <FullScreenLoading />}
               </div>
             </ErrorBoundary>
           </div>
         </>
       ) : (
-        <main className="flex flex-col flex-grow overflow-y-auto min-h-0">
+        <main className="flex flex-col flex-grow overflow-auto min-h-0">
           <div className="p-10">
             <ErrorBoundary
               key={pathname}
@@ -754,7 +756,7 @@ export default function Dashboard() {
               buttonTitle={currentRouteHandle?.error?.buttonTitle}
               buttonLinkPath={currentRouteHandle?.error?.buttonLinkPath}
             >
-              <div className="w-full max-w-[1800px]">
+              <div className="w-full max-w-[1800px] min-w-0">
                 <Outlet />
               </div>
             </ErrorBoundary>

--- a/client/src/webpages/dashboard/components/table/Table.tsx
+++ b/client/src/webpages/dashboard/components/table/Table.tsx
@@ -19,6 +19,9 @@ export default function Table(
     customMaxHeight?: `max-h-[${number}px]`;
     disableFilter?: boolean;
     containerClassName?: string;
+    /** Force the horizontal scrollbar to always render. Opt-in because tables
+     * that always fit the viewport would otherwise show an unnecessary scrollbar. */
+    alwaysShowScrollbar?: boolean;
   } & (
     | {
         isCollapsed?: boolean;
@@ -38,6 +41,7 @@ export default function Table(
     customMaxHeight,
     disableFilter,
     containerClassName,
+    alwaysShowScrollbar,
   } = props;
   const {
     isCollapsed = undefined,
@@ -63,7 +67,9 @@ export default function Table(
   };
 
   return (
-    <div className={`flex flex-col items-start max-w-full mb-8 ${containerClassName ?? 'w-fit'}`}>
+    <div
+      className={`flex flex-col items-start max-w-full mb-8 ${containerClassName ?? 'w-fit'}`}
+    >
       <div
         className={`flex w-full pb-2 items-start gap-4 ${
           topLeftComponent || topRightComponent
@@ -81,11 +87,11 @@ export default function Table(
         )}
         {topRightComponent}
       </div>
-      <div className="w-full border border-gray-200 border-solid rounded-md">
+      <div className="w-full min-w-0 border border-gray-200 border-solid rounded-md">
         <div
-          className={`overflow-x-auto overflow-y-auto rounded-md ${
-            customMaxHeight ?? 'max-h-[1200px]'
-          }`}
+          className={`min-w-0 overflow-x-auto overflow-y-auto rounded-md ${
+            alwaysShowScrollbar ? 'scrollbar-show' : ''
+          } ${customMaxHeight ?? 'max-h-[1200px]'}`}
         >
           <table {...getTableProps()} className="w-full">
             <thead className="sticky top-0 z-10 bg-slate-50">
@@ -128,8 +134,8 @@ export default function Table(
                             index === 0
                               ? 'rounded-tl-md'
                               : index === headerGroup.headers.length - 1
-                              ? 'rounded-tr-md'
-                              : ''
+                                ? 'rounded-tr-md'
+                                : ''
                           }`}
                         >
                           <div className="flex flex-row items-center p-4 flex-nowrap whitespace-nowrap gap-3">
@@ -179,8 +185,8 @@ export default function Table(
                               rowIndex % 2 === 0 ? 'bg-white' : 'bg-slate-50'
                             }`
                         : rowIndex % 2 === 0
-                        ? 'bg-white'
-                        : 'bg-slate-50'
+                          ? 'bg-white'
+                          : 'bg-slate-50'
                     }
                     onClick={() => selectRow(row, rowIndex)}
                   >
@@ -205,8 +211,8 @@ export default function Table(
                               rowIndex % 2 === 0 ? 'bg-white' : 'bg-slate-50'
                             }`
                         : rowIndex % 2 === 0
-                        ? 'bg-white'
-                        : 'bg-slate-50'
+                          ? 'bg-white'
+                          : 'bg-slate-50'
                     }
                     onClick={() => selectRow(row, rowIndex)}
                   >

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobMagnifyImageComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobMagnifyImageComponent.tsx
@@ -104,9 +104,9 @@ export default function ManualReviewJobMagnifyImageComponent(props: {
     footerComponent == null
   ) {
     return (
-      <div className="flex flex-row items-center gap-2">
+      <div className="flex flex-row items-center gap-2 min-w-0">
         <div
-          className={`flex border-solid rounded-full ${
+          className={`flex shrink-0 border-solid rounded-full ${
             borderAndTextColor
               ? `${borderAndTextColor} border-2`
               : 'border-slate-500 border'
@@ -116,8 +116,8 @@ export default function ManualReviewJobMagnifyImageComponent(props: {
         </div>
         {label ? (
           <div
-            className={`ml-3 font-medium ${
-              labelTruncationType === 'wrap' ? 'overflow-auto' : 'truncate'
+            className={`ml-3 font-medium min-w-0 flex-1 ${
+              labelTruncationType === 'wrap' ? 'break-all' : 'truncate'
             }`}
           >
             {label}
@@ -162,11 +162,11 @@ export default function ManualReviewJobMagnifyImageComponent(props: {
         </div>
       }
     >
-      <div className="flex flex-row items-center cursor-pointer flex-nowrap">
+      <div className="flex flex-row items-center cursor-pointer min-w-0">
         {finalImageUrl ? (
           <img
             alt=""
-            className={`rounded-full ${
+            className={`rounded-full shrink-0 ${
               borderAndTextColor
                 ? `p-0.5 border-2 border-solid ${borderAndTextColor} w-12 h-12`
                 : 'border-current w-12 h-12'
@@ -175,7 +175,7 @@ export default function ManualReviewJobMagnifyImageComponent(props: {
           />
         ) : (
           <div
-            className={`flex border border-solid rounded-full ${
+            className={`flex shrink-0 border border-solid rounded-full ${
               borderAndTextColor ?? 'border-slate-500'
             }`}
           >
@@ -183,16 +183,22 @@ export default function ManualReviewJobMagnifyImageComponent(props: {
           </div>
         )}
         {label ? (
-          <div className="flex flex-col">
+          <div className="flex flex-col min-w-0 flex-1">
             <div
-              className={`ml-2 truncate font-medium ${
-                borderAndTextColor ?? 'text-slate-500'
-              }`}
+              className={`ml-2 font-medium ${
+                labelTruncationType === 'wrap' ? 'break-all' : 'truncate'
+              } ${borderAndTextColor ?? 'text-slate-500'}`}
             >
               {label}
             </div>
             {sublabel ? (
-              <div className="ml-2 text-xs truncate">{sublabel}</div>
+              <div
+                className={`ml-2 text-xs ${
+                  labelTruncationType === 'wrap' ? 'break-all' : 'truncate'
+                }`}
+              >
+                {sublabel}
+              </div>
             ) : null}
           </div>
         ) : null}

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ncmec/NCMECInspectedMedia.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ncmec/NCMECInspectedMedia.tsx
@@ -1,4 +1,5 @@
 import UserAlt4 from '@/icons/lni/User/user-alt-4.svg?react';
+import { isTypingInEditableElement } from '@/utils/misc';
 import type { ItemTypeFieldFieldData } from '@/webpages/dashboard/item_types/itemTypeUtils';
 import {
   ArrowLeftOutlined,
@@ -21,7 +22,6 @@ import {
   GQLUserItemType,
 } from '../../../../../../graphql/generated';
 import { getFieldValueForRole } from '../../../../../../utils/itemUtils';
-import { isTypingInEditableElement } from '../../../../../../utils/misc';
 import FieldsComponent from '../ManualReviewJobFieldsComponent';
 import ManualReviewJobMagnifyImageComponent from '../ManualReviewJobMagnifyImageComponent';
 import NCMECLabelSelector from './NCMECLabelSelector';

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ncmec/NCMECInspectedMedia.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ncmec/NCMECInspectedMedia.tsx
@@ -21,6 +21,7 @@ import {
   GQLUserItemType,
 } from '../../../../../../graphql/generated';
 import { getFieldValueForRole } from '../../../../../../utils/itemUtils';
+import { isTypingInEditableElement } from '../../../../../../utils/misc';
 import FieldsComponent from '../ManualReviewJobFieldsComponent';
 import ManualReviewJobMagnifyImageComponent from '../ManualReviewJobMagnifyImageComponent';
 import NCMECLabelSelector from './NCMECLabelSelector';
@@ -119,6 +120,9 @@ export default function NCMECInspectedMedia(props: {
       if (disableKeyboardShortcuts || isLabelSelectorInInspectedMediaVisible) {
         return;
       }
+      if (isTypingInEditableElement(event.target)) {
+        return;
+      }
       const currentCategory = state?.category;
       const newCategory = (() => {
         switch (event.key) {
@@ -167,21 +171,24 @@ export default function NCMECInspectedMedia(props: {
   const navigationButtons = (
     <div className="flex items-center justify-between w-full mb-3">
       <div
-        className={`cursor-pointer py-1 px-3 rounded border border-solid ${index === 0
+        className={`cursor-pointer py-1 px-3 rounded border border-solid ${
+          index === 0
             ? 'text-slate-300 border-slate-100'
             : 'text-coop-blue border-coop-blue hover:border-coop-blue hover:bg-coop-lightblue'
-          }`}
+        }`}
         onClick={goToPreviousMedia}
       >
         <ArrowLeftOutlined className="pr-1 text-xs" /> Previous
       </div>
-      <div className="text-sm text-slate-500">{`${index + 1
-        } / ${totalLength}`}</div>
+      <div className="text-sm text-slate-500">{`${
+        index + 1
+      } / ${totalLength}`}</div>
       <div
-        className={`cursor-pointer py-1 px-3 rounded border border-solid ${index === totalLength - 1
+        className={`cursor-pointer py-1 px-3 rounded border border-solid ${
+          index === totalLength - 1
             ? 'text-slate-300 border-slate-100'
             : 'text-coop-blue border-coop-blue hover:border-coop-blue hover:bg-coop-lightblue'
-          }`}
+        }`}
         onClick={goToNextMedia}
       >
         Next <ArrowRightOutlined className="pl-1 text-xs" />
@@ -190,22 +197,22 @@ export default function NCMECInspectedMedia(props: {
   );
   const threadInfoFields = threadInfo
     ? threadInfo.type.baseFields
-      .map(
-        (itemTypeField) =>
-          ({
-            ...itemTypeField,
-            value: threadInfo.data[itemTypeField.name],
-          }) as ItemTypeFieldFieldData,
-      )
-      .filter((field) => {
-        return isContainerType(field.type)
-          ? !isMediaType(field.container!.valueScalarType) &&
-          field.container!.valueScalarType !== ScalarTypes.RELATED_ITEM &&
-          threadInfo.data[field.name] !== undefined
-          : !isMediaType(field.type) &&
-          field.type !== ScalarTypes.RELATED_ITEM &&
-          threadInfo.data[field.name] !== undefined;
-      })
+        .map(
+          (itemTypeField) =>
+            ({
+              ...itemTypeField,
+              value: threadInfo.data[itemTypeField.name],
+            }) as ItemTypeFieldFieldData,
+        )
+        .filter((field) => {
+          return isContainerType(field.type)
+            ? !isMediaType(field.container!.valueScalarType) &&
+                field.container!.valueScalarType !== ScalarTypes.RELATED_ITEM &&
+                threadInfo.data[field.name] !== undefined
+            : !isMediaType(field.type) &&
+                field.type !== ScalarTypes.RELATED_ITEM &&
+                threadInfo.data[field.name] !== undefined;
+        })
     : [];
   const threadComponent = (() => {
     if (threadLoading) {
@@ -319,10 +326,10 @@ export default function NCMECInspectedMedia(props: {
               fields={fieldData.filter((field) => {
                 return isContainerType(field.type)
                   ? !isMediaType(field.container!.valueScalarType) &&
-                  field.container!.valueScalarType !==
-                  ScalarTypes.RELATED_ITEM
+                      field.container!.valueScalarType !==
+                        ScalarTypes.RELATED_ITEM
                   : !isMediaType(field.type) &&
-                  field.type !== ScalarTypes.RELATED_ITEM;
+                      field.type !== ScalarTypes.RELATED_ITEM;
               })}
               itemTypeId={fullNcmecContentItem.contentItem.type.id}
             />

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ncmec/NCMECInspectedMedia.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ncmec/NCMECInspectedMedia.tsx
@@ -342,11 +342,12 @@ export default function NCMECInspectedMedia(props: {
             </div>
           ) : undefined}
           <div className="pb-2 text-base font-bold text-start">User</div>
-          <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="flex flex-wrap items-center justify-between gap-2 min-w-0 w-full">
             <ManualReviewJobMagnifyImageComponent
               itemIdentifier={{ id: user.id, typeId: user.type.id }}
               imageUrl={profilePicUrl?.url}
               label={displayName ? `${displayName} (${user.id})` : user.id}
+              labelTruncationType="wrap"
               fallbackComponent={
                 <UserAlt4 className="p-3 fill-slate-500 w-11" />
               }

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ncmec/NCMECReviewUser.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ncmec/NCMECReviewUser.tsx
@@ -30,6 +30,7 @@ import {
   getFieldValueForRole,
   getFieldValueOrValues,
 } from '../../../../../../utils/itemUtils';
+import { isTypingInEditableElement } from '../../../../../../utils/misc';
 import { titleCaseEnumString } from '../../../../../../utils/string';
 import { jsonStringify } from '../../../../../../utils/typescript-types';
 import ManualReviewJobContentBlurableVideo from '../../ManualReviewJobContentBlurableVideo';
@@ -134,9 +135,9 @@ function getUrlsFromItem(
         }
         return Array.isArray(valueOrValues)
           ? valueOrValues.map((it) => ({
-            url: it.value.url,
-            mediaType: it.type,
-          }))
+              url: it.value.url,
+              mediaType: it.type,
+            }))
           : { url: valueOrValues.value.url, mediaType: valueOrValues.type };
       })
       .flat(),
@@ -161,7 +162,9 @@ export function getMatchedBanksForMediaUrl(
       | { value: { url?: string; matchedBanks?: string[] }; type: string }[]
       | undefined;
     if (valueOrValues === undefined) continue;
-    const values = Array.isArray(valueOrValues) ? valueOrValues : [valueOrValues];
+    const values = Array.isArray(valueOrValues)
+      ? valueOrValues
+      : [valueOrValues];
     for (const tagged of values) {
       const v = tagged.value;
       if (v?.url === mediaUrl) {
@@ -203,7 +206,7 @@ export default function NCMECReviewUser(
     payload: NCMECJobPayloadQueryResult;
     showMessages?: boolean;
   } & (
-      | {
+    | {
         isActionable: false;
         ncmecDecisions?: readonly {
           readonly id: string;
@@ -213,13 +216,13 @@ export default function NCMECReviewUser(
           readonly industryClassification: GQLNcmecIndustryClassification;
         }[];
       }
-      | {
+    | {
         isActionable: true;
         submitDecision: (input: GQLDecisionSubmission) => Promise<void>;
         skipToNextJob: () => Promise<void>;
         ncmecDecisions: undefined;
       }
-    ),
+  ),
 ) {
   const { orgId, payload, isActionable, ncmecDecisions, showMessages } = props;
   const { item, allMediaItems } = payload;
@@ -267,9 +270,9 @@ export default function NCMECReviewUser(
                   : undefined;
               return threadId
                 ? {
-                  id: threadId.id,
-                  typeId: threadId.typeId,
-                }
+                    id: threadId.id,
+                    typeId: threadId.typeId,
+                  }
                 : undefined;
             }),
           ),
@@ -285,10 +288,10 @@ export default function NCMECReviewUser(
   >(
     allMediaItemsWithUrls.length > 0
       ? {
-        itemId: allMediaItemsWithUrls[0].contentItem.id,
-        urlInfo: allMediaItemsWithUrls[0].urlInfo,
-        itemTypeId: allMediaItemsWithUrls[0].contentItem.type.id,
-      }
+          itemId: allMediaItemsWithUrls[0].contentItem.id,
+          urlInfo: allMediaItemsWithUrls[0].urlInfo,
+          itemTypeId: allMediaItemsWithUrls[0].contentItem.type.id,
+        }
       : undefined,
   );
   // Selected Media = media that has been selected to be included in the
@@ -296,28 +299,28 @@ export default function NCMECReviewUser(
   const [selectedMedia, setSelectedMedia] = useState<NCMECMediaState[]>(
     ncmecDecisions
       ? allMediaItemsWithUrls.map((media) => {
-        const decision = ncmecDecisions.find(
-          (decision) =>
-            media.contentItem.id === decision.id &&
-            media.contentItem.type.id === decision.typeId,
-        );
-        if (decision) {
+          const decision = ncmecDecisions.find(
+            (decision) =>
+              media.contentItem.id === decision.id &&
+              media.contentItem.type.id === decision.typeId,
+          );
+          if (decision) {
+            return {
+              itemId: decision.id,
+              itemTypeId: decision.typeId,
+              urlInfo: media.urlInfo,
+              category: decision.industryClassification,
+              labels: [...decision.fileAnnotations],
+            };
+          }
           return {
-            itemId: decision.id,
-            itemTypeId: decision.typeId,
+            itemId: media.contentItem.id,
+            itemTypeId: media.contentItem.type.id,
             urlInfo: media.urlInfo,
-            category: decision.industryClassification,
-            labels: [...decision.fileAnnotations],
+            category: 'None',
+            labels: [],
           };
-        }
-        return {
-          itemId: media.contentItem.id,
-          itemTypeId: media.contentItem.type.id,
-          urlInfo: media.urlInfo,
-          category: 'None',
-          labels: [],
-        };
-      })
+        })
       : [],
   );
   const [selectedThreadsWithMessages, setSelectedThreadsWithMessages] =
@@ -326,6 +329,11 @@ export default function NCMECReviewUser(
     GQLNcmecIncidentType.ChildPornography,
   );
   const [escalateToHighPriority, setEscalateToHighPriority] = useState('');
+  const [escalateChecked, setEscalateChecked] = useState(false);
+  const [additionalInfo, setAdditionalInfo] = useState('');
+  const trimmedEscalate = escalateToHighPriority.trim();
+  const trimmedAdditionalInfo = additionalInfo.trim();
+  const escalateMissingReason = escalateChecked && trimmedEscalate === '';
   const [sendReportModalVisible, setSendReportModalVisible] = useState(false);
   const [deselectAndIgnoreModalVisible, setDeselectAndIgnoreModalVisible] =
     useState(false);
@@ -355,9 +363,11 @@ export default function NCMECReviewUser(
         </div>
         <CopyTextComponent
           value={erroredMedia.map((it) => it.id).join(',')}
-          displayValue={`${erroredMedia.length} video${erroredMedia.length === 1 ? '' : 's'
-            } or image${erroredMedia.length === 1 ? '' : 's'
-            } failed to load. Click here to copy a list of the IDs that failed to load.`}
+          displayValue={`${erroredMedia.length} video${
+            erroredMedia.length === 1 ? '' : 's'
+          } or image${
+            erroredMedia.length === 1 ? '' : 's'
+          } failed to load. Click here to copy a list of the IDs that failed to load.`}
           isError={true}
         />
         {isActionable ? (
@@ -580,22 +590,24 @@ export default function NCMECReviewUser(
           >
             <div className="overflow-hidden shadow-lg rounded-2xl w-fit">
               {!loading &&
-                moderatorSafetyBlurLevel != null &&
-                moderatorSafetyGrayscale != null ? (
+              moderatorSafetyBlurLevel != null &&
+              moderatorSafetyGrayscale != null ? (
                 media.urlInfo.mediaType === 'IMAGE' ? (
                   <img
-                    className={`object-scale-down w-64 h-48 rounded-2xl ${unblurAllMediaInConfirmation
+                    className={`object-scale-down w-64 h-48 rounded-2xl ${
+                      unblurAllMediaInConfirmation
                         ? 'blur-0'
                         : BLUR_LEVELS[moderatorSafetyBlurLevel as BlurStrength]
-                      } ${moderatorSafetyGrayscale ? 'grayscale' : ''}`}
+                    } ${moderatorSafetyGrayscale ? 'grayscale' : ''}`}
                     alt=""
                     src={media.urlInfo.url}
                   />
                 ) : (
                   <ManualReviewJobContentBlurableVideo
                     url={media.urlInfo.url}
-                    className={`object-scale-down w-64 h-48 rounded-2xl ${moderatorSafetyGrayscale ? 'grayscale' : ''
-                      }`}
+                    className={`object-scale-down w-64 h-48 rounded-2xl ${
+                      moderatorSafetyGrayscale ? 'grayscale' : ''
+                    }`}
                     options={{
                       shouldBlur:
                         !unblurAllMediaInConfirmation &&
@@ -640,6 +652,7 @@ export default function NCMECReviewUser(
       footer={[
         {
           title: 'Submit Report',
+          disabled: escalateMissingReason,
           onClick: async () => {
             await props.submitDecision({
               submitNcmecReport: {
@@ -658,8 +671,11 @@ export default function NCMECReviewUser(
                   }),
                 reportedMessages: selectedThreadsWithMessages,
                 incidentType,
-                ...(escalateToHighPriority.trim() !== ''
-                  ? { escalateToHighPriority: escalateToHighPriority.trim() }
+                ...(escalateChecked && trimmedEscalate !== ''
+                  ? { escalateToHighPriority: trimmedEscalate }
+                  : {}),
+                ...(trimmedAdditionalInfo !== ''
+                  ? { additionalInfo: trimmedAdditionalInfo }
                   : {}),
               },
             });
@@ -706,11 +722,12 @@ export default function NCMECReviewUser(
         <div className="!my-4 divider" />
         <div className="text-base font-bold">Messages</div>
         ${selectedThreadsWithMessages.map((thread) => (
-            <div key={thread.threadId}>
-              {thread.threadId}: {thread.reportedContent.length} reported
-            </div>
-          ))}
-        ` : undefined}
+          <div key={thread.threadId}>
+            {thread.threadId}: {thread.reportedContent.length} reported
+          </div>
+        ))}
+        `
+          : undefined}
 
         <div className="!my-4 divider" />
         <div className="flex flex-col gap-2">
@@ -730,23 +747,67 @@ export default function NCMECReviewUser(
           </select>
         </div>
         <div className="flex flex-col gap-2">
-          <label
-            htmlFor="escalateToHighPriority"
-            className="text-base font-bold"
-          >
-            Escalate as High Priority (optional)
+          <label className="flex items-center gap-2 text-base font-bold">
+            <input
+              type="checkbox"
+              checked={escalateChecked}
+              onChange={(e) => {
+                const next = e.target.checked;
+                setEscalateChecked(next);
+                if (!next) {
+                  setEscalateToHighPriority('');
+                }
+              }}
+            />
+            Escalate as High Priority
+          </label>
+          {escalateChecked ? (
+            <>
+              <label
+                htmlFor="escalateToHighPriority"
+                className="text-sm font-medium"
+              >
+                Reason for escalation (required)
+              </label>
+              <textarea
+                id="escalateToHighPriority"
+                maxLength={3000}
+                value={escalateToHighPriority}
+                onChange={(e) => setEscalateToHighPriority(e.target.value)}
+                placeholder="e.g. immediate risk to child."
+                className="min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                rows={3}
+              />
+              <div className="flex items-center justify-between">
+                {escalateMissingReason ? (
+                  <span className="text-xs text-red-600">
+                    A reason is required when escalating.
+                  </span>
+                ) : (
+                  <span />
+                )}
+                <span className="text-xs text-slate-500">
+                  {escalateToHighPriority.length}/3000 characters
+                </span>
+              </div>
+            </>
+          ) : null}
+        </div>
+        <div className="flex flex-col gap-2">
+          <label htmlFor="ncmecAdditionalInfo" className="text-base font-bold">
+            Additional details (optional)
           </label>
           <textarea
-            id="escalateToHighPriority"
+            id="ncmecAdditionalInfo"
             maxLength={3000}
-            value={escalateToHighPriority}
-            onChange={(e) => setEscalateToHighPriority(e.target.value)}
-            placeholder="e.g. immediate risk to child. Supplying a value will escalate the report."
+            value={additionalInfo}
+            onChange={(e) => setAdditionalInfo(e.target.value)}
+            placeholder="Any other context/notes to be added to the report."
             className="min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
             rows={3}
           />
           <span className="text-xs text-slate-500">
-            {escalateToHighPriority.length}/3000 characters
+            {additionalInfo.length}/3000 characters
           </span>
         </div>
       </div>
@@ -800,7 +861,8 @@ export default function NCMECReviewUser(
           e.repeat ||
           sendReportModalVisible ||
           deselectAndIgnoreModalVisible ||
-          isLabelSelectorInInspectedMediaVisible
+          isLabelSelectorInInspectedMediaVisible ||
+          isTypingInEditableElement(e.target)
         ) {
           return;
         } else if (moveToQueueMenuVisible) {
@@ -968,13 +1030,13 @@ export default function NCMECReviewUser(
             threadId={mediaInDetailViewThread?.id}
             threadInfo={
               threadInfo?.partialItems.__typename ===
-                'PartialItemsSuccessResponse'
+              'PartialItemsSuccessResponse'
                 ? (threadInfo.partialItems.items.find(
-                  (it) =>
-                    it.__typename === 'ThreadItem' &&
-                    it.id === mediaInDetailViewThread?.id &&
-                    it.type.id === mediaInDetailViewThread?.typeId,
-                ) as GQLThreadItem)
+                    (it) =>
+                      it.__typename === 'ThreadItem' &&
+                      it.id === mediaInDetailViewThread?.id &&
+                      it.type.id === mediaInDetailViewThread?.typeId,
+                  ) as GQLThreadItem)
                 : undefined
             }
             threadLoading={threadLoading}
@@ -983,9 +1045,11 @@ export default function NCMECReviewUser(
             <div className="self-start pt-2">
               <CopyTextComponent
                 value={erroredMedia.map((it) => it.id).join(',')}
-                displayValue={`${erroredMedia.length} video${erroredMedia.length === 1 ? '' : 's'
-                  } or image${erroredMedia.length === 1 ? '' : 's'
-                  } failed to load. Click here to copy a list of the IDs that failed to load.`}
+                displayValue={`${erroredMedia.length} video${
+                  erroredMedia.length === 1 ? '' : 's'
+                } or image${
+                  erroredMedia.length === 1 ? '' : 's'
+                } failed to load. Click here to copy a list of the IDs that failed to load.`}
                 isError={true}
               />
             </div>

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ncmec/NCMECReviewUser.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ncmec/NCMECReviewUser.tsx
@@ -1,3 +1,4 @@
+import { isTypingInEditableElement } from '@/utils/misc';
 import { BulbOutlined, ExclamationCircleOutlined } from '@ant-design/icons';
 import { gql } from '@apollo/client';
 import { ItemIdentifier, TaggedScalar } from '@roostorg/types';
@@ -30,7 +31,6 @@ import {
   getFieldValueForRole,
   getFieldValueOrValues,
 } from '../../../../../../utils/itemUtils';
-import { isTypingInEditableElement } from '../../../../../../utils/misc';
 import { titleCaseEnumString } from '../../../../../../utils/string';
 import { jsonStringify } from '../../../../../../utils/typescript-types';
 import ManualReviewJobContentBlurableVideo from '../../ManualReviewJobContentBlurableVideo';
@@ -302,7 +302,8 @@ export default function NCMECReviewUser(
           const decision = ncmecDecisions.find(
             (decision) =>
               media.contentItem.id === decision.id &&
-              media.contentItem.type.id === decision.typeId,
+              media.contentItem.type.id === decision.typeId &&
+              media.urlInfo.url === decision.url,
           );
           if (decision) {
             return {
@@ -717,17 +718,17 @@ export default function NCMECReviewUser(
         <div className="!my-4 divider" />
         <div className="text-base font-bold">Media</div>
         {selectedMediaConfirmationGrid}
-        {selectedThreadsWithMessages.length > 0
-          ? `
-        <div className="!my-4 divider" />
-        <div className="text-base font-bold">Messages</div>
-        ${selectedThreadsWithMessages.map((thread) => (
-          <div key={thread.threadId}>
-            {thread.threadId}: {thread.reportedContent.length} reported
-          </div>
-        ))}
-        `
-          : undefined}
+        {selectedThreadsWithMessages.length > 0 ? (
+          <>
+            <div className="!my-4 divider" />
+            <div className="text-base font-bold">Messages</div>
+            {selectedThreadsWithMessages.map((thread) => (
+              <div key={thread.threadId}>
+                {thread.threadId}: {thread.reportedContent.length} reported
+              </div>
+            ))}
+          </>
+        ) : null}
 
         <div className="!my-4 divider" />
         <div className="flex flex-col gap-2">

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ncmec/NCMECReviewUser.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ncmec/NCMECReviewUser.tsx
@@ -651,6 +651,7 @@ export default function NCMECReviewUser(
 
   const sendReportModal = isActionable ? (
     <CoopModal
+      className="!w-[64rem] !max-w-[90vw]"
       visible={sendReportModalVisible}
       onClose={() => setSendReportModalVisible(false)}
       title="Confirm & Send NCMEC Report"
@@ -689,31 +690,26 @@ export default function NCMECReviewUser(
         },
       ]}
     >
-      <div className="flex flex-col w-full">
+      <div className="flex flex-col w-full min-w-0">
         <div className="!my-4 divider" />
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-4 text-start">
-            <div className="text-base font-bold">Suspect</div>
-            <div className="flex flex-row items-center mr-12">
+        <div className="flex items-start justify-between gap-4 min-w-0">
+          <div className="flex items-start gap-4 text-start min-w-0 flex-1">
+            <div className="text-base font-bold shrink-0 pt-1">Suspect</div>
+            <div className="flex flex-row items-start min-w-0 flex-1">
               {profilePicUrl ? (
                 <img
                   alt="profile pic"
-                  className="w-10 h-10 border-2 border-solid rounded-full border-slate-400"
+                  className="w-10 h-10 border-2 border-solid rounded-full border-slate-400 shrink-0"
                   src={profilePicUrl.url}
                 />
               ) : null}
-              {displayName ? (
-                <div className="ml-3 font-bold truncate text-slate-700">
-                  {displayName} ({item.id})
-                </div>
-              ) : (
-                <div className="ml-3 font-bold truncate text-slate-700">
-                  {item.id}
-                </div>
-              )}
+              <div className="ml-3 font-bold text-slate-700 break-all min-w-0 flex-1">
+                {displayName ? `${displayName} (${item.id})` : item.id}
+              </div>
             </div>
           </div>
           <Button
+            className="shrink-0"
             onClick={() => setUnblurAllMediaInConfirmation((prev) => !prev)}
           >
             {unblurAllMediaInConfirmation ? 'Blur All' : 'Unblur All'}

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ncmec/NCMECReviewUser.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ncmec/NCMECReviewUser.tsx
@@ -299,11 +299,15 @@ export default function NCMECReviewUser(
   const [selectedMedia, setSelectedMedia] = useState<NCMECMediaState[]>(
     ncmecDecisions
       ? allMediaItemsWithUrls.map((media) => {
+          // Match on (id, typeId) only — media URLs in this codebase are
+          // signed/ephemeral and don't round-trip byte-identical across
+          // fetches, so adding `url` to the predicate drops every prior
+          // classification. Multi-media-per-item gets the first decision;
+          // fixing that needs a stable per-media identifier (follow-up).
           const decision = ncmecDecisions.find(
             (decision) =>
               media.contentItem.id === decision.id &&
-              media.contentItem.type.id === decision.typeId &&
-              media.urlInfo.url === decision.url,
+              media.contentItem.type.id === decision.typeId,
           );
           if (decision) {
             return {

--- a/client/src/webpages/dashboard/ncmec/NcmecReportsDashboard.tsx
+++ b/client/src/webpages/dashboard/ncmec/NcmecReportsDashboard.tsx
@@ -1,10 +1,47 @@
+import { toast } from '@/coop-ui/Toast';
+import GridAlt from '@/icons/lnif/Design/grid-alt.svg?react';
 import { AuditOutlined, DownloadOutlined } from '@ant-design/icons';
 import { gql } from '@apollo/client';
-import { Button, Input } from 'antd';
+import { Button, Checkbox, Input, Tag, Tooltip } from 'antd';
 import { format } from 'date-fns';
-import { useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useNavigate } from 'react-router-dom';
+
+/** Anchor that lazily creates a Blob URL on click and revokes it shortly
+ * after the download is triggered. Avoids leaking Blob URLs on every render
+ * (the previous inline `URL.createObjectURL` pattern leaked one per row per
+ * re-render, which adds up on a long-lived dashboard). */
+function BlobDownloadLink(props: {
+  fileName: string;
+  contents: string;
+  mimeType: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  const { fileName, contents, mimeType, children, className } = props;
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLAnchorElement>) => {
+      event.preventDefault();
+      const url = URL.createObjectURL(new Blob([contents], { type: mimeType }));
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = fileName;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      // Revoke after the browser has had a chance to start the download.
+      // Revoking immediately can cancel the download in some browsers.
+      setTimeout(() => URL.revokeObjectURL(url), 0);
+    },
+    [contents, fileName, mimeType],
+  );
+  return (
+    <a href="#" onClick={handleClick} className={className}>
+      {children}
+    </a>
+  );
+}
 
 import CopyTextComponent from '../../../components/common/CopyTextComponent';
 import FullScreenLoading from '../../../components/common/FullScreenLoading';
@@ -24,8 +61,10 @@ import {
   useGQLAllNcmecReportsQuery,
   useGQLGetNcmecReportLazyQuery,
   useGQLPermissionsQuery,
-} from '../../../graphql/generated';
-import { userHasPermissions } from '../../../routing/permissions';
+  useGQLRetryNcmecSubmissionMutation,
+} from '@/graphql/generated';
+import { userHasPermissions } from '@/routing/permissions';
+import { filterNullOrUndefined } from '@/utils/collections';
 
 gql`
   fragment NCMECReportValues on NCMECReport {
@@ -54,11 +93,27 @@ gql`
     isTest
   }
 
+  fragment NcmecFailedSubmissionValues on NcmecFailedSubmission {
+    decisionId
+    ts
+    reviewerId
+    userId
+    userItemType {
+      name
+    }
+    status
+    retryCount
+    lastError
+  }
+
   query AllNCMECReports {
     myOrg {
       hasNCMECReportingEnabled
       ncmecReports {
         ...NCMECReportValues
+      }
+      failedNcmecSubmissions {
+        ...NcmecFailedSubmissionValues
       }
       users {
         id
@@ -79,7 +134,60 @@ gql`
       ...NCMECReportValues
     }
   }
+
+  mutation RetryNcmecSubmission($decisionId: ID!) {
+    retryNcmecSubmission(decisionId: $decisionId) {
+      success
+      error
+    }
+  }
 `;
+
+type ColumnId =
+  | 'date'
+  | 'reviewer'
+  | 'reportId'
+  | 'userId'
+  | 'userItemType'
+  | 'status'
+  | 'reportedMedia'
+  | 'additionalFiles'
+  | 'reportedMessages'
+  | 'isTest'
+  | 'lastError'
+  | 'action';
+
+const COLUMN_VISIBILITY_STORAGE_KEY = 'ncmec-reports-column-visibility';
+
+const defaultColumnVisibility: Record<ColumnId, boolean> = {
+  date: true,
+  reviewer: true,
+  reportId: true,
+  userId: true,
+  userItemType: true,
+  status: true,
+  reportedMedia: true,
+  additionalFiles: true,
+  reportedMessages: true,
+  isTest: true,
+  lastError: false,
+  action: true,
+};
+
+const columnLabels: Record<ColumnId, string> = {
+  date: 'Date',
+  reviewer: 'Reviewer',
+  reportId: 'Report ID',
+  userId: 'User ID',
+  userItemType: 'User Item Type',
+  status: 'Status',
+  reportedMedia: 'Reported Media',
+  additionalFiles: 'Additional Files',
+  reportedMessages: 'Reported Messages',
+  isTest: 'Test Report',
+  lastError: 'Last Error',
+  action: 'Action',
+};
 
 export default function NcmecReportsDashboard() {
   const navigate = useNavigate();
@@ -92,8 +200,12 @@ export default function NcmecReportsDashboard() {
     error: allReportsError,
     data: allReportsData,
   } = useGQLAllNcmecReportsQuery();
-  const { hasNCMECReportingEnabled, ncmecReports, users } =
-    allReportsData?.myOrg ?? {};
+  const {
+    hasNCMECReportingEnabled,
+    ncmecReports,
+    failedNcmecSubmissions,
+    users,
+  } = allReportsData?.myOrg ?? {};
 
   const [
     getNcmecReportById,
@@ -104,6 +216,97 @@ export default function NcmecReportsDashboard() {
     },
   ] = useGQLGetNcmecReportLazyQuery();
 
+  const [retryNcmecSubmission] = useGQLRetryNcmecSubmissionMutation();
+  const [retryingDecisionId, setRetryingDecisionId] = useState<string | null>(
+    null,
+  );
+
+  const handleRetry = useCallback(
+    async (decisionId: string) => {
+      setRetryingDecisionId(decisionId);
+      try {
+        const { data } = await retryNcmecSubmission({
+          variables: { decisionId },
+          // Refetching keeps the table consistent: a successful retry should
+          // move the row from "Failed" to "Successful" the next render.
+          refetchQueries: ['AllNCMECReports'],
+          awaitRefetchQueries: true,
+        });
+        if (data?.retryNcmecSubmission.success) {
+          toast.success('NCMEC submission retried successfully');
+        } else {
+          toast.error(
+            data?.retryNcmecSubmission.error ??
+              'Retry failed for an unknown reason',
+          );
+        }
+      } catch (e: unknown) {
+        toast.error(
+          e instanceof Error ? e.message : 'Retry failed unexpectedly',
+        );
+      } finally {
+        setRetryingDecisionId(null);
+      }
+    },
+    [retryNcmecSubmission],
+  );
+
+  // Column visibility state, persisted to localStorage so users keep their
+  // chosen view across sessions. Mirrors the queues-dashboard pattern.
+  const [columnVisibility, setColumnVisibility] = useState<
+    Record<ColumnId, boolean>
+  >(() => {
+    try {
+      const stored = localStorage.getItem(COLUMN_VISIBILITY_STORAGE_KEY);
+      if (stored) {
+        return {
+          ...defaultColumnVisibility,
+          ...(JSON.parse(stored) as Partial<Record<ColumnId, boolean>>),
+        };
+      }
+    } catch {
+      // Ignore corrupt or inaccessible localStorage entries; fall through to
+      // the defaults rather than blocking the whole page.
+    }
+    return defaultColumnVisibility;
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(
+        COLUMN_VISIBILITY_STORAGE_KEY,
+        JSON.stringify(columnVisibility),
+      );
+    } catch {
+      // Best-effort persistence; quota / private-mode failures are non-fatal.
+    }
+  }, [columnVisibility]);
+
+  const toggleColumnVisibility = useCallback((columnId: ColumnId) => {
+    setColumnVisibility((prev) => ({ ...prev, [columnId]: !prev[columnId] }));
+  }, []);
+
+  const [columnsMenuVisible, setColumnsMenuVisible] = useState(false);
+  const columnsMenuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        columnsMenuRef.current &&
+        !columnsMenuRef.current.contains(event.target as Node)
+      ) {
+        setColumnsMenuVisible(false);
+      }
+    };
+    if (columnsMenuVisible) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => {
+        document.removeEventListener('mousedown', handleClickOutside);
+      };
+    }
+    return undefined;
+  }, [columnsMenuVisible]);
+
   const fetchReportById = () => {
     if (!searchId) {
       return;
@@ -112,227 +315,311 @@ export default function NcmecReportsDashboard() {
   };
 
   const columns = useMemo(
-    () => [
-      {
-        Header: 'Date',
-        accessor: 'date',
-        sortType: stringSort,
-        sortDescFirst: true,
-        Filter: (props: ColumnProps) =>
-          DateRangeColumnFilter({
-            columnProps: props,
-            accessor: 'date',
-            placeholder: '',
-          }),
-        filter: 'dateRange',
-      },
-      {
-        Header: 'Reviewer',
-        accessor: 'reviewer',
-        filter: 'includes',
-        sortType: stringSort,
-        Filter: (props: ColumnProps) =>
-          SelectColumnFilter({
-            columnProps: props,
-            accessor: 'reviewer',
-          }),
-      },
-      {
-        Header: 'Report ID',
-        accessor: 'reportId',
-        filter: 'text',
-        canSort: false,
-        Filter: (props: ColumnProps) =>
-          DefaultColumnFilter({
-            columnProps: props,
-            accessor: 'reportId',
-            placeholder: 'Report ID',
-          }),
-      },
-      {
-        Header: 'User ID',
-        accessor: 'userId',
-        filter: 'text',
-        canSort: false,
-        Filter: (props: ColumnProps) =>
-          DefaultColumnFilter({
-            columnProps: props,
-            accessor: 'userId',
-            placeholder: 'User ID',
-          }),
-      },
-      {
-        Header: 'User Item Type',
-        accessor: 'userItemType',
-        filter: 'text',
-        canSort: false,
-        Filter: (props: ColumnProps) =>
-          DefaultColumnFilter({
-            columnProps: props,
-            accessor: 'userItemType',
-            placeholder: 'User Type',
-          }),
-      },
-      {
-        Header: 'Reported Media',
-        accessor: 'reportedMedia',
-      },
-      {
-        Header: 'Additional Files',
-        accessor: 'additionalFiles',
-      },
-      {
-        Header: 'Reported Messages',
-        accessor: 'reportedMessages',
-      },
-      {
-        Header: 'Test Report',
-        accessor: 'isTest',
-      },
-    ],
-    [],
+    () =>
+      filterNullOrUndefined([
+        columnVisibility.date
+          ? {
+              Header: 'Date',
+              accessor: 'date',
+              sortType: stringSort,
+              sortDescFirst: true,
+              Filter: (props: ColumnProps) =>
+                DateRangeColumnFilter({
+                  columnProps: props,
+                  accessor: 'date',
+                  placeholder: '',
+                }),
+              filter: 'dateRange',
+            }
+          : undefined,
+        columnVisibility.reviewer
+          ? {
+              Header: 'Reviewer',
+              accessor: 'reviewer',
+              filter: 'includes',
+              sortType: stringSort,
+              Filter: (props: ColumnProps) =>
+                SelectColumnFilter({
+                  columnProps: props,
+                  accessor: 'reviewer',
+                }),
+            }
+          : undefined,
+        columnVisibility.status
+          ? {
+              // Cell renders the colored Tag from row.status; the filter
+              // reads the plain string from row.original.values.status.
+              Header: 'Status',
+              accessor: 'status',
+              filter: 'includes',
+              sortType: stringSort,
+              Filter: (props: ColumnProps) =>
+                SelectColumnFilter({
+                  columnProps: props,
+                  accessor: 'status',
+                }),
+            }
+          : undefined,
+        columnVisibility.reportId
+          ? {
+              Header: 'Report ID',
+              accessor: 'reportId',
+              filter: 'text',
+              canSort: false,
+              Filter: (props: ColumnProps) =>
+                DefaultColumnFilter({
+                  columnProps: props,
+                  accessor: 'reportId',
+                  placeholder: 'Report ID',
+                }),
+            }
+          : undefined,
+        columnVisibility.userId
+          ? {
+              Header: 'User ID',
+              accessor: 'userId',
+              filter: 'text',
+              canSort: false,
+              Filter: (props: ColumnProps) =>
+                DefaultColumnFilter({
+                  columnProps: props,
+                  accessor: 'userId',
+                  placeholder: 'User ID',
+                }),
+            }
+          : undefined,
+        columnVisibility.userItemType
+          ? {
+              Header: 'User Item Type',
+              accessor: 'userItemType',
+              filter: 'text',
+              canSort: false,
+              Filter: (props: ColumnProps) =>
+                DefaultColumnFilter({
+                  columnProps: props,
+                  accessor: 'userItemType',
+                  placeholder: 'User Type',
+                }),
+            }
+          : undefined,
+        columnVisibility.reportedMedia
+          ? { Header: 'Reported Media', accessor: 'reportedMedia' }
+          : undefined,
+        columnVisibility.additionalFiles
+          ? { Header: 'Additional Files', accessor: 'additionalFiles' }
+          : undefined,
+        columnVisibility.reportedMessages
+          ? { Header: 'Reported Messages', accessor: 'reportedMessages' }
+          : undefined,
+        columnVisibility.isTest
+          ? { Header: 'Test Report', accessor: 'isTest' }
+          : undefined,
+        columnVisibility.lastError
+          ? { Header: 'Last Error', accessor: 'lastError' }
+          : undefined,
+        columnVisibility.action
+          ? { Header: 'Action', accessor: 'action' }
+          : undefined,
+      ]),
+    [columnVisibility],
   );
 
-  const dataValues = useMemo(() => {
-    const reports =
+  const tableData = useMemo(() => {
+    // Successful reports come from `ncmecReports`; if the user is searching by
+    // a specific report id we substitute the lazy-fetched single report.
+    const successfulReportsSource =
       searchId && ncmecReportData && ncmecReportData.ncmecReportById
         ? [ncmecReportData.ncmecReportById]
-        : ncmecReports;
-    return reports
-      ?.filter((report) =>
+        : (ncmecReports ?? []);
+
+    const successfulRows = successfulReportsSource
+      .filter((report) =>
         searchId ? report.reportId.includes(searchId) : true,
       )
-      .sort((a, b) =>
-        b.ts.toLocaleString().localeCompare(a.ts.toLocaleString()),
-      )
       .map((report) => {
-        const reviewer = users?.find((user) => user.id === report.reviewerId);
+        const reviewer = users?.find((u) => u.id === report.reviewerId);
+        const reviewerName = reviewer
+          ? `${reviewer.firstName} ${reviewer.lastName}`
+          : 'Other';
         return {
-          ...report,
-          date: report.ts,
-          reviewer: reviewer
-            ? `${reviewer.firstName} ${reviewer.lastName}`
-            : 'Other',
+          // Sort key: numeric ms since epoch on the underlying timestamp.
+          tsMs: new Date(report.ts).getTime(),
+          row: {
+            // Plain strings here back the SelectColumnFilter dropdowns.
+            values: {
+              reviewer: reviewerName,
+              status: 'Successful' as const,
+            },
+            date: <div>{format(new Date(report.ts), 'MM/dd/yy h:mm a')}</div>,
+            reviewer: <div className="whitespace-nowrap">{reviewerName}</div>,
+            status: <Tag color="success">Successful</Tag>,
+            reportId: (
+              <div key={report.reportId} className="flex flex-row">
+                <CopyTextComponent value={report.reportId} />
+                <div className="pl-2">
+                  <BlobDownloadLink
+                    fileName={`ncmec_report_${report.reportId}.xml`}
+                    contents={formatXml(report.reportXml)}
+                    mimeType="text/plain"
+                  >
+                    <DownloadOutlined />
+                  </BlobDownloadLink>
+                </div>
+              </div>
+            ),
+            userId: <CopyTextComponent value={report.userId} />,
+            userItemType: <div>{report.userItemType.name}</div>,
+            reportedMedia: (
+              <div className="flex flex-col justify-start gap-1 text-start">
+                {report.reportedMedia.length < 2
+                  ? null
+                  : `${report.reportedMedia.length} media files: `}
+                <div className="flex flex-wrap overflow-auto max-h-12">
+                  {report.reportedMedia.map((media) => (
+                    <div key={media.id} className="flex flex-row">
+                      <CopyTextComponent value={`ID: ${media.id}`} />
+                      <div className="pl-2">
+                        <BlobDownloadLink
+                          fileName={`ncmec_report_${report.reportId}_media_${media.id}.xml`}
+                          contents={formatXml(media.xml)}
+                          mimeType="text/plain"
+                        >
+                          <DownloadOutlined />
+                        </BlobDownloadLink>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ),
+            additionalFiles: (
+              <div className="flex flex-col justify-start max-w-md gap-1 text-start">
+                {report.additionalFiles.length < 2
+                  ? null
+                  : `${report.additionalFiles.length} additional files: `}
+                <div className="flex flex-wrap overflow-auto max-h-12">
+                  {report.additionalFiles.map((additionalFile) => (
+                    <div
+                      key={additionalFile.ncmecFileId}
+                      className="flex flex-row"
+                    >
+                      <div className="pl-2">
+                        <BlobDownloadLink
+                          fileName={`ncmec_report_additional_file_${additionalFile.ncmecFileId}.xml`}
+                          contents={formatXml(additionalFile.xml)}
+                          mimeType="text/plain"
+                        >
+                          <DownloadOutlined className="pr-1" />
+                        </BlobDownloadLink>
+                      </div>
+                      <div className="overflow-ellipsis">
+                        {`URL: ${additionalFile.url}`}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ),
+            reportedMessages: (
+              <div className="flex flex-col justify-start gap-1 text-start">
+                {report.reportedMessages.length < 2
+                  ? null
+                  : `${report.reportedMessages.length} reported threads: `}
+                <div className="flex flex-wrap overflow-auto max-h-12">
+                  {report.reportedMessages.map((reportedMessage) => (
+                    <div
+                      key={reportedMessage.fileName}
+                      className="flex flex-row"
+                    >
+                      {`${reportedMessage.fileName}`}
+                      <div className="pl-2">
+                        <BlobDownloadLink
+                          fileName={reportedMessage.fileName}
+                          contents={reportedMessage.csv}
+                          mimeType="text/csv"
+                        >
+                          <DownloadOutlined />
+                        </BlobDownloadLink>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ),
+            isTest: <div>{report.isTest ? 'True' : 'False'}</div>,
+            lastError: null as React.ReactNode,
+            action: null as React.ReactNode,
+          },
         };
       });
-  }, [ncmecReportData, ncmecReports, searchId, users]);
 
-  const tableData = useMemo(
-    () =>
-      dataValues?.map((report) => {
-        return {
-          date: (
-            <div>{format(new Date(report.date), 'MM/dd/yy h:mm a')}</div>
-          ),
-          reviewer: <div className="whitespace-nowrap">{report.reviewer}</div>,
-          reportId: (
-            <div key={report.reportId} className="flex flex-row">
-              <CopyTextComponent value={report.reportId} />
-              <div className="pl-2">
-                <a
-                  href={URL.createObjectURL(
-                    new Blob([formatXml(report.reportXml)], {
-                      type: 'text/plain',
-                    }),
-                  )}
-                  download={`ncmec_report_${report.reportId}.xml`}
+    // Failed rows: only included when the user isn't searching by report id
+    // (failed submissions don't have a CyberTip report id to match against).
+    const failedRows = searchId
+      ? []
+      : (failedNcmecSubmissions ?? []).map((failed) => {
+          const reviewer = users?.find((u) => u.id === failed.reviewerId);
+          const reviewerName = reviewer
+            ? `${reviewer.firstName} ${reviewer.lastName}`
+            : 'Other';
+          return {
+            tsMs: new Date(failed.ts).getTime(),
+            row: {
+              values: {
+                reviewer: reviewerName,
+                status: 'Failed' as const,
+              },
+              date: <div>{format(new Date(failed.ts), 'MM/dd/yy h:mm a')}</div>,
+              reviewer: <div className="whitespace-nowrap">{reviewerName}</div>,
+              status: <Tag color="error">Failed</Tag>,
+              reportId: <span className="text-zinc-400">—</span>,
+              userId: <CopyTextComponent value={failed.userId} />,
+              userItemType: <div>{failed.userItemType.name}</div>,
+              reportedMedia: <span className="text-zinc-400">—</span>,
+              additionalFiles: <span className="text-zinc-400">—</span>,
+              reportedMessages: <span className="text-zinc-400">—</span>,
+              isTest: <span className="text-zinc-400">—</span>,
+              lastError: failed.lastError ? (
+                <Tooltip title={failed.lastError} placement="topLeft">
+                  <div className="max-w-xs overflow-hidden text-xs text-ellipsis whitespace-nowrap text-red-700">
+                    {failed.lastError}
+                  </div>
+                </Tooltip>
+              ) : (
+                <span className="text-zinc-400">—</span>
+              ),
+              action: (
+                <Button
+                  size="small"
+                  type="primary"
+                  loading={retryingDecisionId === failed.decisionId}
+                  disabled={
+                    retryingDecisionId !== null &&
+                    retryingDecisionId !== failed.decisionId
+                  }
+                  onClick={() => {
+                    void handleRetry(failed.decisionId);
+                  }}
                 >
-                  <DownloadOutlined />
-                </a>
-              </div>
-            </div>
-          ),
-          userId: <CopyTextComponent value={report.userId} />,
-          userItemType: <div>{report.userItemType.name}</div>,
-          reportedMedia: (
-            <div className="flex flex-col justify-start gap-1 text-start">
-              {report.reportedMedia.length < 2
-                ? null
-                : `${report.reportedMedia.length} media files: `}
-              <div className="flex flex-wrap overflow-auto max-h-12">
-                {report.reportedMedia.map((media) => (
-                  <div key={media.id} className="flex flex-row">
-                    <CopyTextComponent value={`ID: ${media.id}`} />
-                    <div className="pl-2">
-                      <a
-                        href={URL.createObjectURL(
-                          new Blob([formatXml(media.xml)], {
-                            type: 'text/plain',
-                          }),
-                        )}
-                        download={`ncmec_report_${report.reportId}_media_${media.id}.xml`}
-                      >
-                        <DownloadOutlined />
-                      </a>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          ),
-          values: report,
-          additionalFiles: (
-            <div className="flex flex-col justify-start max-w-md gap-1 text-start">
-              {report.additionalFiles.length < 2
-                ? null
-                : `${report.additionalFiles.length} additional files: `}
-              <div className="flex flex-wrap overflow-auto max-h-12">
-                {report.additionalFiles.map((additionalFile) => (
-                  <div
-                    key={additionalFile.ncmecFileId}
-                    className="flex flex-row"
-                  >
-                    <div className="pl-2">
-                      <a
-                        href={URL.createObjectURL(
-                          new Blob([formatXml(additionalFile.xml)], {
-                            type: 'text/plain',
-                          }),
-                        )}
-                        download={`ncmec_report_additional_file_${additionalFile.ncmecFileId}.xml`}
-                      >
-                        <DownloadOutlined className="pr-1" />
-                      </a>
-                    </div>
-                    <div className="overflow-ellipsis">
-                      {`URL: ${additionalFile.url}`}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          ),
-          reportedMessages: (
-            <div className="flex flex-col justify-start gap-1 text-start">
-              {report.reportedMessages.length < 2
-                ? null
-                : `${report.reportedMessages.length} reported threads: `}
-              <div className="flex flex-wrap overflow-auto max-h-12">
-                {report.reportedMessages.map((reportedMessage) => (
-                  <div key={reportedMessage.fileName} className="flex flex-row">
-                    {`${reportedMessage.fileName}`}
-                    <div className="pl-2">
-                      <a
-                        href={URL.createObjectURL(
-                          new Blob([reportedMessage.csv], {
-                            type: 'text/csv',
-                          }),
-                        )}
-                        download={`${reportedMessage.fileName}`}
-                      >
-                        <DownloadOutlined />
-                      </a>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          ),
-          isTest: <div>{report.isTest ? 'True' : 'False'}</div>,
-        };
-      }),
-    [dataValues],
-  );
+                  Retry
+                </Button>
+              ),
+            },
+          };
+        });
+
+    return [...successfulRows, ...failedRows]
+      .sort((a, b) => b.tsMs - a.tsMs)
+      .map(({ row }) => row);
+  }, [
+    failedNcmecSubmissions,
+    handleRetry,
+    ncmecReportData,
+    ncmecReports,
+    retryingDecisionId,
+    searchId,
+    users,
+  ]);
 
   if (allReportsError || ncmecReportError) {
     throw allReportsError ?? ncmecReportError!;
@@ -364,7 +651,8 @@ export default function NcmecReportsDashboard() {
       />
       {allReportsLoading || ncmecReportLoading ? (
         <FullScreenLoading />
-      ) : ncmecReports?.length === 0 ? (
+      ) : (ncmecReports?.length ?? 0) === 0 &&
+        (failedNcmecSubmissions?.length ?? 0) === 0 ? (
         <div className="flex items-center justify-center w-full h-full">
           <div className="flex flex-col items-center justify-center p-12 mt-24">
             <div className="pb-3 text-zinc-500 text-8xl">
@@ -384,19 +672,75 @@ export default function NcmecReportsDashboard() {
           </div>
         </div>
       ) : (
-        <div className="flex flex-col max-w-full w-fit">
+        <div className="flex flex-col w-full min-w-0 max-w-full">
           <Table
+            // Override Table's default `w-fit` so its internal overflow-x-auto
+            // can scroll the table when columns overflow the viewport, and
+            // force the horizontal scrollbar to render.
+            containerClassName="w-full min-w-0"
+            alwaysShowScrollbar
             columns={columns}
             data={tableData ?? []}
             topLeftComponent={
-              <div className="flex flex-col items-start" key="input">
-                <div className="mb-2 font-semibold">Search By Report ID</div>
-                <Input
-                  className="rounded-lg w-[300px]"
-                  onChange={(event) => setSearchId(event.target.value)}
-                  autoFocus
-                  allowClear
-                />
+              <div
+                className="flex flex-row flex-wrap items-end gap-4"
+                key="topleft"
+              >
+                <div className="flex flex-col items-start">
+                  <div className="mb-2 font-semibold">Search By Report ID</div>
+                  <Input
+                    className="rounded-lg w-[300px]"
+                    onChange={(event) => setSearchId(event.target.value)}
+                    autoFocus
+                    allowClear
+                  />
+                </div>
+                <div
+                  ref={columnsMenuRef}
+                  className="relative inline-block text-start"
+                >
+                  <Button
+                    className={`font-semibold text-base rounded ${
+                      Object.values(columnVisibility).filter(Boolean).length ===
+                      Object.keys(columnLabels).length
+                        ? 'bg-white text-gray-600 hover:bg-white hover:text-gray-600'
+                        : 'bg-gray-600 text-white border-none hover:bg-gray-500'
+                    }`}
+                    icon={
+                      <GridAlt
+                        className="inline-block w-4 h-4 mr-2"
+                        fill="currentColor"
+                      />
+                    }
+                    onClick={() => setColumnsMenuVisible(!columnsMenuVisible)}
+                  >
+                    Columns
+                  </Button>
+                  {columnsMenuVisible && (
+                    <div className="absolute left-0 z-20 flex flex-col mt-1 bg-white border border-solid border-gray-300 rounded shadow-md min-w-[240px]">
+                      <div className="px-4 py-4 text-base font-semibold">
+                        Show Columns
+                      </div>
+                      <div className="!p-0 !m-0 divider" />
+                      <div className="flex flex-col px-4 py-2">
+                        {(Object.keys(columnLabels) as ColumnId[]).map(
+                          (columnId) => (
+                            <div key={columnId} className="py-2">
+                              <Checkbox
+                                checked={columnVisibility[columnId]}
+                                onChange={() =>
+                                  toggleColumnVisibility(columnId)
+                                }
+                              >
+                                {columnLabels[columnId]}
+                              </Checkbox>
+                            </div>
+                          ),
+                        )}
+                      </div>
+                    </div>
+                  )}
+                </div>
               </div>
             }
           />

--- a/client/src/webpages/dashboard/ncmec/NcmecReportsDashboard.tsx
+++ b/client/src/webpages/dashboard/ncmec/NcmecReportsDashboard.tsx
@@ -1,12 +1,42 @@
 import { toast } from '@/coop-ui/Toast';
+import {
+  GQLUserPermission,
+  useGQLAllNcmecReportsQuery,
+  useGQLGetNcmecReportLazyQuery,
+  useGQLPermissionsQuery,
+  useGQLRetryNcmecSubmissionMutation,
+} from '@/graphql/generated';
 import GridAlt from '@/icons/lnif/Design/grid-alt.svg?react';
+import { userHasPermissions } from '@/routing/permissions';
+import { filterNullOrUndefined } from '@/utils/collections';
 import { AuditOutlined, DownloadOutlined } from '@ant-design/icons';
 import { gql } from '@apollo/client';
 import { Button, Checkbox, Input, Tag, Tooltip } from 'antd';
 import { format } from 'date-fns';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
+} from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useNavigate } from 'react-router-dom';
+
+import CopyTextComponent from '../../../components/common/CopyTextComponent';
+import FullScreenLoading from '../../../components/common/FullScreenLoading';
+import CoopButton from '../components/CoopButton';
+import DashboardHeader from '../components/DashboardHeader';
+import {
+  ColumnProps,
+  DateRangeColumnFilter,
+  DefaultColumnFilter,
+  SelectColumnFilter,
+} from '../components/table/filters';
+import { stringSort } from '../components/table/sort';
+import Table from '../components/table/Table';
 
 /** Anchor that lazily creates a Blob URL on click and revokes it shortly
  * after the download is triggered. Avoids leaking Blob URLs on every render
@@ -16,12 +46,12 @@ function BlobDownloadLink(props: {
   fileName: string;
   contents: string;
   mimeType: string;
-  children: React.ReactNode;
+  children: ReactNode;
   className?: string;
 }) {
   const { fileName, contents, mimeType, children, className } = props;
   const handleClick = useCallback(
-    (event: React.MouseEvent<HTMLAnchorElement>) => {
+    (event: ReactMouseEvent<HTMLAnchorElement>) => {
       event.preventDefault();
       const url = URL.createObjectURL(new Blob([contents], { type: mimeType }));
       const a = document.createElement('a');
@@ -42,29 +72,6 @@ function BlobDownloadLink(props: {
     </a>
   );
 }
-
-import CopyTextComponent from '../../../components/common/CopyTextComponent';
-import FullScreenLoading from '../../../components/common/FullScreenLoading';
-import CoopButton from '../components/CoopButton';
-import DashboardHeader from '../components/DashboardHeader';
-import {
-  ColumnProps,
-  DateRangeColumnFilter,
-  DefaultColumnFilter,
-  SelectColumnFilter,
-} from '../components/table/filters';
-import { stringSort } from '../components/table/sort';
-import Table from '../components/table/Table';
-
-import {
-  GQLUserPermission,
-  useGQLAllNcmecReportsQuery,
-  useGQLGetNcmecReportLazyQuery,
-  useGQLPermissionsQuery,
-  useGQLRetryNcmecSubmissionMutation,
-} from '@/graphql/generated';
-import { userHasPermissions } from '@/routing/permissions';
-import { filterNullOrUndefined } from '@/utils/collections';
 
 gql`
   fragment NCMECReportValues on NCMECReport {
@@ -426,9 +433,11 @@ export default function NcmecReportsDashboard() {
 
   const tableData = useMemo(() => {
     // Successful reports come from `ncmecReports`; if the user is searching by
-    // a specific report id we substitute the lazy-fetched single report.
+    // a specific report id we substitute the lazy-fetched single report — but
+    // only when that fetched report actually matches the current `searchId`,
+    // otherwise editing the input after a fetch would show stale data.
     const successfulReportsSource =
-      searchId && ncmecReportData && ncmecReportData.ncmecReportById
+      searchId && ncmecReportData?.ncmecReportById?.reportId === searchId
         ? [ncmecReportData.ncmecReportById]
         : (ncmecReports ?? []);
 
@@ -445,10 +454,14 @@ export default function NcmecReportsDashboard() {
           // Sort key: numeric ms since epoch on the underlying timestamp.
           tsMs: new Date(report.ts).getTime(),
           row: {
-            // Plain strings here back the SelectColumnFilter dropdowns.
+            // `date` is `YYYY-MM-DD` for the dateRange comparator.
             values: {
+              date: format(new Date(report.ts), 'yyyy-MM-dd'),
               reviewer: reviewerName,
               status: 'Successful' as const,
+              reportId: report.reportId,
+              userId: report.userId,
+              userItemType: report.userItemType.name,
             },
             date: <div>{format(new Date(report.ts), 'MM/dd/yy h:mm a')}</div>,
             reviewer: <div className="whitespace-nowrap">{reviewerName}</div>,
@@ -547,8 +560,8 @@ export default function NcmecReportsDashboard() {
               </div>
             ),
             isTest: <div>{report.isTest ? 'True' : 'False'}</div>,
-            lastError: null as React.ReactNode,
-            action: null as React.ReactNode,
+            lastError: null as ReactNode,
+            action: null as ReactNode,
           },
         };
       });
@@ -565,9 +578,15 @@ export default function NcmecReportsDashboard() {
           return {
             tsMs: new Date(failed.ts).getTime(),
             row: {
+              // `reportId` is empty: failed submissions have no CyberTip id,
+              // so the text filter treats them as non-matching when used.
               values: {
+                date: format(new Date(failed.ts), 'yyyy-MM-dd'),
                 reviewer: reviewerName,
                 status: 'Failed' as const,
+                reportId: '',
+                userId: failed.userId,
+                userItemType: failed.userItemType.name,
               },
               date: <div>{format(new Date(failed.ts), 'MM/dd/yy h:mm a')}</div>,
               reviewer: <div className="whitespace-nowrap">{reviewerName}</div>,

--- a/client/src/webpages/settings/NCMECSettings.tsx
+++ b/client/src/webpages/settings/NCMECSettings.tsx
@@ -10,10 +10,10 @@ import {
 } from '@/coop-ui/Select';
 import { toast } from '@/coop-ui/Toast';
 import { Heading, Text } from '@/coop-ui/Typography';
-import type { GQLNcmecInternetDetailType } from '@/graphql/generated';
 import {
   useGQLNcmecOrgSettingsQuery,
   useGQLUpdateNcmecOrgSettingsMutation,
+  type GQLNcmecInternetDetailType,
 } from '@/graphql/generated';
 import { gql } from '@apollo/client';
 import { useEffect, useState } from 'react';
@@ -120,15 +120,15 @@ export default function NCMECSettings() {
           data.ncmecOrgSettings.ncmecPreservationEndpoint ?? '',
         ncmecAdditionalInfoEndpoint:
           data.ncmecOrgSettings.ncmecAdditionalInfoEndpoint ?? '',
-        defaultNcmecQueueId:
-          data.ncmecOrgSettings.defaultNcmecQueueId ?? '',
+        defaultNcmecQueueId: data.ncmecOrgSettings.defaultNcmecQueueId ?? '',
         defaultInternetDetailType:
           data.ncmecOrgSettings.defaultInternetDetailType ?? '',
         termsOfService: data.ncmecOrgSettings.termsOfService ?? '',
         contactPersonEmail: data.ncmecOrgSettings.contactPersonEmail ?? '',
         contactPersonFirstName:
           data.ncmecOrgSettings.contactPersonFirstName ?? '',
-        contactPersonLastName: data.ncmecOrgSettings.contactPersonLastName ?? '',
+        contactPersonLastName:
+          data.ncmecOrgSettings.contactPersonLastName ?? '',
         contactPersonPhone: data.ncmecOrgSettings.contactPersonPhone ?? '',
       });
     }
@@ -152,7 +152,19 @@ export default function NCMECSettings() {
     }
 
     if (!settings.companyTemplate || !settings.legalUrl) {
-      toast.error('Company Template and Legal URL are required for NCMEC reporting.');
+      toast.error(
+        'Company Template and Legal URL are required for NCMEC reporting.',
+      );
+      return;
+    }
+
+    const trimmedContactEmail = settings.contactEmail.trim();
+    if (trimmedContactEmail === '') {
+      toast.error('Contact Email is required for NCMEC reporting.');
+      return;
+    }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedContactEmail)) {
+      toast.error('Contact Email is not a valid email address.');
       return;
     }
 
@@ -161,12 +173,11 @@ export default function NCMECSettings() {
         input: {
           username: settings.username,
           password: settings.password,
-          contactEmail: settings.contactEmail || null,
+          contactEmail: trimmedContactEmail,
           moreInfoUrl: settings.moreInfoUrl || null,
           companyTemplate: settings.companyTemplate || null,
           legalUrl: settings.legalUrl || null,
-          ncmecPreservationEndpoint:
-            settings.ncmecPreservationEndpoint || null,
+          ncmecPreservationEndpoint: settings.ncmecPreservationEndpoint || null,
           ncmecAdditionalInfoEndpoint:
             settings.ncmecAdditionalInfoEndpoint || null,
           defaultNcmecQueueId: settings.defaultNcmecQueueId || null,
@@ -291,17 +302,21 @@ export default function NCMECSettings() {
 
           <div className="flex flex-col gap-2">
             <Label htmlFor="contactEmail" className="text-sm font-medium">
-              Contact Email
+              Contact Email <span className="text-red-600">*</span>
             </Label>
             <Input
               id="contactEmail"
               type="email"
+              required
               value={settings.contactEmail}
               onChange={(e) =>
                 setSettings({ ...settings, contactEmail: e.target.value })
               }
               placeholder="contact@yourcompany.com"
             />
+            <Text size="XS" className="text-gray-500">
+              Required. Used as the reporter contact on every NCMEC report.
+            </Text>
           </div>
 
           <div className="flex flex-col gap-2">
@@ -320,7 +335,8 @@ export default function NCMECSettings() {
               rows={3}
             />
             <Text size="XS" className="text-gray-500">
-              Optional TOS line included in the CyberTip reporter. {settings.termsOfService.length}/3000 characters.
+              Optional TOS line included in the CyberTip reporter.{' '}
+              {settings.termsOfService.length}/3000 characters.
             </Text>
           </div>
 
@@ -329,7 +345,8 @@ export default function NCMECSettings() {
               Contact person (for law enforcement)
             </Label>
             <Text size="XS" className="text-gray-500 mb-1">
-              Person law enforcement can contact other than the reporting person. All fields optional.
+              Person law enforcement can contact other than the reporting
+              person. All fields optional.
             </Text>
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
               <Input
@@ -410,8 +427,7 @@ export default function NCMECSettings() {
               onValueChange={(value) =>
                 setSettings({
                   ...settings,
-                  defaultNcmecQueueId:
-                    value === '__default__' ? '' : value,
+                  defaultNcmecQueueId: value === '__default__' ? '' : value,
                 })
               }
             >
@@ -448,8 +464,7 @@ export default function NCMECSettings() {
               onValueChange={(value) =>
                 setSettings({
                   ...settings,
-                  defaultInternetDetailType:
-                    value === '__none__' ? '' : value,
+                  defaultInternetDetailType: value === '__none__' ? '' : value,
                 })
               }
             >
@@ -495,7 +510,8 @@ export default function NCMECSettings() {
               placeholder="https://api.yourcompany.com/ncmec/preservation"
             />
             <Text size="XS" className="text-gray-500">
-              Optional: Webhook endpoint for NCMEC preservation requests after reporting
+              Optional: Webhook endpoint for NCMEC preservation requests after
+              reporting
             </Text>
           </div>
 
@@ -531,18 +547,21 @@ export default function NCMECSettings() {
             onClick={handleSave}
             disabled={!settings.username || !settings.password}
           >
-            {isNCMECEnabled ? 'Update Settings' : 'Enable NCMEC & Save Settings'}
+            {isNCMECEnabled
+              ? 'Update Settings'
+              : 'Enable NCMEC & Save Settings'}
           </Button>
         </div>
 
         {!isNCMECEnabled && (
           <Text size="XS" className="mt-4 text-gray-600">
             Note: Saving these settings will enable NCMEC reporting for your
-            organization. Reporting will only work if the organization has a manual review queue and content is only reported if it is flagged during review.
+            organization. Reporting will only work if the organization has a
+            manual review queue and content is only reported if it is flagged
+            during review.
           </Text>
         )}
       </div>
     </>
   );
 }
-

--- a/client/src/webpages/settings/NCMECSettings.tsx
+++ b/client/src/webpages/settings/NCMECSettings.tsx
@@ -163,6 +163,12 @@ export default function NCMECSettings() {
       toast.error('Contact Email is required for NCMEC reporting.');
       return;
     }
+    // Mirror the server's MAX_EMAIL_LENGTH in server/graphql/modules/ncmec.ts
+    // so we reject before the network round-trip.
+    if (trimmedContactEmail.length > 254) {
+      toast.error('Contact Email must be 254 characters or fewer.');
+      return;
+    }
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedContactEmail)) {
       toast.error('Contact Email is not a valid email address.');
       return;

--- a/client/src/webpages/settings/NCMECSettings.tsx
+++ b/client/src/webpages/settings/NCMECSettings.tsx
@@ -163,8 +163,7 @@ export default function NCMECSettings() {
       toast.error('Contact Email is required for NCMEC reporting.');
       return;
     }
-    // Mirror the server's MAX_EMAIL_LENGTH in server/graphql/modules/ncmec.ts
-    // so we reject before the network round-trip.
+    // Mirrors the server's MAX_EMAIL_LENGTH.
     if (trimmedContactEmail.length > 254) {
       toast.error('Contact Email must be 254 characters or fewer.');
       return;

--- a/server/.env.example
+++ b/server/.env.example
@@ -96,6 +96,14 @@ ENABLE_DEMO_REQUEST=false
 # reporting.
 NCMEC_ENV=test
 
+# Set to `1` to enable verbose NCMEC submission debug logging. Emits structured
+# stderr lines for every CyberTipline request/response and dumps the exact
+# `<report>` and `<fileDetails>` XML we send to `ncmec-reports/` (gitignored)
+# so failed submissions can be replayed via curl. Off in production regardless
+# of this value. Leave unset (or empty) in shared environments since the dumps
+# contain reportable content.
+# NCMEC_DEBUG=1
+
 # Other API Keys
 SENDGRID_API_KEY=SG.REAL_API_KEY_HERE
 GOOGLE_PLACES_API_KEY=

--- a/server/graphql/generated.ts
+++ b/server/graphql/generated.ts
@@ -2519,6 +2519,12 @@ export type GQLMutation = {
   readonly reorderRoutingRules: GQLReorderRoutingRulesResponse;
   readonly requestDemo?: Maybe<Scalars['Boolean']['output']>;
   readonly resetPassword: Scalars['Boolean']['output'];
+  /**
+   * Retries a previously-failed NCMEC submission. Org-scoped: callers can only
+   * retry decisions that belong to their own org. Returns success on a fresh
+   * successful submission, or an error with a user-safe summary on failure.
+   */
+  readonly retryNcmecSubmission: GQLRetryNcmecSubmissionResponse;
   readonly rotateApiKey: GQLRotateApiKeyResponse;
   readonly rotateWebhookSigningKey: GQLRotateWebhookSigningKeyResponse;
   readonly runRetroaction?: Maybe<GQLRunRetroactionResponse>;
@@ -2750,6 +2756,10 @@ export type GQLMutationResetPasswordArgs = {
   input: GQLResetPasswordInput;
 };
 
+export type GQLMutationRetryNcmecSubmissionArgs = {
+  decisionId: Scalars['ID']['input'];
+};
+
 export type GQLMutationRotateApiKeyArgs = {
   input: GQLRotateApiKeyInput;
 };
@@ -2946,6 +2956,33 @@ export type GQLNcmecContentItem = {
   readonly isReported: Scalars['Boolean']['output'];
 };
 
+/**
+ * An NCMEC submission that was decisioned in the MRT but never produced a
+ * successful CyberTip report. Reused on the NCMEC Reports dashboard so that
+ * reviewers can see and retry failed submissions in the same place as
+ * successful reports. The userId + userItemTypeId pair uniquely identifies
+ * the reported user; decisionId is the stable handle for retrying.
+ */
+export type GQLNcmecFailedSubmission = {
+  readonly __typename?: 'NcmecFailedSubmission';
+  readonly decisionId: Scalars['ID']['output'];
+  readonly lastError?: Maybe<Scalars['String']['output']>;
+  readonly retryCount: Scalars['Int']['output'];
+  readonly reviewerId?: Maybe<Scalars['String']['output']>;
+  readonly status: GQLNcmecFailedSubmissionStatus;
+  readonly ts: Scalars['DateTime']['output'];
+  readonly userId: Scalars['String']['output'];
+  readonly userItemType: GQLUserItemType;
+};
+
+export const GQLNcmecFailedSubmissionStatus = {
+  NeverAttempted: 'NEVER_ATTEMPTED',
+  PermanentError: 'PERMANENT_ERROR',
+  RetryableError: 'RETRYABLE_ERROR',
+} as const;
+
+export type GQLNcmecFailedSubmissionStatus =
+  (typeof GQLNcmecFailedSubmissionStatus)[keyof typeof GQLNcmecFailedSubmissionStatus];
 export const GQLNcmecFileAnnotation = {
   AnimeDrawingVirtualHentai: 'ANIME_DRAWING_VIRTUAL_HENTAI',
   Bestiality: 'BESTIALITY',
@@ -3111,6 +3148,12 @@ export type GQLOrg = {
   readonly contentTypes: ReadonlyArray<GQLContentType>;
   readonly defaultInterfacePreferences: GQLUserInterfacePreferences;
   readonly email: Scalars['String']['output'];
+  /**
+   * NCMEC decisions that did not produce a successful CyberTip report. Returned
+   * alongside ncmecReports on the dashboard so reviewers can see the full
+   * submission status (successful + failed) in one place and retry failures.
+   */
+  readonly failedNcmecSubmissions: ReadonlyArray<GQLNcmecFailedSubmission>;
   readonly hasAppealsEnabled: Scalars['Boolean']['output'];
   readonly hasNCMECReportingEnabled: Scalars['Boolean']['output'];
   readonly hasPartialItemsEndpoint: Scalars['Boolean']['output'];
@@ -3869,6 +3912,16 @@ export type GQLResolvedJobCount = {
   readonly queueId?: Maybe<Scalars['String']['output']>;
   readonly reviewerId?: Maybe<Scalars['String']['output']>;
   readonly time: Scalars['String']['output'];
+};
+
+export type GQLRetryNcmecSubmissionResponse = {
+  readonly __typename?: 'RetryNcmecSubmissionResponse';
+  /**
+   * Human-readable error summary if the retry failed. Never includes raw
+   * NCMEC response bodies; safe to render in the UI.
+   */
+  readonly error?: Maybe<Scalars['String']['output']>;
+  readonly success: Scalars['Boolean']['output'];
 };
 
 export type GQLRotateApiKeyError = GQLError & {
@@ -6000,6 +6053,12 @@ export type GQLResolversTypes = {
       contentItem: GQLResolversTypes['Item'];
     }
   >;
+  NcmecFailedSubmission: ResolverTypeWrapper<
+    Omit<GQLNcmecFailedSubmission, 'userItemType'> & {
+      userItemType: GQLResolversTypes['UserItemType'];
+    }
+  >;
+  NcmecFailedSubmissionStatus: GQLNcmecFailedSubmissionStatus;
   NcmecFileAnnotation: GQLNcmecFileAnnotation;
   NcmecIndustryClassification: GQLNcmecIndustryClassification;
   NcmecInternetDetailType: GQLNcmecInternetDetailType;
@@ -6100,6 +6159,7 @@ export type GQLResolversTypes = {
   RequestDemoInterest: GQLRequestDemoInterest;
   ResetPasswordInput: GQLResetPasswordInput;
   ResolvedJobCount: ResolverTypeWrapper<GQLResolvedJobCount>;
+  RetryNcmecSubmissionResponse: ResolverTypeWrapper<GQLRetryNcmecSubmissionResponse>;
   RotateApiKeyError: ResolverTypeWrapper<GQLRotateApiKeyError>;
   RotateApiKeyInput: GQLRotateApiKeyInput;
   RotateApiKeyResponse: ResolverTypeWrapper<
@@ -6705,6 +6765,9 @@ export type GQLResolversParentTypes = {
   NcmecContentItem: Omit<GQLNcmecContentItem, 'contentItem'> & {
     contentItem: GQLResolversParentTypes['Item'];
   };
+  NcmecFailedSubmission: Omit<GQLNcmecFailedSubmission, 'userItemType'> & {
+    userItemType: GQLResolversParentTypes['UserItemType'];
+  };
   NcmecManualReviewJobPayload: NcmecManualReviewJobPayload;
   NcmecMediaInput: GQLNcmecMediaInput;
   NcmecOrgSettings: GQLNcmecOrgSettings;
@@ -6789,6 +6852,7 @@ export type GQLResolversParentTypes = {
   RequestDemoInput: GQLRequestDemoInput;
   ResetPasswordInput: GQLResetPasswordInput;
   ResolvedJobCount: GQLResolvedJobCount;
+  RetryNcmecSubmissionResponse: GQLRetryNcmecSubmissionResponse;
   RotateApiKeyError: GQLRotateApiKeyError;
   RotateApiKeyInput: GQLRotateApiKeyInput;
   RotateApiKeyResponse: GQLResolversUnionTypes<GQLResolversParentTypes>['RotateApiKeyResponse'];
@@ -10876,6 +10940,12 @@ export type GQLMutationResolvers<
     ContextType,
     RequireFields<GQLMutationResetPasswordArgs, 'input'>
   >;
+  retryNcmecSubmission?: Resolver<
+    GQLResolversTypes['RetryNcmecSubmissionResponse'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationRetryNcmecSubmissionArgs, 'decisionId'>
+  >;
   rotateApiKey?: Resolver<
     GQLResolversTypes['RotateApiKeyResponse'],
     ParentType,
@@ -11171,6 +11241,37 @@ export type GQLNcmecContentItemResolvers<
   isReported?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
 };
 
+export type GQLNcmecFailedSubmissionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['NcmecFailedSubmission'] =
+    GQLResolversParentTypes['NcmecFailedSubmission'],
+> = {
+  decisionId?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
+  lastError?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  retryCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
+  reviewerId?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  status?: Resolver<
+    GQLResolversTypes['NcmecFailedSubmissionStatus'],
+    ParentType,
+    ContextType
+  >;
+  ts?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
+  userId?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  userItemType?: Resolver<
+    GQLResolversTypes['UserItemType'],
+    ParentType,
+    ContextType
+  >;
+};
+
 export type GQLNcmecManualReviewJobPayloadResolvers<
   ContextType = Context,
   ParentType extends GQLResolversParentTypes['NcmecManualReviewJobPayload'] =
@@ -11427,6 +11528,11 @@ export type GQLOrgResolvers<
     ContextType
   >;
   email?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  failedNcmecSubmissions?: Resolver<
+    ReadonlyArray<GQLResolversTypes['NcmecFailedSubmission']>,
+    ParentType,
+    ContextType
+  >;
   hasAppealsEnabled?: Resolver<
     GQLResolversTypes['Boolean'],
     ParentType,
@@ -12691,6 +12797,15 @@ export type GQLResolvedJobCountResolvers<
     ContextType
   >;
   time?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+};
+
+export type GQLRetryNcmecSubmissionResponseResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['RetryNcmecSubmissionResponse'] =
+    GQLResolversParentTypes['RetryNcmecSubmissionResponse'],
+> = {
+  error?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
+  success?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
 };
 
 export type GQLRotateApiKeyErrorResolvers<
@@ -14652,6 +14767,7 @@ export type GQLResolvers<ContextType = Context> = {
   NCMECReportedThread?: GQLNcmecReportedThreadResolvers<ContextType>;
   NcmecAdditionalFile?: GQLNcmecAdditionalFileResolvers<ContextType>;
   NcmecContentItem?: GQLNcmecContentItemResolvers<ContextType>;
+  NcmecFailedSubmission?: GQLNcmecFailedSubmissionResolvers<ContextType>;
   NcmecManualReviewJobPayload?: GQLNcmecManualReviewJobPayloadResolvers<ContextType>;
   NcmecOrgSettings?: GQLNcmecOrgSettingsResolvers<ContextType>;
   NcmecReportedMediaDetails?: GQLNcmecReportedMediaDetailsResolvers<ContextType>;
@@ -14699,6 +14815,7 @@ export type GQLResolvers<ContextType = Context> = {
   ReportingRuleNameExistsError?: GQLReportingRuleNameExistsErrorResolvers<ContextType>;
   ReportingRulePassRateData?: GQLReportingRulePassRateDataResolvers<ContextType>;
   ResolvedJobCount?: GQLResolvedJobCountResolvers<ContextType>;
+  RetryNcmecSubmissionResponse?: GQLRetryNcmecSubmissionResponseResolvers<ContextType>;
   RotateApiKeyError?: GQLRotateApiKeyErrorResolvers<ContextType>;
   RotateApiKeyResponse?: GQLRotateApiKeyResponseResolvers<ContextType>;
   RotateApiKeySuccessResponse?: GQLRotateApiKeySuccessResponseResolvers<ContextType>;

--- a/server/graphql/generated.ts
+++ b/server/graphql/generated.ts
@@ -4390,6 +4390,7 @@ export type GQLSubmitNcmecReportDecisionComponent =
   };
 
 export type GQLSubmitNcmecReportInput = {
+  readonly additionalInfo?: InputMaybe<Scalars['String']['input']>;
   readonly escalateToHighPriority?: InputMaybe<Scalars['String']['input']>;
   readonly incidentType: GQLNcmecIncidentType;
   readonly reportedMedia: ReadonlyArray<GQLNcmecMediaInput>;

--- a/server/graphql/modules/manualReviewTool.ts
+++ b/server/graphql/modules/manualReviewTool.ts
@@ -243,6 +243,7 @@ const typeDefs = /* GraphQL */ `
     reportedMessages: [NcmecThreadInput!]!
     incidentType: NCMECIncidentType!
     escalateToHighPriority: String
+    additionalInfo: String
   }
 
   enum AppealDecision {
@@ -2204,6 +2205,7 @@ const Mutation: GQLMutationResolvers = {
                 ...decision,
                 escalateToHighPriority:
                   decision.escalateToHighPriority ?? undefined,
+                additionalInfo: decision.additionalInfo ?? undefined,
               };
 
             default:

--- a/server/graphql/modules/ncmec.ts
+++ b/server/graphql/modules/ncmec.ts
@@ -4,7 +4,11 @@ import type {
   GQLNcmecOrgSettings,
   GQLQueryResolvers,
 } from '../generated.js';
-import { unauthenticatedError, userInputError } from '../utils/errors.js';
+import {
+  forbiddenError,
+  unauthenticatedError,
+  userInputError,
+} from '../utils/errors.js';
 
 /** Input shape for updateNcmecOrgSettings; matches NcmecOrgSettingsInput in schema (used so resolver type-checks even if generated types are stale). */
 type NcmecOrgSettingsInputShape = {
@@ -57,6 +61,12 @@ const typeDefs = /* GraphQL */ `
     updateNcmecOrgSettings(
       input: NcmecOrgSettingsInput!
     ): UpdateNcmecOrgSettingsResponse!
+    """
+    Retries a previously-failed NCMEC submission. Org-scoped: callers can only
+    retry decisions that belong to their own org. Returns success on a fresh
+    successful submission, or an error with a user-safe summary on failure.
+    """
+    retryNcmecSubmission(decisionId: ID!): RetryNcmecSubmissionResponse!
   }
 
   enum NcmecInternetDetailType {
@@ -108,6 +118,39 @@ const typeDefs = /* GraphQL */ `
 
   type UpdateNcmecOrgSettingsResponse {
     success: Boolean!
+  }
+
+  type RetryNcmecSubmissionResponse {
+    success: Boolean!
+    """
+    Human-readable error summary if the retry failed. Never includes raw
+    NCMEC response bodies; safe to render in the UI.
+    """
+    error: String
+  }
+
+  enum NcmecFailedSubmissionStatus {
+    RETRYABLE_ERROR
+    PERMANENT_ERROR
+    NEVER_ATTEMPTED
+  }
+
+  """
+  An NCMEC submission that was decisioned in the MRT but never produced a
+  successful CyberTip report. Reused on the NCMEC Reports dashboard so that
+  reviewers can see and retry failed submissions in the same place as
+  successful reports. The userId + userItemTypeId pair uniquely identifies
+  the reported user; decisionId is the stable handle for retrying.
+  """
+  type NcmecFailedSubmission {
+    decisionId: ID!
+    ts: DateTime!
+    reviewerId: String
+    userId: String!
+    userItemType: UserItemType!
+    status: NcmecFailedSubmissionStatus!
+    retryCount: Int!
+    lastError: String
   }
 
   type NCMECReportedMedia {
@@ -341,6 +384,31 @@ const Mutation: GQLMutationResolvers = {
     });
 
     return { success: true };
+  },
+  async retryNcmecSubmission(_, { decisionId }, context) {
+    const user = context.getUser();
+    if (!user) {
+      throw unauthenticatedError('User required.');
+    }
+    if (!user.getPermissions().includes('VIEW_CHILD_SAFETY_DATA')) {
+      throw forbiddenError(
+        'VIEW_CHILD_SAFETY_DATA permission required to retry NCMEC submissions.',
+      );
+    }
+    const result = await context.services.NcmecService.retrySubmission({
+      orgId: user.orgId,
+      decisionId,
+      requestingReviewerId: user.id,
+    });
+    if (result.kind === 'success') {
+      return { success: true, error: null };
+    }
+    if (result.kind === 'not_found') {
+      // Don't disclose whether the decision exists in another org. Surface
+      // the same response as a missing decision.
+      return { success: false, error: 'Decision not found.' };
+    }
+    return { success: false, error: result.error };
   },
 };
 

--- a/server/graphql/modules/ncmec.ts
+++ b/server/graphql/modules/ncmec.ts
@@ -36,6 +36,13 @@ const VALID_NCMEC_INTERNET_DETAIL_TYPES: readonly string[] = [
   'PEER_TO_PEER',
 ];
 
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MAX_EMAIL_LENGTH = 254;
+
+function isValidContactEmail(value: string): boolean {
+  return value.length <= MAX_EMAIL_LENGTH && EMAIL_PATTERN.test(value);
+}
+
 const typeDefs = /* GraphQL */ `
   type Query {
     ncmecReportById(reportId: ID!): NCMECReport
@@ -281,6 +288,24 @@ const Mutation: GQLMutationResolvers = {
       throw unauthenticatedError('User required.');
     }
     const input = rawInput as NcmecOrgSettingsInputShape;
+
+    const username = input.username?.trim() ?? '';
+    const password = input.password ?? '';
+    if (username === '' || password === '') {
+      throw userInputError('Username and password are required.');
+    }
+    const contactEmail = input.contactEmail?.trim() ?? '';
+    if (contactEmail === '') {
+      throw userInputError(
+        'Reporter contact email is required for NCMEC reporting.',
+      );
+    }
+    if (!isValidContactEmail(contactEmail)) {
+      throw userInputError(
+        'Reporter contact email is not a valid email address.',
+      );
+    }
+
     const defaultInternetDetailType =
       input.defaultInternetDetailType == null
         ? null
@@ -290,15 +315,17 @@ const Mutation: GQLMutationResolvers = {
               trimmed !== '' &&
               !VALID_NCMEC_INTERNET_DETAIL_TYPES.includes(trimmed)
             ) {
-              throw userInputError(`defaultInternetDetailType must be one of: ${VALID_NCMEC_INTERNET_DETAIL_TYPES.join(', ')}`);
+              throw userInputError(
+                `defaultInternetDetailType must be one of: ${VALID_NCMEC_INTERNET_DETAIL_TYPES.join(', ')}`,
+              );
             }
             return trimmed === '' ? null : trimmed;
           })();
     await context.services.NcmecService.updateNcmecOrgSettings({
       orgId: user.orgId,
-      username: input.username,
-      password: input.password,
-      contactEmail: input.contactEmail ?? null,
+      username,
+      password,
+      contactEmail,
       moreInfoUrl: input.moreInfoUrl ?? null,
       companyTemplate: input.companyTemplate ?? null,
       legalUrl: input.legalUrl ?? null,

--- a/server/graphql/modules/org.ts
+++ b/server/graphql/modules/org.ts
@@ -520,41 +520,40 @@ const Org: GQLOrgResolvers = {
     const jobIds = failedDecisions.map(
       ({ decision }) => decision.job_payload.id,
     );
-    const errorRows =
-      await context.services.NcmecService.getNcmecErrorsForJobIds(jobIds);
-    const errorByJobId = new Map(errorRows.map((e) => [e.job_id, e]));
-
-    return Promise.all(
-      failedDecisions.map(async ({ decision: d, userId, userItemTypeId }) => {
-        const itemType =
-          await context.services.ModerationConfigService.getItemType({
-            orgId: user.orgId,
-            itemTypeSelector: { id: userItemTypeId },
-          });
-        if (!itemType || itemType.kind !== 'USER') {
-          throw new Error('NCMEC user item type is not of kind USER');
-        }
-        const errorRow = errorByJobId.get(d.job_payload.id);
-        // Map the DB string through a known-set check before returning so a
-        // future migration adding a new status value can't take down the
-        // entire `failedNcmecSubmissions` field via GraphQL enum validation.
-        const status: 'RETRYABLE_ERROR' | 'PERMANENT_ERROR' | 'NEVER_ATTEMPTED' =
-          errorRow?.status === 'RETRYABLE_ERROR' ||
-          errorRow?.status === 'PERMANENT_ERROR'
-            ? errorRow.status
-            : 'NEVER_ATTEMPTED';
-        return {
-          decisionId: d.id,
-          ts: d.created_at,
-          reviewerId: d.reviewer_id ?? null,
-          userId,
-          userItemType: itemType,
-          status,
-          retryCount: errorRow?.retry_count ?? 0,
-          lastError: errorRow?.last_error ?? null,
-        };
+    const [errorRows, allItemTypes] = await Promise.all([
+      context.services.NcmecService.getNcmecErrorsForJobIds(jobIds),
+      context.services.ModerationConfigService.getItemTypes({
+        orgId: user.orgId,
       }),
-    );
+    ]);
+    const errorByJobId = new Map(errorRows.map((e) => [e.job_id, e]));
+    const itemTypeById = new Map(allItemTypes.map((it) => [it.id, it]));
+
+    return failedDecisions.map(({ decision: d, userId, userItemTypeId }) => {
+      const itemType = itemTypeById.get(userItemTypeId);
+      if (!itemType || itemType.kind !== 'USER') {
+        throw new Error('NCMEC user item type is not of kind USER');
+      }
+      const errorRow = errorByJobId.get(d.job_payload.id);
+      // Map the DB string through a known-set check before returning so a
+      // future migration adding a new status value can't take down the
+      // entire `failedNcmecSubmissions` field via GraphQL enum validation.
+      const status: 'RETRYABLE_ERROR' | 'PERMANENT_ERROR' | 'NEVER_ATTEMPTED' =
+        errorRow?.status === 'RETRYABLE_ERROR' ||
+        errorRow?.status === 'PERMANENT_ERROR'
+          ? errorRow.status
+          : 'NEVER_ATTEMPTED';
+      return {
+        decisionId: d.id,
+        ts: d.created_at,
+        reviewerId: d.reviewer_id ?? null,
+        userId,
+        userItemType: itemType,
+        status,
+        retryCount: errorRow?.retry_count ?? 0,
+        lastError: errorRow?.last_error ?? null,
+      };
+    });
   },
   async requiresPolicyForDecisionsInMrt(org, _, context) {
     return context.services.ManualReviewToolService.getRequiresPolicyForDecisions(

--- a/server/graphql/modules/org.ts
+++ b/server/graphql/modules/org.ts
@@ -1,5 +1,8 @@
 /* eslint-disable max-lines */
 
+import { GraphQLError } from 'graphql';
+
+import { filterDecisionsToFailedSubmissions } from '../../services/ncmecService/index.js';
 import { isCoopErrorOfType } from '../../utils/errors.js';
 import { __throw } from '../../utils/misc.js';
 import {
@@ -10,10 +13,9 @@ import {
   type GQLPendingInvite,
   type GQLQueryResolvers,
 } from '../generated.js';
-import { GraphQLError } from 'graphql';
-import { gqlErrorResult, gqlSuccessResult } from '../utils/gqlResult.js';
-import { forbiddenError, unauthenticatedError } from '../utils/errors.js';
 import { type Context } from '../resolvers.js';
+import { forbiddenError, unauthenticatedError } from '../utils/errors.js';
+import { gqlErrorResult, gqlSuccessResult } from '../utils/gqlResult.js';
 
 const typeDefs = /* GraphQL */ `
   type Org {
@@ -44,6 +46,12 @@ const typeDefs = /* GraphQL */ `
     hasNCMECReportingEnabled: Boolean!
     hasAppealsEnabled: Boolean!
     ncmecReports: [NCMECReport!]!
+    """
+    NCMEC decisions that did not produce a successful CyberTip report. Returned
+    alongside ncmecReports on the dashboard so reviewers can see the full
+    submission status (successful + failed) in one place and retry failures.
+    """
+    failedNcmecSubmissions: [NcmecFailedSubmission!]!
     requiresPolicyForDecisionsInMrt: Boolean!
     requiresDecisionReasonInMrt: Boolean!
     previewJobsViewEnabled: Boolean!
@@ -88,7 +96,7 @@ const typeDefs = /* GraphQL */ `
   }
 
   union CreateOrgResponse =
-      CreateOrgSuccessResponse
+    | CreateOrgSuccessResponse
     | OrgWithEmailExistsError
     | OrgWithNameExistsError
 
@@ -206,8 +214,14 @@ const Query: GQLQueryResolvers = {
 type ResolveOrgActionsContext = {
   getUser: () => { orgId: string } | null | undefined;
   services: {
-    ModerationConfigService: Pick<Context['services']['ModerationConfigService'], 'getActions'>;
-    NcmecService: Pick<Context['services']['NcmecService'], 'hasNCMECReportingEnabled'>;
+    ModerationConfigService: Pick<
+      Context['services']['ModerationConfigService'],
+      'getActions'
+    >;
+    NcmecService: Pick<
+      Context['services']['NcmecService'],
+      'hasNCMECReportingEnabled'
+    >;
   };
 };
 
@@ -264,7 +278,9 @@ const Org: GQLOrgResolvers = {
     }
 
     if (!user.getPermissions().includes('MANAGE_ORG')) {
-      throw forbiddenError('User does not have permission to view pending invites');
+      throw forbiddenError(
+        'User does not have permission to view pending invites',
+      );
     }
 
     const invites =
@@ -464,6 +480,82 @@ const Org: GQLOrgResolvers = {
       }),
     );
   },
+  async failedNcmecSubmissions(org, _, context) {
+    const user = context.getUser();
+    if (!user || user.orgId !== org.id) {
+      throw unauthenticatedError('User required.');
+    }
+    if (!user.getPermissions().includes('VIEW_CHILD_SAFETY_DATA')) {
+      throw forbiddenError(
+        'VIEW_CHILD_SAFETY_DATA permission required to view NCMEC submissions.',
+      );
+    }
+
+    // Pull all SUBMIT_NCMEC_REPORT decisions for the org, then subtract those
+    // that already produced a successful report. Whatever remains is "failed"
+    // (either retryable, permanently failed, or pending background retry).
+    const [decisions, successfulKeys] = await Promise.all([
+      context.services.ManualReviewToolService.getNcmecDecisionsForOrg({
+        orgId: user.orgId,
+      }),
+      context.services.NcmecService.getSuccessfulSubmissionKeysForOrg(
+        user.orgId,
+      ),
+    ]);
+
+    const decisionsWithKey = decisions.map((d) => ({
+      decision: d,
+      userId: d.job_payload.payload.item.itemId,
+      userItemTypeId: d.job_payload.payload.item.itemTypeIdentifier.id,
+    }));
+    const failedDecisions = filterDecisionsToFailedSubmissions(
+      decisionsWithKey,
+      successfulKeys,
+    );
+
+    if (failedDecisions.length === 0) {
+      return [];
+    }
+
+    const jobIds = failedDecisions.map(
+      ({ decision }) => decision.job_payload.id,
+    );
+    const errorRows =
+      await context.services.NcmecService.getNcmecErrorsForJobIds(jobIds);
+    const errorByJobId = new Map(errorRows.map((e) => [e.job_id, e]));
+
+    return Promise.all(
+      failedDecisions.map(async ({ decision: d, userId, userItemTypeId }) => {
+        const itemType =
+          await context.services.ModerationConfigService.getItemType({
+            orgId: user.orgId,
+            itemTypeSelector: { id: userItemTypeId },
+          });
+        if (!itemType || itemType.kind !== 'USER') {
+          throw new Error('NCMEC user item type is not of kind USER');
+        }
+        const errorRow = errorByJobId.get(d.job_payload.id);
+        // Map the DB string through a known-set check before returning so a
+        // future migration adding a new status value can't take down the
+        // entire `failedNcmecSubmissions` field via GraphQL enum validation.
+        const status: 'RETRYABLE_ERROR' | 'PERMANENT_ERROR' | 'NEVER_ATTEMPTED' =
+          errorRow?.status === 'RETRYABLE_ERROR' ||
+          errorRow?.status === 'PERMANENT_ERROR'
+            ? errorRow.status
+            : 'NEVER_ATTEMPTED';
+        return {
+          decisionId: d.id,
+          ts: d.created_at,
+          reviewerId: d.reviewer_id ?? null,
+          userId,
+          userItemType: itemType,
+          status,
+          retryCount: errorRow?.retry_count ?? 0,
+          lastError: errorRow?.last_error ?? null,
+        };
+      }),
+    );
+  },
   async requiresPolicyForDecisionsInMrt(org, _, context) {
     return context.services.ManualReviewToolService.getRequiresPolicyForDecisions(
       org.id,
@@ -519,7 +611,9 @@ const Org: GQLOrgResolvers = {
     }
 
     if (!user.getPermissions().includes('MANAGE_ORG')) {
-      throw forbiddenError('User does not have permission to manage SSO settings');
+      throw forbiddenError(
+        'User does not have permission to manage SSO settings',
+      );
     }
 
     const settings = await context.services.OrgSettingsService.getSamlSettings(
@@ -539,7 +633,9 @@ const Org: GQLOrgResolvers = {
     }
 
     if (!user.getPermissions().includes('MANAGE_ORG')) {
-      throw forbiddenError('User does not have permission to manage SSO settings');
+      throw forbiddenError(
+        'User does not have permission to manage SSO settings',
+      );
     }
 
     const settings = await context.services.OrgSettingsService.getSamlSettings(

--- a/server/iocContainer/index.ts
+++ b/server/iocContainer/index.ts
@@ -2,7 +2,7 @@
 import { createRequire } from 'module';
 import Bottle from '@ethanresnick/bottlejs';
 import opentelemetry from '@opentelemetry/api';
-import { makeDateString, type ItemIdentifier } from '@roostorg/types';
+import { type ItemIdentifier } from '@roostorg/types';
 import {
   types as scyllaTypes,
   type Host as ScyllaHost,
@@ -108,7 +108,6 @@ import makeHmaService, {
 } from '../services/hmaService/index.js';
 import { ItemInvestigationService } from '../services/itemInvestigationService/index.js';
 import {
-  getFieldValueForRole,
   itemSubmissionWithTypeIdentifierToItemSubmission,
   type ItemSubmissionWithTypeIdentifier,
   type NormalizedItemData,
@@ -140,6 +139,7 @@ import {
   // eslint-disable-next-line import/no-restricted-paths
 } from '../services/moderationConfigService/moderationConfigServiceQueries.js';
 import {
+  buildSubmitReportParamsFromDecision,
   makeNcmecService,
   type NcmecService,
 } from '../services/ncmecService/index.js';
@@ -1124,7 +1124,7 @@ export default async function getBottle() {
                   actorEmail: reviewerEmail,
                 });
                 break;
-              case 'SUBMIT_NCMEC_REPORT':
+              case 'SUBMIT_NCMEC_REPORT': {
                 if (job.payload.kind !== 'NCMEC') {
                   throw new Error(
                     'Attempting to submit a NCMEC report for a non-NCMEC job',
@@ -1138,64 +1138,19 @@ export default async function getBottle() {
                 if (itemType === undefined || itemType.kind !== 'USER') {
                   throw new Error('Item Type for User does not exist');
                 }
-                const displayName = getFieldValueForRole(
-                  itemType.schema,
-                  itemType.schemaFieldRoles,
-                  'displayName',
-                  data,
-                );
-                const profilePicUrl = getFieldValueForRole(
-                  itemType.schema,
-                  itemType.schemaFieldRoles,
-                  'profileIcon',
-                  data,
-                );
-
-                const allMedia = job.payload.allMediaItems;
-                const media = await Promise.all(
-                  decision.reportedMedia.map(async (it) => {
-                    const reportedItem = allMedia.find(
-                      (payloadMedia) =>
-                        payloadMedia.contentItem.itemId === it.id,
-                    );
-                    if (reportedItem === undefined) {
-                      throw new Error(
-                        'Unable to find reported media in job payload',
-                      );
-                    }
-                    const itemType =
-                      await container.getItemTypeEventuallyConsistent({
-                        orgId,
-                        typeSelector:
-                          reportedItem.contentItem.itemTypeIdentifier,
-                      });
-                    if (itemType === undefined) {
-                      throw new Error(
-                        'Unable to find item type for reported media',
-                      );
-                    }
-
-                    const createdAt =
-                      getFieldValueForRole(
-                        itemType.schema,
-                        itemType.schemaFieldRoles,
-                        'createdAt',
-                        reportedItem.contentItem.data,
-                      ) ?? makeDateString(new Date().toISOString());
-                    if (createdAt === undefined) {
-                      throw new Error('No created at for reported media');
-                    }
-
-                    return {
-                      id: it.id,
-                      typeId: it.typeId,
-                      url: it.url,
-                      createdAt,
-                      industryClassification: it.industryClassification,
-                      fileAnnotations: it.fileAnnotations,
-                    };
-                  }),
-                );
+                const reportParams = await buildSubmitReportParamsFromDecision({
+                  orgId,
+                  reviewerId,
+                  reportedItemId: itemId,
+                  reportedItemTypeId: itemTypeIdentifier.id,
+                  reportedUserItemType: itemType,
+                  reportedUserData: data,
+                  allMediaItems: job.payload.allMediaItems,
+                  decisionComponent: decision,
+                  jobId: job.id,
+                  getItemTypeEventuallyConsistent:
+                    container.getItemTypeEventuallyConsistent,
+                });
                 // Submissions go to the NCMEC test endpoint
                 // (exttest.cybertip.org) unless the deployment is explicitly
                 // configured for production via NCMEC_ENV=production. Operators
@@ -1203,35 +1158,7 @@ export default async function getBottle() {
                 // configured in Settings → NCMEC are production or test
                 // credentials issued by NCMEC.
                 const isTest = process.env.NCMEC_ENV !== 'production';
-                await container.NcmecService.submitReport(
-                  {
-                    reportedUser: {
-                      id: itemId,
-                      typeId: itemTypeIdentifier.id,
-                      ...(displayName ? { displayName } : {}),
-                      ...(profilePicUrl
-                        ? { profilePicture: profilePicUrl.url }
-                        : {}),
-                    },
-                    threads: decision.reportedMessages,
-                    orgId,
-                    media,
-                    reviewerId,
-                    incidentType: decision.incidentType,
-                    ...(decision.escalateToHighPriority != null &&
-                    decision.escalateToHighPriority.trim() !== ''
-                      ? {
-                          escalateToHighPriority:
-                            decision.escalateToHighPriority.trim(),
-                        }
-                      : {}),
-                    ...(decision.additionalInfo != null &&
-                    decision.additionalInfo.trim() !== ''
-                      ? { additionalInfo: decision.additionalInfo.trim() }
-                      : {}),
-                  },
-                  isTest,
-                );
+                await container.NcmecService.submitReport(reportParams, isTest);
                 const actionAndPolicy =
                   await container.NcmecService.getNCMECActionsToRunAndPolicies(
                     orgId,
@@ -1257,6 +1184,7 @@ export default async function getBottle() {
                   });
                 }
                 break;
+              }
               case 'TRANSFORM_JOB_AND_RECREATE_IN_QUEUE': {
                 const reportHistory =
                   'reportHistory' in job.payload

--- a/server/iocContainer/index.ts
+++ b/server/iocContainer/index.ts
@@ -1225,6 +1225,10 @@ export default async function getBottle() {
                             decision.escalateToHighPriority.trim(),
                         }
                       : {}),
+                    ...(decision.additionalInfo != null &&
+                    decision.additionalInfo.trim() !== ''
+                      ? { additionalInfo: decision.additionalInfo.trim() }
+                      : {}),
                   },
                   isTest,
                 );

--- a/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.test.ts
+++ b/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.test.ts
@@ -141,3 +141,90 @@ describe('ClickhouseActionExecutionsAdapter.findInferredUserIdentity', () => {
     expect(sentSql).toContain('org-99');
   });
 });
+
+describe('ClickhouseActionExecutionsAdapter.findContentCreatorIdentity', () => {
+  it('returns null when no rows match', async () => {
+    const { adapter } = makeAdapter([]);
+
+    const result = await adapter.findContentCreatorIdentity({
+      orgId: 'org-1',
+      itemId: 'content-1',
+      itemTypeId: 'content-type-1',
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('projects the creator id + type id from the most-recent CONTENT row', async () => {
+    const ts = '2026-05-10T12:00:00.000Z';
+    const { adapter } = makeAdapter([
+      {
+        ts,
+        item_creator_id: 'user-42',
+        item_creator_type_id: 'user-type-A',
+      },
+    ]);
+
+    const result = await adapter.findContentCreatorIdentity({
+      orgId: 'org-1',
+      itemId: 'content-1',
+      itemTypeId: 'content-type-1',
+    });
+
+    expect(result).toEqual({
+      creatorId: 'user-42',
+      creatorTypeId: 'user-type-A',
+      lastSeenAt: new Date(ts),
+    });
+  });
+
+  it('returns null when the row has empty creator fields', async () => {
+    const { adapter } = makeAdapter([
+      {
+        ts: '2026-05-10T12:00:00.000Z',
+        item_creator_id: null,
+        item_creator_type_id: 'user-type-A',
+      },
+    ]);
+
+    const result = await adapter.findContentCreatorIdentity({
+      orgId: 'org-1',
+      itemId: 'content-1',
+      itemTypeId: 'content-type-1',
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('filters to CONTENT rows with non-empty creator columns and uses LIMIT 1', async () => {
+    const { adapter, query } = makeAdapter([]);
+
+    await adapter.findContentCreatorIdentity({
+      orgId: 'org-1',
+      itemId: 'content-1',
+      itemTypeId: 'content-type-1',
+    });
+
+    const sentSql = query.mock.calls[0][0];
+    expect(sentSql).toContain('analytics.ACTION_EXECUTIONS');
+    expect(sentSql).toContain("item_type_kind = 'CONTENT'");
+    expect(sentSql).toContain('item_creator_id IS NOT NULL');
+    expect(sentSql).toContain("item_creator_id != ''");
+    expect(sentSql).toContain('item_creator_type_id IS NOT NULL');
+    expect(sentSql).toContain("item_creator_type_id != ''");
+    expect(sentSql).toContain('LIMIT 1');
+  });
+
+  it('passes the item type id to disambiguate from other content with the same id', async () => {
+    const { adapter, query } = makeAdapter([]);
+
+    await adapter.findContentCreatorIdentity({
+      orgId: 'org-1',
+      itemId: 'content-1',
+      itemTypeId: 'content-type-PHOTO',
+    });
+
+    const sentSql = query.mock.calls[0][0];
+    expect(sentSql).toContain('content-type-PHOTO');
+  });
+});

--- a/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.ts
+++ b/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.ts
@@ -4,6 +4,8 @@ import type SafeTracer from '../../../utils/SafeTracer.js';
 import { SIX_MONTHS_MS } from '../../../utils/time.js';
 import { formatClickhouseQuery } from '../utils/clickhouseSql.js';
 import {
+  type ContentCreatorIdentityInput,
+  type ContentCreatorIdentityRecord,
   type IActionExecutionsAdapter,
   type InferredUserIdentityInput,
   type InferredUserIdentityRecord,
@@ -203,6 +205,64 @@ export class ClickhouseActionExecutionsAdapter implements IActionExecutionsAdapt
 
     return {
       itemTypeId: userTypeId,
+      lastSeenAt: new Date(row.ts),
+    };
+  }
+
+  async findContentCreatorIdentity(
+    input: ContentCreatorIdentityInput,
+  ): Promise<ContentCreatorIdentityRecord | null> {
+    const {
+      orgId,
+      itemId,
+      itemTypeId,
+      lookbackWindowMs = SIX_MONTHS_MS,
+    } = input;
+
+    const lookbackStart = new Date(Date.now() - Math.max(1, lookbackWindowMs));
+    const lookbackStartDate = lookbackStart.toISOString().slice(0, 10);
+
+    // Filter empty creator rows in SQL so LIMIT 1 always returns a usable row
+    // when one exists; otherwise the most recent action on this content could
+    // legitimately have no creator and hide older rows that do.
+    const sql = `
+      SELECT
+        ts,
+        item_creator_id,
+        item_creator_type_id
+      FROM analytics.ACTION_EXECUTIONS
+      WHERE org_id = ?
+        AND ds >= toDate(?)
+        AND lower(item_id) = lower(?)
+        AND item_type_id = ?
+        AND item_type_kind = 'CONTENT'
+        AND item_creator_id IS NOT NULL
+        AND item_creator_id != ''
+        AND item_creator_type_id IS NOT NULL
+        AND item_creator_type_id != ''
+      ORDER BY ts DESC
+      LIMIT 1
+    `;
+
+    const rows = await this.query<ClickhouseActionExecutionRow>(sql, [
+      orgId,
+      lookbackStartDate,
+      itemId,
+      itemTypeId,
+    ]);
+
+    if (rows.length === 0) {
+      return null;
+    }
+
+    const row = rows[0];
+    if (!row.item_creator_id || !row.item_creator_type_id) {
+      return null;
+    }
+
+    return {
+      creatorId: row.item_creator_id,
+      creatorTypeId: row.item_creator_type_id,
       lastSeenAt: new Date(row.ts),
     };
   }

--- a/server/plugins/warehouse/queries/IActionExecutionsAdapter.ts
+++ b/server/plugins/warehouse/queries/IActionExecutionsAdapter.ts
@@ -46,6 +46,21 @@ export interface InferredUserIdentityRecord {
   lastSeenAt: Date;
 }
 
+export interface ContentCreatorIdentityInput {
+  orgId: string;
+  /** Id of the content item whose creator we want to resolve. */
+  itemId: string;
+  /** Type id of the content item; required to disambiguate id collisions. */
+  itemTypeId: string;
+  lookbackWindowMs?: number;
+}
+
+export interface ContentCreatorIdentityRecord {
+  creatorId: string;
+  creatorTypeId: string;
+  lastSeenAt: Date;
+}
+
 export interface IActionExecutionsAdapter {
   getItemActionHistory(
     input: ItemActionHistoryInput,
@@ -59,4 +74,14 @@ export interface IActionExecutionsAdapter {
   findInferredUserIdentity(
     input: InferredUserIdentityInput,
   ): Promise<InferredUserIdentityRecord | null>;
+
+  /**
+   * Resolve the creator `(id, typeId)` for a CONTENT item by finding the
+   * most-recent action-execution row matching `(item_id, item_type_id)` and
+   * projecting its creator columns. Returns `null` when no row has non-empty
+   * creator fields.
+   */
+  findContentCreatorIdentity(
+    input: ContentCreatorIdentityInput,
+  ): Promise<ContentCreatorIdentityRecord | null>;
 }

--- a/server/rule_engine/ActionPublisher.test.ts
+++ b/server/rule_engine/ActionPublisher.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable max-lines -- scenarios share the `makeIsolatedPublisher`
+ * harness; splitting would duplicate ~100 lines of setup. */
 /**
  * Unit tests for ActionPublisher to verify action execution logging behavior.
  *
@@ -10,58 +12,57 @@ import getBottle, { type Dependencies } from '../iocContainer/index.js';
 import { ActionType } from '../services/moderationConfigService/index.js';
 import { type CorrelationId } from '../utils/correlationIds.js';
 import { jsonParse } from '../utils/encoding.js';
-import ActionPublisherDefault, {
-  type ActionPublisher,
-} from './ActionPublisher.js';
+import { ActionPublisher } from './ActionPublisher.js';
 import { RuleEnvironment } from './RuleEngine.js';
 
-// Hand-rolled mocks for `makeIsolatedPublisher` below — used by tests that
-// need to inspect outgoing webhook bodies without mutating the bottle's
-// shared `ActionPublisher` instance.
-type SpanLike = {
-  setAttribute: () => void;
-  recordException: () => void;
-  isRecording: () => boolean;
-};
-type TracerLike = {
-  addActiveSpan: (_meta: unknown, fn: (span: SpanLike) => unknown) => unknown;
-  getActiveSpan: () => undefined;
+type IsolatedPublisherOptions = {
+  fetchHTTP: jest.Mock;
+  manualReviewToolService?: Partial<Dependencies['ManualReviewToolService']>;
+  ncmecService?: Partial<Dependencies['NcmecService']>;
+  itemInvestigationService?: Partial<Dependencies['ItemInvestigationService']>;
+  getItemTypeEventuallyConsistent?: Dependencies['getItemTypeEventuallyConsistent'];
 };
 
-function makeIsolatedPublisher(opts: { fetchHTTP: jest.Mock }) {
-  const tracer: TracerLike = {
-    addActiveSpan: (_meta, fn) =>
+function makeNoopTracer(): Dependencies['Tracer'] {
+  return {
+    addActiveSpan: (_meta: unknown, fn: (span: unknown) => unknown) =>
       fn({
         setAttribute: () => {},
         recordException: () => {},
         isRecording: () => false,
       }),
     getActiveSpan: () => undefined,
-  };
-  const PublisherCtor = ActionPublisherDefault as unknown as new (
-    actionExecutionLogger: { logActionExecutions: jest.Mock },
-    tracer: TracerLike,
-    fetchHTTP: jest.Mock,
-    signingKeyPairService: { sign: jest.Mock },
-    manualReviewToolService: object,
-    ncmecService: object,
-    itemInvestigationService: { getItemByIdentifier: jest.Mock },
-    userStrikeService: { applyUserStrikeFromPublishedActions: jest.Mock },
-  ) => ActionPublisher;
+  } as unknown as Dependencies['Tracer'];
+}
+
+function makeIsolatedPublisher(opts: IsolatedPublisherOptions) {
   const logActionExecutions = jest.fn().mockResolvedValue(undefined);
-  const publisher = new PublisherCtor(
-    { logActionExecutions },
-    tracer,
+  const actionExecutionLogger = {
+    logActionExecutions,
+  } as unknown as Dependencies['ActionExecutionLogger'];
+  const signingKeyPairService = {
+    sign: jest.fn().mockResolvedValue(undefined),
+  } as unknown as Dependencies['SigningKeyPairService'];
+  const itemInvestigationService = (opts.itemInvestigationService ?? {
+    getItemByIdentifier: jest.fn().mockResolvedValue(undefined),
+  }) as Dependencies['ItemInvestigationService'];
+  const userStrikeService = {
+    applyUserStrikeFromPublishedActions: jest.fn().mockResolvedValue(undefined),
+  } as unknown as Dependencies['UserStrikeService'];
+  const getItemTypeEventuallyConsistent =
+    opts.getItemTypeEventuallyConsistent ??
+    jest.fn().mockResolvedValue(undefined);
+  const publisher = new ActionPublisher(
+    actionExecutionLogger,
+    makeNoopTracer(),
     opts.fetchHTTP,
-    { sign: jest.fn().mockResolvedValue(undefined) },
-    {},
-    {},
-    { getItemByIdentifier: jest.fn().mockResolvedValue(undefined) },
-    {
-      applyUserStrikeFromPublishedActions: jest
-        .fn()
-        .mockResolvedValue(undefined),
-    },
+    signingKeyPairService,
+    (opts.manualReviewToolService ??
+      {}) as Dependencies['ManualReviewToolService'],
+    (opts.ncmecService ?? {}) as Dependencies['NcmecService'],
+    itemInvestigationService,
+    userStrikeService,
+    getItemTypeEventuallyConsistent,
   );
   return { publisher, logActionExecutions };
 }
@@ -185,9 +186,7 @@ describe('ActionPublisher', () => {
     });
 
     it('builds the CUSTOM_ACTION webhook body with parameters merged into `custom` and actorNote at the top level', async () => {
-      const fetchHTTP = jest
-        .fn()
-        .mockResolvedValue({ status: 200, ok: true });
+      const fetchHTTP = jest.fn().mockResolvedValue({ status: 200, ok: true });
       const { publisher } = makeIsolatedPublisher({ fetchHTTP });
 
       await publisher.publishActions(
@@ -248,9 +247,7 @@ describe('ActionPublisher', () => {
     });
 
     it('omits actorNote from the webhook body entirely when no note is supplied', async () => {
-      const fetchHTTP = jest
-        .fn()
-        .mockResolvedValue({ status: 200, ok: true });
+      const fetchHTTP = jest.fn().mockResolvedValue({ status: 200, ok: true });
       const { publisher } = makeIsolatedPublisher({ fetchHTTP });
 
       await publisher.publishActions(
@@ -354,6 +351,288 @@ describe('ActionPublisher', () => {
       expect(logged?.actorNote).toBe('Repeat offender');
 
       logSpy.mockRestore();
+    });
+
+    it('enqueues to NCMEC for a synthetic USER target with no item submission record', async () => {
+      const enqueueForHumanReviewIfApplicable = jest
+        .fn()
+        .mockResolvedValue({ status: 'ENQUEUED' });
+      const userItemType = {
+        id: 'user-type-1',
+        kind: 'USER' as const,
+        name: 'User',
+        version: '1',
+        schemaVariant: 'DEFAULT',
+        schema: [],
+        schemaFieldRoles: {},
+      };
+      const getItemTypeEventuallyConsistent = jest
+        .fn()
+        .mockResolvedValue(userItemType);
+      const { publisher, logActionExecutions } = makeIsolatedPublisher({
+        fetchHTTP: jest.fn(),
+        ncmecService: { enqueueForHumanReviewIfApplicable },
+        itemInvestigationService: {
+          getItemByIdentifier: jest.fn().mockResolvedValue(undefined),
+        },
+        getItemTypeEventuallyConsistent,
+      });
+
+      const results = await publisher.publishActions(
+        [
+          {
+            action: {
+              id: 'action-ncmec',
+              orgId: 'org-synth',
+              name: 'Enqueue for NCMEC Review',
+              description: null,
+              applyUserStrikes: false,
+              penalty: 'NONE' as const,
+              actionType: ActionType.ENQUEUE_TO_NCMEC,
+            },
+            policies: [],
+            matchingRules: undefined,
+            ruleEnvironment: undefined,
+          },
+        ],
+        {
+          orgId: 'org-synth',
+          correlationId:
+            'manual-action-run:synthetic-ncmec' as CorrelationId<'manual-action-run'>,
+          targetItem: {
+            itemId: 'synthetic-user-id',
+            itemType: {
+              id: 'user-type-1',
+              kind: 'USER' as const,
+              name: 'User',
+            },
+          },
+        },
+      );
+
+      expect(results).toEqual([
+        expect.objectContaining({ success: true, actionId: 'action-ncmec' }),
+      ]);
+      expect(enqueueForHumanReviewIfApplicable).toHaveBeenCalledTimes(1);
+      const enqueueArg = enqueueForHumanReviewIfApplicable.mock.calls[0]?.[0];
+      expect(enqueueArg.item.itemId).toBe('synthetic-user-id');
+      expect(enqueueArg.item.itemTypeIdentifier.id).toBe('user-type-1');
+      expect(logActionExecutions).toHaveBeenCalledWith(
+        expect.objectContaining({ failed: false }),
+      );
+    });
+
+    it('enqueues to MRT for a synthetic USER target with no submission record', async () => {
+      const enqueue = jest.fn().mockResolvedValue(undefined);
+      const userItemType = {
+        id: 'user-type-2',
+        kind: 'USER' as const,
+        name: 'User',
+        version: '1',
+        schemaVariant: 'DEFAULT',
+        schema: [],
+        schemaFieldRoles: {},
+      };
+      const getItemTypeEventuallyConsistent = jest
+        .fn()
+        .mockResolvedValue(userItemType);
+      const { publisher, logActionExecutions } = makeIsolatedPublisher({
+        fetchHTTP: jest.fn(),
+        manualReviewToolService: { enqueue },
+        itemInvestigationService: {
+          getItemByIdentifier: jest.fn().mockResolvedValue(undefined),
+        },
+        getItemTypeEventuallyConsistent,
+      });
+
+      const results = await publisher.publishActions(
+        [
+          {
+            action: {
+              id: 'action-mrt',
+              orgId: 'org-synth',
+              name: 'Enqueue to MRT',
+              description: null,
+              applyUserStrikes: false,
+              penalty: 'NONE' as const,
+              actionType: ActionType.ENQUEUE_TO_MRT,
+            },
+            policies: [],
+            matchingRules: undefined,
+            ruleEnvironment: undefined,
+          },
+        ],
+        {
+          orgId: 'org-synth',
+          correlationId:
+            'manual-action-run:synthetic-mrt' as CorrelationId<'manual-action-run'>,
+          targetItem: {
+            itemId: 'synthetic-user-id',
+            itemType: {
+              id: 'user-type-2',
+              kind: 'USER' as const,
+              name: 'User',
+            },
+          },
+        },
+      );
+
+      expect(results).toEqual([
+        expect.objectContaining({ success: true, actionId: 'action-mrt' }),
+      ]);
+      expect(enqueue).toHaveBeenCalledTimes(1);
+      expect(logActionExecutions).toHaveBeenCalledWith(
+        expect.objectContaining({ failed: false }),
+      );
+    });
+
+    it('infers the creator and enqueues to NCMEC for a CONTENT target with no submission', async () => {
+      const enqueueForHumanReviewIfApplicable = jest
+        .fn()
+        .mockResolvedValue({ status: 'ENQUEUED' });
+      const userItemType = {
+        id: 'user-type-3',
+        kind: 'USER' as const,
+        name: 'User',
+        version: '1',
+        schemaVariant: 'DEFAULT',
+        schema: [],
+        schemaFieldRoles: {},
+      };
+      // The real helper resolves the creator id from ACTION_EXECUTIONS and
+      // then synthesizes a submission keyed on *the creator's* id (not the
+      // content's id). The mock mirrors that shape so the test exercises a
+      // payload production can actually produce.
+      const synthesizeUserItemFromContentTarget = jest.fn().mockResolvedValue({
+        latestSubmission: {
+          itemId: 'creator-user-id-7',
+          itemType: userItemType,
+          data: {},
+          submissionId: 'synthetic:creator-user-id-7',
+          submissionTime: undefined,
+          creator: undefined,
+        },
+      });
+      const { publisher, logActionExecutions } = makeIsolatedPublisher({
+        fetchHTTP: jest.fn(),
+        ncmecService: { enqueueForHumanReviewIfApplicable },
+        itemInvestigationService: {
+          getItemByIdentifier: jest.fn().mockResolvedValue(undefined),
+          synthesizeUserItemFromContentTarget,
+        },
+      });
+
+      const results = await publisher.publishActions(
+        [
+          {
+            action: {
+              id: 'action-ncmec-inferred',
+              orgId: 'org-synth',
+              name: 'Enqueue for NCMEC Review',
+              description: null,
+              applyUserStrikes: false,
+              penalty: 'NONE' as const,
+              actionType: ActionType.ENQUEUE_TO_NCMEC,
+            },
+            policies: [],
+            matchingRules: undefined,
+            ruleEnvironment: undefined,
+          },
+        ],
+        {
+          orgId: 'org-synth',
+          correlationId:
+            'manual-action-run:inferred-ncmec' as CorrelationId<'manual-action-run'>,
+          targetItem: {
+            itemId: 'phantom-content-id',
+            itemType: {
+              id: 'content-type-1',
+              kind: 'CONTENT' as const,
+              name: 'Post',
+            },
+          },
+        },
+      );
+
+      expect(results).toEqual([expect.objectContaining({ success: true })]);
+      expect(synthesizeUserItemFromContentTarget).toHaveBeenCalledWith({
+        orgId: 'org-synth',
+        itemId: 'phantom-content-id',
+        itemTypeId: 'content-type-1',
+      });
+      expect(enqueueForHumanReviewIfApplicable).toHaveBeenCalledTimes(1);
+      const enqueueArg = enqueueForHumanReviewIfApplicable.mock.calls[0]?.[0];
+      expect(enqueueArg.item.itemId).toBe('creator-user-id-7');
+      expect(enqueueArg.item.itemTypeIdentifier.id).toBe('user-type-3');
+      expect(logActionExecutions).toHaveBeenCalledWith(
+        expect.objectContaining({ failed: false }),
+      );
+    });
+
+    it('fails loudly when ENQUEUE_TO_NCMEC targets a CONTENT item with no submission and no inferable creator', async () => {
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const enqueueForHumanReviewIfApplicable = jest.fn();
+      const synthesizeUserItemFromContentTarget = jest
+        .fn()
+        .mockResolvedValue(null);
+      const { publisher, logActionExecutions } = makeIsolatedPublisher({
+        fetchHTTP: jest.fn(),
+        ncmecService: { enqueueForHumanReviewIfApplicable },
+        itemInvestigationService: {
+          getItemByIdentifier: jest.fn().mockResolvedValue(undefined),
+          synthesizeUserItemFromContentTarget,
+        },
+      });
+
+      const results = await publisher.publishActions(
+        [
+          {
+            action: {
+              id: 'action-ncmec-content',
+              orgId: 'org-synth',
+              name: 'Enqueue for NCMEC Review',
+              description: null,
+              applyUserStrikes: false,
+              penalty: 'NONE' as const,
+              actionType: ActionType.ENQUEUE_TO_NCMEC,
+            },
+            policies: [],
+            matchingRules: undefined,
+            ruleEnvironment: undefined,
+          },
+        ],
+        {
+          orgId: 'org-synth',
+          correlationId:
+            'manual-action-run:synthetic-ncmec-content' as CorrelationId<'manual-action-run'>,
+          targetItem: {
+            itemId: 'phantom-content-id',
+            itemType: {
+              id: 'content-type-1',
+              kind: 'CONTENT' as const,
+              name: 'Post',
+            },
+          },
+        },
+      );
+
+      expect(results).toEqual([expect.objectContaining({ success: false })]);
+      expect(synthesizeUserItemFromContentTarget).toHaveBeenCalled();
+      expect(enqueueForHumanReviewIfApplicable).not.toHaveBeenCalled();
+      expect(logActionExecutions).toHaveBeenCalledWith(
+        expect.objectContaining({ failed: true }),
+      );
+      expect(consoleSpy).toHaveBeenCalled();
+      const loggedLine = consoleSpy.mock.calls[0]?.[0];
+      expect(loggedLine).toEqual(
+        expect.stringContaining('action-ncmec-content'),
+      );
+      expect(loggedLine).toEqual(
+        expect.stringContaining('actionPublisher.publishAction.failed'),
+      );
+      consoleSpy.mockRestore();
     });
   });
 });

--- a/server/rule_engine/ActionPublisher.ts
+++ b/server/rule_engine/ActionPublisher.ts
@@ -11,6 +11,7 @@ import {
   type MatchingRule,
   type Policy,
 } from '../services/analyticsLoggers/index.js';
+import { makeSyntheticUserSubmission } from '../services/itemInvestigationService/index.js';
 import {
   getFieldValueForRole,
   itemSubmissionToItemSubmissionWithTypeIdentifier,
@@ -121,6 +122,7 @@ class ActionPublisher {
     private ncmecService: Dependencies['NcmecService'],
     private itemInvestigationService: Dependencies['ItemInvestigationService'],
     private userStrikeService: Dependencies['UserStrikeService'],
+    private getItemTypeEventuallyConsistent: Dependencies['getItemTypeEventuallyConsistent'],
   ) {}
 
   /**
@@ -325,6 +327,50 @@ class ActionPublisher {
             })
           )?.latestSubmission;
         };
+
+        // USER target with no record: synthesize a minimal submission from
+        // the id. Returns undefined for non-USER targets — MRT needs the
+        // real content submission, so it must fail loudly for CONTENT.
+        const getFullItemOrSyntheticUserForUserTarget = async () => {
+          const fullItem = await getFullItem();
+          if (fullItem) {
+            return fullItem;
+          }
+          if (targetItem.itemType.kind !== 'USER') {
+            return undefined;
+          }
+          const userItemType = await this.getItemTypeEventuallyConsistent({
+            orgId,
+            typeSelector: { id: targetItem.itemType.id },
+          });
+          if (!userItemType || userItemType.kind !== 'USER') {
+            return undefined;
+          }
+          return makeSyntheticUserSubmission(targetItem.itemId, userItemType);
+        };
+
+        // NCMEC fallback: USER target → synthetic user (as above); CONTENT
+        // target → resolve the creator via ACTION_EXECUTIONS and synthesize a
+        // user submission keyed on the creator id. THREAD has no single
+        // owner, so we refuse.
+        const getFullItemOrSyntheticUserForNcmec = async () => {
+          const userTarget = await getFullItemOrSyntheticUserForUserTarget();
+          if (userTarget) {
+            return userTarget;
+          }
+          if (targetItem.itemType.kind !== 'CONTENT') {
+            return undefined;
+          }
+          const inferred =
+            await this.itemInvestigationService.synthesizeUserItemFromContentTarget(
+              {
+                orgId,
+                itemId: targetItem.itemId,
+                itemTypeId: targetItem.itemType.id,
+              },
+            );
+          return inferred?.latestSubmission;
+        };
         const actionSource = getSourceType(
           correlationId,
         ) as ActionExecutionSourceType;
@@ -389,11 +435,14 @@ class ActionPublisher {
               }
 
               return true;
-            case ActionType.ENQUEUE_TO_MRT:
-              const fullItemForMrt = await getFullItem();
+            case ActionType.ENQUEUE_TO_MRT: {
+              const fullItemForMrt =
+                await getFullItemOrSyntheticUserForUserTarget();
               if (!fullItemForMrt) {
                 throw new Error(
-                  "Actions without full item submissions can't be enqueued to MRT yet",
+                  `Cannot enqueue to MRT: no submission record for ${targetItem.itemType.kind} ` +
+                    `item ${targetItem.itemId} (type ${targetItem.itemType.id}). ` +
+                    `POST the item to the items endpoint first.`,
                 );
               }
 
@@ -430,11 +479,15 @@ class ActionPublisher {
               });
 
               return true;
-            case ActionType.ENQUEUE_TO_NCMEC:
-              const fullItemForNcmec = await getFullItem();
+            }
+            case ActionType.ENQUEUE_TO_NCMEC: {
+              const fullItemForNcmec =
+                await getFullItemOrSyntheticUserForNcmec();
               if (!fullItemForNcmec) {
                 throw new Error(
-                  "Actions without full item submissions can't be enqueued to NCMEC yet",
+                  `Cannot enqueue to NCMEC: no submission record for ${targetItem.itemType.kind} ` +
+                    `item ${targetItem.itemId} (type ${targetItem.itemType.id}). ` +
+                    `POST the item to the items endpoint first.`,
                 );
               }
 
@@ -463,6 +516,7 @@ class ActionPublisher {
               });
 
               return true;
+            }
             case ActionType.ENQUEUE_AUTHOR_TO_MRT:
               const fullItemForAuthor = await getFullItem();
               if (
@@ -573,6 +627,23 @@ class ActionPublisher {
           }
         } catch (e) {
           span.recordException(e as Exception);
+          // Log to stderr so operators see action failures without having
+          // to pull traces. Identifiers only, no item `data`.
+          // eslint-disable-next-line no-console
+          console.error(
+            jsonStringify({
+              event: 'actionPublisher.publishAction.failed',
+              orgId,
+              actionId: action.id,
+              actionName: action.name,
+              actionType: action.actionType,
+              itemId: targetItem.itemId,
+              itemTypeId: targetItem.itemType.id,
+              itemTypeKind: targetItem.itemType.kind,
+              correlationId,
+              error: e instanceof Error ? e.message : String(e),
+            }),
+          );
           return false;
         }
       },
@@ -590,6 +661,7 @@ export default inject(
     'NcmecService',
     'ItemInvestigationService',
     'UserStrikeService',
+    'getItemTypeEventuallyConsistent',
   ],
   ActionPublisher,
 );

--- a/server/services/hmaService/index.ts
+++ b/server/services/hmaService/index.ts
@@ -832,8 +832,6 @@ export class HmaService {
         handleResponseBody: 'as-json',
       });
     } else {
-      // Guarded by the precondition above: when `url` is absent, both `file`
-      // and `contentType` are guaranteed to be set.
       if (!file || !contentType) {
         throw new Error(
           'addContentToBank reached file-upload branch without file/contentType',

--- a/server/services/hmaService/index.ts
+++ b/server/services/hmaService/index.ts
@@ -806,8 +806,10 @@ export class HmaService {
   ): Promise<BankContentResponse> {
     const { file, contentType, url, metadata } = options;
 
-    if (!file && !url) {
-      throw new Error('Either file or url must be provided');
+    if (!url && (!file || !contentType)) {
+      throw new Error(
+        'Either url or (file + contentType) must be provided to addContentToBank',
+      );
     }
 
     let response;
@@ -830,9 +832,15 @@ export class HmaService {
         handleResponseBody: 'as-json',
       });
     } else {
-      // File upload
+      // Guarded by the precondition above: when `url` is absent, both `file`
+      // and `contentType` are guaranteed to be set.
+      if (!file || !contentType) {
+        throw new Error(
+          'addContentToBank reached file-upload branch without file/contentType',
+        );
+      }
       const formData = new FormData();
-      formData.append(contentType!, file!);
+      formData.append(contentType, file);
 
       if (metadata) {
         if (metadata.content_id)

--- a/server/services/hmaService/index.ts
+++ b/server/services/hmaService/index.ts
@@ -1,7 +1,9 @@
 /* eslint-disable max-lines */
 import { type JsonValue } from 'type-fest';
-import { inject } from '../../iocContainer/utils.js';
+import { FormData } from 'undici';
+
 import type { Dependencies } from '../../iocContainer/index.js';
+import { inject } from '../../iocContainer/utils.js';
 import { jsonStringify } from '../../utils/encoding.js';
 import type { HashBank } from './dbTypes.js';
 import { HashBankService } from './hashBankService.js';
@@ -178,12 +180,13 @@ const KNOWN_EXCHANGE_SCHEMAS: Partial<Record<string, ExchangeApiSchema>> = {
 export class HmaService {
   private readonly hmaServiceUrl: string;
   private readonly hashBankService: HashBankService;
-  
+
   constructor(
     private readonly fetchHTTP: Dependencies['fetchHTTP'],
-    kyselyPg: Dependencies['KyselyPg']
+    kyselyPg: Dependencies['KyselyPg'],
   ) {
-    this.hmaServiceUrl = process.env.HMA_SERVICE_URL ?? 'http://localhost:9876/';
+    this.hmaServiceUrl =
+      process.env.HMA_SERVICE_URL ?? 'http://localhost:9876/';
     this.hashBankService = new HashBankService(kyselyPg);
   }
 
@@ -203,7 +206,7 @@ export class HmaService {
     name: string,
     description: string,
     enabled_ratio: number,
-    exchange?: { apiName: string; apiJson: Record<string, unknown> }
+    exchange?: { apiName: string; apiJson: Record<string, unknown> },
   ): Promise<HashBank> {
     const hmaName = this.getHmaName(orgId, name);
 
@@ -225,7 +228,7 @@ export class HmaService {
 
       if (!response.ok) {
         throw new Error(
-          `Failed to create exchange in HMA: status=${response.status}`
+          `Failed to create exchange in HMA: status=${response.status}`,
         );
       }
 
@@ -260,7 +263,9 @@ export class HmaService {
           url: `${this.hmaServiceUrl}/c/banks`,
           headers: response.headers,
         };
-        throw new Error(`Failed to create HMA bank: ${jsonStringify(errorDetails)}`);
+        throw new Error(
+          `Failed to create HMA bank: ${jsonStringify(errorDetails)}`,
+        );
       }
     }
 
@@ -283,13 +288,20 @@ export class HmaService {
         });
       } catch (cleanupError) {
         // eslint-disable-next-line no-console
-        console.error('Failed to clean up HMA bank after local creation failed:', cleanupError);
+        console.error(
+          'Failed to clean up HMA bank after local creation failed:',
+          cleanupError,
+        );
       }
       throw error;
     }
   }
 
-  async updateBank(orgId: string, id: string, updates: { name?: string; description?: string; enabled_ratio?: number }): Promise<HashBank> {
+  async updateBank(
+    orgId: string,
+    id: string,
+    updates: { name?: string; description?: string; enabled_ratio?: number },
+  ): Promise<HashBank> {
     // Get the existing bank
     const bank = await this.hashBankService.findById(parseInt(id), orgId);
 
@@ -300,16 +312,16 @@ export class HmaService {
     // If name is being updated, we need to update the HMA bank name
     if (updates.name && updates.name !== bank.name) {
       const newHmaName = this.getHmaName(orgId, updates.name);
-      
+
       // Create new bank in HMA with new name
       const createRequestBody = {
         name: newHmaName,
-        enabled_ratio: (updates.enabled_ratio ?? bank.enabled_ratio).toString()
+        enabled_ratio: (updates.enabled_ratio ?? bank.enabled_ratio).toString(),
       };
 
       const createResponse = await this.fetchHTTP({
         url: `${this.hmaServiceUrl}/c/banks`,
-        method: "post",
+        method: 'post',
         body: jsonStringify(createRequestBody),
         headers: {
           'Content-Type': 'application/json',
@@ -323,16 +335,18 @@ export class HmaService {
           responseBody: createResponse.body,
           requestBody: createRequestBody,
           url: `${this.hmaServiceUrl}/c/banks`,
-          headers: createResponse.headers
+          headers: createResponse.headers,
         };
-        throw new Error(`Failed to create new HMA bank: ${jsonStringify(errorDetails)}`);
+        throw new Error(
+          `Failed to create new HMA bank: ${jsonStringify(errorDetails)}`,
+        );
       }
 
       // Delete old HMA bank
       try {
         await this.fetchHTTP({
           url: `${this.hmaServiceUrl}/c/bank/${bank.hma_name}`,
-          method: "delete",
+          method: 'delete',
           handleResponseBody: 'discard',
         });
       } catch (deleteError) {
@@ -341,22 +355,29 @@ export class HmaService {
       }
 
       // Update local bank with new name and HMA name
-      const updatedBank = await this.hashBankService.update(Number(bank.id), orgId, {
-        name: updates.name,
-        hma_name: newHmaName,
-        description: updates.description,
-        enabled_ratio: updates.enabled_ratio,
-      });
+      const updatedBank = await this.hashBankService.update(
+        Number(bank.id),
+        orgId,
+        {
+          name: updates.name,
+          hma_name: newHmaName,
+          description: updates.description,
+          enabled_ratio: updates.enabled_ratio,
+        },
+      );
       return updatedBank;
-    } else if (updates.enabled_ratio !== undefined && updates.enabled_ratio !== bank.enabled_ratio) {
+    } else if (
+      updates.enabled_ratio !== undefined &&
+      updates.enabled_ratio !== bank.enabled_ratio
+    ) {
       // If only enabled_ratio is being updated, use PUT to update HMA service
       const updateRequestBody = {
-        enabled_ratio: updates.enabled_ratio
+        enabled_ratio: updates.enabled_ratio,
       };
 
       const updateResponse = await this.fetchHTTP({
         url: `${this.hmaServiceUrl}/c/bank/${bank.hma_name}`,
-        method: "put",
+        method: 'put',
         body: jsonStringify(updateRequestBody),
         headers: {
           'Content-Type': 'application/json',
@@ -370,14 +391,19 @@ export class HmaService {
           responseBody: updateResponse.body,
           requestBody: updateRequestBody,
           url: `${this.hmaServiceUrl}/c/bank/${bank.hma_name}`,
-          headers: updateResponse.headers
+          headers: updateResponse.headers,
         };
-        throw new Error(`Failed to update HMA bank: ${jsonStringify(errorDetails)}`);
+        throw new Error(
+          `Failed to update HMA bank: ${jsonStringify(errorDetails)}`,
+        );
       }
     }
 
     // Update other fields if they weren't already updated above
-    const fieldsToUpdate: { description?: string | null; enabled_ratio?: number } = {};
+    const fieldsToUpdate: {
+      description?: string | null;
+      enabled_ratio?: number;
+    } = {};
     if (updates.description !== undefined) {
       fieldsToUpdate.description = updates.description;
     }
@@ -386,7 +412,11 @@ export class HmaService {
     }
 
     if (Object.keys(fieldsToUpdate).length > 0) {
-      const updatedBank = await this.hashBankService.update(Number(bank.id), orgId, fieldsToUpdate);
+      const updatedBank = await this.hashBankService.update(
+        Number(bank.id),
+        orgId,
+        fieldsToUpdate,
+      );
       return updatedBank;
     }
 
@@ -405,7 +435,7 @@ export class HmaService {
     try {
       const response = await this.fetchHTTP({
         url: `${this.hmaServiceUrl}/c/bank/${bank.hma_name}`,
-        method: "delete",
+        method: 'delete',
         handleResponseBody: 'discard',
       });
 
@@ -433,7 +463,7 @@ export class HmaService {
     try {
       const response = await this.fetchHTTP({
         url: `${this.hmaServiceUrl}/c/bank/${bank.hma_name}`,
-        method: "get",
+        method: 'get',
         handleResponseBody: 'discard',
       });
 
@@ -445,7 +475,9 @@ export class HmaService {
 
       if (!response.ok) {
         // eslint-disable-next-line no-console
-        console.error(`Failed to verify bank ${bank.hma_name} in HMA service: ${response.status}`);
+        console.error(
+          `Failed to verify bank ${bank.hma_name} in HMA service: ${response.status}`,
+        );
       }
     } catch (error) {
       // eslint-disable-next-line no-console
@@ -467,7 +499,7 @@ export class HmaService {
     try {
       const response = await this.fetchHTTP({
         url: `${this.hmaServiceUrl}/c/bank/${bank.hma_name}`,
-        method: "get",
+        method: 'get',
         handleResponseBody: 'discard',
       });
 
@@ -479,7 +511,9 @@ export class HmaService {
 
       if (!response.ok) {
         // eslint-disable-next-line no-console
-        console.error(`Failed to verify bank ${bank.hma_name} in HMA service: ${response.status}`);
+        console.error(
+          `Failed to verify bank ${bank.hma_name} in HMA service: ${response.status}`,
+        );
       }
     } catch (error) {
       // eslint-disable-next-line no-console
@@ -500,7 +534,7 @@ export class HmaService {
           try {
             const response = await this.fetchHTTP({
               url: `${this.hmaServiceUrl}/c/bank/${bank.hma_name}`,
-              method: "get",
+              method: 'get',
               headers: {
                 'Content-Type': 'application/json',
               },
@@ -515,16 +549,21 @@ export class HmaService {
 
             if (!response.ok) {
               // eslint-disable-next-line no-console
-              console.error(`Failed to verify bank ${bank.hma_name} in HMA service: ${response.status}`);
+              console.error(
+                `Failed to verify bank ${bank.hma_name} in HMA service: ${response.status}`,
+              );
             }
 
             return bank;
           } catch (error) {
             // eslint-disable-next-line no-console
-            console.error(`Network error verifying bank ${bank.hma_name}:`, error);
+            console.error(
+              `Network error verifying bank ${bank.hma_name}:`,
+              error,
+            );
             return bank;
           }
-        })
+        }),
       );
 
       return validBanks.filter((bank): bank is HashBank => bank !== null);
@@ -570,7 +609,7 @@ export class HmaService {
           // fall through to default
         }
         return { name, supports_auth: false, has_auth: false };
-      })
+      }),
     );
     return infos;
   }
@@ -601,7 +640,7 @@ export class HmaService {
   async createExchange(
     bankName: string,
     apiType: string,
-    apiJson: Record<string, unknown>
+    apiJson: Record<string, unknown>,
   ): Promise<void> {
     const requestBody = {
       bank: bankName,
@@ -624,13 +663,15 @@ export class HmaService {
         requestBody,
         url: `${this.hmaServiceUrl}/c/exchanges`,
       };
-      throw new Error(`Failed to create exchange: ${jsonStringify(errorDetails)}`);
+      throw new Error(
+        `Failed to create exchange: ${jsonStringify(errorDetails)}`,
+      );
     }
   }
 
   async setExchangeCredentials(
     apiName: string,
-    credentialJson: Record<string, unknown>
+    credentialJson: Record<string, unknown>,
   ): Promise<void> {
     const requestBody = { credential_json: credentialJson };
 
@@ -644,7 +685,7 @@ export class HmaService {
 
     if (!response.ok) {
       throw new Error(
-        `Failed to set exchange credentials for '${apiName}': status=${response.status}`
+        `Failed to set exchange credentials for '${apiName}': status=${response.status}`,
       );
     }
   }
@@ -724,7 +765,9 @@ export class HmaService {
         info.fetched_items = status.fetched_items;
         info.is_fetching = status.running_fetch_start_ts != null;
         if (status.last_fetch_complete_ts != null) {
-          info.last_fetch_time = new Date(status.last_fetch_complete_ts * 1000).toISOString();
+          info.last_fetch_time = new Date(
+            status.last_fetch_complete_ts * 1000,
+          ).toISOString();
         }
       }
     } catch {
@@ -759,7 +802,7 @@ export class HmaService {
         content_uri?: string;
         json?: Record<string, unknown>;
       };
-    }
+    },
   ): Promise<BankContentResponse> {
     const { file, contentType, url, metadata } = options;
 
@@ -773,9 +816,12 @@ export class HmaService {
       const params = new URLSearchParams();
       params.append('url', url);
       if (metadata) {
-        if (metadata.content_id) params.append('content_id', metadata.content_id);
-        if (metadata.content_uri) params.append('content_uri', metadata.content_uri);
-        if (metadata.json) params.append('metadata', jsonStringify(metadata.json));
+        if (metadata.content_id)
+          params.append('content_id', metadata.content_id);
+        if (metadata.content_uri)
+          params.append('content_uri', metadata.content_uri);
+        if (metadata.json)
+          params.append('metadata', jsonStringify(metadata.json));
       }
 
       response = await this.fetchHTTP({
@@ -789,19 +835,20 @@ export class HmaService {
       formData.append(contentType!, file!);
 
       if (metadata) {
-        if (metadata.content_id) formData.append('content_id', metadata.content_id);
-        if (metadata.content_uri) formData.append('content_uri', metadata.content_uri);
-        if (metadata.json) formData.append('metadata', jsonStringify(metadata.json));
+        if (metadata.content_id)
+          formData.append('content_id', metadata.content_id);
+        if (metadata.content_uri)
+          formData.append('content_uri', metadata.content_uri);
+        if (metadata.json)
+          formData.append('metadata', jsonStringify(metadata.json));
       }
 
       response = await this.fetchHTTP({
         url: `${this.hmaServiceUrl}/c/bank/${bankName}/content`,
         method: 'post',
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        body: formData as any,
-        headers: {
-          'Content-Type': 'multipart/form-data',
-        },
+        // Don't set Content-Type explicitly: undici needs to add the multipart
+        // boundary parameter itself when serializing the FormData.
+        body: formData,
         handleResponseBody: 'as-json',
       });
     }
@@ -813,14 +860,12 @@ export class HmaService {
     return response.body as unknown as BankContentResponse;
   }
 
-  async lookupContent(
-    options: {
-      url?: string;
-      contentType?: ContentType;
-      signalType?: string;
-      signal?: string;
-    }
-  ): Promise<LookupResponse> {
+  async lookupContent(options: {
+    url?: string;
+    contentType?: ContentType;
+    signalType?: string;
+    signal?: string;
+  }): Promise<LookupResponse> {
     const { url, contentType, signalType, signal } = options;
 
     const params = new URLSearchParams();
@@ -851,9 +896,9 @@ export class HmaService {
    * @returns A promise that resolves to an object with matched status and list of matched banks
    */
   async checkImageMatchWithDetails(
-    hmaBankIds: string[], 
-    signalType: string, 
-    signal: string
+    hmaBankIds: string[],
+    signalType: string,
+    signal: string,
   ): Promise<{ matched: boolean; matchedBanks: string[] }> {
     const matches: LookupResponse = await this.lookupContent({
       signal,
@@ -863,7 +908,7 @@ export class HmaService {
     const matchedBanks: string[] = [];
 
     // Check which banks have matches
-    hmaBankIds.forEach(bankId => {
+    hmaBankIds.forEach((bankId) => {
       const bankMatches = matches[bankId];
       if (bankMatches && bankMatches.length > 0) {
         // TODO: Implement some configuration for the distance threshold
@@ -885,8 +930,16 @@ export class HmaService {
    * @returns A promise that resolves to true if the image matches any images in any of the banks
    * @deprecated Use checkImageMatchWithDetails for more detailed information
    */
-  async checkImageMatch(hmaBankIds: string[], signalType: string, signal: string): Promise<boolean> {
-    const result = await this.checkImageMatchWithDetails(hmaBankIds, signalType, signal);
+  async checkImageMatch(
+    hmaBankIds: string[],
+    signalType: string,
+    signal: string,
+  ): Promise<boolean> {
+    const result = await this.checkImageMatchWithDetails(
+      hmaBankIds,
+      signalType,
+      signal,
+    );
     return result.matched;
   }
 }

--- a/server/services/itemInvestigationService/index.ts
+++ b/server/services/itemInvestigationService/index.ts
@@ -2,3 +2,4 @@ export {
   ItemInvestigationServiceAdapter as ItemInvestigationService,
   RETURN_UNLIMITED_RESULTS_AND_POTENTIALLY_HANG_DB,
 } from './itemInvestigationServiceAdapter.js';
+export { makeSyntheticUserSubmission } from './synthesizeUserItemFromCreatorReferences.js';

--- a/server/services/itemInvestigationService/itemInvestigationServiceAdapter.ts
+++ b/server/services/itemInvestigationService/itemInvestigationServiceAdapter.ts
@@ -25,6 +25,7 @@ import {
   ItemInvestigationService,
   type SubmissionsForItemWithTypeIdentifier,
 } from './itemInvestigationService.js';
+import { synthesizeUserItemFromContentTarget } from './synthesizeUserItemFromContentTarget.js';
 import { synthesizeUserItemFromCreatorReferences } from './synthesizeUserItemFromCreatorReferences.js';
 
 type AdaptedReturnType<T extends PublicMethodNames<ItemInvestigationService>> =
@@ -286,6 +287,22 @@ export class ItemInvestigationServiceAdapter {
     knownUserTypeId?: string;
   }): Promise<SubmissionsForItem | null> {
     return synthesizeUserItemFromCreatorReferences({
+      ...opts,
+      scyllaCreatorRefExists: async (input) =>
+        this.#hasAnySubmissionsCreatedBy(input.orgId, input.creatorIdentifier),
+      actionExecutionsAdapter: this.actionExecutionsAdapter,
+      contentApiRequestsAdapter: this.contentApiRequestsAdapter,
+      moderationConfigService: this.moderationConfigService,
+    });
+  }
+
+  /** See `synthesizeUserItemFromContentTarget.ts`. */
+  async synthesizeUserItemFromContentTarget(opts: {
+    orgId: string;
+    itemId: string;
+    itemTypeId: string;
+  }): Promise<SubmissionsForItem | null> {
+    return synthesizeUserItemFromContentTarget({
       ...opts,
       scyllaCreatorRefExists: async (input) =>
         this.#hasAnySubmissionsCreatedBy(input.orgId, input.creatorIdentifier),

--- a/server/services/itemInvestigationService/synthesizeUserItemFromContentTarget.ts
+++ b/server/services/itemInvestigationService/synthesizeUserItemFromContentTarget.ts
@@ -1,0 +1,66 @@
+import { type Dependencies } from '../../iocContainer/index.js';
+import { type IActionExecutionsAdapter } from '../../plugins/warehouse/queries/IActionExecutionsAdapter.js';
+import { type IContentApiRequestsAdapter } from '../../plugins/warehouse/queries/IContentApiRequestsAdapter.js';
+import {
+  synthesizeUserItemFromCreatorReferences,
+  type SyntheticUserItemSubmissionsForItem,
+} from './synthesizeUserItemFromCreatorReferences.js';
+
+/**
+ * Resolve a synthetic `UserItem` submission for the *creator* of a CONTENT
+ * item whose own submission record is missing. Looks up the most-recent
+ * `(creator_id, creator_type_id)` for `(itemId, itemTypeId)` in
+ * `ACTION_EXECUTIONS`, then delegates to
+ * `synthesizeUserItemFromCreatorReferences` with the resolved user id so the
+ * returned submission is keyed on the creator (not the content).
+ */
+export async function synthesizeUserItemFromContentTarget(opts: {
+  orgId: string;
+  itemId: string;
+  itemTypeId: string;
+  actionExecutionsAdapter: Pick<
+    IActionExecutionsAdapter,
+    'findContentCreatorIdentity' | 'findInferredUserIdentity'
+  >;
+  contentApiRequestsAdapter: Pick<
+    IContentApiRequestsAdapter,
+    'findInferredUserIdentityFromCreators'
+  >;
+  scyllaCreatorRefExists: Parameters<
+    typeof synthesizeUserItemFromCreatorReferences
+  >[0]['scyllaCreatorRefExists'];
+  moderationConfigService: Pick<
+    Dependencies['ModerationConfigService'],
+    'getItemType' | 'getItemTypes'
+  >;
+}): Promise<SyntheticUserItemSubmissionsForItem | null> {
+  const {
+    orgId,
+    itemId,
+    itemTypeId,
+    actionExecutionsAdapter,
+    contentApiRequestsAdapter,
+    scyllaCreatorRefExists,
+    moderationConfigService,
+  } = opts;
+
+  const creator = await actionExecutionsAdapter.findContentCreatorIdentity({
+    orgId,
+    itemId,
+    itemTypeId,
+  });
+
+  if (!creator) {
+    return null;
+  }
+
+  return synthesizeUserItemFromCreatorReferences({
+    orgId,
+    itemId: creator.creatorId,
+    knownUserTypeId: creator.creatorTypeId,
+    scyllaCreatorRefExists,
+    actionExecutionsAdapter,
+    contentApiRequestsAdapter,
+    moderationConfigService,
+  });
+}

--- a/server/services/manualReviewToolService/manualReviewToolService.ts
+++ b/server/services/manualReviewToolService/manualReviewToolService.ts
@@ -1174,6 +1174,17 @@ export class ManualReviewToolService {
     return this.jobDecisioning.getNcmecDecisions(opts);
   }
 
+  async getNcmecDecisionsForOrg(opts: { orgId: string; limit?: number }) {
+    return this.jobDecisioning.getNcmecDecisionsForOrg(opts);
+  }
+
+  async getNcmecDecisionByIdForOrg(opts: {
+    orgId: string;
+    decisionId: string;
+  }) {
+    return this.jobDecisioning.getNcmecDecisionByIdForOrg(opts);
+  }
+
   async upsertDefaultSettings(opts: { orgId: string }) {
     return this.manualReviewToolSettings.upsertDefaultSettings(opts);
   }

--- a/server/services/manualReviewToolService/modules/JobDecisioning.ts
+++ b/server/services/manualReviewToolService/modules/JobDecisioning.ts
@@ -470,6 +470,102 @@ export default class JobDecisioning {
     );
   }
 
+  async getNcmecDecisionsForOrg(opts: { orgId: string; limit?: number }) {
+    const { orgId } = opts;
+    // Clamp `limit` so callers can't request an unreasonable number of rows;
+    // default of 500 matches the previous behavior. Non-numeric values fall
+    // back to the default via Number.isFinite.
+    const requestedLimit = opts.limit ?? 500;
+    const safeLimit =
+      Number.isFinite(requestedLimit) && requestedLimit > 0
+        ? Math.min(Math.floor(requestedLimit), 500)
+        : 500;
+    const allNcmecDecisions = await this.pgQuery
+      .selectFrom('manual_review_tool.manual_review_decisions')
+      .where('org_id', '=', orgId)
+      .where(({ eb, selectFrom }) => {
+        return eb.exists(
+          selectFrom(
+            sql`unnest(manual_review_tool.manual_review_decisions.decision_components)`.as(
+              'decision_component',
+            ),
+          )
+            .selectAll()
+            .where(
+              sql<string>`decision_component->>'type'`,
+              '=',
+              'SUBMIT_NCMEC_REPORT',
+            ),
+        );
+      })
+      .select([
+        'org_id',
+        'decision_components',
+        'job_payload',
+        'id',
+        'queue_id',
+        'reviewer_id',
+        'created_at',
+      ])
+      .orderBy('created_at', 'desc')
+      .limit(safeLimit)
+      .execute();
+    return filterNullOrUndefined(
+      allNcmecDecisions.map((it) => {
+        if (
+          'policyIds' in it.job_payload &&
+          'submissionId' in it.job_payload.payload.item
+        ) {
+          return { ...it, job_payload: it.job_payload };
+        }
+        return undefined;
+      }),
+    );
+  }
+
+  /** Single-decision lookup gated on the caller's org. Returns `undefined` if
+   * the decision doesn't exist or belongs to a different org (callers should
+   * treat both cases as "not found" — never confirm cross-org existence). */
+  async getNcmecDecisionByIdForOrg(opts: {
+    orgId: string;
+    decisionId: string;
+  }) {
+    const { orgId, decisionId } = opts;
+    const row = await this.pgQuery
+      .selectFrom('manual_review_tool.manual_review_decisions')
+      .where('id', '=', decisionId)
+      .where('org_id', '=', orgId)
+      .select([
+        'org_id',
+        'decision_components',
+        'job_payload',
+        'id',
+        'queue_id',
+        'reviewer_id',
+        'created_at',
+      ])
+      .executeTakeFirst();
+    if (!row) {
+      return undefined;
+    }
+    // Only return decisions that actually contain a SUBMIT_NCMEC_REPORT
+    // component so callers get the same `not_found` shape for both
+    // "wrong-org" and "wrong-decision-type" lookups.
+    const hasNcmecComponent = row.decision_components.some(
+      (component) => component.type === 'SUBMIT_NCMEC_REPORT',
+    );
+    if (!hasNcmecComponent) {
+      return undefined;
+    }
+    if (
+      !('policyIds' in row.job_payload) ||
+      !('submissionId' in row.job_payload.payload.item)
+    ) {
+      return undefined;
+    }
+    return { ...row, job_payload: row.job_payload };
+  }
+
   async getIgnoreCallbackForOrg(orgId: string): Promise<string | undefined> {
     const settings = await this.pgQuery
       .selectFrom('manual_review_tool.manual_review_tool_settings')

--- a/server/services/manualReviewToolService/modules/JobDecisioning.ts
+++ b/server/services/manualReviewToolService/modules/JobDecisioning.ts
@@ -80,6 +80,7 @@ export type ManualReviewDecisionComponent =
       reportedMessages: readonly NCMECThreadReport[];
       incidentType: string;
       escalateToHighPriority?: string;
+      additionalInfo?: string;
     }
   | {
       type: 'TRANSFORM_JOB_AND_RECREATE_IN_QUEUE';

--- a/server/services/ncmecService/buildSubmitReportParamsFromDecision.ts
+++ b/server/services/ncmecService/buildSubmitReportParamsFromDecision.ts
@@ -108,7 +108,9 @@ export async function buildSubmitReportParamsFromDecision(
   const media = await Promise.all(
     decisionComponent.reportedMedia.map(async (it) => {
       const reportedItem = allMediaItems.find(
-        (m) => m.contentItem.itemId === it.id,
+        (m) =>
+          m.contentItem.itemId === it.id &&
+          m.contentItem.itemTypeIdentifier.id === it.typeId,
       );
       if (reportedItem === undefined) {
         throw new Error('Unable to find reported media in job payload');

--- a/server/services/ncmecService/buildSubmitReportParamsFromDecision.ts
+++ b/server/services/ncmecService/buildSubmitReportParamsFromDecision.ts
@@ -105,12 +105,23 @@ export async function buildSubmitReportParamsFromDecision(
     reportedUserData,
   );
 
+  // Pre-index allMediaItems by (itemId, typeId) so the per-decisionComponent
+  // lookup below is O(1) instead of O(n) for every reportedMedia entry. The
+  // composite key avoids the same-id-different-type collision the lookup
+  // already guards against.
+  const mediaIndexKey = (itemId: string, typeId: string) =>
+    `${itemId}\u0000${typeId}`;
+  const mediaByIdAndType = new Map(
+    allMediaItems.map((m) => [
+      mediaIndexKey(m.contentItem.itemId, m.contentItem.itemTypeIdentifier.id),
+      m,
+    ]),
+  );
+
   const media = await Promise.all(
     decisionComponent.reportedMedia.map(async (it) => {
-      const reportedItem = allMediaItems.find(
-        (m) =>
-          m.contentItem.itemId === it.id &&
-          m.contentItem.itemTypeIdentifier.id === it.typeId,
+      const reportedItem = mediaByIdAndType.get(
+        mediaIndexKey(it.id, it.typeId),
       );
       if (reportedItem === undefined) {
         throw new Error('Unable to find reported media in job payload');

--- a/server/services/ncmecService/buildSubmitReportParamsFromDecision.ts
+++ b/server/services/ncmecService/buildSubmitReportParamsFromDecision.ts
@@ -1,0 +1,179 @@
+import { makeDateString } from '@roostorg/types';
+
+import { type Dependencies } from '../../iocContainer/index.js';
+import {
+  getFieldValueForRole,
+  type NormalizedItemData,
+} from '../itemProcessingService/index.js';
+import { type UserItemType } from '../moderationConfigService/types/itemTypes.js';
+import { type NCMECReportParams } from './ncmecReporting.js';
+
+/** NCMEC's accepted "Incident Type Category" string used as a safe fallback
+ * for legacy decisions whose DB row predates the `incidentType` column. */
+export const LEGACY_FALLBACK_INCIDENT_TYPE =
+  'Child Pornography (possession, manufacture, and distribution)';
+
+/** Single source of truth for assembling the NCMEC `submitReport` payload
+ * from a SUBMIT_NCMEC_REPORT decision component. Three call sites use this:
+ *  - the IoC `onRecordDecision` flow (initial submission after a reviewer's
+ *    decision)
+ *  - the background `RetryFailedNcmecDecisionsJob`
+ *  - the user-initiated `retryNcmecSubmission` GraphQL mutation
+ *
+ * Centralising the assembly here means each site behaves identically: the
+ * reviewer's `escalateToHighPriority` and `additionalInfo` are preserved on
+ * retry, and any future field added to the decision component is delivered to
+ * NCMEC from every code path. */
+export interface BuildSubmitReportParamsInput {
+  orgId: string;
+  reviewerId: string;
+  /** ID of the reported user item (the subject of the report). */
+  reportedItemId: string;
+  /** Item-type ID of the reported user item. */
+  reportedItemTypeId: string;
+  /** USER-kind item type, already resolved by the caller. The caller is
+   * responsible for ensuring `itemType.kind === 'USER'` (this helper does
+   * not re-validate); narrowing the type here gives us proper typing for
+   * the schema-field-role lookups below. */
+  reportedUserItemType: Readonly<UserItemType>;
+  /** Raw item data for the reported user (used to read displayName / icon). */
+  reportedUserData: NormalizedItemData;
+  /** All media items attached to the MRT job; used to resolve each reported
+   * media id to its full content item (so we can read its createdAt etc). */
+  allMediaItems: ReadonlyArray<{
+    contentItem: {
+      itemId: string;
+      itemTypeIdentifier: { id: string; name?: string };
+      data: NormalizedItemData;
+    };
+  }>;
+  /** The SUBMIT_NCMEC_REPORT decision component. */
+  decisionComponent: {
+    reportedMedia: ReadonlyArray<{
+      id: string;
+      typeId: string;
+      url: string;
+      industryClassification: NCMECReportParams['media'][number]['industryClassification'];
+      fileAnnotations: NCMECReportParams['media'][number]['fileAnnotations'];
+    }>;
+    reportedMessages: NCMECReportParams['threads'];
+    /** Optional because legacy DB rows predate the `incidentType` column on
+     * `decision_components`; callers should pass `fallbackIncidentType` when
+     * they want a safe default. */
+    incidentType?: string;
+    escalateToHighPriority?: string;
+    additionalInfo?: string;
+  };
+  /** Optional fallback used when `decisionComponent.incidentType` is empty
+   * (legacy DB rows). Callers that don't want a fallback should omit this. */
+  fallbackIncidentType?: string;
+  /** MRT decision id; forwarded to `NCMECReportParams.jobId` for failure recording. */
+  jobId?: string;
+  getItemTypeEventuallyConsistent: Dependencies['getItemTypeEventuallyConsistent'];
+}
+
+export async function buildSubmitReportParamsFromDecision(
+  input: BuildSubmitReportParamsInput,
+): Promise<NCMECReportParams> {
+  const {
+    orgId,
+    reviewerId,
+    reportedItemId,
+    reportedItemTypeId,
+    reportedUserItemType,
+    reportedUserData,
+    allMediaItems,
+    decisionComponent,
+    fallbackIncidentType,
+    jobId,
+    getItemTypeEventuallyConsistent,
+  } = input;
+
+  // Reading these via getFieldValueForRole keeps the helper agnostic to the
+  // org's field-naming conventions; if the role isn't mapped, the field is
+  // simply omitted from the report.
+  const displayName = getFieldValueForRole(
+    reportedUserItemType.schema,
+    reportedUserItemType.schemaFieldRoles,
+    'displayName',
+    reportedUserData,
+  );
+  const profilePicUrl = getFieldValueForRole(
+    reportedUserItemType.schema,
+    reportedUserItemType.schemaFieldRoles,
+    'profileIcon',
+    reportedUserData,
+  );
+
+  const media = await Promise.all(
+    decisionComponent.reportedMedia.map(async (it) => {
+      const reportedItem = allMediaItems.find(
+        (m) => m.contentItem.itemId === it.id,
+      );
+      if (reportedItem === undefined) {
+        throw new Error('Unable to find reported media in job payload');
+      }
+      const mediaItemType = await getItemTypeEventuallyConsistent({
+        orgId,
+        typeSelector: reportedItem.contentItem.itemTypeIdentifier,
+      });
+      if (mediaItemType === undefined) {
+        throw new Error('Unable to find item type for reported media');
+      }
+      // Fall back to "now" when the source row is missing `createdAt`.
+      // This keeps retries submittable for legacy data (predates the field)
+      // better to send the retry timestamp than to permanently block the
+      // report from being submitted to NCMEC at all.
+      const createdAt =
+        getFieldValueForRole(
+          mediaItemType.schema,
+          mediaItemType.schemaFieldRoles,
+          'createdAt',
+          reportedItem.contentItem.data,
+        ) ?? makeDateString(new Date().toISOString());
+      if (createdAt === undefined) {
+        throw new Error('No created at for reported media');
+      }
+      return {
+        id: it.id,
+        typeId: it.typeId,
+        url: it.url,
+        createdAt,
+        industryClassification: it.industryClassification,
+        fileAnnotations: it.fileAnnotations,
+      };
+    }),
+  );
+
+  const trimmedIncidentType = (decisionComponent.incidentType ?? '').trim();
+  const incidentType =
+    trimmedIncidentType !== ''
+      ? trimmedIncidentType
+      : (fallbackIncidentType ?? '');
+
+  return {
+    reportedUser: {
+      id: reportedItemId,
+      typeId: reportedItemTypeId,
+      ...(displayName ? { displayName } : {}),
+      ...(profilePicUrl ? { profilePicture: profilePicUrl.url } : {}),
+    },
+    orgId,
+    media,
+    reviewerId,
+    threads: decisionComponent.reportedMessages,
+    incidentType,
+    ...(decisionComponent.escalateToHighPriority != null &&
+    decisionComponent.escalateToHighPriority.trim() !== ''
+      ? {
+          escalateToHighPriority:
+            decisionComponent.escalateToHighPriority.trim(),
+        }
+      : {}),
+    ...(decisionComponent.additionalInfo != null &&
+    decisionComponent.additionalInfo.trim() !== ''
+      ? { additionalInfo: decisionComponent.additionalInfo.trim() }
+      : {}),
+    ...(jobId !== undefined ? { jobId } : {}),
+  };
+}

--- a/server/services/ncmecService/index.ts
+++ b/server/services/ncmecService/index.ts
@@ -4,3 +4,8 @@ export {
 } from './ncmecService.js';
 
 export { NCMECIncidentType } from './ncmecReporting.js';
+export { filterDecisionsToFailedSubmissions } from './ncmecSubmissionFilters.js';
+export {
+  buildSubmitReportParamsFromDecision,
+  LEGACY_FALLBACK_INCIDENT_TYPE,
+} from './buildSubmitReportParamsFromDecision.js';

--- a/server/services/ncmecService/ncmecDebug.ts
+++ b/server/services/ncmecService/ncmecDebug.ts
@@ -1,13 +1,8 @@
 import { jsonStringify } from '../../utils/encoding.js';
 
-// Opt-in debugging utilities for the NCMEC submission flow. Activate by
-// setting `NCMEC_DEBUG=1` on a dev machine. Logs structured one-liners to
-// stderr and dumps XML/JSON payloads to `ncmec-reports/` (gitignored) so the
-// exact bytes we sent to NCMEC can be replayed via curl.
-//
-// Disabled in `NODE_ENV=production` so we cannot accidentally leak reportable
-// content in shared environments. Never log credentials or request/response
-// headers from this module.
+// Opt-in debug logs + XML/JSON dumps for NCMEC submissions. Gated on
+// `NCMEC_DEBUG=1` and `NODE_ENV !== 'production'` so we cannot leak
+// reportable content in shared environments. Never log credentials.
 
 export function ncmecDebugEnabled(): boolean {
   return (

--- a/server/services/ncmecService/ncmecDebug.ts
+++ b/server/services/ncmecService/ncmecDebug.ts
@@ -1,0 +1,45 @@
+import { jsonStringify } from '../../utils/encoding.js';
+
+// Opt-in debugging utilities for the NCMEC submission flow. Activate by
+// setting `NCMEC_DEBUG=1` on a dev machine. Logs structured one-liners to
+// stderr and dumps XML/JSON payloads to `ncmec-reports/` (gitignored) so the
+// exact bytes we sent to NCMEC can be replayed via curl.
+//
+// Disabled in `NODE_ENV=production` so we cannot accidentally leak reportable
+// content in shared environments. Never log credentials or request/response
+// headers from this module.
+
+export function ncmecDebugEnabled(): boolean {
+  return (
+    process.env.NCMEC_DEBUG === '1' && process.env.NODE_ENV !== 'production'
+  );
+}
+
+export function ncmecDebugLog(
+  event: string,
+  fields: Record<string, unknown>,
+): void {
+  if (!ncmecDebugEnabled()) {
+    return;
+  }
+  // eslint-disable-next-line no-console
+  console.error(jsonStringify({ ncmecDebug: event, ...fields }));
+}
+
+export async function ncmecDebugDump(
+  filename: string,
+  contents: string,
+): Promise<void> {
+  if (!ncmecDebugEnabled()) {
+    return;
+  }
+  try {
+    const fs = await import('fs/promises');
+    const path = await import('path');
+    const dir = path.join(process.cwd(), 'ncmec-reports');
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, filename), contents, 'utf-8');
+  } catch {
+    // Don't let local debugging IO break submission.
+  }
+}

--- a/server/services/ncmecService/ncmecEnqueueToMrt.ts
+++ b/server/services/ncmecService/ncmecEnqueueToMrt.ts
@@ -211,8 +211,6 @@ export default class NcmecEnqueueToMrt {
       },
       input.targetQueueId,
     );
-    // eslint-disable-next-line no-console
-    console.log('[NCMEC] ✅ Successfully created NCMEC manual review job!');
     return { status: 'ENQUEUED' };
   }
 

--- a/server/services/ncmecService/ncmecReporting.test.ts
+++ b/server/services/ncmecService/ncmecReporting.test.ts
@@ -101,27 +101,41 @@ describe('NCMEC reporting', () => {
   describe('clampIncidentDateTimeToPast', () => {
     const NOW_MS = Date.UTC(2026, 0, 15, 12, 0, 0);
 
-    it('clamps future timestamps to now - 1s', () => {
+    it('clamps future timestamps to now - 1s and reports wasClamped=true', () => {
       const future = new Date(NOW_MS + 60_000).toISOString();
-      expect(clampIncidentDateTimeToPast(future, NOW_MS)).toBe(
-        new Date(NOW_MS - 1000).toISOString(),
-      );
+      expect(clampIncidentDateTimeToPast(future, NOW_MS)).toEqual({
+        value: new Date(NOW_MS - 1000).toISOString(),
+        wasClamped: true,
+      });
     });
 
-    it('leaves past timestamps untouched (canonicalized to UTC ISO)', () => {
+    it('leaves canonical UTC past timestamps untouched and reports wasClamped=false', () => {
       const pastMs = NOW_MS - 60_000;
       const past = new Date(pastMs).toISOString();
-      expect(clampIncidentDateTimeToPast(past, NOW_MS)).toBe(past);
+      expect(clampIncidentDateTimeToPast(past, NOW_MS)).toEqual({
+        value: past,
+        wasClamped: false,
+      });
     });
 
     it('handles non-UTC ISO offsets via numeric (not lexicographic) compare', () => {
-      // 2026-01-15T11:30:00-01:00 === 2026-01-15T12:30:00Z (30 min in the future);
-      // a lex compare against "2026-01-15T11:59:59.000Z" would mis-classify this
-      // as past because the string sorts earlier.
+      // 11:30:00-01:00 === 12:30:00Z (30 min after NOW); lex compare would
+      // classify it as past since the string sorts earlier than 11:59:59Z.
       const futureWithOffset = '2026-01-15T11:30:00-01:00';
-      expect(clampIncidentDateTimeToPast(futureWithOffset, NOW_MS)).toBe(
-        new Date(NOW_MS - 1000).toISOString(),
-      );
+      expect(clampIncidentDateTimeToPast(futureWithOffset, NOW_MS)).toEqual({
+        value: new Date(NOW_MS - 1000).toISOString(),
+        wasClamped: true,
+      });
+    });
+
+    it('does not flag wasClamped when a non-UTC past timestamp is merely normalized to Z', () => {
+      // 11:30:00+02:00 === 09:30:00Z (in the past, but round-trips to a
+      // different string). String inequality would have false-flagged it.
+      const pastWithOffset = '2026-01-15T11:30:00+02:00';
+      expect(clampIncidentDateTimeToPast(pastWithOffset, NOW_MS)).toEqual({
+        value: '2026-01-15T09:30:00.000Z',
+        wasClamped: false,
+      });
     });
 
     it('throws on invalid timestamps', () => {

--- a/server/services/ncmecService/ncmecReporting.test.ts
+++ b/server/services/ncmecService/ncmecReporting.test.ts
@@ -1,4 +1,8 @@
-import { buildInternetDetailsFromOrgSetting } from './ncmecReporting.js';
+import {
+  buildInternetDetailsFromOrgSetting,
+  clampIncidentDateTimeToPast,
+  summarizeCyberTipFailure,
+} from './ncmecReporting.js';
 
 describe('NCMEC reporting', () => {
   describe('buildInternetDetailsFromOrgSetting', () => {
@@ -91,6 +95,102 @@ describe('NCMEC reporting', () => {
       expect(
         buildInternetDetailsFromOrgSetting('  CHAT_IM  ', undefined),
       ).toEqual([{ chatImIncident: {} }]);
+    });
+  });
+
+  describe('clampIncidentDateTimeToPast', () => {
+    const NOW_MS = Date.UTC(2026, 0, 15, 12, 0, 0);
+
+    it('clamps future timestamps to now - 1s', () => {
+      const future = new Date(NOW_MS + 60_000).toISOString();
+      expect(clampIncidentDateTimeToPast(future, NOW_MS)).toBe(
+        new Date(NOW_MS - 1000).toISOString(),
+      );
+    });
+
+    it('leaves past timestamps untouched (canonicalized to UTC ISO)', () => {
+      const pastMs = NOW_MS - 60_000;
+      const past = new Date(pastMs).toISOString();
+      expect(clampIncidentDateTimeToPast(past, NOW_MS)).toBe(past);
+    });
+
+    it('handles non-UTC ISO offsets via numeric (not lexicographic) compare', () => {
+      // 2026-01-15T11:30:00-01:00 === 2026-01-15T12:30:00Z (30 min in the future);
+      // a lex compare against "2026-01-15T11:59:59.000Z" would mis-classify this
+      // as past because the string sorts earlier.
+      const futureWithOffset = '2026-01-15T11:30:00-01:00';
+      expect(clampIncidentDateTimeToPast(futureWithOffset, NOW_MS)).toBe(
+        new Date(NOW_MS - 1000).toISOString(),
+      );
+    });
+
+    it('throws on invalid timestamps', () => {
+      expect(() => clampIncidentDateTimeToPast('not-a-date', NOW_MS)).toThrow(
+        /Invalid media createdAt timestamp/,
+      );
+    });
+  });
+
+  describe('summarizeCyberTipFailure', () => {
+    const previousDebug = process.env.NCMEC_DEBUG;
+    const previousNodeEnv = process.env.NODE_ENV;
+
+    afterEach(() => {
+      process.env.NCMEC_DEBUG = previousDebug;
+      process.env.NODE_ENV = previousNodeEnv;
+    });
+
+    it('includes NCMEC responseCode and description in production', () => {
+      process.env.NCMEC_DEBUG = undefined;
+      process.env.NODE_ENV = 'production';
+      const body = {
+        reportResponse: {
+          responseCode: { _text: '4100' },
+          responseDescription: { _text: 'incidentSummary out of order' },
+        },
+      };
+      const message = summarizeCyberTipFailure('/submit', 400, body);
+      expect(message).toContain('status=400');
+      expect(message).toContain('responseCode=4100');
+      expect(message).toContain('incidentSummary out of order');
+      expect(message).not.toContain('body=');
+    });
+
+    it('does not leak unknown body fields in production', () => {
+      process.env.NCMEC_DEBUG = undefined;
+      process.env.NODE_ENV = 'production';
+      const body = {
+        secret: 'reportable-content-or-pii',
+        unrelated: { nested: 'data' },
+      };
+      const message = summarizeCyberTipFailure('/submit', 500, body);
+      expect(message).toContain('status=500');
+      expect(message).not.toContain('reportable-content-or-pii');
+      expect(message).not.toContain('unrelated');
+    });
+
+    it('appends the truncated body when NCMEC_DEBUG is enabled in dev', () => {
+      process.env.NCMEC_DEBUG = '1';
+      process.env.NODE_ENV = 'test';
+      const body = {
+        reportResponse: {
+          responseCode: { _text: '4000' },
+          responseDescription: { _text: 'Invalid request' },
+        },
+      };
+      const message = summarizeCyberTipFailure('/finish', 400, body);
+      expect(message).toContain('responseCode=4000');
+      expect(message).toContain('Invalid request');
+      expect(message).toContain('body=');
+      expect(message).toContain('reportResponse');
+    });
+
+    it('still keeps body off in production even with NCMEC_DEBUG=1', () => {
+      process.env.NCMEC_DEBUG = '1';
+      process.env.NODE_ENV = 'production';
+      const body = { reportResponse: { responseCode: { _text: '0' } } };
+      const message = summarizeCyberTipFailure('/submit', 502, body);
+      expect(message).not.toContain('body=');
     });
   });
 });

--- a/server/services/ncmecService/ncmecReporting.test.ts
+++ b/server/services/ncmecService/ncmecReporting.test.ts
@@ -1,67 +1,96 @@
-import {
-  buildInternetDetailsFromOrgSetting,
-} from './ncmecReporting.js';
+import { buildInternetDetailsFromOrgSetting } from './ncmecReporting.js';
 
 describe('NCMEC reporting', () => {
   describe('buildInternetDetailsFromOrgSetting', () => {
     it('returns undefined when type is null or undefined', () => {
-      expect(buildInternetDetailsFromOrgSetting(null, undefined)).toBeUndefined();
-      expect(buildInternetDetailsFromOrgSetting(undefined, 'https://example.com')).toBeUndefined();
+      expect(
+        buildInternetDetailsFromOrgSetting(null, undefined),
+      ).toBeUndefined();
+      expect(
+        buildInternetDetailsFromOrgSetting(undefined, 'https://example.com'),
+      ).toBeUndefined();
     });
 
     it('returns undefined when type is blank string', () => {
       expect(buildInternetDetailsFromOrgSetting('', undefined)).toBeUndefined();
-      expect(buildInternetDetailsFromOrgSetting('   ', undefined)).toBeUndefined();
+      expect(
+        buildInternetDetailsFromOrgSetting('   ', undefined),
+      ).toBeUndefined();
     });
 
     it('returns undefined for unknown type', () => {
-      expect(buildInternetDetailsFromOrgSetting('UNKNOWN', undefined)).toBeUndefined();
-      expect(buildInternetDetailsFromOrgSetting('web_page', undefined)).toBeUndefined();
+      expect(
+        buildInternetDetailsFromOrgSetting('UNKNOWN', undefined),
+      ).toBeUndefined();
+      expect(
+        buildInternetDetailsFromOrgSetting('web_page', undefined),
+      ).toBeUndefined();
     });
 
     it('returns WEB_PAGE incident with moreInfoUrl when provided', () => {
-      const result = buildInternetDetailsFromOrgSetting('WEB_PAGE', 'https://example.com/info');
-      expect(result).toEqual([{ webPageIncident: { url: 'https://example.com/info' } }]);
+      const result = buildInternetDetailsFromOrgSetting(
+        'WEB_PAGE',
+        'https://example.com/info',
+      );
+      expect(result).toEqual([
+        { webPageIncident: { url: 'https://example.com/info' } },
+      ]);
     });
 
-    it('returns WEB_PAGE incident with "Not specified" when moreInfoUrl is empty', () => {
+    it('omits url when moreInfoUrl is empty', () => {
       const result = buildInternetDetailsFromOrgSetting('WEB_PAGE', undefined);
-      expect(result).toEqual([{ webPageIncident: { url: 'Not specified' } }]);
+      expect(result).toEqual([{ webPageIncident: {} }]);
     });
 
-    it('returns WEB_PAGE incident with "Not specified" when moreInfoUrl is blank', () => {
+    it('omits url when moreInfoUrl is blank', () => {
       const result = buildInternetDetailsFromOrgSetting('WEB_PAGE', '   ');
-      expect(result).toEqual([{ webPageIncident: { url: 'Not specified' } }]);
+      expect(result).toEqual([{ webPageIncident: {} }]);
+    });
+
+    it('omits url when moreInfoUrl contains whitespace (NCMEC rejects it)', () => {
+      const result = buildInternetDetailsFromOrgSetting(
+        'WEB_PAGE',
+        'Not specified',
+      );
+      expect(result).toEqual([{ webPageIncident: {} }]);
+    });
+
+    it('omits url when moreInfoUrl contains ASCII control characters', () => {
+      const result = buildInternetDetailsFromOrgSetting(
+        'WEB_PAGE',
+        'https://example.com/\x01bad',
+      );
+      expect(result).toEqual([{ webPageIncident: {} }]);
     });
 
     it('returns correct structure for each valid type (no extra fields)', () => {
       expect(buildInternetDetailsFromOrgSetting('EMAIL', undefined)).toEqual([
         { emailIncident: {} },
       ]);
-      expect(buildInternetDetailsFromOrgSetting('NEWSGROUP', undefined)).toEqual([
-        { newsgroupIncident: {} },
-      ]);
+      expect(
+        buildInternetDetailsFromOrgSetting('NEWSGROUP', undefined),
+      ).toEqual([{ newsgroupIncident: {} }]);
       expect(buildInternetDetailsFromOrgSetting('CHAT_IM', undefined)).toEqual([
         { chatImIncident: {} },
       ]);
-      expect(buildInternetDetailsFromOrgSetting('ONLINE_GAMING', undefined)).toEqual([
-        { onlineGamingIncident: {} },
-      ]);
-      expect(buildInternetDetailsFromOrgSetting('CELL_PHONE', undefined)).toEqual([
-        { cellPhoneIncident: {} },
-      ]);
-      expect(buildInternetDetailsFromOrgSetting('NON_INTERNET', undefined)).toEqual([
-        { nonInternetIncident: {} },
-      ]);
-      expect(buildInternetDetailsFromOrgSetting('PEER_TO_PEER', undefined)).toEqual([
-        { peer2peerIncident: {} },
-      ]);
+      expect(
+        buildInternetDetailsFromOrgSetting('ONLINE_GAMING', undefined),
+      ).toEqual([{ onlineGamingIncident: {} }]);
+      expect(
+        buildInternetDetailsFromOrgSetting('CELL_PHONE', undefined),
+      ).toEqual([{ cellPhoneIncident: {} }]);
+      expect(
+        buildInternetDetailsFromOrgSetting('NON_INTERNET', undefined),
+      ).toEqual([{ nonInternetIncident: {} }]);
+      expect(
+        buildInternetDetailsFromOrgSetting('PEER_TO_PEER', undefined),
+      ).toEqual([{ peer2peerIncident: {} }]);
     });
 
     it('trims type before matching', () => {
-      expect(buildInternetDetailsFromOrgSetting('  CHAT_IM  ', undefined)).toEqual([
-        { chatImIncident: {} },
-      ]);
+      expect(
+        buildInternetDetailsFromOrgSetting('  CHAT_IM  ', undefined),
+      ).toEqual([{ chatImIncident: {} }]);
     });
   });
 });

--- a/server/services/ncmecService/ncmecReporting.ts
+++ b/server/services/ncmecService/ncmecReporting.ts
@@ -395,12 +395,9 @@ const NCMEC_INTERNET_DETAIL_TYPES = [
 type NcmecInternetDetailTypeSetting =
   (typeof NCMEC_INTERNET_DETAIL_TYPES)[number];
 
-/**
- * Pull the documented NCMEC status fields out of a parsed response body
- * regardless of which wrapper element (`reportResponse`, `uploadResponse`,
- * `fileinfoResponse`, ...) NCMEC used. Returns `undefined` if neither field
- * is present so callers can fall back to a minimal error message.
- */
+/** Extract NCMEC's `responseCode`/`responseDescription` from any wrapper
+ * element (`reportResponse`, `uploadResponse`, ...). Either field may be
+ * `undefined` when not present. */
 function extractNcmecResponseStatus(body: unknown): {
   responseCode?: string;
   responseDescription?: string;
@@ -442,13 +439,9 @@ function extractNcmecResponseStatus(body: unknown): {
   return {};
 }
 
-/**
- * Build an error message for a non-2xx CyberTip response. In production we
- * surface only NCMEC's documented `responseCode` / `responseDescription`
- * (per coding rules: don't echo arbitrary upstream bodies into logs/errors,
- * they may contain reportable content). With `NCMEC_DEBUG=1` the full
- * truncated body is appended for local diagnosis.
- */
+/** Error message for a failed CyberTip response. In production only NCMEC's
+ * documented codes are surfaced (the body may echo reportable content); the
+ * full truncated body is appended only with `NCMEC_DEBUG=1`. */
 export function summarizeCyberTipFailure(
   route: string,
   status: number,
@@ -479,19 +472,14 @@ export function summarizeCyberTipFailure(
   return parts.join(', ');
 }
 
-/**
- * Clamp a media `createdAt` ISO timestamp to "now - 1s" if it's in the future
- * against our wall clock. NCMEC rejects `<incidentDateTime>` values that are
- * ahead of their server clock; this absorbs small skew while preserving the
- * caller's original timestamp when it's already in the past.
- *
- * Uses numeric `Date` comparison (not lexicographic string compare) so it
- * stays correct for non-canonical ISO inputs (e.g. timezone offsets, no `Z`).
- */
+/** Clamp a `createdAt` ISO to "now - 1s" if it's ahead of our clock — NCMEC
+ * rejects `<incidentDateTime>` in the future. `value` is always canonicalized
+ * to UTC ISO; `wasClamped` reflects the numeric (not string) comparison so
+ * callers don't misreport plain UTC normalization as a clamp. */
 export function clampIncidentDateTimeToPast(
   maxCreatedAt: string,
   nowMs: number = Date.now(),
-): string {
+): { value: string; wasClamped: boolean } {
   const maxCreatedAtMs = new Date(maxCreatedAt).getTime();
   if (Number.isNaN(maxCreatedAtMs)) {
     throw new Error(
@@ -499,7 +487,12 @@ export function clampIncidentDateTimeToPast(
     );
   }
   const ceilingMs = nowMs - 1000;
-  return new Date(Math.min(maxCreatedAtMs, ceilingMs)).toISOString();
+  const wasClamped = maxCreatedAtMs > ceilingMs;
+  const finalMs = wasClamped ? ceilingMs : maxCreatedAtMs;
+  return {
+    value: new Date(finalMs).toISOString(),
+    wasClamped,
+  };
 }
 
 export function buildInternetDetailsFromOrgSetting(
@@ -1334,9 +1327,9 @@ export default class NcmecReporting {
             throw new Error('No media in report');
           }
 
-          const clampedIncidentDateTime =
+          const { value: clampedIncidentDateTime, wasClamped } =
             clampIncidentDateTimeToPast(maxCreatedAt);
-          if (clampedIncidentDateTime !== maxCreatedAt) {
+          if (wasClamped) {
             ncmecDebugLog('incidentDateTime.clamped', {
               originalCreatedAt: maxCreatedAt,
               clampedTo: clampedIncidentDateTime,

--- a/server/services/ncmecService/ncmecReporting.ts
+++ b/server/services/ncmecService/ncmecReporting.ts
@@ -2,7 +2,7 @@
 import type { Exception } from '@opentelemetry/api';
 import { makeEnumLike, type ItemIdentifier } from '@roostorg/types';
 import _Ajv from 'ajv';
-import { type Kysely } from 'kysely';
+import { sql, type Kysely } from 'kysely';
 import _ from 'lodash';
 import { FormData } from 'undici';
 import { js2xml } from 'xml-js';
@@ -189,6 +189,8 @@ export type NCMECReportParams = {
   escalateToHighPriority?: string;
   /** Optional free-text notes; if present must be non-blank and max 3000 chars. */
   additionalInfo?: string;
+  /** MRT decision id; when set, failures are recorded to `ncmec_reports_errors`. */
+  jobId?: string;
 };
 
 // Key insertion order in these object literals must match the NCMEC XSD
@@ -1651,6 +1653,17 @@ export default class NcmecReporting {
             message: jsonStringify({ reportParams, isTest }),
           });
           span.recordException(e as Exception);
+          if (reportParams.jobId !== undefined) {
+            await this.#recordSubmissionError({
+              jobId: reportParams.jobId,
+              userId: reportParams.reportedUser.id,
+              userTypeId: reportParams.reportedUser.typeId,
+              error:
+                e instanceof Error
+                  ? e.message
+                  : 'Unknown NCMEC submission error',
+            });
+          }
           return 'FAILURE';
         }
       },
@@ -2059,6 +2072,52 @@ export default class NcmecReporting {
 
     const responseJson = response.body as CyberTipFinishResponse;
     return responseJson.reportDoneResponse.reportId;
+  }
+
+  /** Best-effort write of a failed-submission row. Swallows its own DB errors
+   * so a follow-on failure can't turn a NCMEC FAILURE into an unhandled
+   * exception. */
+  async #recordSubmissionError(opts: {
+    jobId: string;
+    userId: string;
+    userTypeId: string;
+    error: string;
+  }) {
+    try {
+      // user_id/user_type_id are varchar(255); trim so an over-long org id
+      // can't make this failure-recording write itself fail.
+      const safeUserId = opts.userId.slice(0, 255);
+      const safeUserTypeId = opts.userTypeId.slice(0, 255);
+      // Atomic increment in `doUpdateSet` avoids the read-modify-write race
+      // when two retries land on the same job_id concurrently.
+      await this.pgQuery
+        .insertInto('ncmec_reporting.ncmec_reports_errors')
+        .values({
+          job_id: opts.jobId,
+          user_id: safeUserId,
+          user_type_id: safeUserTypeId,
+          status: 'RETRYABLE_ERROR',
+          last_error: opts.error,
+          retry_count: 1,
+        })
+        .onConflict((oc) =>
+          oc.columns(['job_id']).doUpdateSet({
+            retry_count: sql`ncmec_reporting.ncmec_reports_errors.retry_count + 1`,
+            last_error: opts.error,
+            status: 'RETRYABLE_ERROR',
+          }),
+        )
+        .execute();
+    } catch (e: unknown) {
+      // eslint-disable-next-line no-restricted-syntax
+      logErrorJson({
+        error: e,
+        message: jsonStringify({
+          context: 'recordSubmissionError',
+          jobId: opts.jobId,
+        }),
+      });
+    }
   }
 
   async #sendCyberTipRequest(input: {

--- a/server/services/ncmecService/ncmecReporting.ts
+++ b/server/services/ncmecService/ncmecReporting.ts
@@ -1317,6 +1317,16 @@ export default class NcmecReporting {
           }
 
           if (testOrgs.includes(reportParams.orgId)) {
+            if (reportParams.jobId !== undefined) {
+              await this.#recordSubmissionError({
+                jobId: reportParams.jobId,
+                userId: reportParams.reportedUser.id,
+                userTypeId: reportParams.reportedUser.typeId,
+                status: 'PERMANENT_ERROR',
+                error:
+                  'Org is on the NCMEC test allowlist; reports are suppressed.',
+              });
+            }
             return 'UNSUPPORTED_ORG';
           }
 
@@ -1405,6 +1415,16 @@ export default class NcmecReporting {
               ),
           );
           if (additionalInfo === 'ALL_MEDIA_MISSING') {
+            if (reportParams.jobId !== undefined) {
+              await this.#recordSubmissionError({
+                jobId: reportParams.jobId,
+                userId: reportParams.reportedUser.id,
+                userTypeId: reportParams.reportedUser.typeId,
+                status: 'PERMANENT_ERROR',
+                error:
+                  'All reportable media is missing from storage; nothing to submit.',
+              });
+            }
             return 'ALL_MEDIA_MISSING';
           }
           // This should be validated in getNCMECAdditionalInfo so the ! is safe
@@ -2082,12 +2102,14 @@ export default class NcmecReporting {
     userId: string;
     userTypeId: string;
     error: string;
+    status?: 'RETRYABLE_ERROR' | 'PERMANENT_ERROR';
   }) {
     try {
       // user_id/user_type_id are varchar(255); trim so an over-long org id
       // can't make this failure-recording write itself fail.
       const safeUserId = opts.userId.slice(0, 255);
       const safeUserTypeId = opts.userTypeId.slice(0, 255);
+      const status = opts.status ?? 'RETRYABLE_ERROR';
       // Atomic increment in `doUpdateSet` avoids the read-modify-write race
       // when two retries land on the same job_id concurrently.
       await this.pgQuery
@@ -2096,7 +2118,7 @@ export default class NcmecReporting {
           job_id: opts.jobId,
           user_id: safeUserId,
           user_type_id: safeUserTypeId,
-          status: 'RETRYABLE_ERROR',
+          status,
           last_error: opts.error,
           retry_count: 1,
         })
@@ -2104,7 +2126,7 @@ export default class NcmecReporting {
           oc.columns(['job_id']).doUpdateSet({
             retry_count: sql`ncmec_reporting.ncmec_reports_errors.retry_count + 1`,
             last_error: opts.error,
-            status: 'RETRYABLE_ERROR',
+            status,
           }),
         )
         .execute();

--- a/server/services/ncmecService/ncmecReporting.ts
+++ b/server/services/ncmecService/ncmecReporting.ts
@@ -1289,16 +1289,25 @@ export default class NcmecReporting {
       },
       // eslint-disable-next-line complexity
       async (span) => {
-        span.setAttribute(`ncmecReportParams`, jsonStringify(reportParams));
-        ncmecDebugLog('submitReport.start', {
-          isTest,
+        const logSafeReportParams = {
           orgId: reportParams.orgId,
+          reviewerId: reportParams.reviewerId,
           reportedUserId: reportParams.reportedUser.id,
+          reportedUserTypeId: reportParams.reportedUser.typeId,
           mediaCount: reportParams.media.length,
           threadsCount: reportParams.threads.length,
           incidentType: reportParams.incidentType,
-          hasEscalation: Boolean(reportParams.escalateToHighPriority),
-          hasAdditionalInfo: Boolean(reportParams.additionalInfo),
+          hasEscalation: Boolean(reportParams.escalateToHighPriority?.trim()),
+          hasAdditionalInfo: Boolean(reportParams.additionalInfo?.trim()),
+          jobId: reportParams.jobId,
+        };
+        span.setAttribute(
+          `ncmecReportParams`,
+          jsonStringify(logSafeReportParams),
+        );
+        ncmecDebugLog('submitReport.start', {
+          isTest,
+          ...logSafeReportParams,
         });
 
         // We try/catch this whole process in order to do custom logging on
@@ -1330,14 +1339,22 @@ export default class NcmecReporting {
             return 'UNSUPPORTED_ORG';
           }
 
-          const maxCreatedAt = _.maxBy(
-            reportParams.media,
-            'createdAt',
-          )?.createdAt;
-
-          if (!maxCreatedAt) {
+          if (reportParams.media.length === 0) {
             throw new Error('No media in report');
           }
+          const latestMedia = _.maxBy(reportParams.media, (m) => {
+            const ms = Date.parse(m.createdAt);
+            if (Number.isNaN(ms)) {
+              throw new Error(
+                `Invalid media createdAt timestamp for incidentDateTime: ${m.createdAt}`,
+              );
+            }
+            return ms;
+          });
+          if (latestMedia === undefined) {
+            throw new Error('No media in report');
+          }
+          const maxCreatedAt = latestMedia.createdAt;
 
           const { value: clampedIncidentDateTime, wasClamped } =
             clampIncidentDateTimeToPast(maxCreatedAt);
@@ -1670,7 +1687,10 @@ export default class NcmecReporting {
           // eslint-disable-next-line no-restricted-syntax
           logErrorJson({
             error: e,
-            message: jsonStringify({ reportParams, isTest }),
+            message: jsonStringify({
+              reportParams: logSafeReportParams,
+              isTest,
+            }),
           });
           span.recordException(e as Exception);
           if (reportParams.jobId !== undefined) {
@@ -2105,10 +2125,6 @@ export default class NcmecReporting {
     status?: 'RETRYABLE_ERROR' | 'PERMANENT_ERROR';
   }) {
     try {
-      // user_id/user_type_id are varchar(255); trim so an over-long org id
-      // can't make this failure-recording write itself fail.
-      const safeUserId = opts.userId.slice(0, 255);
-      const safeUserTypeId = opts.userTypeId.slice(0, 255);
       const status = opts.status ?? 'RETRYABLE_ERROR';
       // Atomic increment in `doUpdateSet` avoids the read-modify-write race
       // when two retries land on the same job_id concurrently.
@@ -2116,8 +2132,8 @@ export default class NcmecReporting {
         .insertInto('ncmec_reporting.ncmec_reports_errors')
         .values({
           job_id: opts.jobId,
-          user_id: safeUserId,
-          user_type_id: safeUserTypeId,
+          user_id: opts.userId,
+          user_type_id: opts.userTypeId,
           status,
           last_error: opts.error,
           retry_count: 1,

--- a/server/services/ncmecService/ncmecReporting.ts
+++ b/server/services/ncmecService/ncmecReporting.ts
@@ -32,7 +32,11 @@ import {
   type FormDataLikeWithStreams,
 } from '../networkingService/index.js';
 import { type NcmecReportingServicePg } from './dbTypes.js';
-import { ncmecDebugDump, ncmecDebugLog } from './ncmecDebug.js';
+import {
+  ncmecDebugDump,
+  ncmecDebugEnabled,
+  ncmecDebugLog,
+} from './ncmecDebug.js';
 
 export const NCMECEvent = makeEnumLike([
   'Login',
@@ -390,6 +394,113 @@ const NCMEC_INTERNET_DETAIL_TYPES = [
 ] as const;
 type NcmecInternetDetailTypeSetting =
   (typeof NCMEC_INTERNET_DETAIL_TYPES)[number];
+
+/**
+ * Pull the documented NCMEC status fields out of a parsed response body
+ * regardless of which wrapper element (`reportResponse`, `uploadResponse`,
+ * `fileinfoResponse`, ...) NCMEC used. Returns `undefined` if neither field
+ * is present so callers can fall back to a minimal error message.
+ */
+function extractNcmecResponseStatus(body: unknown): {
+  responseCode?: string;
+  responseDescription?: string;
+} {
+  if (!body || typeof body !== 'object') {
+    return {};
+  }
+  const readText = (value: unknown): string | undefined => {
+    if (typeof value === 'string') {
+      return value;
+    }
+    if (
+      value &&
+      typeof value === 'object' &&
+      '_text' in (value as Record<string, unknown>)
+    ) {
+      const inner = (value as { _text: unknown })._text;
+      return typeof inner === 'string' ? inner : undefined;
+    }
+    return undefined;
+  };
+  const truncate = (value: string | undefined): string | undefined =>
+    value && value.length > 200 ? `${value.slice(0, 200)}…` : value;
+
+  for (const wrapper of Object.values(body as Record<string, unknown>)) {
+    if (!wrapper || typeof wrapper !== 'object') {
+      continue;
+    }
+    const obj = wrapper as Record<string, unknown>;
+    const responseCode = readText(obj.responseCode);
+    const responseDescription = readText(obj.responseDescription);
+    if (responseCode != null || responseDescription != null) {
+      return {
+        responseCode,
+        responseDescription: truncate(responseDescription),
+      };
+    }
+  }
+  return {};
+}
+
+/**
+ * Build an error message for a non-2xx CyberTip response. In production we
+ * surface only NCMEC's documented `responseCode` / `responseDescription`
+ * (per coding rules: don't echo arbitrary upstream bodies into logs/errors,
+ * they may contain reportable content). With `NCMEC_DEBUG=1` the full
+ * truncated body is appended for local diagnosis.
+ */
+export function summarizeCyberTipFailure(
+  route: string,
+  status: number,
+  body: unknown,
+): string {
+  const { responseCode, responseDescription } =
+    extractNcmecResponseStatus(body);
+  const parts: string[] = [
+    `CyberTip request to ${route} failed: status=${status}`,
+  ];
+  if (responseCode != null) {
+    parts.push(`responseCode=${responseCode}`);
+  }
+  if (responseDescription != null) {
+    parts.push(`responseDescription=${responseDescription}`);
+  }
+  if (ncmecDebugEnabled()) {
+    let snippet: string;
+    try {
+      const serialized = jsonStringify(body ?? null);
+      snippet =
+        serialized.length > 500 ? `${serialized.slice(0, 500)}…` : serialized;
+    } catch {
+      snippet = '<unserializable>';
+    }
+    parts.push(`body=${snippet}`);
+  }
+  return parts.join(', ');
+}
+
+/**
+ * Clamp a media `createdAt` ISO timestamp to "now - 1s" if it's in the future
+ * against our wall clock. NCMEC rejects `<incidentDateTime>` values that are
+ * ahead of their server clock; this absorbs small skew while preserving the
+ * caller's original timestamp when it's already in the past.
+ *
+ * Uses numeric `Date` comparison (not lexicographic string compare) so it
+ * stays correct for non-canonical ISO inputs (e.g. timezone offsets, no `Z`).
+ */
+export function clampIncidentDateTimeToPast(
+  maxCreatedAt: string,
+  nowMs: number = Date.now(),
+): string {
+  const maxCreatedAtMs = new Date(maxCreatedAt).getTime();
+  if (Number.isNaN(maxCreatedAtMs)) {
+    throw new Error(
+      `Invalid media createdAt timestamp for incidentDateTime: ${maxCreatedAt}`,
+    );
+  }
+  const ceilingMs = nowMs - 1000;
+  return new Date(Math.min(maxCreatedAtMs, ceilingMs)).toISOString();
+}
 
 export function buildInternetDetailsFromOrgSetting(
   defaultInternetDetailType: string | null | undefined,
@@ -1223,11 +1334,8 @@ export default class NcmecReporting {
             throw new Error('No media in report');
           }
 
-          // NCMEC requires `<incidentDateTime>` be in the past against their
-          // server clock; clamp to "now - 1s" to absorb clock skew.
-          const nowMinusOneSec = new Date(Date.now() - 1000).toISOString();
           const clampedIncidentDateTime =
-            maxCreatedAt > nowMinusOneSec ? nowMinusOneSec : maxCreatedAt;
+            clampIncidentDateTimeToPast(maxCreatedAt);
           if (clampedIncidentDateTime !== maxCreatedAt) {
             ncmecDebugLog('incidentDateTime.clamped', {
               originalCreatedAt: maxCreatedAt,
@@ -2018,19 +2126,8 @@ export default class NcmecReporting {
         });
 
         if (!response.ok) {
-          // Don't log the request body/headers: they contain reportable content and basic-auth.
-          const responseSnippet = (() => {
-            try {
-              const serialized = jsonStringify(response.body ?? null);
-              return serialized.length > 500
-                ? `${serialized.slice(0, 500)}…`
-                : serialized;
-            } catch {
-              return '<unserializable>';
-            }
-          })();
           throw new Error(
-            `CyberTip request to ${route} failed: status=${response.status}, body=${responseSnippet}`,
+            summarizeCyberTipFailure(route, response.status, response.body),
           );
         }
         return response;

--- a/server/services/ncmecService/ncmecReporting.ts
+++ b/server/services/ncmecService/ncmecReporting.ts
@@ -4,7 +4,7 @@ import { makeEnumLike, type ItemIdentifier } from '@roostorg/types';
 import _Ajv from 'ajv';
 import { type Kysely } from 'kysely';
 import _ from 'lodash';
-import { type FormData as FormDataType } from 'undici';
+import { FormData } from 'undici';
 import { js2xml } from 'xml-js';
 
 import { type Dependencies } from '../../iocContainer/index.js';
@@ -32,6 +32,7 @@ import {
   type FormDataLikeWithStreams,
 } from '../networkingService/index.js';
 import { type NcmecReportingServicePg } from './dbTypes.js';
+import { ncmecDebugDump, ncmecDebugLog } from './ncmecDebug.js';
 
 export const NCMECEvent = makeEnumLike([
   'Login',
@@ -113,6 +114,8 @@ type NCMECPerson = {
   deviceId?: DeviceNCMECEvent[];
 };
 
+// Key insertion order must match the NCMEC XSD `<fileDetails>` sequence
+// (Appendix C); see the `Report` type comment for why this matters.
 type FileDetails = {
   fileDetails: {
     reportId: number;
@@ -180,8 +183,13 @@ export type NCMECReportParams = {
   incidentType: string;
   /** Optional reason for higher urgency; if present must be non-blank and max 3000 chars. */
   escalateToHighPriority?: string;
+  /** Optional free-text notes; if present must be non-blank and max 3000 chars. */
+  additionalInfo?: string;
 };
 
+// Key insertion order in these object literals must match the NCMEC XSD
+// sequence (Appendix B): js2xml emits children in insertion order, and NCMEC
+// rejects out-of-order submissions with responseCode=4100.
 type Report = {
   report: {
     incidentSummary: {
@@ -193,7 +201,7 @@ type Report = {
     internetDetails?: (
       | {
           webPageIncident: {
-            url: string;
+            url?: string;
             additionalInfo?: string;
             thirdPartyHostedContent?: boolean;
           };
@@ -395,12 +403,20 @@ export function buildInternetDetailsFromOrgSetting(
   if (!NCMEC_INTERNET_DETAIL_TYPES.includes(type)) {
     return undefined;
   }
-  // Use || so blank/empty URL becomes 'Not specified' (?? would keep '')
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- intentional: empty string should fallback
-  const webPageUrl = moreInfoUrl?.trim() || 'Not specified';
+  // NCMEC returns 4100 if `<url>` contains whitespace or control chars; since
+  // the element is optional per the XSD, omit it unless we have a clean value.
+  // eslint-disable-next-line no-control-regex
+  const URL_INVALID_CHARS = /[\s\u0000-\u001f\u007f]/;
+  const trimmedUrl = moreInfoUrl?.trim();
+  const webPageUrl =
+    trimmedUrl && !URL_INVALID_CHARS.test(trimmedUrl) ? trimmedUrl : undefined;
   switch (type) {
     case 'WEB_PAGE':
-      return [{ webPageIncident: { url: webPageUrl } }];
+      return [
+        {
+          webPageIncident: webPageUrl ? { url: webPageUrl } : {},
+        },
+      ];
     case 'EMAIL':
       return [{ emailIncident: {} }];
     case 'NEWSGROUP':
@@ -802,13 +818,12 @@ export default class NcmecReporting {
   > {
     const row = await this.pgQuery
       .selectFrom('ncmec_reporting.ncmec_org_settings')
+      .selectAll()
       .where('org_id', '=', orgId)
       .executeTakeFirst();
-    if (!row) {
-      return undefined;
-    }
-
-    return row as NcmecReportingServicePg['ncmec_reporting.ncmec_org_settings'];
+    return row as
+      | NcmecReportingServicePg['ncmec_reporting.ncmec_org_settings']
+      | undefined;
   }
 
   async getNCMECActionsToRunAndPolicies(
@@ -901,9 +916,8 @@ export default class NcmecReporting {
     reportedUsers: ItemIdentifier[],
     reportedMedia: readonly ItemIdentifier[],
   ): Promise<NcmecAdditionalInfo | 'ALL_MEDIA_MISSING'> {
-    const additionalInfoEndpoint = await this.ncmecAdditionalInfoEndpoint(
-      orgId,
-    );
+    const additionalInfoEndpoint =
+      await this.ncmecAdditionalInfoEndpoint(orgId);
 
     // If no additional info endpoint is configured, return minimal default data
     if (!additionalInfoEndpoint) {
@@ -1081,9 +1095,8 @@ export default class NcmecReporting {
     reportId: number;
   }) {
     const { orgId, user, reportedMedia, reportId } = input;
-    const ncmecPreservationEndpoint = await this.ncmecPreservationEndpoint(
-      orgId,
-    );
+    const ncmecPreservationEndpoint =
+      await this.ncmecPreservationEndpoint(orgId);
 
     if (ncmecPreservationEndpoint == null) {
       throw new Error(
@@ -1171,6 +1184,16 @@ export default class NcmecReporting {
       // eslint-disable-next-line complexity
       async (span) => {
         span.setAttribute(`ncmecReportParams`, jsonStringify(reportParams));
+        ncmecDebugLog('submitReport.start', {
+          isTest,
+          orgId: reportParams.orgId,
+          reportedUserId: reportParams.reportedUser.id,
+          mediaCount: reportParams.media.length,
+          threadsCount: reportParams.threads.length,
+          incidentType: reportParams.incidentType,
+          hasEscalation: Boolean(reportParams.escalateToHighPriority),
+          hasAdditionalInfo: Boolean(reportParams.additionalInfo),
+        });
 
         // We try/catch this whole process in order to do custom logging on
         // failure, since we can't guarantee all traces with exceptions are
@@ -1191,11 +1214,25 @@ export default class NcmecReporting {
             return 'UNSUPPORTED_ORG';
           }
 
-          const maxCreatedAt = _.maxBy(reportParams.media, 'createdAt')
-            ?.createdAt;
+          const maxCreatedAt = _.maxBy(
+            reportParams.media,
+            'createdAt',
+          )?.createdAt;
 
           if (!maxCreatedAt) {
             throw new Error('No media in report');
+          }
+
+          // NCMEC requires `<incidentDateTime>` be in the past against their
+          // server clock; clamp to "now - 1s" to absorb clock skew.
+          const nowMinusOneSec = new Date(Date.now() - 1000).toISOString();
+          const clampedIncidentDateTime =
+            maxCreatedAt > nowMinusOneSec ? nowMinusOneSec : maxCreatedAt;
+          if (clampedIncidentDateTime !== maxCreatedAt) {
+            ncmecDebugLog('incidentDateTime.clamped', {
+              originalCreatedAt: maxCreatedAt,
+              clampedTo: clampedIncidentDateTime,
+            });
           }
 
           const cybertipAuthenticationCredentials =
@@ -1294,76 +1331,94 @@ export default class NcmecReporting {
             );
           }
 
+          const reportAdditionalInfo =
+            reportParams.additionalInfo != null
+              ? reportParams.additionalInfo.trim()
+              : undefined;
+          if (
+            reportAdditionalInfo !== undefined &&
+            (reportAdditionalInfo === '' || reportAdditionalInfo.length > 3000)
+          ) {
+            throw new Error(
+              'additionalInfo must be non-blank when supplied and at most 3000 characters',
+            );
+          }
+
           const internetDetails = buildInternetDetailsFromOrgSetting(
             queryResponse.defaultInternetDetailType,
             ncmecConfig?.more_info_url,
           );
 
+          const reportingPersonEmail = ncmecConfig?.contact_email?.trim();
+          if (!reportingPersonEmail) {
+            throw new Error(
+              'NCMEC report requires a non-empty reporter contact email; configure it in Settings → NCMEC.',
+            );
+          }
+
+          const contactPersonEmail = queryResponse.contactPersonEmail?.trim();
+          const contactPersonFirstName =
+            queryResponse.contactPersonFirstName?.trim();
+          const contactPersonLastName =
+            queryResponse.contactPersonLastName?.trim();
+          const contactPersonPhone = queryResponse.contactPersonPhone?.trim();
+          const contactPerson =
+            contactPersonEmail ||
+            contactPersonFirstName ||
+            contactPersonLastName ||
+            contactPersonPhone
+              ? {
+                  ...(contactPersonFirstName
+                    ? { firstName: contactPersonFirstName }
+                    : {}),
+                  ...(contactPersonLastName
+                    ? { lastName: contactPersonLastName }
+                    : {}),
+                  ...(contactPersonPhone
+                    ? { phone: { _text: contactPersonPhone } }
+                    : {}),
+                  ...(contactPersonEmail
+                    ? { email: [emailStringToNCMECEmail(contactPersonEmail)] }
+                    : {}),
+                }
+              : undefined;
+
+          const termsOfService =
+            queryResponse.termsOfService != null &&
+            queryResponse.termsOfService.trim() !== '' &&
+            queryResponse.termsOfService.length <= 3000
+              ? queryResponse.termsOfService.trim()
+              : undefined;
+
+          const reportedPersonEmail =
+            userAdditionalInfo.email && userAdditionalInfo.email.length > 0
+              ? userAdditionalInfo.email
+              : undefined;
+          const personOrUserReportedPerson = reportedPersonEmail
+            ? { email: reportedPersonEmail }
+            : undefined;
+
           const report: Report = {
             report: {
               incidentSummary: {
                 incidentType,
-                incidentDateTime: maxCreatedAt,
                 ...(escalateToHighPriority ? { escalateToHighPriority } : {}),
+                incidentDateTime: clampedIncidentDateTime,
               },
               ...(internetDetails ? { internetDetails } : {}),
               reporter: {
                 reportingPerson: {
-                  email: [
-                    emailStringToNCMECEmail(ncmecConfig?.contact_email ?? ''),
-                  ],
+                  email: [emailStringToNCMECEmail(reportingPersonEmail)],
                 },
+                ...(contactPerson ? { contactPerson } : {}),
                 companyTemplate: queryResponse.companyTemplate,
+                ...(termsOfService ? { termsOfService } : {}),
                 legalURL: queryResponse.legalURL,
-                ...(queryResponse.termsOfService != null &&
-                queryResponse.termsOfService.trim() !== '' &&
-                queryResponse.termsOfService.length <= 3000
-                  ? { termsOfService: queryResponse.termsOfService.trim() }
-                  : {}),
-                // Use || so we only add contactPerson when at least one field is non-empty (?? would use first non-null even if empty)
-
-                ...(queryResponse.contactPersonEmail?.trim() ||
-                queryResponse.contactPersonFirstName?.trim() ||
-                queryResponse.contactPersonLastName?.trim() ||
-                queryResponse.contactPersonPhone?.trim()
-                  ? {
-                      contactPerson: {
-                        ...(queryResponse.contactPersonEmail?.trim()
-                          ? {
-                              email: [
-                                emailStringToNCMECEmail(
-                                  queryResponse.contactPersonEmail.trim(),
-                                ),
-                              ],
-                            }
-                          : {}),
-                        ...(queryResponse.contactPersonFirstName?.trim()
-                          ? {
-                              firstName:
-                                queryResponse.contactPersonFirstName.trim(),
-                            }
-                          : {}),
-                        ...(queryResponse.contactPersonLastName?.trim()
-                          ? {
-                              lastName:
-                                queryResponse.contactPersonLastName.trim(),
-                            }
-                          : {}),
-                        ...(queryResponse.contactPersonPhone?.trim()
-                          ? {
-                              phone: {
-                                _text: queryResponse.contactPersonPhone.trim(),
-                              },
-                            }
-                          : {}),
-                      },
-                    }
-                  : {}),
               },
               personOrUserReported: {
-                personOrUserReportedPerson: {
-                  email: userAdditionalInfo.email,
-                },
+                ...(personOrUserReportedPerson
+                  ? { personOrUserReportedPerson }
+                  : {}),
                 espIdentifier: reportParams.reportedUser.id,
                 espService: queryResponse.companyTemplate,
                 screenName: userAdditionalInfo.screenName,
@@ -1377,6 +1432,9 @@ export default class NcmecReporting {
                   ? { ipCaptureEvent: userAdditionalInfo.ipCaptureEvent }
                   : {}),
               },
+              ...(reportAdditionalInfo !== undefined
+                ? { additionalInfo: reportAdditionalInfo }
+                : {}),
             },
           };
 
@@ -1485,16 +1543,7 @@ export default class NcmecReporting {
           // We are intentionally using logErrorJson instead of relying on
           // safeTracer's logging because those logs are sampled in DD. For
           // NCMEC submission errors we need to record all failures and be
-          // able to see the logs
-
-          // eslint-disable-next-line no-console
-          console.error('[NCMEC] ❌ Error during report submission:', e);
-          // eslint-disable-next-line no-console
-          console.error('[NCMEC] Error details:', {
-            message: e instanceof Error ? e.message : String(e),
-            stack: e instanceof Error ? e.stack : undefined,
-          });
-
+          // able to see the logs.
           // eslint-disable-next-line no-restricted-syntax
           logErrorJson({
             error: e,
@@ -1589,28 +1638,13 @@ export default class NcmecReporting {
   ) {
     const reportXML = js2xml(report, { compact: true });
 
-    // Save XML to file for review (development only)
-    if (process.env.NODE_ENV === 'development') {
-      try {
-        const fs = await import('fs/promises');
-        const path = await import('path');
-
-        // Create ncmec-reports directory if it doesn't exist
-        const reportsDir = path.join(process.cwd(), 'ncmec-reports');
-        await fs.mkdir(reportsDir, { recursive: true });
-
-        // Generate filename with timestamp and test indicator
-        const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-        const testPrefix = isTest ? 'TEST-' : 'PROD-';
-        const filename = `${testPrefix}${timestamp}.xml`;
-        const filepath = path.join(reportsDir, filename);
-
-        // Write XML to file
-        await fs.writeFile(filepath, reportXML, 'utf-8');
-      } catch (e) {
-        // Silent fail - don't let file saving break the submission
-      }
-    }
+    ncmecDebugLog('submit.xml', { isTest, length: reportXML.length });
+    await ncmecDebugDump(
+      `${isTest ? 'TEST-' : 'PROD-'}${new Date()
+        .toISOString()
+        .replace(/[:.]/g, '-')}-submit.xml`,
+      reportXML,
+    );
 
     const response = await this.#sendCyberTipRequest({
       cybertipAuthenticationCredentials,
@@ -1621,14 +1655,10 @@ export default class NcmecReporting {
 
     const responseJson = response.body as CyberTipSubmitResponse;
     if (responseJson.reportResponse.responseCode._text !== '0') {
-      throw new Error('NCMEC report submission failed.');
+      throw new Error(
+        `NCMEC report submission failed: responseCode=${responseJson.reportResponse.responseCode._text}`,
+      );
     }
-
-    // eslint-disable-next-line no-console
-    console.log(
-      '[NCMEC] ✅ Report submitted successfully! Report ID:',
-      responseJson.reportResponse.reportId._text,
-    );
 
     return {
       reportId: responseJson.reportResponse.reportId._text,
@@ -1686,23 +1716,21 @@ export default class NcmecReporting {
       throw new Error('NCMEC file upload failed.');
     }
     const fileId = responseJson.reportResponse.fileId._text;
+    const fileAnnotations = this.#fileAnnotationArrayToNCMECFileAnnotation(
+      media.fileAnnotations,
+    );
     const xml = await this.#uploadFileDetails(
       {
         fileDetails: {
           reportId: parseInt(reportId),
           fileId,
-          // All reported content is reviewed by the ESP before submission.
           fileViewedByEsp: true,
           exifViewedByEsp: true,
-          fileAnnotations: this.#fileAnnotationArrayToNCMECFileAnnotation(
-            media.fileAnnotations,
-          ),
-          industryClassification: media.industryClassification,
           ...(additionalInfo.publiclyAvailable !== undefined
             ? { publiclyAvailable: additionalInfo.publiclyAvailable }
             : {}),
-          // Annoyingly, NCMEC only accepts IP Address XML in order so unwrap it
-          // in the correct order in case it was passed in incorrectly
+          ...(fileAnnotations ? { fileAnnotations } : {}),
+          industryClassification: media.industryClassification,
           ...(additionalInfo.ipCaptureEvent &&
           additionalInfo.ipCaptureEvent.length > 0
             ? {
@@ -1735,61 +1763,42 @@ export default class NcmecReporting {
 
   #fileAnnotationArrayToNCMECFileAnnotation(
     fileAnnotations?: readonly NCMECFileAnnotationType[],
-  ): FileAnnotations {
+  ): FileAnnotations | undefined {
+    if (!fileAnnotations || fileAnnotations.length === 0) {
+      return undefined;
+    }
     return {
-      ...(fileAnnotations?.includes(
+      ...(fileAnnotations.includes(
         NCMECFileAnnotation.ANIME_DRAWING_VIRTUAL_HENTAI,
       )
-        ? {
-            animeDrawingVirtualHentai: undefined,
-          }
+        ? { animeDrawingVirtualHentai: undefined }
         : {}),
-      ...(fileAnnotations?.includes(NCMECFileAnnotation.POTENTIAL_MEME)
-        ? {
-            potentialMeme: undefined,
-          }
+      ...(fileAnnotations.includes(NCMECFileAnnotation.POTENTIAL_MEME)
+        ? { potentialMeme: undefined }
         : {}),
-      ...(fileAnnotations?.includes(NCMECFileAnnotation.VIRAL)
-        ? {
-            viral: undefined,
-          }
+      ...(fileAnnotations.includes(NCMECFileAnnotation.VIRAL)
+        ? { viral: undefined }
         : {}),
-      ...(fileAnnotations?.includes(
-        NCMECFileAnnotation.POSSIBLE_SELF_PRODUCTION,
-      )
-        ? {
-            possibleSelfProduction: undefined,
-          }
+      ...(fileAnnotations.includes(NCMECFileAnnotation.POSSIBLE_SELF_PRODUCTION)
+        ? { possibleSelfProduction: undefined }
         : {}),
-      ...(fileAnnotations?.includes(NCMECFileAnnotation.PHYSICAL_HARM)
-        ? {
-            physicalHarm: undefined,
-          }
+      ...(fileAnnotations.includes(NCMECFileAnnotation.PHYSICAL_HARM)
+        ? { physicalHarm: undefined }
         : {}),
-      ...(fileAnnotations?.includes(NCMECFileAnnotation.VIOLENCE_GORE)
-        ? {
-            violenceGore: undefined,
-          }
+      ...(fileAnnotations.includes(NCMECFileAnnotation.VIOLENCE_GORE)
+        ? { violenceGore: undefined }
         : {}),
-      ...(fileAnnotations?.includes(NCMECFileAnnotation.BESTIALITY)
-        ? {
-            bestiality: undefined,
-          }
+      ...(fileAnnotations.includes(NCMECFileAnnotation.BESTIALITY)
+        ? { bestiality: undefined }
         : {}),
-      ...(fileAnnotations?.includes(NCMECFileAnnotation.LIVE_STREAMING)
-        ? {
-            liveStreaming: undefined,
-          }
+      ...(fileAnnotations.includes(NCMECFileAnnotation.LIVE_STREAMING)
+        ? { liveStreaming: undefined }
         : {}),
-      ...(fileAnnotations?.includes(NCMECFileAnnotation.INFANT)
-        ? {
-            infant: undefined,
-          }
+      ...(fileAnnotations.includes(NCMECFileAnnotation.INFANT)
+        ? { infant: undefined }
         : {}),
-      ...(fileAnnotations?.includes(NCMECFileAnnotation.GENERATIVE_AI)
-        ? {
-            generativeAi: undefined,
-          }
+      ...(fileAnnotations.includes(NCMECFileAnnotation.GENERATIVE_AI)
+        ? { generativeAi: undefined }
         : {}),
     };
   }
@@ -1800,6 +1809,18 @@ export default class NcmecReporting {
     isTest: boolean,
   ) {
     const fileDetailsXML = js2xml(fileDetails, { compact: true });
+    ncmecDebugLog('fileinfo.xml', {
+      isTest,
+      reportId: fileDetails.fileDetails.reportId,
+      fileId: fileDetails.fileDetails.fileId,
+      length: fileDetailsXML.length,
+    });
+    await ncmecDebugDump(
+      `${isTest ? 'TEST-' : 'PROD-'}${new Date()
+        .toISOString()
+        .replace(/[:.]/g, '-')}-fileinfo-${fileDetails.fileDetails.fileId}.xml`,
+      fileDetailsXML,
+    );
     const response = await this.#sendCyberTipRequest({
       cybertipAuthenticationCredentials,
       body: fileDetailsXML,
@@ -1873,7 +1894,7 @@ export default class NcmecReporting {
 
         const response = await this.#sendCyberTipRequest({
           cybertipAuthenticationCredentials,
-          body: requestBody as FormDataType,
+          body: requestBody,
           route: '/upload',
           includeContentType: false,
           isTest,
@@ -1919,12 +1940,13 @@ export default class NcmecReporting {
     cybertipAuthenticationCredentials: CyberTipAuth,
     isTest: boolean,
   ) {
+    ncmecDebugLog('finish.request', { reportId, isTest });
     const requestBody = new FormData();
     requestBody.append('id', reportId);
 
     const response = await this.#sendCyberTipRequest({
       cybertipAuthenticationCredentials,
-      body: requestBody as FormDataType,
+      body: requestBody,
       route: '/finish',
       includeContentType: false,
       isTest,
@@ -1940,7 +1962,7 @@ export default class NcmecReporting {
 
   async #sendCyberTipRequest(input: {
     cybertipAuthenticationCredentials: CyberTipAuth;
-    body: string | FormDataType | FormDataLikeWithStreams;
+    body: string | FormData | FormDataLikeWithStreams;
     route: `/${string}`;
     isTest: boolean;
     includeContentType?: boolean;
@@ -1966,10 +1988,17 @@ export default class NcmecReporting {
         jitter: true,
       },
       async () => {
+        const url = isTest
+          ? `https://exttest.cybertip.org/ispws${route}`
+          : `https://report.cybertip.org/ispws${route}`;
+        ncmecDebugLog('cybertip.request', {
+          route,
+          isTest,
+          bodyKind: typeof body === 'string' ? 'xml' : 'formData',
+          bodyLength: typeof body === 'string' ? body.length : undefined,
+        });
         const response = await this.fetchHTTP({
-          url: isTest
-            ? `https://exttest.cybertip.org/ispws${route}`
-            : `https://report.cybertip.org/ispws${route}`,
+          url,
           method: 'post',
           headers: {
             ...(includeContentType ? { 'Content-Type': 'text/xml' } : {}),
@@ -1981,8 +2010,28 @@ export default class NcmecReporting {
           handleResponseBody: 'as-json-from-xml',
         });
 
+        ncmecDebugLog('cybertip.response', {
+          route,
+          status: response.status,
+          ok: response.ok,
+          body: response.body ?? null,
+        });
+
         if (!response.ok) {
-          throw new Error('CyberTip Request Failed');
+          // Don't log the request body/headers: they contain reportable content and basic-auth.
+          const responseSnippet = (() => {
+            try {
+              const serialized = jsonStringify(response.body ?? null);
+              return serialized.length > 500
+                ? `${serialized.slice(0, 500)}…`
+                : serialized;
+            } catch {
+              return '<unserializable>';
+            }
+          })();
+          throw new Error(
+            `CyberTip request to ${route} failed: status=${response.status}, body=${responseSnippet}`,
+          );
         }
         return response;
       },

--- a/server/services/ncmecService/ncmecService.ts
+++ b/server/services/ncmecService/ncmecService.ts
@@ -186,10 +186,6 @@ export class NcmecService {
     status: 'RETRYABLE_ERROR' | 'PERMANENT_ERROR';
     error: string;
   }) {
-    // user_id/user_type_id are varchar(255); trim so an over-long org id
-    // can't make this failure-recording write itself fail.
-    const safeUserId = opts.userId.slice(0, 255);
-    const safeUserTypeId = opts.userTypeId.slice(0, 255);
     // Atomic increment in `doUpdateSet` avoids the read-modify-write race
     // when two callers (e.g. background retry job + user-clicked Retry)
     // attempt to record an error for the same job_id concurrently.
@@ -197,8 +193,8 @@ export class NcmecService {
       .insertInto('ncmec_reporting.ncmec_reports_errors')
       .values({
         job_id: opts.jobId,
-        user_id: safeUserId,
-        user_type_id: safeUserTypeId,
+        user_id: opts.userId,
+        user_type_id: opts.userTypeId,
         status: opts.status,
         last_error: opts.error,
         retry_count: 1,

--- a/server/services/ncmecService/ncmecService.ts
+++ b/server/services/ncmecService/ncmecService.ts
@@ -1,6 +1,6 @@
-import type { ItemIdentifier } from '@roostorg/types';
+import { type ItemIdentifier } from '@roostorg/types';
 import _Ajv from 'ajv-draft-04';
-import { type Kysely } from 'kysely';
+import { sql, type Kysely } from 'kysely';
 
 import { inject, type Dependencies } from '../../iocContainer/index.js';
 import { type ActionExecutionCorrelationId } from '../analyticsLoggers/ActionExecutionLogger.js';
@@ -18,6 +18,10 @@ import {
 import { type NcmecReportingServicePg } from './dbTypes.js';
 import NcmecEnqueueToMrt from './ncmecEnqueueToMrt.js';
 import NcmecReporting, { type NCMECReportParams } from './ncmecReporting.js';
+import {
+  retryNcmecSubmission,
+  type RetryNcmecSubmissionResult,
+} from './retryNcmecSubmission.js';
 
 export class NcmecService {
   private readonly ncmecReporting: NcmecReporting;
@@ -57,6 +61,24 @@ export class NcmecService {
 
   async submitReport(reportParams: NCMECReportParams, isTest: boolean) {
     return this.ncmecReporting.submitReport(reportParams, isTest);
+  }
+
+  /** Org-scoped retry for a previously-failed NCMEC submission. See
+   * `retryNcmecSubmission.ts` for the orchestration; this is a thin wrapper
+   * that supplies dependencies. */
+  async retrySubmission(opts: {
+    orgId: string;
+    decisionId: string;
+    requestingReviewerId: string;
+  }): Promise<RetryNcmecSubmissionResult> {
+    return retryNcmecSubmission(
+      {
+        manualReviewToolService: this.manualReviewToolService,
+        ncmecReporting: this.ncmecReporting,
+        getItemTypeEventuallyConsistent: this.getItemTypeEventuallyConsistent,
+      },
+      opts,
+    );
   }
 
   async hasNCMECReportingEnabled(orgId: string) {
@@ -128,10 +150,32 @@ export class NcmecService {
   }
 
   async getNcmecErrorsForJobIds(jobIds: string[]) {
+    if (jobIds.length === 0) {
+      return [];
+    }
     return this.pqQueryReadReplica
       .selectFrom('ncmec_reporting.ncmec_reports_errors')
-      .select(['job_id', 'retry_count', 'user_id', 'user_type_id', 'status'])
+      .select([
+        'job_id',
+        'retry_count',
+        'user_id',
+        'user_type_id',
+        'status',
+        'last_error',
+      ])
       .where('job_id', 'in', jobIds)
+      .execute();
+  }
+
+  /** Returns the `(user_id, user_item_type_id)` pairs that already have a
+   * successful NCMEC submission for this org. Used to filter MRT decisions
+   * down to "failed" submissions (those without a matching report row). */
+  async getSuccessfulSubmissionKeysForOrg(orgId: string) {
+    return this.pqQueryReadReplica
+      .selectFrom('ncmec_reporting.ncmec_reports')
+      .select(['user_id as userId', 'user_item_type_id as userItemTypeId'])
+      .where('org_id', '=', orgId)
+      .groupBy(['user_id', 'user_item_type_id'])
       .execute();
   }
 
@@ -142,24 +186,26 @@ export class NcmecService {
     status: 'RETRYABLE_ERROR' | 'PERMANENT_ERROR';
     error: string;
   }) {
-    const retryCountRow = await this.pqQueryReadReplica
-      .selectFrom('ncmec_reporting.ncmec_reports_errors')
-      .select('retry_count')
-      .where('job_id', '=', opts.jobId)
-      .executeTakeFirst();
+    // user_id/user_type_id are varchar(255); trim so an over-long org id
+    // can't make this failure-recording write itself fail.
+    const safeUserId = opts.userId.slice(0, 255);
+    const safeUserTypeId = opts.userTypeId.slice(0, 255);
+    // Atomic increment in `doUpdateSet` avoids the read-modify-write race
+    // when two callers (e.g. background retry job + user-clicked Retry)
+    // attempt to record an error for the same job_id concurrently.
     return this.pgQuery
       .insertInto('ncmec_reporting.ncmec_reports_errors')
       .values({
         job_id: opts.jobId,
-        user_id: opts.userId,
-        user_type_id: opts.userTypeId,
+        user_id: safeUserId,
+        user_type_id: safeUserTypeId,
         status: opts.status,
         last_error: opts.error,
-        retry_count: retryCountRow ? retryCountRow.retry_count + 1 : 1,
+        retry_count: 1,
       })
       .onConflict((oc) =>
         oc.columns(['job_id']).doUpdateSet({
-          retry_count: retryCountRow ? retryCountRow.retry_count + 1 : 1,
+          retry_count: sql`ncmec_reporting.ncmec_reports_errors.retry_count + 1`,
           last_error: opts.error,
           status: opts.status,
         }),

--- a/server/services/ncmecService/ncmecSubmissionFilters.test.ts
+++ b/server/services/ncmecService/ncmecSubmissionFilters.test.ts
@@ -1,0 +1,66 @@
+import { filterDecisionsToFailedSubmissions } from './ncmecSubmissionFilters.js';
+
+describe('filterDecisionsToFailedSubmissions', () => {
+  it('returns all decisions when no submissions are successful', () => {
+    const decisions = [
+      { userId: 'u1', userItemTypeId: 't1', payload: 'a' },
+      { userId: 'u2', userItemTypeId: 't1', payload: 'b' },
+    ];
+    expect(filterDecisionsToFailedSubmissions(decisions, [])).toEqual(
+      decisions,
+    );
+  });
+
+  it('removes decisions that match a successful (userId, userItemTypeId) pair', () => {
+    const decisions = [
+      { userId: 'u1', userItemTypeId: 't1', payload: 'a' },
+      { userId: 'u2', userItemTypeId: 't1', payload: 'b' },
+      { userId: 'u3', userItemTypeId: 't2', payload: 'c' },
+    ];
+    const successful = [{ userId: 'u2', userItemTypeId: 't1' }];
+    expect(filterDecisionsToFailedSubmissions(decisions, successful)).toEqual([
+      { userId: 'u1', userItemTypeId: 't1', payload: 'a' },
+      { userId: 'u3', userItemTypeId: 't2', payload: 'c' },
+    ]);
+  });
+
+  it('does NOT match across different userItemTypeIds when userId is the same', () => {
+    // Same user id under a different type identifier counts as a different
+    // submission and should remain in the failed list.
+    const decisions = [
+      { userId: 'u1', userItemTypeId: 't1', payload: 'a' },
+      { userId: 'u1', userItemTypeId: 't2', payload: 'b' },
+    ];
+    const successful = [{ userId: 'u1', userItemTypeId: 't1' }];
+    expect(filterDecisionsToFailedSubmissions(decisions, successful)).toEqual([
+      { userId: 'u1', userItemTypeId: 't2', payload: 'b' },
+    ]);
+  });
+
+  it('returns empty when every decision has a corresponding successful submission', () => {
+    const decisions = [
+      { userId: 'u1', userItemTypeId: 't1' },
+      { userId: 'u2', userItemTypeId: 't1' },
+    ];
+    const successful = [
+      { userId: 'u1', userItemTypeId: 't1' },
+      { userId: 'u2', userItemTypeId: 't1' },
+    ];
+    expect(filterDecisionsToFailedSubmissions(decisions, successful)).toEqual(
+      [],
+    );
+  });
+
+  it('does not collide when userId+userItemTypeId concatenation is ambiguous', () => {
+    // Without a delimiter, ('a', 'bc') and ('ab', 'c') would collide. The
+    // helper uses NUL as a delimiter, so these stay distinct.
+    const decisions = [
+      { userId: 'a', userItemTypeId: 'bc', payload: '1' },
+      { userId: 'ab', userItemTypeId: 'c', payload: '2' },
+    ];
+    const successful = [{ userId: 'a', userItemTypeId: 'bc' }];
+    expect(filterDecisionsToFailedSubmissions(decisions, successful)).toEqual([
+      { userId: 'ab', userItemTypeId: 'c', payload: '2' },
+    ]);
+  });
+});

--- a/server/services/ncmecService/ncmecSubmissionFilters.ts
+++ b/server/services/ncmecService/ncmecSubmissionFilters.ts
@@ -1,0 +1,23 @@
+/** Pure helpers for filtering NCMEC submission lists. Lives in its own file
+ * (no deps on the wider service container) so it can be unit-tested without
+ * pulling in DB clients or the IoC bottle. */
+
+/** Subtracts the set of successful submission keys from a list of NCMEC
+ * decisions, returning only decisions whose `(userId, userItemTypeId)` pair
+ * does NOT have a corresponding successful report row. */
+export function filterDecisionsToFailedSubmissions<
+  D extends { userId: string; userItemTypeId: string },
+>(
+  decisions: readonly D[],
+  successfulKeys: readonly { userId: string; userItemTypeId: string }[],
+): D[] {
+  // NUL is a delimiter chosen because real userId / userItemTypeId values
+  // never contain it; this avoids ambiguity between e.g. ('a','bc') and
+  // ('ab','c') that a naive concatenation would conflate.
+  const successfulKeySet = new Set(
+    successfulKeys.map((k) => `${k.userId}\u0000${k.userItemTypeId}`),
+  );
+  return decisions.filter(
+    (d) => !successfulKeySet.has(`${d.userId}\u0000${d.userItemTypeId}`),
+  );
+}

--- a/server/services/ncmecService/retryNcmecSubmission.test.ts
+++ b/server/services/ncmecService/retryNcmecSubmission.test.ts
@@ -1,0 +1,93 @@
+import {
+  retryNcmecSubmission,
+  type RetryDeps,
+} from './retryNcmecSubmission.js';
+
+/** Helper that builds a `RetryDeps` mock with sensible defaults. Each test
+ * overrides only the fields it cares about; everything else throws if invoked
+ * unexpectedly so missing assertions surface as failures. */
+function makeDeps(overrides: Partial<RetryDeps> = {}): RetryDeps {
+  const fail = (name: string) => () => {
+    throw new Error(`Unexpected call to ${name}`);
+  };
+  return {
+    manualReviewToolService: {
+      getNcmecDecisionByIdForOrg: fail('getNcmecDecisionByIdForOrg'),
+    } as unknown as RetryDeps['manualReviewToolService'],
+    ncmecReporting: {
+      submitReport: fail('submitReport'),
+    } as unknown as RetryDeps['ncmecReporting'],
+    getItemTypeEventuallyConsistent: fail('getItemTypeEventuallyConsistent'),
+    ...overrides,
+  };
+}
+
+describe('retryNcmecSubmission', () => {
+  // SECURITY: a decision belonging to a different org must look identical to
+  // a missing decision so that callers cannot probe cross-org existence. The
+  // SQL-level filter in getNcmecDecisionByIdForOrg returns undefined for
+  // cross-org IDs; this test pins that behavior at the orchestration layer.
+  it('returns not_found when the underlying lookup returns undefined (cross-org or missing)', async () => {
+    const deps = makeDeps({
+      manualReviewToolService: {
+        getNcmecDecisionByIdForOrg: async () => undefined,
+      } as unknown as RetryDeps['manualReviewToolService'],
+    });
+    const result = await retryNcmecSubmission(deps, {
+      orgId: 'org-A',
+      decisionId: 'decision-belonging-to-org-B',
+      requestingReviewerId: 'reviewer-1',
+    });
+    expect(result).toEqual({ kind: 'not_found' });
+  });
+
+  it('returns permanent_error when the decision lacks an NCMEC component', async () => {
+    const deps = makeDeps({
+      manualReviewToolService: {
+        getNcmecDecisionByIdForOrg: async () => ({
+          id: 'd1',
+          org_id: 'org-A',
+          decision_components: [{ type: 'TAKE_USER_ACTION' }],
+          job_payload: { payload: { kind: 'NCMEC' } },
+          reviewer_id: 'r1',
+          queue_id: 'q1',
+          created_at: new Date(),
+        }),
+      } as unknown as RetryDeps['manualReviewToolService'],
+    });
+    const result = await retryNcmecSubmission(deps, {
+      orgId: 'org-A',
+      decisionId: 'd1',
+      requestingReviewerId: 'reviewer-1',
+    });
+    expect(result.kind).toBe('permanent_error');
+    if (result.kind === 'permanent_error') {
+      expect(result.error).toMatch(/NCMEC report component/i);
+    }
+  });
+
+  it('returns permanent_error when the job payload is not an NCMEC payload', async () => {
+    const deps = makeDeps({
+      manualReviewToolService: {
+        getNcmecDecisionByIdForOrg: async () => ({
+          id: 'd1',
+          org_id: 'org-A',
+          decision_components: [{ type: 'SUBMIT_NCMEC_REPORT' }],
+          job_payload: { payload: { kind: 'OTHER' } },
+          reviewer_id: 'r1',
+          queue_id: 'q1',
+          created_at: new Date(),
+        }),
+      } as unknown as RetryDeps['manualReviewToolService'],
+    });
+    const result = await retryNcmecSubmission(deps, {
+      orgId: 'org-A',
+      decisionId: 'd1',
+      requestingReviewerId: 'reviewer-1',
+    });
+    expect(result.kind).toBe('permanent_error');
+    if (result.kind === 'permanent_error') {
+      expect(result.error).toMatch(/NCMEC payload/i);
+    }
+  });
+});

--- a/server/services/ncmecService/retryNcmecSubmission.ts
+++ b/server/services/ncmecService/retryNcmecSubmission.ts
@@ -105,11 +105,8 @@ export async function retryNcmecSubmission(
   }
 
   const isTest = process.env.NCMEC_ENV !== 'production';
-  // submitReport records its own RETRYABLE_ERROR row via jobId when it throws
-  // and returns 'FAILURE' / 'UNSUPPORTED_ORG' / 'ALL_MEDIA_MISSING' for
-  // explicit non-success cases. The defensive try/catch here only translates
-  // those outcomes for the caller — error persistence stays centralized in
-  // submitReport so we never double-write or downgrade RETRYABLE to PERMANENT.
+  // submitReport owns `ncmec_reports_errors` writes via `jobId` so retries
+  // always update retry_count/last_error. Don't double-write here.
   try {
     const result = await deps.ncmecReporting.submitReport(reportParams, isTest);
     if (result === 'SUCCESS') {

--- a/server/services/ncmecService/retryNcmecSubmission.ts
+++ b/server/services/ncmecService/retryNcmecSubmission.ts
@@ -112,6 +112,12 @@ export async function retryNcmecSubmission(
     if (result === 'SUCCESS') {
       return { kind: 'success' };
     }
+    // 'FAILURE' is the catch-and-retry path inside submitReport surface as
+    // retryable so the scheduled retry job keeps picking it up.
+    // Only the explicitly non-retryable results map to permanent_error.
+    if (result === 'FAILURE') {
+      return { kind: 'retryable_error', error: result };
+    }
     return { kind: 'permanent_error', error: result };
   } catch (e: unknown) {
     const error = e instanceof Error ? e.message : 'Unknown error';

--- a/server/services/ncmecService/retryNcmecSubmission.ts
+++ b/server/services/ncmecService/retryNcmecSubmission.ts
@@ -1,0 +1,123 @@
+import { type Dependencies } from '../../iocContainer/index.js';
+import { type ManualReviewToolService } from '../manualReviewToolService/manualReviewToolService.js';
+import {
+  buildSubmitReportParamsFromDecision,
+  LEGACY_FALLBACK_INCIDENT_TYPE,
+} from './buildSubmitReportParamsFromDecision.js';
+import type NcmecReporting from './ncmecReporting.js';
+
+/** Result of a retry attempt. Distinct cases let the GraphQL layer return a
+ * uniform error message for cross-org `not_found` (no information disclosure)
+ * while still differentiating retryable vs permanent failures internally for
+ * logging / `ncmec_reports_errors` updates. */
+export type RetryNcmecSubmissionResult =
+  | { kind: 'success' }
+  | { kind: 'not_found' }
+  | { kind: 'permanent_error'; error: string }
+  | { kind: 'retryable_error'; error: string };
+
+export interface RetryDeps {
+  manualReviewToolService: ManualReviewToolService;
+  ncmecReporting: NcmecReporting;
+  getItemTypeEventuallyConsistent: Dependencies['getItemTypeEventuallyConsistent'];
+}
+
+/** Retries a previously-failed NCMEC submission for the given decision.
+ *
+ * Org-scoped: the caller's `orgId` is forwarded to
+ * `getNcmecDecisionByIdForOrg`, which filters on `org_id` at the SQL level.
+ * Cross-org callers (or callers with an unknown decisionId) get the same
+ * `not_found` response — never confirm cross-org existence. */
+export async function retryNcmecSubmission(
+  deps: RetryDeps,
+  opts: {
+    orgId: string;
+    decisionId: string;
+    requestingReviewerId: string;
+  },
+): Promise<RetryNcmecSubmissionResult> {
+  const { orgId, decisionId, requestingReviewerId } = opts;
+
+  const decisionRow =
+    await deps.manualReviewToolService.getNcmecDecisionByIdForOrg({
+      orgId,
+      decisionId,
+    });
+  if (!decisionRow) {
+    return { kind: 'not_found' };
+  }
+
+  const submitNcmecReportComponent = decisionRow.decision_components.find(
+    (c) => c.type === 'SUBMIT_NCMEC_REPORT',
+  );
+  if (submitNcmecReportComponent === undefined) {
+    return {
+      kind: 'permanent_error',
+      error: 'Decision does not contain an NCMEC report component',
+    };
+  }
+  if (decisionRow.job_payload.payload.kind !== 'NCMEC') {
+    return {
+      kind: 'permanent_error',
+      error: 'Decision job payload is not an NCMEC payload',
+    };
+  }
+
+  // Use the original reviewer when available so the resulting report keeps
+  // its provenance; otherwise attribute to the user clicking Retry.
+  const reviewerId = decisionRow.reviewer_id ?? requestingReviewerId;
+
+  const itemId = decisionRow.job_payload.payload.item.itemId;
+  const itemTypeIdentifier =
+    decisionRow.job_payload.payload.item.itemTypeIdentifier;
+  const itemTypeId = itemTypeIdentifier.id;
+
+  const itemType = await deps.getItemTypeEventuallyConsistent({
+    orgId,
+    typeSelector: itemTypeIdentifier,
+  });
+  if (itemType === undefined || itemType.kind !== 'USER') {
+    return {
+      kind: 'permanent_error',
+      error: 'Reported item type is missing or not a USER type',
+    };
+  }
+
+  let reportParams;
+  try {
+    reportParams = await buildSubmitReportParamsFromDecision({
+      orgId,
+      reviewerId,
+      reportedItemId: itemId,
+      reportedItemTypeId: itemTypeId,
+      reportedUserItemType: itemType,
+      reportedUserData: decisionRow.job_payload.payload.item.data,
+      allMediaItems: decisionRow.job_payload.payload.allMediaItems,
+      decisionComponent: submitNcmecReportComponent,
+      fallbackIncidentType: LEGACY_FALLBACK_INCIDENT_TYPE,
+      jobId: decisionRow.job_payload.id,
+      getItemTypeEventuallyConsistent: deps.getItemTypeEventuallyConsistent,
+    });
+  } catch (e: unknown) {
+    const error =
+      e instanceof Error ? e.message : 'Failed to assemble reported media';
+    return { kind: 'permanent_error', error };
+  }
+
+  const isTest = process.env.NCMEC_ENV !== 'production';
+  // submitReport records its own RETRYABLE_ERROR row via jobId when it throws
+  // and returns 'FAILURE' / 'UNSUPPORTED_ORG' / 'ALL_MEDIA_MISSING' for
+  // explicit non-success cases. The defensive try/catch here only translates
+  // those outcomes for the caller — error persistence stays centralized in
+  // submitReport so we never double-write or downgrade RETRYABLE to PERMANENT.
+  try {
+    const result = await deps.ncmecReporting.submitReport(reportParams, isTest);
+    if (result === 'SUCCESS') {
+      return { kind: 'success' };
+    }
+    return { kind: 'permanent_error', error: result };
+  } catch (e: unknown) {
+    const error = e instanceof Error ? e.message : 'Unknown error';
+    return { kind: 'retryable_error', error };
+  }
+}

--- a/server/workers_jobs/RetryFailedNcmecDecisionsJob.ts
+++ b/server/workers_jobs/RetryFailedNcmecDecisionsJob.ts
@@ -1,9 +1,11 @@
-import { makeDateString } from '@roostorg/types';
 import _ from 'lodash';
 import { v1 as uuidv1 } from 'uuid';
 
 import { inject } from '../iocContainer/utils.js';
-import { getFieldValueForRole } from '../services/itemProcessingService/index.js';
+import {
+  buildSubmitReportParamsFromDecision,
+  LEGACY_FALLBACK_INCIDENT_TYPE,
+} from '../services/ncmecService/index.js';
 import { toCorrelationId } from '../utils/correlationIds.js';
 
 export default inject(
@@ -97,76 +99,21 @@ export default inject(
         return;
       }
       try {
-        const displayName = getFieldValueForRole(
-          itemType.schema,
-          itemType.schemaFieldRoles,
-          'displayName',
-          data,
-        );
-        const profilePicUrl = getFieldValueForRole(
-          itemType.schema,
-          itemType.schemaFieldRoles,
-          'profileIcon',
-          data,
-        );
-
-        const allMedia = row.job_payload.payload.allMediaItems;
-        const media = await Promise.all(
-          submitNcmecReportDecisionComponent.reportedMedia.map(async (it) => {
-            const reportedItem = allMedia.find(
-              (payloadMedia) => payloadMedia.contentItem.itemId === it.id,
-            );
-            if (reportedItem === undefined) {
-              throw new Error('Unable to find reported media in job payload');
-            }
-            const itemType = await getItemTypeEventuallyConsistent({
-              orgId,
-              typeSelector: reportedItem.contentItem.itemTypeIdentifier,
-            });
-            if (itemType === undefined) {
-              throw new Error('Unable to find item type for reported media');
-            }
-
-            const createdAt =
-              getFieldValueForRole(
-                itemType.schema,
-                itemType.schemaFieldRoles,
-                'createdAt',
-                reportedItem.contentItem.data,
-              ) ?? makeDateString(new Date().toISOString());
-            if (createdAt === undefined) {
-              throw new Error('No created at for reported media');
-            }
-
-            return {
-              id: it.id,
-              typeId: it.typeId,
-              url: it.url,
-              createdAt,
-              industryClassification: it.industryClassification,
-              fileAnnotations: it.fileAnnotations,
-            };
-          }),
-        );
+        const reportParams = await buildSubmitReportParamsFromDecision({
+          orgId,
+          reviewerId: row.reviewer_id,
+          reportedItemId: itemId,
+          reportedItemTypeId: itemTypeId,
+          reportedUserItemType: itemType,
+          reportedUserData: data,
+          allMediaItems: row.job_payload.payload.allMediaItems,
+          decisionComponent: submitNcmecReportDecisionComponent,
+          fallbackIncidentType: LEGACY_FALLBACK_INCIDENT_TYPE,
+          jobId: row.job_payload.id,
+          getItemTypeEventuallyConsistent,
+        });
         const reportResult = await ncmecService.submitReport(
-          {
-            reportedUser: {
-              id: itemId,
-              typeId: itemTypeId,
-              ...(displayName ? { displayName } : {}),
-              ...(profilePicUrl ? { profilePicture: profilePicUrl.url } : {}),
-            },
-            orgId,
-            media,
-            reviewerId: row.reviewer_id,
-            threads: submitNcmecReportDecisionComponent.reportedMessages,
-            // Use the stored incidentType if available, otherwise default to the most common one
-            // The type says it's required, but old decisions in the DB won't have it
-
-            incidentType:
-              submitNcmecReportDecisionComponent.incidentType ||
-              'Child Pornography (possession, manufacture, and distribution)',
-          },
+          reportParams,
           false,
         );
         if (

--- a/server/workers_jobs/RetryFailedNcmecDecisionsJob.ts
+++ b/server/workers_jobs/RetryFailedNcmecDecisionsJob.ts
@@ -98,6 +98,11 @@ export default inject(
         });
         return;
       }
+      // Tracks whether submitReport was invoked. submitReport persists its
+      // own error rows when reportParams.jobId is set, so this worker only
+      // records errors from the pre-submitReport phase (payload-build /
+      // item-type resolution) to avoid double-incrementing retry_count.
+      let submitReportInvoked = false;
       try {
         const reportParams = await buildSubmitReportParamsFromDecision({
           orgId,
@@ -112,69 +117,68 @@ export default inject(
           jobId: row.job_payload.id,
           getItemTypeEventuallyConsistent,
         });
+        submitReportInvoked = true;
         const reportResult = await ncmecService.submitReport(
           reportParams,
           false,
         );
         if (
           reportResult === 'UNSUPPORTED_ORG' ||
-          reportResult === 'ALL_MEDIA_MISSING'
+          reportResult === 'ALL_MEDIA_MISSING' ||
+          reportResult === 'FAILURE'
         ) {
-          await ncmecService.insertOrUpdateNcmecReportError({
-            jobId: row.job_payload.id,
-            userId: itemId,
-            userTypeId: itemTypeId,
-            status: 'PERMANENT_ERROR',
-            error: reportResult,
-          });
           return;
         }
-        if (reportResult === 'SUCCESS') {
-          const actionAndPolicy =
-            await ncmecService.getNCMECActionsToRunAndPolicies(orgId);
-          if (
-            actionAndPolicy != null &&
-            actionAndPolicy.actionsToRunIds != null
-          ) {
-            const actions = await moderationConfigService.getActions({
+        const actionAndPolicy =
+          await ncmecService.getNCMECActionsToRunAndPolicies(orgId);
+        if (
+          actionAndPolicy != null &&
+          actionAndPolicy.actionsToRunIds != null
+        ) {
+          const actions = await moderationConfigService.getActions({
+            orgId,
+            ids: actionAndPolicy.actionsToRunIds,
+          });
+          const policies = await moderationConfigService.getPolicies({
+            orgId,
+            readFromReplica: true,
+          });
+          const correlationId = toCorrelationId({
+            type: 'mrt-decision',
+            id: uuidv1(),
+          });
+          await actionPublisher.publishActions(
+            actions.map((action) => ({
+              action,
+              matchingRules: undefined,
+              ruleEnvironment: undefined,
+              policies: policies.filter((policy) => {
+                return actionAndPolicy.policyIds.includes(policy.id);
+              }),
+            })),
+            {
               orgId,
-              ids: actionAndPolicy.actionsToRunIds,
-            });
-            const policies = await moderationConfigService.getPolicies({
-              orgId,
-              readFromReplica: true,
-            });
-            const correlationId = toCorrelationId({
-              type: 'mrt-decision',
-              id: uuidv1(),
-            });
-            await actionPublisher.publishActions(
-              actions.map((action) => ({
-                action,
-                matchingRules: undefined,
-                ruleEnvironment: undefined,
-                policies: policies.filter((policy) => {
-                  return actionAndPolicy.policyIds.includes(policy.id);
-                }),
-              })),
-              {
-                orgId,
-                correlationId,
-                targetItem: {
-                  itemId,
-                  itemType: {
-                    id: itemType.id,
-                    kind: itemType.kind,
-                    name: itemType.name,
-                  },
+              correlationId,
+              targetItem: {
+                itemId,
+                itemType: {
+                  id: itemType.id,
+                  kind: itemType.kind,
+                  name: itemType.name,
                 },
-                actorId: row.reviewer_id,
-                actorEmail: user?.email,
               },
-            );
-          }
+              actorId: row.reviewer_id,
+              actorEmail: user?.email,
+            },
+          );
         }
       } catch (e: unknown) {
+        if (submitReportInvoked) {
+          // submitReport already wrote its own ncmec_reports_errors row.
+          // Don't double-write here; let the next batch pick the row up via
+          // its retry_count.
+          return;
+        }
         await ncmecService.insertOrUpdateNcmecReportError({
           jobId: row.job_payload.id,
           userId: itemId,


### PR DESCRIPTION
Fixes #470

## Context & Requests for Reviewers

Adds the `additionalInfo` free-text field to NCMEC reports per the [NCMEC report-details spec](https://report.cybertip.org/ispws/documentation/index.html#report-details-types), and fixes a set of bugs that surfaced while end-to-end testing against `exttest.cybertip.org`.

### Feature: `additionalInfo` on the report (closes #470)
- New optional, 3000-char free-text field, wired UI → GraphQL (`SubmitNcmecReportInput.additionalInfo`) → service → XML.
- Emitted as the **last** child of `<report>` per the XSD.
- "Escalate as High Priority" is now a checkbox; the reason textarea is only shown (and required) when the checkbox is checked. Previously two free-text boxes side-by-side confused reviewers about which signal was for which thing.

### Fix: NCMEC XSD element ordering (responseCode=4100)
NCMEC rejects submissions whose elements aren't in XSD sequence order. js2xml emits children in object-literal key insertion order, so the `Report` type and all builders now match the XSD sequence:


added a new Opt-in, dev-only (`NODE_ENV !== 'production'`) structured logging plus a local XML dump under `server/ncmec-reports/` to make future NCMEC validation debugging tractable. Documented in `server/.env.example`. No-ops in production.

<img width="785" height="565" alt="Screenshot 2026-05-15 at 12 26 59 PM" src="https://github.com/user-attachments/assets/6058346c-6d5b-49e7-84be-6c8b281244be" />
<img width="808" height="569" alt="Screenshot 2026-05-15 at 12 26 44 PM" src="https://github.com/user-attachments/assets/ac0d723b-331f-4a24-a05b-1f6125e4d69f" />
<img width="796" height="953" alt="Screenshot 2026-05-15 at 12 26 36 PM" src="https://github.com/user-attachments/assets/51762475-e8f2-44e3-ab46-64214e051ac4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Display failed NCMEC submissions in Reports with per-row "Retry" and "Last Error" tooltip; configurable table columns persisted
  * Optional "Additional details" on NCMEC report submissions; escalation requires explicit checkbox + reason
  * Keyboard shortcuts suppressed while typing to avoid interference

* **Bug Fixes / Validation**
  * Contact email trimmed, required, validated, and length-limited
  * Web page URL sanitization omits invalid/blank values from reports

* **Other**
  * Opt-in NCMEC debug logging and local dump support (non-production)


<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/477)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->