### PR TITLE
server: Add end-to-end item submission integration test and harness

### DIFF
--- a/server/test/integ/README.md
+++ b/server/test/integ/README.md
@@ -1,0 +1,49 @@
+# Integration tests
+
+End-to-end tests that exercise the real Coop stack — Postgres, Scylla,
+ClickHouse, Redis, and an inline item-processing worker. Unlike unit tests
+(which mock the data warehouse), these run against the same services that
+`npm start` uses.
+
+These tests implement the scenarios filed under issue
+[#288](https://github.com/roostorg/coop/issues/288).
+
+## Running
+
+From the repo root:
+
+```bash
+npm run up           # boot postgres, clickhouse, scylla, redis, hma, otel
+npm run db:update    # apply Postgres + ClickHouse migrations
+cd server && npm run test:integ
+```
+
+`npm run up` opens Jaeger at <http://localhost:16686>. Stop infra with
+`npm run down` when done.
+
+## Layout
+
+| File                        | Purpose                                                                                                                                |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `setupIntegrationServer.ts` | Boots the real IoC container, starts the express app and `ItemProcessingWorker` inline, returns a `supertest` agent + shutdown handle. |
+| `wait.ts`                   | Polling helpers — `waitForItemInScylla`, `waitForItemInClickHouse`, generic `waitFor`.                                                 |
+| `*.integ.test.ts`           | The tests themselves. Picked up by `jest.integ.config.cjs`, excluded from the unit `jest.config.cjs`.                                  |
+
+Fixture helpers (`createOrg`, `createContentItemTypes`, ...) live in
+`server/test/fixtureHelpers/` and are shared with unit tests.
+
+## Conventions
+
+- One `describe` per scenario; one or more `test()`s inside.
+- Generate unique `orgId` / `itemId` per `describe` so concurrent runs don't
+  collide.
+- `beforeAll` boots the harness and creates fixtures; `afterAll` cleans them
+  up and calls `harness.shutdown()`.
+- Default timeouts: 60s for `beforeAll`/`test`, 30s for `afterAll`.
+- Polls default to 250ms interval, 30s timeout — override per-call when a
+  scenario is known to be faster or slower.
+
+## CI
+
+Not yet wired. A follow-up PR will add a workflow that boots the
+`docker-compose.yaml` services and runs `npm run test:integ`.

--- a/server/test/integ/items-submission.integ.test.ts
+++ b/server/test/integ/items-submission.integ.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Integration test for #339: end-to-end item submission.
+ *
+ * Submits an item via POST /api/v1/items/async against a real running stack
+ * (Postgres, Scylla, ClickHouse, Redis) and asserts the item lands in both
+ * Scylla (item_submission_by_thread) and ClickHouse (CONTENT_API_REQUESTS).
+ *
+ * Run with: npm run test:integ
+ * Requires: `npm run up && npm run db:update`
+ */
+import { ScalarTypes } from '@roostorg/types';
+import { uid } from 'uid';
+
+import createContentItemTypes from '../fixtureHelpers/createContentItemTypes.js';
+import createOrg from '../fixtureHelpers/createOrg.js';
+import {
+  makeIntegrationServer,
+  type IntegrationServer,
+} from './setupIntegrationServer.js';
+import { waitForItemInClickHouse, waitForItemInScylla } from './wait.js';
+
+describe('Items submission (integration)', () => {
+  const orgId = uid();
+  let harness: IntegrationServer;
+  let apiKey: string;
+  let orgCleanup: () => Promise<void>;
+  let itemTypeCleanup: () => Promise<void>;
+  let itemTypeId: string;
+
+  beforeAll(async () => {
+    harness = await makeIntegrationServer();
+
+    const orgFixture = await createOrg(
+      {
+        KyselyPg: harness.deps.KyselyPg,
+        ModerationConfigService: harness.deps.ModerationConfigService,
+        ApiKeyService: harness.deps.ApiKeyService,
+      },
+      orgId,
+    );
+    apiKey = orgFixture.apiKey;
+    orgCleanup = orgFixture.cleanup;
+
+    const itemTypeFixture = await createContentItemTypes({
+      moderationConfigService: harness.deps.ModerationConfigService,
+      orgId,
+      extra: {
+        fields: [
+          {
+            name: 'text',
+            type: ScalarTypes.STRING,
+            required: true,
+            container: null,
+          },
+        ],
+      },
+    });
+    itemTypeId = itemTypeFixture.itemTypes[0].id;
+    itemTypeCleanup = itemTypeFixture.cleanup;
+  }, 60_000);
+
+  afterAll(async () => {
+    await itemTypeCleanup?.();
+    await orgCleanup?.();
+    await harness?.shutdown();
+  }, 30_000);
+
+  test('submitted item lands in Scylla and ClickHouse', async () => {
+    const itemId = uid();
+
+    await harness.request
+      .post('/api/v1/items/async')
+      .set('x-api-key', apiKey)
+      .send({
+        items: [
+          { id: itemId, typeId: itemTypeId, data: { text: 'hello integ' } },
+        ],
+      })
+      .expect(202);
+
+    const scyllaItem = await waitForItemInScylla(harness.deps, {
+      orgId,
+      itemIdentifier: { id: itemId, typeId: itemTypeId },
+    });
+    expect(scyllaItem.latestSubmission).toBeDefined();
+
+    const chRow = await waitForItemInClickHouse(harness.deps, {
+      orgId,
+      itemIdentifier: { id: itemId, typeId: itemTypeId },
+    });
+    expect(chRow).toBeDefined();
+  }, 60_000);
+});

--- a/server/test/integ/items-submission.integ.test.ts
+++ b/server/test/integ/items-submission.integ.test.ts
@@ -60,9 +60,9 @@ describe('Items submission (integration)', () => {
   }, 60_000);
 
   afterAll(async () => {
-    await itemTypeCleanup?.();
-    await orgCleanup?.();
-    await harness?.shutdown();
+    await itemTypeCleanup();
+    await orgCleanup();
+    await harness.shutdown();
   }, 30_000);
 
   test('submitted item lands in Scylla and ClickHouse', async () => {

--- a/server/test/integ/items-submission.integ.test.ts
+++ b/server/test/integ/items-submission.integ.test.ts
@@ -21,10 +21,10 @@ import { waitForItemInClickHouse, waitForItemInScylla } from './wait.js';
 
 describe('Items submission (integration)', () => {
   const orgId = uid();
-  let harness: IntegrationServer;
+  let harness: IntegrationServer | undefined;
   let apiKey: string;
-  let orgCleanup: () => Promise<void>;
-  let itemTypeCleanup: () => Promise<void>;
+  let orgCleanup: (() => Promise<void>) | undefined;
+  let itemTypeCleanup: (() => Promise<void>) | undefined;
   let itemTypeId: string;
 
   beforeAll(async () => {
@@ -60,12 +60,18 @@ describe('Items submission (integration)', () => {
   }, 60_000);
 
   afterAll(async () => {
-    await itemTypeCleanup();
-    await orgCleanup();
-    await harness.shutdown();
+    // Guard each step so a failure in `beforeAll` doesn't trigger a second,
+    // misleading "X is not a function" error here that masks the root cause.
+    try {
+      await itemTypeCleanup?.();
+      await orgCleanup?.();
+    } finally {
+      await harness?.shutdown();
+    }
   }, 30_000);
 
   test('submitted item lands in Scylla and ClickHouse', async () => {
+    if (!harness) throw new Error('harness was not initialized');
     const itemId = uid();
 
     await harness.request
@@ -78,11 +84,12 @@ describe('Items submission (integration)', () => {
       })
       .expect(202);
 
-    const scyllaItem = await waitForItemInScylla(harness.deps, {
+    const scyllaRow = await waitForItemInScylla(harness.deps, {
       orgId,
       itemIdentifier: { id: itemId, typeId: itemTypeId },
     });
-    expect(scyllaItem.latestSubmission).toBeDefined();
+    expect(scyllaRow).toBeDefined();
+    expect(scyllaRow.org_id).toBe(orgId);
 
     const chRow = await waitForItemInClickHouse(harness.deps, {
       orgId,

--- a/server/test/integ/setupIntegrationServer.ts
+++ b/server/test/integ/setupIntegrationServer.ts
@@ -41,20 +41,56 @@ export async function makeIntegrationServer(): Promise<IntegrationServer> {
     deps,
     request,
     async shutdown() {
+      // Best-effort teardown: run every step even if an earlier one throws,
+      // so we don't leak the server or shared resources into the next test.
       workerAbort.abort();
-      await deps.ItemProcessingWorker.shutdown();
-      await shutdownServer();
-      // BullMQ's Worker.close() already closes the shared ioredis connection,
-      // which makes `closeSharedResourcesForShutdown` throw "Connection is
-      // closed" when it tries to `quit()` redis a second time. The error is
-      // benign — every shared resource is already torn down — so we swallow
-      // it here rather than leak the failure into afterAll.
-      await deps.closeSharedResourcesForShutdown().catch((err) => {
-        if (err instanceof Error && err.message === 'Connection is closed.') {
-          return;
+
+      const runStep = async (
+        fn: () => Promise<void>,
+      ): Promise<unknown | null> => {
+        try {
+          await fn();
+          return null;
+        } catch (err) {
+          return err;
         }
-        throw err;
-      });
+      };
+
+      // Awaited left-to-right inside the array literal, so steps still run
+      // sequentially — closeSharedResourcesForShutdown depends on the worker
+      // having closed its Redis connection first.
+      const teardownErrors = [
+        await runStep(async () => {
+          await deps.ItemProcessingWorker.shutdown();
+        }),
+        await runStep(async () => {
+          await shutdownServer();
+        }),
+        await runStep(async () => {
+          // BullMQ's Worker.close() already closes the shared ioredis
+          // connection, which makes closeSharedResourcesForShutdown throw
+          // "Connection is closed" when it tries to quit() redis a second
+          // time. That specific error is benign — every shared resource is
+          // already torn down — so we swallow it here rather than leak the
+          // failure into afterAll.
+          await deps.closeSharedResourcesForShutdown().catch((err) => {
+            if (
+              err instanceof Error &&
+              err.message === 'Connection is closed.'
+            ) {
+              return;
+            }
+            throw err;
+          });
+        }),
+      ].filter((e): e is unknown => e !== null);
+
+      if (teardownErrors.length > 0) {
+        throw new AggregateError(
+          teardownErrors,
+          'Integration server shutdown failed',
+        );
+      }
     },
   };
 }

--- a/server/test/integ/setupIntegrationServer.ts
+++ b/server/test/integ/setupIntegrationServer.ts
@@ -6,6 +6,11 @@
  * Requires the docker-compose stack from `npm run up` and migrations applied
  * via `npm run db:update`.
  */
+// Load .env before any module that reads process.env (notably the IoC
+// container). The unit-test `npm test` path goes through dotenv via its
+// NODE_OPTIONS; `test:integ` does not, so we do it here.
+import 'dotenv/config';
+
 import * as superTest from 'supertest';
 
 import getBottle, { type Dependencies } from '../../iocContainer/index.js';
@@ -29,7 +34,6 @@ export async function makeIntegrationServer(): Promise<IntegrationServer> {
   // or shutdown, so we don't await it here.
   const workerRun = deps.ItemProcessingWorker.run(workerAbort.signal);
   workerRun.catch((err) => {
-     
     console.error('ItemProcessingWorker exited with error', err);
   });
 
@@ -40,7 +44,17 @@ export async function makeIntegrationServer(): Promise<IntegrationServer> {
       workerAbort.abort();
       await deps.ItemProcessingWorker.shutdown();
       await shutdownServer();
-      await deps.closeSharedResourcesForShutdown();
+      // BullMQ's Worker.close() already closes the shared ioredis connection,
+      // which makes `closeSharedResourcesForShutdown` throw "Connection is
+      // closed" when it tries to `quit()` redis a second time. The error is
+      // benign — every shared resource is already torn down — so we swallow
+      // it here rather than leak the failure into afterAll.
+      await deps.closeSharedResourcesForShutdown().catch((err) => {
+        if (err instanceof Error && err.message === 'Connection is closed.') {
+          return;
+        }
+        throw err;
+      });
     },
   };
 }

--- a/server/test/integ/setupIntegrationServer.ts
+++ b/server/test/integ/setupIntegrationServer.ts
@@ -1,0 +1,46 @@
+/**
+ * Integration test harness: boots the real IoC container against running infra
+ * (Postgres, Scylla, ClickHouse, Redis) and starts the item-processing worker
+ * inline so that submissions land in the data stores within the same process.
+ *
+ * Requires the docker-compose stack from `npm run up` and migrations applied
+ * via `npm run db:update`.
+ */
+import * as superTest from 'supertest';
+
+import getBottle, { type Dependencies } from '../../iocContainer/index.js';
+import makeServer from '../../server.js';
+
+export type IntegrationServer = {
+  deps: Dependencies;
+  request: ReturnType<typeof superTest.agent>;
+  shutdown: () => Promise<void>;
+};
+
+export async function makeIntegrationServer(): Promise<IntegrationServer> {
+  const bottle = await getBottle();
+  const deps = bottle.container as Dependencies;
+
+  const { app, shutdown: shutdownServer } = await makeServer(deps);
+  const request = superTest.agent(app);
+
+  const workerAbort = new AbortController();
+  // Run the worker in the background — its run() promise only settles on error
+  // or shutdown, so we don't await it here.
+  const workerRun = deps.ItemProcessingWorker.run(workerAbort.signal);
+  workerRun.catch((err) => {
+     
+    console.error('ItemProcessingWorker exited with error', err);
+  });
+
+  return {
+    deps,
+    request,
+    async shutdown() {
+      workerAbort.abort();
+      await deps.ItemProcessingWorker.shutdown();
+      await shutdownServer();
+      await deps.closeSharedResourcesForShutdown();
+    },
+  };
+}

--- a/server/test/integ/wait.ts
+++ b/server/test/integ/wait.ts
@@ -65,16 +65,12 @@ export async function waitForItemInClickHouse(
       const rows = await deps.DataWarehouse.query(
         `SELECT item_id, item_type_id, event
            FROM analytics.CONTENT_API_REQUESTS
-          WHERE org_id = {orgId:String}
-            AND item_id = {itemId:String}
-            AND item_type_id = {itemTypeId:String}
+          WHERE org_id = ?
+            AND item_id = ?
+            AND item_type_id = ?
           LIMIT 1`,
         deps.Tracer,
-        [
-          { name: 'orgId', value: orgId },
-          { name: 'itemId', value: itemIdentifier.id },
-          { name: 'itemTypeId', value: itemIdentifier.typeId },
-        ],
+        [orgId, itemIdentifier.id, itemIdentifier.typeId],
       );
       return rows.length > 0 ? rows[0] : null;
     },

--- a/server/test/integ/wait.ts
+++ b/server/test/integ/wait.ts
@@ -8,6 +8,7 @@
 import { type ItemIdentifier } from '@roostorg/types';
 
 import { type Dependencies } from '../../iocContainer/index.js';
+import { itemIdentifierToScyllaItemIdentifier } from '../../scylla/index.js';
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_INTERVAL_MS = 250;
@@ -31,8 +32,14 @@ export async function waitFor<T>(
   }
 }
 
+/**
+ * Query Scylla directly rather than going through ItemInvestigationService:
+ * that service falls back to the partial-items endpoint and the data warehouse
+ * if Scylla returns nothing, which would mask a real Scylla write failure as a
+ * passing test.
+ */
 export async function waitForItemInScylla(
-  deps: Pick<Dependencies, 'ItemInvestigationService'>,
+  deps: Pick<Dependencies, 'Scylla'>,
   opts: {
     orgId: string;
     itemIdentifier: ItemIdentifier;
@@ -40,12 +47,21 @@ export async function waitForItemInScylla(
   },
 ) {
   return waitFor(
-    `item ${opts.itemIdentifier.id} in Scylla`,
-    async () =>
-      deps.ItemInvestigationService.getItemByIdentifier({
-        orgId: opts.orgId,
-        itemIdentifier: opts.itemIdentifier,
-      }),
+    `item ${opts.itemIdentifier.id} in Scylla item_submission_by_thread`,
+    async () => {
+      const rows = await deps.Scylla.select({
+        from: 'item_submission_by_thread',
+        select: '*',
+        where: [
+          [
+            'item_identifier',
+            '=',
+            itemIdentifierToScyllaItemIdentifier(opts.itemIdentifier),
+          ],
+        ],
+      }).catch(() => []);
+      return rows.length > 0 ? rows[0] : null;
+    },
     { timeoutMs: opts.timeoutMs },
   );
 }

--- a/server/test/integ/wait.ts
+++ b/server/test/integ/wait.ts
@@ -1,0 +1,83 @@
+/**
+ * Polling helpers for integration tests.
+ *
+ * Item submission is async (POST returns 202, worker processes off Redis,
+ * writes to Scylla and ClickHouse), so tests poll the data stores until the
+ * row appears or a timeout elapses.
+ */
+import { type ItemIdentifier } from '@roostorg/types';
+
+import { type Dependencies } from '../../iocContainer/index.js';
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_INTERVAL_MS = 250;
+
+export async function waitFor<T>(
+  what: string,
+  check: () => Promise<T | null | undefined>,
+  opts: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<T> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const deadline = Date.now() + timeoutMs;
+
+  for (;;) {
+    const result = await check();
+    if (result != null) return result;
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out after ${timeoutMs}ms waiting for: ${what}`);
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+export async function waitForItemInScylla(
+  deps: Pick<Dependencies, 'ItemInvestigationService'>,
+  opts: {
+    orgId: string;
+    itemIdentifier: ItemIdentifier;
+    timeoutMs?: number;
+  },
+) {
+  return waitFor(
+    `item ${opts.itemIdentifier.id} in Scylla`,
+    async () =>
+      deps.ItemInvestigationService.getItemByIdentifier({
+        orgId: opts.orgId,
+        itemIdentifier: opts.itemIdentifier,
+      }),
+    { timeoutMs: opts.timeoutMs },
+  );
+}
+
+export async function waitForItemInClickHouse(
+  deps: Pick<Dependencies, 'DataWarehouse' | 'Tracer'>,
+  opts: {
+    orgId: string;
+    itemIdentifier: ItemIdentifier;
+    timeoutMs?: number;
+  },
+) {
+  const { orgId, itemIdentifier } = opts;
+  return waitFor(
+    `item ${itemIdentifier.id} in ClickHouse CONTENT_API_REQUESTS`,
+    async () => {
+      const rows = await deps.DataWarehouse.query(
+        `SELECT item_id, item_type_id, event
+           FROM analytics.CONTENT_API_REQUESTS
+          WHERE org_id = {orgId:String}
+            AND item_id = {itemId:String}
+            AND item_type_id = {itemTypeId:String}
+          LIMIT 1`,
+        deps.Tracer,
+        [
+          { name: 'orgId', value: orgId },
+          { name: 'itemId', value: itemIdentifier.id },
+          { name: 'itemTypeId', value: itemIdentifier.typeId },
+        ],
+      );
+      return rows.length > 0 ? rows[0] : null;
+    },
+    { timeoutMs: opts.timeoutMs },
+  );
+}

--- a/server/test/integ/wait.ts
+++ b/server/test/integ/wait.ts
@@ -37,6 +37,18 @@ export async function waitFor<T>(
  * that service falls back to the partial-items endpoint and the data warehouse
  * if Scylla returns nothing, which would mask a real Scylla write failure as a
  * passing test.
+ *
+ * Filtering by `item_identifier` alone matches the production lookup path
+ * (`ItemInvestigationService.getItemByIdentifier`), which leans on the
+ * secondary index on `item_identifier`. The table's partition key is
+ * `(org_id, synthetic_thread_id)`, so a partial-partition-key restriction
+ * (`org_id = ?` without `synthetic_thread_id`) would need `ALLOW FILTERING`.
+ * Callers should still assert on `org_id` after the row comes back to guard
+ * against the theoretical cross-org collision.
+ *
+ * Query errors are intentionally NOT swallowed — a structural Scylla error
+ * (bad query, schema drift) should surface immediately instead of polling
+ * itself into a misleading timeout.
  */
 export async function waitForItemInScylla(
   deps: Pick<Dependencies, 'Scylla'>,
@@ -59,7 +71,7 @@ export async function waitForItemInScylla(
             itemIdentifierToScyllaItemIdentifier(opts.itemIdentifier),
           ],
         ],
-      }).catch(() => []);
+      });
       return rows.length > 0 ? rows[0] : null;
     },
     { timeoutMs: opts.timeoutMs },


### PR DESCRIPTION
- fixes #339

## Context & Requests for Reviewers

Implements #339 (sub-issue of #288). Adds a real-infra integration test harness under `server/test/integ/` and the first scenario: end-to-end item submission landing in Scylla and ClickHouse.

The harness is intentionally generic — the four remaining #288 sub-issues (#340 rule change, #341 report flow, #342 background jobs, #343 outage) can build on top of it without rebuilding the bootstrap.

What's new:

- `setupIntegrationServer.ts` — boots the real IoC container, starts the express app, and runs `ItemProcessingWorker` inline; exposes `{ deps, request, shutdown }`.
- `wait.ts` — polling helpers (`waitForItemInScylla`, `waitForItemInClickHouse`, generic `waitFor`).
- `items-submission.integ.test.ts` — the first scenario: `POST /api/v1/items/async` → row in Scylla `item_submission_by_thread` *and* ClickHouse `analytics.CONTENT_API_REQUESTS`.
- `README.md` — how to run, layout, conventions.

Reuses existing `server/test/fixtureHelpers/` (`createOrg`, `createContentItemTypes`).

Findings worth flagging (also posted on #339):

- `test:integ` doesn't preload `dotenv` like `server:start` does — the harness imports `dotenv/config` so the IoC container sees env vars.
- ClickHouse queries use `?` placeholders + positional binds (`formatClickhouseQuery` convention), not the native `{name:Type}` substitution.
- BullMQ's `Worker.close()` closes the shared ioredis connection; `closeSharedResourcesForShutdown` then errors trying to `quit()` it again. Harness swallows that one specific error — a cleaner fix lives upstream (idempotent `quit` or `sharedConnection: true` for BullMQ workers).

Not in this PR (filed as follow-ups):

- CI workflow that boots docker-compose and runs `npm run test:integ`. Local cycle works today via `npm run up && npm run db:update && npm run test:integ`.
- Adoption for #340-#344. Whichever goes second is the right time to extract any shared scenario glue beyond what's already in `fixtureHelpers/` and `wait.ts`.

## Tests

The test itself is the test. Locally:

```bash
npm run up           # docker-compose: postgres, clickhouse, scylla, redis, hma, otel
npm run db:update -- --env staging
(cd server && npm run test:integ)
```

Output:

```
PASS test/integ/items-submission.integ.test.ts
  Items submission (integration)
    ✓ submitted item lands in Scylla and ClickHouse
Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Time:        ~8.6s
```

Reviewer checks:

- [ ] `npm run up && npm run db:update -- --env staging` succeeds (Node ≥22 required — db-migrator uses `fs/promises`'s `glob` export)
- [ ] `(cd server && npm run test:integ)` reports 1 passing test
- [ ] `(cd server && npm run lint)` — no new errors; 3 lint warnings in the integ test file were cleaned up before push
- [ ] `(cd server && npx tsc --noEmit)` — exit 0

## (Optional) Rollout Plan

None — test-only change. No production code touched, no schema changes, no deps added. Test does not run in CI yet (follow-up issue to wire it in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a README describing how to run the integration (end-to-end) test suite, required infrastructure, setup commands, test layout, conventions, and teardown notes.

* **Tests**
  * Added an end-to-end test for async item submission that verifies results in storage and analytics and includes safe teardown guards.
  * Added a reusable integration test harness and polling utilities to wait for asynchronous processing and assert outcomes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/488?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->