### PR TITLE
Persist failed submissions and surface retry in the NCMEC Reports dashboard

### DIFF
--- a/client/src/components/ItemAction.tsx
+++ b/client/src/components/ItemAction.tsx
@@ -1,21 +1,21 @@
-import ActionParametersModal, {
-  defaultValuesForParameters,
-} from '@/components/ActionParametersModal';
-import { type ActionParameterValues } from '@/components/ActionParameterInputs';
-import { type JsonObject } from 'type-fest';
 import {
-  type GQLActionParameter,
   namedOperations,
   useGQLBulkActionExecutionMutation,
   useGQLBulkActionsFormDataQuery,
+  type GQLActionParameter,
 } from '@/graphql/generated';
 import { stripTypename } from '@/graphql/inputHelpers';
-import { ItemIdentifier } from '@roostorg/types';
 import Pencil from '@/icons/lni/Education/pencil.svg?react';
+import { ItemIdentifier } from '@roostorg/types';
 import { Button, Input, Select } from 'antd';
 import orderBy from 'lodash/orderBy';
 import { useCallback, useMemo, useState } from 'react';
+import { type JsonObject } from 'type-fest';
 
+import { type ActionParameterValues } from '@/components/ActionParameterInputs';
+import ActionParametersModal, {
+  defaultValuesForParameters,
+} from '@/components/ActionParametersModal';
 import { selectFilterByLabelOption } from '@/webpages/dashboard/components/antDesignUtils';
 import CoopButton from '@/webpages/dashboard/components/CoopButton';
 import CoopModal from '@/webpages/dashboard/components/CoopModal';
@@ -50,7 +50,9 @@ export default function ItemAction(props: {
       const anyFailed = results.some((r) => r.success === false);
       if (anyFailed) {
         setModalBody(
-          'One or more actions failed. The callback URL may have returned an error. If your org requires a policy for decisions, select a policy and try again.',
+          'One or more actions failed. Check server logs for details. ' +
+            'If the action posts to a callback URL, the URL may have returned an error. ' +
+            'If your org requires a policy for decisions, select a policy and try again.',
         );
       } else {
         setModalBody('Actions submitted successfully.');
@@ -76,7 +78,9 @@ export default function ItemAction(props: {
   const [moderatorNote, setModeratorNote] = useState<string>('');
 
   const eligibleActions: EligibleAction[] = (queryData?.myOrg?.actions ?? [])
-    .filter((it) => it.itemTypes.map((t) => t.id).includes(itemIdentifier.typeId))
+    .filter((it) =>
+      it.itemTypes.map((t) => t.id).includes(itemIdentifier.typeId),
+    )
     .map((it) => ({
       id: it.id,
       name: it.name,
@@ -211,7 +215,8 @@ export default function ItemAction(props: {
               Object.keys(parametersByActionId).length > 0
                 ? (parametersByActionId as unknown as JsonObject)
                 : undefined,
-            note: moderatorNote.trim() === '' ? undefined : moderatorNote.trim(),
+            note:
+              moderatorNote.trim() === '' ? undefined : moderatorNote.trim(),
           },
         },
       }),

--- a/client/src/graphql/generated.ts
+++ b/client/src/graphql/generated.ts
@@ -2452,6 +2452,12 @@ export type GQLMutation = {
   readonly reorderRoutingRules: GQLReorderRoutingRulesResponse;
   readonly requestDemo?: Maybe<Scalars['Boolean']['output']>;
   readonly resetPassword: Scalars['Boolean']['output'];
+  /**
+   * Retries a previously-failed NCMEC submission. Org-scoped: callers can only
+   * retry decisions that belong to their own org. Returns success on a fresh
+   * successful submission, or an error with a user-safe summary on failure.
+   */
+  readonly retryNcmecSubmission: GQLRetryNcmecSubmissionResponse;
   readonly rotateApiKey: GQLRotateApiKeyResponse;
   readonly rotateWebhookSigningKey: GQLRotateWebhookSigningKeyResponse;
   readonly runRetroaction?: Maybe<GQLRunRetroactionResponse>;
@@ -2683,6 +2689,10 @@ export type GQLMutationResetPasswordArgs = {
   input: GQLResetPasswordInput;
 };
 
+export type GQLMutationRetryNcmecSubmissionArgs = {
+  decisionId: Scalars['ID']['input'];
+};
+
 export type GQLMutationRotateApiKeyArgs = {
   input: GQLRotateApiKeyInput;
 };
@@ -2879,6 +2889,33 @@ export type GQLNcmecContentItem = {
   readonly isReported: Scalars['Boolean']['output'];
 };
 
+/**
+ * An NCMEC submission that was decisioned in the MRT but never produced a
+ * successful CyberTip report. Reused on the NCMEC Reports dashboard so that
+ * reviewers can see and retry failed submissions in the same place as
+ * successful reports. The userId + userItemTypeId pair uniquely identifies
+ * the reported user; decisionId is the stable handle for retrying.
+ */
+export type GQLNcmecFailedSubmission = {
+  readonly __typename: 'NcmecFailedSubmission';
+  readonly decisionId: Scalars['ID']['output'];
+  readonly lastError?: Maybe<Scalars['String']['output']>;
+  readonly retryCount: Scalars['Int']['output'];
+  readonly reviewerId?: Maybe<Scalars['String']['output']>;
+  readonly status: GQLNcmecFailedSubmissionStatus;
+  readonly ts: Scalars['DateTime']['output'];
+  readonly userId: Scalars['String']['output'];
+  readonly userItemType: GQLUserItemType;
+};
+
+export const GQLNcmecFailedSubmissionStatus = {
+  NeverAttempted: 'NEVER_ATTEMPTED',
+  PermanentError: 'PERMANENT_ERROR',
+  RetryableError: 'RETRYABLE_ERROR',
+} as const;
+
+export type GQLNcmecFailedSubmissionStatus =
+  (typeof GQLNcmecFailedSubmissionStatus)[keyof typeof GQLNcmecFailedSubmissionStatus];
 export const GQLNcmecFileAnnotation = {
   AnimeDrawingVirtualHentai: 'ANIME_DRAWING_VIRTUAL_HENTAI',
   Bestiality: 'BESTIALITY',
@@ -3044,6 +3081,12 @@ export type GQLOrg = {
   readonly contentTypes: ReadonlyArray<GQLContentType>;
   readonly defaultInterfacePreferences: GQLUserInterfacePreferences;
   readonly email: Scalars['String']['output'];
+  /**
+   * NCMEC decisions that did not produce a successful CyberTip report. Returned
+   * alongside ncmecReports on the dashboard so reviewers can see the full
+   * submission status (successful + failed) in one place and retry failures.
+   */
+  readonly failedNcmecSubmissions: ReadonlyArray<GQLNcmecFailedSubmission>;
   readonly hasAppealsEnabled: Scalars['Boolean']['output'];
   readonly hasNCMECReportingEnabled: Scalars['Boolean']['output'];
   readonly hasPartialItemsEndpoint: Scalars['Boolean']['output'];
@@ -3802,6 +3845,16 @@ export type GQLResolvedJobCount = {
   readonly queueId?: Maybe<Scalars['String']['output']>;
   readonly reviewerId?: Maybe<Scalars['String']['output']>;
   readonly time: Scalars['String']['output'];
+};
+
+export type GQLRetryNcmecSubmissionResponse = {
+  readonly __typename: 'RetryNcmecSubmissionResponse';
+  /**
+   * Human-readable error summary if the retry failed. Never includes raw
+   * NCMEC response bodies; safe to render in the UI.
+   */
+  readonly error?: Maybe<Scalars['String']['output']>;
+  readonly success: Scalars['Boolean']['output'];
 };
 
 export type GQLRotateApiKeyError = GQLError & {
@@ -18383,6 +18436,21 @@ export type GQLNcmecReportValuesFragment = {
   }>;
 };
 
+export type GQLNcmecFailedSubmissionValuesFragment = {
+  readonly __typename: 'NcmecFailedSubmission';
+  readonly decisionId: string;
+  readonly ts: Date | string;
+  readonly reviewerId?: string | null;
+  readonly userId: string;
+  readonly status: GQLNcmecFailedSubmissionStatus;
+  readonly retryCount: number;
+  readonly lastError?: string | null;
+  readonly userItemType: {
+    readonly __typename: 'UserItemType';
+    readonly name: string;
+  };
+};
+
 export type GQLAllNcmecReportsQueryVariables = Exact<{ [key: string]: never }>;
 
 export type GQLAllNcmecReportsQuery = {
@@ -18419,6 +18487,20 @@ export type GQLAllNcmecReportsQuery = {
         readonly csv: string;
         readonly ncmecFileId: string;
       }>;
+    }>;
+    readonly failedNcmecSubmissions: ReadonlyArray<{
+      readonly __typename: 'NcmecFailedSubmission';
+      readonly decisionId: string;
+      readonly ts: Date | string;
+      readonly reviewerId?: string | null;
+      readonly userId: string;
+      readonly status: GQLNcmecFailedSubmissionStatus;
+      readonly retryCount: number;
+      readonly lastError?: string | null;
+      readonly userItemType: {
+        readonly __typename: 'UserItemType';
+        readonly name: string;
+      };
     }>;
     readonly users: ReadonlyArray<{
       readonly __typename: 'User';
@@ -18475,6 +18557,19 @@ export type GQLGetNcmecReportQuery = {
       readonly ncmecFileId: string;
     }>;
   } | null;
+};
+
+export type GQLRetryNcmecSubmissionMutationVariables = Exact<{
+  decisionId: Scalars['ID']['input'];
+}>;
+
+export type GQLRetryNcmecSubmissionMutation = {
+  readonly __typename: 'Mutation';
+  readonly retryNcmecSubmission: {
+    readonly __typename: 'RetryNcmecSubmissionResponse';
+    readonly success: boolean;
+    readonly error?: string | null;
+  };
 };
 
 export type GQLIsWarehouseAvailableQueryVariables = Exact<{
@@ -24873,6 +24968,20 @@ export const GQLNcmecReportValuesFragmentDoc = gql`
       ncmecFileId
     }
     isTest
+  }
+`;
+export const GQLNcmecFailedSubmissionValuesFragmentDoc = gql`
+  fragment NcmecFailedSubmissionValues on NcmecFailedSubmission {
+    decisionId
+    ts
+    reviewerId
+    userId
+    userItemType {
+      name
+    }
+    status
+    retryCount
+    lastError
   }
 `;
 export const GQLPolicyFieldsFragmentDoc = gql`
@@ -37096,6 +37205,9 @@ export const GQLAllNcmecReportsDocument = gql`
       ncmecReports {
         ...NCMECReportValues
       }
+      failedNcmecSubmissions {
+        ...NcmecFailedSubmissionValues
+      }
       users {
         id
         firstName
@@ -37104,6 +37216,7 @@ export const GQLAllNcmecReportsDocument = gql`
     }
   }
   ${GQLNcmecReportValuesFragmentDoc}
+  ${GQLNcmecFailedSubmissionValuesFragmentDoc}
 `;
 
 /**
@@ -37397,6 +37510,57 @@ export type GQLGetNcmecReportSuspenseQueryHookResult = ReturnType<
 export type GQLGetNcmecReportQueryResult = Apollo.QueryResult<
   GQLGetNcmecReportQuery,
   GQLGetNcmecReportQueryVariables
+>;
+export const GQLRetryNcmecSubmissionDocument = gql`
+  mutation RetryNcmecSubmission($decisionId: ID!) {
+    retryNcmecSubmission(decisionId: $decisionId) {
+      success
+      error
+    }
+  }
+`;
+export type GQLRetryNcmecSubmissionMutationFn = Apollo.MutationFunction<
+  GQLRetryNcmecSubmissionMutation,
+  GQLRetryNcmecSubmissionMutationVariables
+>;
+
+/**
+ * __useGQLRetryNcmecSubmissionMutation__
+ *
+ * To run a mutation, you first call `useGQLRetryNcmecSubmissionMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useGQLRetryNcmecSubmissionMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [gqlRetryNcmecSubmissionMutation, { data, loading, error }] = useGQLRetryNcmecSubmissionMutation({
+ *   variables: {
+ *      decisionId: // value for 'decisionId'
+ *   },
+ * });
+ */
+export function useGQLRetryNcmecSubmissionMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    GQLRetryNcmecSubmissionMutation,
+    GQLRetryNcmecSubmissionMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    GQLRetryNcmecSubmissionMutation,
+    GQLRetryNcmecSubmissionMutationVariables
+  >(GQLRetryNcmecSubmissionDocument, options);
+}
+export type GQLRetryNcmecSubmissionMutationHookResult = ReturnType<
+  typeof useGQLRetryNcmecSubmissionMutation
+>;
+export type GQLRetryNcmecSubmissionMutationResult =
+  Apollo.MutationResult<GQLRetryNcmecSubmissionMutation>;
+export type GQLRetryNcmecSubmissionMutationOptions = Apollo.BaseMutationOptions<
+  GQLRetryNcmecSubmissionMutation,
+  GQLRetryNcmecSubmissionMutationVariables
 >;
 export const GQLIsWarehouseAvailableDocument = gql`
   query IsWarehouseAvailable {
@@ -43402,6 +43566,7 @@ export const namedOperations = {
     UpdateRoutingRule: 'UpdateRoutingRule',
     ReorderRoutingRules: 'ReorderRoutingRules',
     SetMrtChartConfigurationSettings: 'SetMrtChartConfigurationSettings',
+    RetryNcmecSubmission: 'RetryNcmecSubmission',
     AddPolicies: 'AddPolicies',
     UpdatePolicy: 'UpdatePolicy',
     DeletePolicy: 'DeletePolicy',
@@ -43438,6 +43603,7 @@ export const namedOperations = {
     JobFields: 'JobFields',
     ManualReviewJobCommentFields: 'ManualReviewJobCommentFields',
     NCMECReportValues: 'NCMECReportValues',
+    NcmecFailedSubmissionValues: 'NcmecFailedSubmissionValues',
     PolicyFields: 'PolicyFields',
     RulesDashboardRuleFieldsFragment: 'RulesDashboardRuleFieldsFragment',
     SampleReportingRuleExecutionResultFields:

--- a/client/src/webpages/dashboard/Dashboard.css
+++ b/client/src/webpages/dashboard/Dashboard.css
@@ -186,3 +186,33 @@ body {
   -ms-overflow-style: none; /* IE and Edge */
   scrollbar-width: none; /* Firefox */
 }
+
+.scrollbar-show {
+  scrollbar-width: thin; /* Firefox */
+  scrollbar-color: rgba(0, 0, 0, 0.25) transparent; /* Firefox */
+}
+
+.scrollbar-show::-webkit-scrollbar {
+  -webkit-appearance: none;
+  width: 10px;
+  height: 10px;
+}
+
+.scrollbar-show::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.scrollbar-show::-webkit-scrollbar-thumb {
+  background-color: rgba(0, 0, 0, 0.25);
+  border-radius: 9999px;
+  border: 2px solid transparent;
+  background-clip: content-box;
+}
+
+.scrollbar-show::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(0, 0, 0, 0.45);
+}
+
+.scrollbar-show::-webkit-scrollbar-corner {
+  background: transparent;
+}

--- a/client/src/webpages/dashboard/Dashboard.tsx
+++ b/client/src/webpages/dashboard/Dashboard.tsx
@@ -739,14 +739,16 @@ export default function Dashboard() {
                   : '/dashboard'
               }
             >
-              <div className="w-full max-w-[1800px]">
+              {/* min-w-0 lets descendants' overflow-x-auto scroll instead of
+                  the whole page when content is wider than the viewport. */}
+              <div className="w-full max-w-[1800px] min-w-0">
                 {isCSSLoaded ? <Outlet /> : <FullScreenLoading />}
               </div>
             </ErrorBoundary>
           </div>
         </>
       ) : (
-        <main className="flex flex-col flex-grow overflow-y-auto min-h-0">
+        <main className="flex flex-col flex-grow overflow-auto min-h-0">
           <div className="p-10">
             <ErrorBoundary
               key={pathname}
@@ -754,7 +756,7 @@ export default function Dashboard() {
               buttonTitle={currentRouteHandle?.error?.buttonTitle}
               buttonLinkPath={currentRouteHandle?.error?.buttonLinkPath}
             >
-              <div className="w-full max-w-[1800px]">
+              <div className="w-full max-w-[1800px] min-w-0">
                 <Outlet />
               </div>
             </ErrorBoundary>

--- a/client/src/webpages/dashboard/components/table/Table.tsx
+++ b/client/src/webpages/dashboard/components/table/Table.tsx
@@ -19,6 +19,9 @@ export default function Table(
     customMaxHeight?: `max-h-[${number}px]`;
     disableFilter?: boolean;
     containerClassName?: string;
+    /** Force the horizontal scrollbar to always render. Opt-in because tables
+     * that always fit the viewport would otherwise show an unnecessary scrollbar. */
+    alwaysShowScrollbar?: boolean;
   } & (
     | {
         isCollapsed?: boolean;
@@ -38,6 +41,7 @@ export default function Table(
     customMaxHeight,
     disableFilter,
     containerClassName,
+    alwaysShowScrollbar,
   } = props;
   const {
     isCollapsed = undefined,
@@ -85,9 +89,9 @@ export default function Table(
       </div>
       <div className="w-full min-w-0 border border-gray-200 border-solid rounded-md">
         <div
-          className={`min-w-0 overflow-x-scroll overflow-y-auto rounded-md scrollbar-show ${
-            customMaxHeight ?? 'max-h-[1200px]'
-          }`}
+          className={`min-w-0 overflow-x-auto overflow-y-auto rounded-md ${
+            alwaysShowScrollbar ? 'scrollbar-show' : ''
+          } ${customMaxHeight ?? 'max-h-[1200px]'}`}
         >
           <table {...getTableProps()} className="w-full">
             <thead className="sticky top-0 z-10 bg-slate-50">

--- a/client/src/webpages/dashboard/components/table/Table.tsx
+++ b/client/src/webpages/dashboard/components/table/Table.tsx
@@ -63,7 +63,9 @@ export default function Table(
   };
 
   return (
-    <div className={`flex flex-col items-start max-w-full mb-8 ${containerClassName ?? 'w-fit'}`}>
+    <div
+      className={`flex flex-col items-start max-w-full mb-8 ${containerClassName ?? 'w-fit'}`}
+    >
       <div
         className={`flex w-full pb-2 items-start gap-4 ${
           topLeftComponent || topRightComponent
@@ -81,9 +83,9 @@ export default function Table(
         )}
         {topRightComponent}
       </div>
-      <div className="w-full border border-gray-200 border-solid rounded-md">
+      <div className="w-full min-w-0 border border-gray-200 border-solid rounded-md">
         <div
-          className={`overflow-x-auto overflow-y-auto rounded-md ${
+          className={`min-w-0 overflow-x-scroll overflow-y-auto rounded-md scrollbar-show ${
             customMaxHeight ?? 'max-h-[1200px]'
           }`}
         >
@@ -128,8 +130,8 @@ export default function Table(
                             index === 0
                               ? 'rounded-tl-md'
                               : index === headerGroup.headers.length - 1
-                              ? 'rounded-tr-md'
-                              : ''
+                                ? 'rounded-tr-md'
+                                : ''
                           }`}
                         >
                           <div className="flex flex-row items-center p-4 flex-nowrap whitespace-nowrap gap-3">
@@ -179,8 +181,8 @@ export default function Table(
                               rowIndex % 2 === 0 ? 'bg-white' : 'bg-slate-50'
                             }`
                         : rowIndex % 2 === 0
-                        ? 'bg-white'
-                        : 'bg-slate-50'
+                          ? 'bg-white'
+                          : 'bg-slate-50'
                     }
                     onClick={() => selectRow(row, rowIndex)}
                   >
@@ -205,8 +207,8 @@ export default function Table(
                               rowIndex % 2 === 0 ? 'bg-white' : 'bg-slate-50'
                             }`
                         : rowIndex % 2 === 0
-                        ? 'bg-white'
-                        : 'bg-slate-50'
+                          ? 'bg-white'
+                          : 'bg-slate-50'
                     }
                     onClick={() => selectRow(row, rowIndex)}
                   >

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobMagnifyImageComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobMagnifyImageComponent.tsx
@@ -104,9 +104,9 @@ export default function ManualReviewJobMagnifyImageComponent(props: {
     footerComponent == null
   ) {
     return (
-      <div className="flex flex-row items-center gap-2">
+      <div className="flex flex-row items-center gap-2 min-w-0">
         <div
-          className={`flex border-solid rounded-full ${
+          className={`flex shrink-0 border-solid rounded-full ${
             borderAndTextColor
               ? `${borderAndTextColor} border-2`
               : 'border-slate-500 border'
@@ -116,8 +116,8 @@ export default function ManualReviewJobMagnifyImageComponent(props: {
         </div>
         {label ? (
           <div
-            className={`ml-3 font-medium ${
-              labelTruncationType === 'wrap' ? 'overflow-auto' : 'truncate'
+            className={`ml-3 font-medium min-w-0 flex-1 ${
+              labelTruncationType === 'wrap' ? 'break-all' : 'truncate'
             }`}
           >
             {label}
@@ -162,11 +162,11 @@ export default function ManualReviewJobMagnifyImageComponent(props: {
         </div>
       }
     >
-      <div className="flex flex-row items-center cursor-pointer flex-nowrap">
+      <div className="flex flex-row items-center cursor-pointer min-w-0">
         {finalImageUrl ? (
           <img
             alt=""
-            className={`rounded-full ${
+            className={`rounded-full shrink-0 ${
               borderAndTextColor
                 ? `p-0.5 border-2 border-solid ${borderAndTextColor} w-12 h-12`
                 : 'border-current w-12 h-12'
@@ -175,7 +175,7 @@ export default function ManualReviewJobMagnifyImageComponent(props: {
           />
         ) : (
           <div
-            className={`flex border border-solid rounded-full ${
+            className={`flex shrink-0 border border-solid rounded-full ${
               borderAndTextColor ?? 'border-slate-500'
             }`}
           >
@@ -183,16 +183,22 @@ export default function ManualReviewJobMagnifyImageComponent(props: {
           </div>
         )}
         {label ? (
-          <div className="flex flex-col">
+          <div className="flex flex-col min-w-0 flex-1">
             <div
-              className={`ml-2 truncate font-medium ${
-                borderAndTextColor ?? 'text-slate-500'
-              }`}
+              className={`ml-2 font-medium ${
+                labelTruncationType === 'wrap' ? 'break-all' : 'truncate'
+              } ${borderAndTextColor ?? 'text-slate-500'}`}
             >
               {label}
             </div>
             {sublabel ? (
-              <div className="ml-2 text-xs truncate">{sublabel}</div>
+              <div
+                className={`ml-2 text-xs ${
+                  labelTruncationType === 'wrap' ? 'break-all' : 'truncate'
+                }`}
+              >
+                {sublabel}
+              </div>
             ) : null}
           </div>
         ) : null}

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ncmec/NCMECInspectedMedia.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ncmec/NCMECInspectedMedia.tsx
@@ -342,11 +342,12 @@ export default function NCMECInspectedMedia(props: {
             </div>
           ) : undefined}
           <div className="pb-2 text-base font-bold text-start">User</div>
-          <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="flex flex-wrap items-center justify-between gap-2 min-w-0 w-full">
             <ManualReviewJobMagnifyImageComponent
               itemIdentifier={{ id: user.id, typeId: user.type.id }}
               imageUrl={profilePicUrl?.url}
               label={displayName ? `${displayName} (${user.id})` : user.id}
+              labelTruncationType="wrap"
               fallbackComponent={
                 <UserAlt4 className="p-3 fill-slate-500 w-11" />
               }

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ncmec/NCMECReviewUser.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ncmec/NCMECReviewUser.tsx
@@ -651,6 +651,7 @@ export default function NCMECReviewUser(
 
   const sendReportModal = isActionable ? (
     <CoopModal
+      className="!w-[64rem] !max-w-[90vw]"
       visible={sendReportModalVisible}
       onClose={() => setSendReportModalVisible(false)}
       title="Confirm & Send NCMEC Report"
@@ -689,31 +690,26 @@ export default function NCMECReviewUser(
         },
       ]}
     >
-      <div className="flex flex-col w-full">
+      <div className="flex flex-col w-full min-w-0">
         <div className="!my-4 divider" />
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-4 text-start">
-            <div className="text-base font-bold">Suspect</div>
-            <div className="flex flex-row items-center mr-12">
+        <div className="flex items-start justify-between gap-4 min-w-0">
+          <div className="flex items-start gap-4 text-start min-w-0 flex-1">
+            <div className="text-base font-bold shrink-0 pt-1">Suspect</div>
+            <div className="flex flex-row items-start min-w-0 flex-1">
               {profilePicUrl ? (
                 <img
                   alt="profile pic"
-                  className="w-10 h-10 border-2 border-solid rounded-full border-slate-400"
+                  className="w-10 h-10 border-2 border-solid rounded-full border-slate-400 shrink-0"
                   src={profilePicUrl.url}
                 />
               ) : null}
-              {displayName ? (
-                <div className="ml-3 font-bold truncate text-slate-700">
-                  {displayName} ({item.id})
-                </div>
-              ) : (
-                <div className="ml-3 font-bold truncate text-slate-700">
-                  {item.id}
-                </div>
-              )}
+              <div className="ml-3 font-bold text-slate-700 break-all min-w-0 flex-1">
+                {displayName ? `${displayName} (${item.id})` : item.id}
+              </div>
             </div>
           </div>
           <Button
+            className="shrink-0"
             onClick={() => setUnblurAllMediaInConfirmation((prev) => !prev)}
           >
             {unblurAllMediaInConfirmation ? 'Blur All' : 'Unblur All'}

--- a/client/src/webpages/dashboard/ncmec/NcmecReportsDashboard.tsx
+++ b/client/src/webpages/dashboard/ncmec/NcmecReportsDashboard.tsx
@@ -8,6 +8,41 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useNavigate } from 'react-router-dom';
 
+/** Anchor that lazily creates a Blob URL on click and revokes it shortly
+ * after the download is triggered. Avoids leaking Blob URLs on every render
+ * (the previous inline `URL.createObjectURL` pattern leaked one per row per
+ * re-render, which adds up on a long-lived dashboard). */
+function BlobDownloadLink(props: {
+  fileName: string;
+  contents: string;
+  mimeType: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  const { fileName, contents, mimeType, children, className } = props;
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLAnchorElement>) => {
+      event.preventDefault();
+      const url = URL.createObjectURL(new Blob([contents], { type: mimeType }));
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = fileName;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      // Revoke after the browser has had a chance to start the download.
+      // Revoking immediately can cancel the download in some browsers.
+      setTimeout(() => URL.revokeObjectURL(url), 0);
+    },
+    [contents, fileName, mimeType],
+  );
+  return (
+    <a href="#" onClick={handleClick} className={className}>
+      {children}
+    </a>
+  );
+}
+
 import CopyTextComponent from '../../../components/common/CopyTextComponent';
 import FullScreenLoading from '../../../components/common/FullScreenLoading';
 import CoopButton from '../components/CoopButton';
@@ -27,9 +62,9 @@ import {
   useGQLGetNcmecReportLazyQuery,
   useGQLPermissionsQuery,
   useGQLRetryNcmecSubmissionMutation,
-} from '../../../graphql/generated';
-import { userHasPermissions } from '../../../routing/permissions';
-import { filterNullOrUndefined } from '../../../utils/collections';
+} from '@/graphql/generated';
+import { userHasPermissions } from '@/routing/permissions';
+import { filterNullOrUndefined } from '@/utils/collections';
 
 gql`
   fragment NCMECReportValues on NCMECReport {
@@ -422,16 +457,13 @@ export default function NcmecReportsDashboard() {
               <div key={report.reportId} className="flex flex-row">
                 <CopyTextComponent value={report.reportId} />
                 <div className="pl-2">
-                  <a
-                    href={URL.createObjectURL(
-                      new Blob([formatXml(report.reportXml)], {
-                        type: 'text/plain',
-                      }),
-                    )}
-                    download={`ncmec_report_${report.reportId}.xml`}
+                  <BlobDownloadLink
+                    fileName={`ncmec_report_${report.reportId}.xml`}
+                    contents={formatXml(report.reportXml)}
+                    mimeType="text/plain"
                   >
                     <DownloadOutlined />
-                  </a>
+                  </BlobDownloadLink>
                 </div>
               </div>
             ),
@@ -447,16 +479,13 @@ export default function NcmecReportsDashboard() {
                     <div key={media.id} className="flex flex-row">
                       <CopyTextComponent value={`ID: ${media.id}`} />
                       <div className="pl-2">
-                        <a
-                          href={URL.createObjectURL(
-                            new Blob([formatXml(media.xml)], {
-                              type: 'text/plain',
-                            }),
-                          )}
-                          download={`ncmec_report_${report.reportId}_media_${media.id}.xml`}
+                        <BlobDownloadLink
+                          fileName={`ncmec_report_${report.reportId}_media_${media.id}.xml`}
+                          contents={formatXml(media.xml)}
+                          mimeType="text/plain"
                         >
                           <DownloadOutlined />
-                        </a>
+                        </BlobDownloadLink>
                       </div>
                     </div>
                   ))}
@@ -475,16 +504,13 @@ export default function NcmecReportsDashboard() {
                       className="flex flex-row"
                     >
                       <div className="pl-2">
-                        <a
-                          href={URL.createObjectURL(
-                            new Blob([formatXml(additionalFile.xml)], {
-                              type: 'text/plain',
-                            }),
-                          )}
-                          download={`ncmec_report_additional_file_${additionalFile.ncmecFileId}.xml`}
+                        <BlobDownloadLink
+                          fileName={`ncmec_report_additional_file_${additionalFile.ncmecFileId}.xml`}
+                          contents={formatXml(additionalFile.xml)}
+                          mimeType="text/plain"
                         >
                           <DownloadOutlined className="pr-1" />
-                        </a>
+                        </BlobDownloadLink>
                       </div>
                       <div className="overflow-ellipsis">
                         {`URL: ${additionalFile.url}`}
@@ -507,16 +533,13 @@ export default function NcmecReportsDashboard() {
                     >
                       {`${reportedMessage.fileName}`}
                       <div className="pl-2">
-                        <a
-                          href={URL.createObjectURL(
-                            new Blob([reportedMessage.csv], {
-                              type: 'text/csv',
-                            }),
-                          )}
-                          download={`${reportedMessage.fileName}`}
+                        <BlobDownloadLink
+                          fileName={reportedMessage.fileName}
+                          contents={reportedMessage.csv}
+                          mimeType="text/csv"
                         >
                           <DownloadOutlined />
-                        </a>
+                        </BlobDownloadLink>
                       </div>
                     </div>
                   ))}
@@ -652,8 +675,10 @@ export default function NcmecReportsDashboard() {
         <div className="flex flex-col w-full min-w-0 max-w-full">
           <Table
             // Override Table's default `w-fit` so its internal overflow-x-auto
-            // can scroll the table when columns overflow the viewport.
+            // can scroll the table when columns overflow the viewport, and
+            // force the horizontal scrollbar to render.
             containerClassName="w-full min-w-0"
+            alwaysShowScrollbar
             columns={columns}
             data={tableData ?? []}
             topLeftComponent={

--- a/client/src/webpages/dashboard/ncmec/NcmecReportsDashboard.tsx
+++ b/client/src/webpages/dashboard/ncmec/NcmecReportsDashboard.tsx
@@ -1,8 +1,10 @@
+import { toast } from '@/coop-ui/Toast';
+import GridAlt from '@/icons/lnif/Design/grid-alt.svg?react';
 import { AuditOutlined, DownloadOutlined } from '@ant-design/icons';
 import { gql } from '@apollo/client';
-import { Button, Input } from 'antd';
+import { Button, Checkbox, Input, Tag, Tooltip } from 'antd';
 import { format } from 'date-fns';
-import { useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useNavigate } from 'react-router-dom';
 
@@ -24,8 +26,10 @@ import {
   useGQLAllNcmecReportsQuery,
   useGQLGetNcmecReportLazyQuery,
   useGQLPermissionsQuery,
+  useGQLRetryNcmecSubmissionMutation,
 } from '../../../graphql/generated';
 import { userHasPermissions } from '../../../routing/permissions';
+import { filterNullOrUndefined } from '../../../utils/collections';
 
 gql`
   fragment NCMECReportValues on NCMECReport {
@@ -54,11 +58,27 @@ gql`
     isTest
   }
 
+  fragment NcmecFailedSubmissionValues on NcmecFailedSubmission {
+    decisionId
+    ts
+    reviewerId
+    userId
+    userItemType {
+      name
+    }
+    status
+    retryCount
+    lastError
+  }
+
   query AllNCMECReports {
     myOrg {
       hasNCMECReportingEnabled
       ncmecReports {
         ...NCMECReportValues
+      }
+      failedNcmecSubmissions {
+        ...NcmecFailedSubmissionValues
       }
       users {
         id
@@ -79,7 +99,60 @@ gql`
       ...NCMECReportValues
     }
   }
+
+  mutation RetryNcmecSubmission($decisionId: ID!) {
+    retryNcmecSubmission(decisionId: $decisionId) {
+      success
+      error
+    }
+  }
 `;
+
+type ColumnId =
+  | 'date'
+  | 'reviewer'
+  | 'reportId'
+  | 'userId'
+  | 'userItemType'
+  | 'status'
+  | 'reportedMedia'
+  | 'additionalFiles'
+  | 'reportedMessages'
+  | 'isTest'
+  | 'lastError'
+  | 'action';
+
+const COLUMN_VISIBILITY_STORAGE_KEY = 'ncmec-reports-column-visibility';
+
+const defaultColumnVisibility: Record<ColumnId, boolean> = {
+  date: true,
+  reviewer: true,
+  reportId: true,
+  userId: true,
+  userItemType: true,
+  status: true,
+  reportedMedia: true,
+  additionalFiles: true,
+  reportedMessages: true,
+  isTest: true,
+  lastError: false,
+  action: true,
+};
+
+const columnLabels: Record<ColumnId, string> = {
+  date: 'Date',
+  reviewer: 'Reviewer',
+  reportId: 'Report ID',
+  userId: 'User ID',
+  userItemType: 'User Item Type',
+  status: 'Status',
+  reportedMedia: 'Reported Media',
+  additionalFiles: 'Additional Files',
+  reportedMessages: 'Reported Messages',
+  isTest: 'Test Report',
+  lastError: 'Last Error',
+  action: 'Action',
+};
 
 export default function NcmecReportsDashboard() {
   const navigate = useNavigate();
@@ -92,8 +165,12 @@ export default function NcmecReportsDashboard() {
     error: allReportsError,
     data: allReportsData,
   } = useGQLAllNcmecReportsQuery();
-  const { hasNCMECReportingEnabled, ncmecReports, users } =
-    allReportsData?.myOrg ?? {};
+  const {
+    hasNCMECReportingEnabled,
+    ncmecReports,
+    failedNcmecSubmissions,
+    users,
+  } = allReportsData?.myOrg ?? {};
 
   const [
     getNcmecReportById,
@@ -104,6 +181,97 @@ export default function NcmecReportsDashboard() {
     },
   ] = useGQLGetNcmecReportLazyQuery();
 
+  const [retryNcmecSubmission] = useGQLRetryNcmecSubmissionMutation();
+  const [retryingDecisionId, setRetryingDecisionId] = useState<string | null>(
+    null,
+  );
+
+  const handleRetry = useCallback(
+    async (decisionId: string) => {
+      setRetryingDecisionId(decisionId);
+      try {
+        const { data } = await retryNcmecSubmission({
+          variables: { decisionId },
+          // Refetching keeps the table consistent: a successful retry should
+          // move the row from "Failed" to "Successful" the next render.
+          refetchQueries: ['AllNCMECReports'],
+          awaitRefetchQueries: true,
+        });
+        if (data?.retryNcmecSubmission.success) {
+          toast.success('NCMEC submission retried successfully');
+        } else {
+          toast.error(
+            data?.retryNcmecSubmission.error ??
+              'Retry failed for an unknown reason',
+          );
+        }
+      } catch (e: unknown) {
+        toast.error(
+          e instanceof Error ? e.message : 'Retry failed unexpectedly',
+        );
+      } finally {
+        setRetryingDecisionId(null);
+      }
+    },
+    [retryNcmecSubmission],
+  );
+
+  // Column visibility state, persisted to localStorage so users keep their
+  // chosen view across sessions. Mirrors the queues-dashboard pattern.
+  const [columnVisibility, setColumnVisibility] = useState<
+    Record<ColumnId, boolean>
+  >(() => {
+    try {
+      const stored = localStorage.getItem(COLUMN_VISIBILITY_STORAGE_KEY);
+      if (stored) {
+        return {
+          ...defaultColumnVisibility,
+          ...(JSON.parse(stored) as Partial<Record<ColumnId, boolean>>),
+        };
+      }
+    } catch {
+      // Ignore corrupt or inaccessible localStorage entries; fall through to
+      // the defaults rather than blocking the whole page.
+    }
+    return defaultColumnVisibility;
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(
+        COLUMN_VISIBILITY_STORAGE_KEY,
+        JSON.stringify(columnVisibility),
+      );
+    } catch {
+      // Best-effort persistence; quota / private-mode failures are non-fatal.
+    }
+  }, [columnVisibility]);
+
+  const toggleColumnVisibility = useCallback((columnId: ColumnId) => {
+    setColumnVisibility((prev) => ({ ...prev, [columnId]: !prev[columnId] }));
+  }, []);
+
+  const [columnsMenuVisible, setColumnsMenuVisible] = useState(false);
+  const columnsMenuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        columnsMenuRef.current &&
+        !columnsMenuRef.current.contains(event.target as Node)
+      ) {
+        setColumnsMenuVisible(false);
+      }
+    };
+    if (columnsMenuVisible) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => {
+        document.removeEventListener('mousedown', handleClickOutside);
+      };
+    }
+    return undefined;
+  }, [columnsMenuVisible]);
+
   const fetchReportById = () => {
     if (!searchId) {
       return;
@@ -112,227 +280,323 @@ export default function NcmecReportsDashboard() {
   };
 
   const columns = useMemo(
-    () => [
-      {
-        Header: 'Date',
-        accessor: 'date',
-        sortType: stringSort,
-        sortDescFirst: true,
-        Filter: (props: ColumnProps) =>
-          DateRangeColumnFilter({
-            columnProps: props,
-            accessor: 'date',
-            placeholder: '',
-          }),
-        filter: 'dateRange',
-      },
-      {
-        Header: 'Reviewer',
-        accessor: 'reviewer',
-        filter: 'includes',
-        sortType: stringSort,
-        Filter: (props: ColumnProps) =>
-          SelectColumnFilter({
-            columnProps: props,
-            accessor: 'reviewer',
-          }),
-      },
-      {
-        Header: 'Report ID',
-        accessor: 'reportId',
-        filter: 'text',
-        canSort: false,
-        Filter: (props: ColumnProps) =>
-          DefaultColumnFilter({
-            columnProps: props,
-            accessor: 'reportId',
-            placeholder: 'Report ID',
-          }),
-      },
-      {
-        Header: 'User ID',
-        accessor: 'userId',
-        filter: 'text',
-        canSort: false,
-        Filter: (props: ColumnProps) =>
-          DefaultColumnFilter({
-            columnProps: props,
-            accessor: 'userId',
-            placeholder: 'User ID',
-          }),
-      },
-      {
-        Header: 'User Item Type',
-        accessor: 'userItemType',
-        filter: 'text',
-        canSort: false,
-        Filter: (props: ColumnProps) =>
-          DefaultColumnFilter({
-            columnProps: props,
-            accessor: 'userItemType',
-            placeholder: 'User Type',
-          }),
-      },
-      {
-        Header: 'Reported Media',
-        accessor: 'reportedMedia',
-      },
-      {
-        Header: 'Additional Files',
-        accessor: 'additionalFiles',
-      },
-      {
-        Header: 'Reported Messages',
-        accessor: 'reportedMessages',
-      },
-      {
-        Header: 'Test Report',
-        accessor: 'isTest',
-      },
-    ],
-    [],
+    () =>
+      filterNullOrUndefined([
+        columnVisibility.date
+          ? {
+              Header: 'Date',
+              accessor: 'date',
+              sortType: stringSort,
+              sortDescFirst: true,
+              Filter: (props: ColumnProps) =>
+                DateRangeColumnFilter({
+                  columnProps: props,
+                  accessor: 'date',
+                  placeholder: '',
+                }),
+              filter: 'dateRange',
+            }
+          : undefined,
+        columnVisibility.reviewer
+          ? {
+              Header: 'Reviewer',
+              accessor: 'reviewer',
+              filter: 'includes',
+              sortType: stringSort,
+              Filter: (props: ColumnProps) =>
+                SelectColumnFilter({
+                  columnProps: props,
+                  accessor: 'reviewer',
+                }),
+            }
+          : undefined,
+        columnVisibility.status
+          ? {
+              // Cell renders the colored Tag from row.status; the filter
+              // reads the plain string from row.original.values.status.
+              Header: 'Status',
+              accessor: 'status',
+              filter: 'includes',
+              sortType: stringSort,
+              Filter: (props: ColumnProps) =>
+                SelectColumnFilter({
+                  columnProps: props,
+                  accessor: 'status',
+                }),
+            }
+          : undefined,
+        columnVisibility.reportId
+          ? {
+              Header: 'Report ID',
+              accessor: 'reportId',
+              filter: 'text',
+              canSort: false,
+              Filter: (props: ColumnProps) =>
+                DefaultColumnFilter({
+                  columnProps: props,
+                  accessor: 'reportId',
+                  placeholder: 'Report ID',
+                }),
+            }
+          : undefined,
+        columnVisibility.userId
+          ? {
+              Header: 'User ID',
+              accessor: 'userId',
+              filter: 'text',
+              canSort: false,
+              Filter: (props: ColumnProps) =>
+                DefaultColumnFilter({
+                  columnProps: props,
+                  accessor: 'userId',
+                  placeholder: 'User ID',
+                }),
+            }
+          : undefined,
+        columnVisibility.userItemType
+          ? {
+              Header: 'User Item Type',
+              accessor: 'userItemType',
+              filter: 'text',
+              canSort: false,
+              Filter: (props: ColumnProps) =>
+                DefaultColumnFilter({
+                  columnProps: props,
+                  accessor: 'userItemType',
+                  placeholder: 'User Type',
+                }),
+            }
+          : undefined,
+        columnVisibility.reportedMedia
+          ? { Header: 'Reported Media', accessor: 'reportedMedia' }
+          : undefined,
+        columnVisibility.additionalFiles
+          ? { Header: 'Additional Files', accessor: 'additionalFiles' }
+          : undefined,
+        columnVisibility.reportedMessages
+          ? { Header: 'Reported Messages', accessor: 'reportedMessages' }
+          : undefined,
+        columnVisibility.isTest
+          ? { Header: 'Test Report', accessor: 'isTest' }
+          : undefined,
+        columnVisibility.lastError
+          ? { Header: 'Last Error', accessor: 'lastError' }
+          : undefined,
+        columnVisibility.action
+          ? { Header: 'Action', accessor: 'action' }
+          : undefined,
+      ]),
+    [columnVisibility],
   );
 
-  const dataValues = useMemo(() => {
-    const reports =
+  const tableData = useMemo(() => {
+    // Successful reports come from `ncmecReports`; if the user is searching by
+    // a specific report id we substitute the lazy-fetched single report.
+    const successfulReportsSource =
       searchId && ncmecReportData && ncmecReportData.ncmecReportById
         ? [ncmecReportData.ncmecReportById]
-        : ncmecReports;
-    return reports
-      ?.filter((report) =>
+        : (ncmecReports ?? []);
+
+    const successfulRows = successfulReportsSource
+      .filter((report) =>
         searchId ? report.reportId.includes(searchId) : true,
       )
-      .sort((a, b) =>
-        b.ts.toLocaleString().localeCompare(a.ts.toLocaleString()),
-      )
       .map((report) => {
-        const reviewer = users?.find((user) => user.id === report.reviewerId);
+        const reviewer = users?.find((u) => u.id === report.reviewerId);
+        const reviewerName = reviewer
+          ? `${reviewer.firstName} ${reviewer.lastName}`
+          : 'Other';
         return {
-          ...report,
-          date: report.ts,
-          reviewer: reviewer
-            ? `${reviewer.firstName} ${reviewer.lastName}`
-            : 'Other',
+          // Sort key: numeric ms since epoch on the underlying timestamp.
+          tsMs: new Date(report.ts).getTime(),
+          row: {
+            // Plain strings here back the SelectColumnFilter dropdowns.
+            values: {
+              reviewer: reviewerName,
+              status: 'Successful' as const,
+            },
+            date: <div>{format(new Date(report.ts), 'MM/dd/yy h:mm a')}</div>,
+            reviewer: <div className="whitespace-nowrap">{reviewerName}</div>,
+            status: <Tag color="success">Successful</Tag>,
+            reportId: (
+              <div key={report.reportId} className="flex flex-row">
+                <CopyTextComponent value={report.reportId} />
+                <div className="pl-2">
+                  <a
+                    href={URL.createObjectURL(
+                      new Blob([formatXml(report.reportXml)], {
+                        type: 'text/plain',
+                      }),
+                    )}
+                    download={`ncmec_report_${report.reportId}.xml`}
+                  >
+                    <DownloadOutlined />
+                  </a>
+                </div>
+              </div>
+            ),
+            userId: <CopyTextComponent value={report.userId} />,
+            userItemType: <div>{report.userItemType.name}</div>,
+            reportedMedia: (
+              <div className="flex flex-col justify-start gap-1 text-start">
+                {report.reportedMedia.length < 2
+                  ? null
+                  : `${report.reportedMedia.length} media files: `}
+                <div className="flex flex-wrap overflow-auto max-h-12">
+                  {report.reportedMedia.map((media) => (
+                    <div key={media.id} className="flex flex-row">
+                      <CopyTextComponent value={`ID: ${media.id}`} />
+                      <div className="pl-2">
+                        <a
+                          href={URL.createObjectURL(
+                            new Blob([formatXml(media.xml)], {
+                              type: 'text/plain',
+                            }),
+                          )}
+                          download={`ncmec_report_${report.reportId}_media_${media.id}.xml`}
+                        >
+                          <DownloadOutlined />
+                        </a>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ),
+            additionalFiles: (
+              <div className="flex flex-col justify-start max-w-md gap-1 text-start">
+                {report.additionalFiles.length < 2
+                  ? null
+                  : `${report.additionalFiles.length} additional files: `}
+                <div className="flex flex-wrap overflow-auto max-h-12">
+                  {report.additionalFiles.map((additionalFile) => (
+                    <div
+                      key={additionalFile.ncmecFileId}
+                      className="flex flex-row"
+                    >
+                      <div className="pl-2">
+                        <a
+                          href={URL.createObjectURL(
+                            new Blob([formatXml(additionalFile.xml)], {
+                              type: 'text/plain',
+                            }),
+                          )}
+                          download={`ncmec_report_additional_file_${additionalFile.ncmecFileId}.xml`}
+                        >
+                          <DownloadOutlined className="pr-1" />
+                        </a>
+                      </div>
+                      <div className="overflow-ellipsis">
+                        {`URL: ${additionalFile.url}`}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ),
+            reportedMessages: (
+              <div className="flex flex-col justify-start gap-1 text-start">
+                {report.reportedMessages.length < 2
+                  ? null
+                  : `${report.reportedMessages.length} reported threads: `}
+                <div className="flex flex-wrap overflow-auto max-h-12">
+                  {report.reportedMessages.map((reportedMessage) => (
+                    <div
+                      key={reportedMessage.fileName}
+                      className="flex flex-row"
+                    >
+                      {`${reportedMessage.fileName}`}
+                      <div className="pl-2">
+                        <a
+                          href={URL.createObjectURL(
+                            new Blob([reportedMessage.csv], {
+                              type: 'text/csv',
+                            }),
+                          )}
+                          download={`${reportedMessage.fileName}`}
+                        >
+                          <DownloadOutlined />
+                        </a>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ),
+            isTest: <div>{report.isTest ? 'True' : 'False'}</div>,
+            lastError: null as React.ReactNode,
+            action: null as React.ReactNode,
+          },
         };
       });
-  }, [ncmecReportData, ncmecReports, searchId, users]);
 
-  const tableData = useMemo(
-    () =>
-      dataValues?.map((report) => {
-        return {
-          date: (
-            <div>{format(new Date(report.date), 'MM/dd/yy h:mm a')}</div>
-          ),
-          reviewer: <div className="whitespace-nowrap">{report.reviewer}</div>,
-          reportId: (
-            <div key={report.reportId} className="flex flex-row">
-              <CopyTextComponent value={report.reportId} />
-              <div className="pl-2">
-                <a
-                  href={URL.createObjectURL(
-                    new Blob([formatXml(report.reportXml)], {
-                      type: 'text/plain',
-                    }),
-                  )}
-                  download={`ncmec_report_${report.reportId}.xml`}
+    // Failed rows: only included when the user isn't searching by report id
+    // (failed submissions don't have a CyberTip report id to match against).
+    const failedRows = searchId
+      ? []
+      : (failedNcmecSubmissions ?? []).map((failed) => {
+          const reviewer = users?.find((u) => u.id === failed.reviewerId);
+          const reviewerName = reviewer
+            ? `${reviewer.firstName} ${reviewer.lastName}`
+            : 'Other';
+          return {
+            tsMs: new Date(failed.ts).getTime(),
+            row: {
+              values: {
+                reviewer: reviewerName,
+                status: 'Failed' as const,
+              },
+              date: <div>{format(new Date(failed.ts), 'MM/dd/yy h:mm a')}</div>,
+              reviewer: <div className="whitespace-nowrap">{reviewerName}</div>,
+              status: <Tag color="error">Failed</Tag>,
+              reportId: <span className="text-zinc-400">—</span>,
+              userId: <CopyTextComponent value={failed.userId} />,
+              userItemType: <div>{failed.userItemType.name}</div>,
+              reportedMedia: <span className="text-zinc-400">—</span>,
+              additionalFiles: <span className="text-zinc-400">—</span>,
+              reportedMessages: <span className="text-zinc-400">—</span>,
+              isTest: <span className="text-zinc-400">—</span>,
+              lastError: failed.lastError ? (
+                <Tooltip title={failed.lastError} placement="topLeft">
+                  <div className="max-w-xs overflow-hidden text-xs text-ellipsis whitespace-nowrap text-red-700">
+                    {failed.lastError}
+                  </div>
+                </Tooltip>
+              ) : (
+                <span className="text-zinc-400">—</span>
+              ),
+              action: (
+                <Button
+                  size="small"
+                  type="primary"
+                  loading={retryingDecisionId === failed.decisionId}
+                  disabled={
+                    retryingDecisionId !== null &&
+                    retryingDecisionId !== failed.decisionId
+                  }
+                  onClick={() => {
+                    void handleRetry(failed.decisionId);
+                  }}
                 >
-                  <DownloadOutlined />
-                </a>
-              </div>
-            </div>
-          ),
-          userId: <CopyTextComponent value={report.userId} />,
-          userItemType: <div>{report.userItemType.name}</div>,
-          reportedMedia: (
-            <div className="flex flex-col justify-start gap-1 text-start">
-              {report.reportedMedia.length < 2
-                ? null
-                : `${report.reportedMedia.length} media files: `}
-              <div className="flex flex-wrap overflow-auto max-h-12">
-                {report.reportedMedia.map((media) => (
-                  <div key={media.id} className="flex flex-row">
-                    <CopyTextComponent value={`ID: ${media.id}`} />
-                    <div className="pl-2">
-                      <a
-                        href={URL.createObjectURL(
-                          new Blob([formatXml(media.xml)], {
-                            type: 'text/plain',
-                          }),
-                        )}
-                        download={`ncmec_report_${report.reportId}_media_${media.id}.xml`}
-                      >
-                        <DownloadOutlined />
-                      </a>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          ),
-          values: report,
-          additionalFiles: (
-            <div className="flex flex-col justify-start max-w-md gap-1 text-start">
-              {report.additionalFiles.length < 2
-                ? null
-                : `${report.additionalFiles.length} additional files: `}
-              <div className="flex flex-wrap overflow-auto max-h-12">
-                {report.additionalFiles.map((additionalFile) => (
-                  <div
-                    key={additionalFile.ncmecFileId}
-                    className="flex flex-row"
-                  >
-                    <div className="pl-2">
-                      <a
-                        href={URL.createObjectURL(
-                          new Blob([formatXml(additionalFile.xml)], {
-                            type: 'text/plain',
-                          }),
-                        )}
-                        download={`ncmec_report_additional_file_${additionalFile.ncmecFileId}.xml`}
-                      >
-                        <DownloadOutlined className="pr-1" />
-                      </a>
-                    </div>
-                    <div className="overflow-ellipsis">
-                      {`URL: ${additionalFile.url}`}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          ),
-          reportedMessages: (
-            <div className="flex flex-col justify-start gap-1 text-start">
-              {report.reportedMessages.length < 2
-                ? null
-                : `${report.reportedMessages.length} reported threads: `}
-              <div className="flex flex-wrap overflow-auto max-h-12">
-                {report.reportedMessages.map((reportedMessage) => (
-                  <div key={reportedMessage.fileName} className="flex flex-row">
-                    {`${reportedMessage.fileName}`}
-                    <div className="pl-2">
-                      <a
-                        href={URL.createObjectURL(
-                          new Blob([reportedMessage.csv], {
-                            type: 'text/csv',
-                          }),
-                        )}
-                        download={`${reportedMessage.fileName}`}
-                      >
-                        <DownloadOutlined />
-                      </a>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          ),
-          isTest: <div>{report.isTest ? 'True' : 'False'}</div>,
-        };
-      }),
-    [dataValues],
-  );
+                  Retry
+                </Button>
+              ),
+            },
+          };
+        });
+
+    return [...successfulRows, ...failedRows]
+      .sort((a, b) => b.tsMs - a.tsMs)
+      .map(({ row }) => row);
+  }, [
+    failedNcmecSubmissions,
+    handleRetry,
+    ncmecReportData,
+    ncmecReports,
+    retryingDecisionId,
+    searchId,
+    users,
+  ]);
 
   if (allReportsError || ncmecReportError) {
     throw allReportsError ?? ncmecReportError!;
@@ -364,7 +628,8 @@ export default function NcmecReportsDashboard() {
       />
       {allReportsLoading || ncmecReportLoading ? (
         <FullScreenLoading />
-      ) : ncmecReports?.length === 0 ? (
+      ) : (ncmecReports?.length ?? 0) === 0 &&
+        (failedNcmecSubmissions?.length ?? 0) === 0 ? (
         <div className="flex items-center justify-center w-full h-full">
           <div className="flex flex-col items-center justify-center p-12 mt-24">
             <div className="pb-3 text-zinc-500 text-8xl">
@@ -384,19 +649,73 @@ export default function NcmecReportsDashboard() {
           </div>
         </div>
       ) : (
-        <div className="flex flex-col max-w-full w-fit">
+        <div className="flex flex-col w-full min-w-0 max-w-full">
           <Table
+            // Override Table's default `w-fit` so its internal overflow-x-auto
+            // can scroll the table when columns overflow the viewport.
+            containerClassName="w-full min-w-0"
             columns={columns}
             data={tableData ?? []}
             topLeftComponent={
-              <div className="flex flex-col items-start" key="input">
-                <div className="mb-2 font-semibold">Search By Report ID</div>
-                <Input
-                  className="rounded-lg w-[300px]"
-                  onChange={(event) => setSearchId(event.target.value)}
-                  autoFocus
-                  allowClear
-                />
+              <div
+                className="flex flex-row flex-wrap items-end gap-4"
+                key="topleft"
+              >
+                <div className="flex flex-col items-start">
+                  <div className="mb-2 font-semibold">Search By Report ID</div>
+                  <Input
+                    className="rounded-lg w-[300px]"
+                    onChange={(event) => setSearchId(event.target.value)}
+                    autoFocus
+                    allowClear
+                  />
+                </div>
+                <div
+                  ref={columnsMenuRef}
+                  className="relative inline-block text-start"
+                >
+                  <Button
+                    className={`font-semibold text-base rounded ${
+                      Object.values(columnVisibility).filter(Boolean).length ===
+                      Object.keys(columnLabels).length
+                        ? 'bg-white text-gray-600 hover:bg-white hover:text-gray-600'
+                        : 'bg-gray-600 text-white border-none hover:bg-gray-500'
+                    }`}
+                    icon={
+                      <GridAlt
+                        className="inline-block w-4 h-4 mr-2"
+                        fill="currentColor"
+                      />
+                    }
+                    onClick={() => setColumnsMenuVisible(!columnsMenuVisible)}
+                  >
+                    Columns
+                  </Button>
+                  {columnsMenuVisible && (
+                    <div className="absolute left-0 z-20 flex flex-col mt-1 bg-white border border-solid border-gray-300 rounded shadow-md min-w-[240px]">
+                      <div className="px-4 py-4 text-base font-semibold">
+                        Show Columns
+                      </div>
+                      <div className="!p-0 !m-0 divider" />
+                      <div className="flex flex-col px-4 py-2">
+                        {(Object.keys(columnLabels) as ColumnId[]).map(
+                          (columnId) => (
+                            <div key={columnId} className="py-2">
+                              <Checkbox
+                                checked={columnVisibility[columnId]}
+                                onChange={() =>
+                                  toggleColumnVisibility(columnId)
+                                }
+                              >
+                                {columnLabels[columnId]}
+                              </Checkbox>
+                            </div>
+                          ),
+                        )}
+                      </div>
+                    </div>
+                  )}
+                </div>
               </div>
             }
           />

--- a/server/graphql/generated.ts
+++ b/server/graphql/generated.ts
@@ -2519,6 +2519,12 @@ export type GQLMutation = {
   readonly reorderRoutingRules: GQLReorderRoutingRulesResponse;
   readonly requestDemo?: Maybe<Scalars['Boolean']['output']>;
   readonly resetPassword: Scalars['Boolean']['output'];
+  /**
+   * Retries a previously-failed NCMEC submission. Org-scoped: callers can only
+   * retry decisions that belong to their own org. Returns success on a fresh
+   * successful submission, or an error with a user-safe summary on failure.
+   */
+  readonly retryNcmecSubmission: GQLRetryNcmecSubmissionResponse;
   readonly rotateApiKey: GQLRotateApiKeyResponse;
   readonly rotateWebhookSigningKey: GQLRotateWebhookSigningKeyResponse;
   readonly runRetroaction?: Maybe<GQLRunRetroactionResponse>;
@@ -2750,6 +2756,10 @@ export type GQLMutationResetPasswordArgs = {
   input: GQLResetPasswordInput;
 };
 
+export type GQLMutationRetryNcmecSubmissionArgs = {
+  decisionId: Scalars['ID']['input'];
+};
+
 export type GQLMutationRotateApiKeyArgs = {
   input: GQLRotateApiKeyInput;
 };
@@ -2946,6 +2956,33 @@ export type GQLNcmecContentItem = {
   readonly isReported: Scalars['Boolean']['output'];
 };
 
+/**
+ * An NCMEC submission that was decisioned in the MRT but never produced a
+ * successful CyberTip report. Reused on the NCMEC Reports dashboard so that
+ * reviewers can see and retry failed submissions in the same place as
+ * successful reports. The userId + userItemTypeId pair uniquely identifies
+ * the reported user; decisionId is the stable handle for retrying.
+ */
+export type GQLNcmecFailedSubmission = {
+  readonly __typename?: 'NcmecFailedSubmission';
+  readonly decisionId: Scalars['ID']['output'];
+  readonly lastError?: Maybe<Scalars['String']['output']>;
+  readonly retryCount: Scalars['Int']['output'];
+  readonly reviewerId?: Maybe<Scalars['String']['output']>;
+  readonly status: GQLNcmecFailedSubmissionStatus;
+  readonly ts: Scalars['DateTime']['output'];
+  readonly userId: Scalars['String']['output'];
+  readonly userItemType: GQLUserItemType;
+};
+
+export const GQLNcmecFailedSubmissionStatus = {
+  NeverAttempted: 'NEVER_ATTEMPTED',
+  PermanentError: 'PERMANENT_ERROR',
+  RetryableError: 'RETRYABLE_ERROR',
+} as const;
+
+export type GQLNcmecFailedSubmissionStatus =
+  (typeof GQLNcmecFailedSubmissionStatus)[keyof typeof GQLNcmecFailedSubmissionStatus];
 export const GQLNcmecFileAnnotation = {
   AnimeDrawingVirtualHentai: 'ANIME_DRAWING_VIRTUAL_HENTAI',
   Bestiality: 'BESTIALITY',
@@ -3111,6 +3148,12 @@ export type GQLOrg = {
   readonly contentTypes: ReadonlyArray<GQLContentType>;
   readonly defaultInterfacePreferences: GQLUserInterfacePreferences;
   readonly email: Scalars['String']['output'];
+  /**
+   * NCMEC decisions that did not produce a successful CyberTip report. Returned
+   * alongside ncmecReports on the dashboard so reviewers can see the full
+   * submission status (successful + failed) in one place and retry failures.
+   */
+  readonly failedNcmecSubmissions: ReadonlyArray<GQLNcmecFailedSubmission>;
   readonly hasAppealsEnabled: Scalars['Boolean']['output'];
   readonly hasNCMECReportingEnabled: Scalars['Boolean']['output'];
   readonly hasPartialItemsEndpoint: Scalars['Boolean']['output'];
@@ -3869,6 +3912,16 @@ export type GQLResolvedJobCount = {
   readonly queueId?: Maybe<Scalars['String']['output']>;
   readonly reviewerId?: Maybe<Scalars['String']['output']>;
   readonly time: Scalars['String']['output'];
+};
+
+export type GQLRetryNcmecSubmissionResponse = {
+  readonly __typename?: 'RetryNcmecSubmissionResponse';
+  /**
+   * Human-readable error summary if the retry failed. Never includes raw
+   * NCMEC response bodies; safe to render in the UI.
+   */
+  readonly error?: Maybe<Scalars['String']['output']>;
+  readonly success: Scalars['Boolean']['output'];
 };
 
 export type GQLRotateApiKeyError = GQLError & {
@@ -6000,6 +6053,12 @@ export type GQLResolversTypes = {
       contentItem: GQLResolversTypes['Item'];
     }
   >;
+  NcmecFailedSubmission: ResolverTypeWrapper<
+    Omit<GQLNcmecFailedSubmission, 'userItemType'> & {
+      userItemType: GQLResolversTypes['UserItemType'];
+    }
+  >;
+  NcmecFailedSubmissionStatus: GQLNcmecFailedSubmissionStatus;
   NcmecFileAnnotation: GQLNcmecFileAnnotation;
   NcmecIndustryClassification: GQLNcmecIndustryClassification;
   NcmecInternetDetailType: GQLNcmecInternetDetailType;
@@ -6100,6 +6159,7 @@ export type GQLResolversTypes = {
   RequestDemoInterest: GQLRequestDemoInterest;
   ResetPasswordInput: GQLResetPasswordInput;
   ResolvedJobCount: ResolverTypeWrapper<GQLResolvedJobCount>;
+  RetryNcmecSubmissionResponse: ResolverTypeWrapper<GQLRetryNcmecSubmissionResponse>;
   RotateApiKeyError: ResolverTypeWrapper<GQLRotateApiKeyError>;
   RotateApiKeyInput: GQLRotateApiKeyInput;
   RotateApiKeyResponse: ResolverTypeWrapper<
@@ -6705,6 +6765,9 @@ export type GQLResolversParentTypes = {
   NcmecContentItem: Omit<GQLNcmecContentItem, 'contentItem'> & {
     contentItem: GQLResolversParentTypes['Item'];
   };
+  NcmecFailedSubmission: Omit<GQLNcmecFailedSubmission, 'userItemType'> & {
+    userItemType: GQLResolversParentTypes['UserItemType'];
+  };
   NcmecManualReviewJobPayload: NcmecManualReviewJobPayload;
   NcmecMediaInput: GQLNcmecMediaInput;
   NcmecOrgSettings: GQLNcmecOrgSettings;
@@ -6789,6 +6852,7 @@ export type GQLResolversParentTypes = {
   RequestDemoInput: GQLRequestDemoInput;
   ResetPasswordInput: GQLResetPasswordInput;
   ResolvedJobCount: GQLResolvedJobCount;
+  RetryNcmecSubmissionResponse: GQLRetryNcmecSubmissionResponse;
   RotateApiKeyError: GQLRotateApiKeyError;
   RotateApiKeyInput: GQLRotateApiKeyInput;
   RotateApiKeyResponse: GQLResolversUnionTypes<GQLResolversParentTypes>['RotateApiKeyResponse'];
@@ -10876,6 +10940,12 @@ export type GQLMutationResolvers<
     ContextType,
     RequireFields<GQLMutationResetPasswordArgs, 'input'>
   >;
+  retryNcmecSubmission?: Resolver<
+    GQLResolversTypes['RetryNcmecSubmissionResponse'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationRetryNcmecSubmissionArgs, 'decisionId'>
+  >;
   rotateApiKey?: Resolver<
     GQLResolversTypes['RotateApiKeyResponse'],
     ParentType,
@@ -11171,6 +11241,37 @@ export type GQLNcmecContentItemResolvers<
   isReported?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
 };
 
+export type GQLNcmecFailedSubmissionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['NcmecFailedSubmission'] =
+    GQLResolversParentTypes['NcmecFailedSubmission'],
+> = {
+  decisionId?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
+  lastError?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  retryCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
+  reviewerId?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  status?: Resolver<
+    GQLResolversTypes['NcmecFailedSubmissionStatus'],
+    ParentType,
+    ContextType
+  >;
+  ts?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
+  userId?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  userItemType?: Resolver<
+    GQLResolversTypes['UserItemType'],
+    ParentType,
+    ContextType
+  >;
+};
+
 export type GQLNcmecManualReviewJobPayloadResolvers<
   ContextType = Context,
   ParentType extends GQLResolversParentTypes['NcmecManualReviewJobPayload'] =
@@ -11427,6 +11528,11 @@ export type GQLOrgResolvers<
     ContextType
   >;
   email?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  failedNcmecSubmissions?: Resolver<
+    ReadonlyArray<GQLResolversTypes['NcmecFailedSubmission']>,
+    ParentType,
+    ContextType
+  >;
   hasAppealsEnabled?: Resolver<
     GQLResolversTypes['Boolean'],
     ParentType,
@@ -12691,6 +12797,15 @@ export type GQLResolvedJobCountResolvers<
     ContextType
   >;
   time?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+};
+
+export type GQLRetryNcmecSubmissionResponseResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['RetryNcmecSubmissionResponse'] =
+    GQLResolversParentTypes['RetryNcmecSubmissionResponse'],
+> = {
+  error?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
+  success?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
 };
 
 export type GQLRotateApiKeyErrorResolvers<
@@ -14652,6 +14767,7 @@ export type GQLResolvers<ContextType = Context> = {
   NCMECReportedThread?: GQLNcmecReportedThreadResolvers<ContextType>;
   NcmecAdditionalFile?: GQLNcmecAdditionalFileResolvers<ContextType>;
   NcmecContentItem?: GQLNcmecContentItemResolvers<ContextType>;
+  NcmecFailedSubmission?: GQLNcmecFailedSubmissionResolvers<ContextType>;
   NcmecManualReviewJobPayload?: GQLNcmecManualReviewJobPayloadResolvers<ContextType>;
   NcmecOrgSettings?: GQLNcmecOrgSettingsResolvers<ContextType>;
   NcmecReportedMediaDetails?: GQLNcmecReportedMediaDetailsResolvers<ContextType>;
@@ -14699,6 +14815,7 @@ export type GQLResolvers<ContextType = Context> = {
   ReportingRuleNameExistsError?: GQLReportingRuleNameExistsErrorResolvers<ContextType>;
   ReportingRulePassRateData?: GQLReportingRulePassRateDataResolvers<ContextType>;
   ResolvedJobCount?: GQLResolvedJobCountResolvers<ContextType>;
+  RetryNcmecSubmissionResponse?: GQLRetryNcmecSubmissionResponseResolvers<ContextType>;
   RotateApiKeyError?: GQLRotateApiKeyErrorResolvers<ContextType>;
   RotateApiKeyResponse?: GQLRotateApiKeyResponseResolvers<ContextType>;
   RotateApiKeySuccessResponse?: GQLRotateApiKeySuccessResponseResolvers<ContextType>;

--- a/server/graphql/modules/ncmec.ts
+++ b/server/graphql/modules/ncmec.ts
@@ -4,7 +4,11 @@ import type {
   GQLNcmecOrgSettings,
   GQLQueryResolvers,
 } from '../generated.js';
-import { unauthenticatedError, userInputError } from '../utils/errors.js';
+import {
+  forbiddenError,
+  unauthenticatedError,
+  userInputError,
+} from '../utils/errors.js';
 
 /** Input shape for updateNcmecOrgSettings; matches NcmecOrgSettingsInput in schema (used so resolver type-checks even if generated types are stale). */
 type NcmecOrgSettingsInputShape = {
@@ -57,6 +61,12 @@ const typeDefs = /* GraphQL */ `
     updateNcmecOrgSettings(
       input: NcmecOrgSettingsInput!
     ): UpdateNcmecOrgSettingsResponse!
+    """
+    Retries a previously-failed NCMEC submission. Org-scoped: callers can only
+    retry decisions that belong to their own org. Returns success on a fresh
+    successful submission, or an error with a user-safe summary on failure.
+    """
+    retryNcmecSubmission(decisionId: ID!): RetryNcmecSubmissionResponse!
   }
 
   enum NcmecInternetDetailType {
@@ -108,6 +118,39 @@ const typeDefs = /* GraphQL */ `
 
   type UpdateNcmecOrgSettingsResponse {
     success: Boolean!
+  }
+
+  type RetryNcmecSubmissionResponse {
+    success: Boolean!
+    """
+    Human-readable error summary if the retry failed. Never includes raw
+    NCMEC response bodies; safe to render in the UI.
+    """
+    error: String
+  }
+
+  enum NcmecFailedSubmissionStatus {
+    RETRYABLE_ERROR
+    PERMANENT_ERROR
+    NEVER_ATTEMPTED
+  }
+
+  """
+  An NCMEC submission that was decisioned in the MRT but never produced a
+  successful CyberTip report. Reused on the NCMEC Reports dashboard so that
+  reviewers can see and retry failed submissions in the same place as
+  successful reports. The userId + userItemTypeId pair uniquely identifies
+  the reported user; decisionId is the stable handle for retrying.
+  """
+  type NcmecFailedSubmission {
+    decisionId: ID!
+    ts: DateTime!
+    reviewerId: String
+    userId: String!
+    userItemType: UserItemType!
+    status: NcmecFailedSubmissionStatus!
+    retryCount: Int!
+    lastError: String
   }
 
   type NCMECReportedMedia {
@@ -341,6 +384,31 @@ const Mutation: GQLMutationResolvers = {
     });
 
     return { success: true };
+  },
+  async retryNcmecSubmission(_, { decisionId }, context) {
+    const user = context.getUser();
+    if (!user) {
+      throw unauthenticatedError('User required.');
+    }
+    if (!user.getPermissions().includes('VIEW_CHILD_SAFETY_DATA')) {
+      throw forbiddenError(
+        'VIEW_CHILD_SAFETY_DATA permission required to retry NCMEC submissions.',
+      );
+    }
+    const result = await context.services.NcmecService.retrySubmission({
+      orgId: user.orgId,
+      decisionId,
+      requestingReviewerId: user.id,
+    });
+    if (result.kind === 'success') {
+      return { success: true, error: null };
+    }
+    if (result.kind === 'not_found') {
+      // Don't disclose whether the decision exists in another org. Surface
+      // the same response as a missing decision.
+      return { success: false, error: 'Decision not found.' };
+    }
+    return { success: false, error: result.error };
   },
 };
 

--- a/server/graphql/modules/org.ts
+++ b/server/graphql/modules/org.ts
@@ -535,13 +535,21 @@ const Org: GQLOrgResolvers = {
           throw new Error('NCMEC user item type is not of kind USER');
         }
         const errorRow = errorByJobId.get(d.job_payload.id);
+        // Map the DB string through a known-set check before returning so a
+        // future migration adding a new status value can't take down the
+        // entire `failedNcmecSubmissions` field via GraphQL enum validation.
+        const status: 'RETRYABLE_ERROR' | 'PERMANENT_ERROR' | 'NEVER_ATTEMPTED' =
+          errorRow?.status === 'RETRYABLE_ERROR' ||
+          errorRow?.status === 'PERMANENT_ERROR'
+            ? errorRow.status
+            : 'NEVER_ATTEMPTED';
         return {
           decisionId: d.id,
           ts: d.created_at,
           reviewerId: d.reviewer_id ?? null,
           userId,
           userItemType: itemType,
-          status: errorRow?.status ?? 'NEVER_ATTEMPTED',
+          status,
           retryCount: errorRow?.retry_count ?? 0,
           lastError: errorRow?.last_error ?? null,
         };

--- a/server/graphql/modules/org.ts
+++ b/server/graphql/modules/org.ts
@@ -1,5 +1,8 @@
 /* eslint-disable max-lines */
 
+import { GraphQLError } from 'graphql';
+
+import { filterDecisionsToFailedSubmissions } from '../../services/ncmecService/index.js';
 import { isCoopErrorOfType } from '../../utils/errors.js';
 import { __throw } from '../../utils/misc.js';
 import {
@@ -10,10 +13,9 @@ import {
   type GQLPendingInvite,
   type GQLQueryResolvers,
 } from '../generated.js';
-import { GraphQLError } from 'graphql';
-import { gqlErrorResult, gqlSuccessResult } from '../utils/gqlResult.js';
-import { forbiddenError, unauthenticatedError } from '../utils/errors.js';
 import { type Context } from '../resolvers.js';
+import { forbiddenError, unauthenticatedError } from '../utils/errors.js';
+import { gqlErrorResult, gqlSuccessResult } from '../utils/gqlResult.js';
 
 const typeDefs = /* GraphQL */ `
   type Org {
@@ -44,6 +46,12 @@ const typeDefs = /* GraphQL */ `
     hasNCMECReportingEnabled: Boolean!
     hasAppealsEnabled: Boolean!
     ncmecReports: [NCMECReport!]!
+    """
+    NCMEC decisions that did not produce a successful CyberTip report. Returned
+    alongside ncmecReports on the dashboard so reviewers can see the full
+    submission status (successful + failed) in one place and retry failures.
+    """
+    failedNcmecSubmissions: [NcmecFailedSubmission!]!
     requiresPolicyForDecisionsInMrt: Boolean!
     requiresDecisionReasonInMrt: Boolean!
     previewJobsViewEnabled: Boolean!
@@ -88,7 +96,7 @@ const typeDefs = /* GraphQL */ `
   }
 
   union CreateOrgResponse =
-      CreateOrgSuccessResponse
+    | CreateOrgSuccessResponse
     | OrgWithEmailExistsError
     | OrgWithNameExistsError
 
@@ -206,8 +214,14 @@ const Query: GQLQueryResolvers = {
 type ResolveOrgActionsContext = {
   getUser: () => { orgId: string } | null | undefined;
   services: {
-    ModerationConfigService: Pick<Context['services']['ModerationConfigService'], 'getActions'>;
-    NcmecService: Pick<Context['services']['NcmecService'], 'hasNCMECReportingEnabled'>;
+    ModerationConfigService: Pick<
+      Context['services']['ModerationConfigService'],
+      'getActions'
+    >;
+    NcmecService: Pick<
+      Context['services']['NcmecService'],
+      'hasNCMECReportingEnabled'
+    >;
   };
 };
 
@@ -264,7 +278,9 @@ const Org: GQLOrgResolvers = {
     }
 
     if (!user.getPermissions().includes('MANAGE_ORG')) {
-      throw forbiddenError('User does not have permission to view pending invites');
+      throw forbiddenError(
+        'User does not have permission to view pending invites',
+      );
     }
 
     const invites =
@@ -464,6 +480,74 @@ const Org: GQLOrgResolvers = {
       }),
     );
   },
+  async failedNcmecSubmissions(org, _, context) {
+    const user = context.getUser();
+    if (!user || user.orgId !== org.id) {
+      throw unauthenticatedError('User required.');
+    }
+    if (!user.getPermissions().includes('VIEW_CHILD_SAFETY_DATA')) {
+      throw forbiddenError(
+        'VIEW_CHILD_SAFETY_DATA permission required to view NCMEC submissions.',
+      );
+    }
+
+    // Pull all SUBMIT_NCMEC_REPORT decisions for the org, then subtract those
+    // that already produced a successful report. Whatever remains is "failed"
+    // (either retryable, permanently failed, or pending background retry).
+    const [decisions, successfulKeys] = await Promise.all([
+      context.services.ManualReviewToolService.getNcmecDecisionsForOrg({
+        orgId: user.orgId,
+      }),
+      context.services.NcmecService.getSuccessfulSubmissionKeysForOrg(
+        user.orgId,
+      ),
+    ]);
+
+    const decisionsWithKey = decisions.map((d) => ({
+      decision: d,
+      userId: d.job_payload.payload.item.itemId,
+      userItemTypeId: d.job_payload.payload.item.itemTypeIdentifier.id,
+    }));
+    const failedDecisions = filterDecisionsToFailedSubmissions(
+      decisionsWithKey,
+      successfulKeys,
+    );
+
+    if (failedDecisions.length === 0) {
+      return [];
+    }
+
+    const jobIds = failedDecisions.map(
+      ({ decision }) => decision.job_payload.id,
+    );
+    const errorRows =
+      await context.services.NcmecService.getNcmecErrorsForJobIds(jobIds);
+    const errorByJobId = new Map(errorRows.map((e) => [e.job_id, e]));
+
+    return Promise.all(
+      failedDecisions.map(async ({ decision: d, userId, userItemTypeId }) => {
+        const itemType =
+          await context.services.ModerationConfigService.getItemType({
+            orgId: user.orgId,
+            itemTypeSelector: { id: userItemTypeId },
+          });
+        if (!itemType || itemType.kind !== 'USER') {
+          throw new Error('NCMEC user item type is not of kind USER');
+        }
+        const errorRow = errorByJobId.get(d.job_payload.id);
+        return {
+          decisionId: d.id,
+          ts: d.created_at,
+          reviewerId: d.reviewer_id ?? null,
+          userId,
+          userItemType: itemType,
+          status: errorRow?.status ?? 'NEVER_ATTEMPTED',
+          retryCount: errorRow?.retry_count ?? 0,
+          lastError: errorRow?.last_error ?? null,
+        };
+      }),
+    );
+  },
   async requiresPolicyForDecisionsInMrt(org, _, context) {
     return context.services.ManualReviewToolService.getRequiresPolicyForDecisions(
       org.id,
@@ -519,7 +603,9 @@ const Org: GQLOrgResolvers = {
     }
 
     if (!user.getPermissions().includes('MANAGE_ORG')) {
-      throw forbiddenError('User does not have permission to manage SSO settings');
+      throw forbiddenError(
+        'User does not have permission to manage SSO settings',
+      );
     }
 
     const settings = await context.services.OrgSettingsService.getSamlSettings(
@@ -539,7 +625,9 @@ const Org: GQLOrgResolvers = {
     }
 
     if (!user.getPermissions().includes('MANAGE_ORG')) {
-      throw forbiddenError('User does not have permission to manage SSO settings');
+      throw forbiddenError(
+        'User does not have permission to manage SSO settings',
+      );
     }
 
     const settings = await context.services.OrgSettingsService.getSamlSettings(

--- a/server/iocContainer/index.ts
+++ b/server/iocContainer/index.ts
@@ -1124,7 +1124,7 @@ export default async function getBottle() {
                   actorEmail: reviewerEmail,
                 });
                 break;
-              case 'SUBMIT_NCMEC_REPORT':
+              case 'SUBMIT_NCMEC_REPORT': {
                 if (job.payload.kind !== 'NCMEC') {
                   throw new Error(
                     'Attempting to submit a NCMEC report for a non-NCMEC job',
@@ -1184,6 +1184,7 @@ export default async function getBottle() {
                   });
                 }
                 break;
+              }
               case 'TRANSFORM_JOB_AND_RECREATE_IN_QUEUE': {
                 const reportHistory =
                   'reportHistory' in job.payload

--- a/server/iocContainer/index.ts
+++ b/server/iocContainer/index.ts
@@ -2,7 +2,7 @@
 import { createRequire } from 'module';
 import Bottle from '@ethanresnick/bottlejs';
 import opentelemetry from '@opentelemetry/api';
-import { makeDateString, type ItemIdentifier } from '@roostorg/types';
+import { type ItemIdentifier } from '@roostorg/types';
 import {
   types as scyllaTypes,
   type Host as ScyllaHost,
@@ -108,7 +108,6 @@ import makeHmaService, {
 } from '../services/hmaService/index.js';
 import { ItemInvestigationService } from '../services/itemInvestigationService/index.js';
 import {
-  getFieldValueForRole,
   itemSubmissionWithTypeIdentifierToItemSubmission,
   type ItemSubmissionWithTypeIdentifier,
   type NormalizedItemData,
@@ -140,6 +139,7 @@ import {
   // eslint-disable-next-line import/no-restricted-paths
 } from '../services/moderationConfigService/moderationConfigServiceQueries.js';
 import {
+  buildSubmitReportParamsFromDecision,
   makeNcmecService,
   type NcmecService,
 } from '../services/ncmecService/index.js';
@@ -1138,64 +1138,19 @@ export default async function getBottle() {
                 if (itemType === undefined || itemType.kind !== 'USER') {
                   throw new Error('Item Type for User does not exist');
                 }
-                const displayName = getFieldValueForRole(
-                  itemType.schema,
-                  itemType.schemaFieldRoles,
-                  'displayName',
-                  data,
-                );
-                const profilePicUrl = getFieldValueForRole(
-                  itemType.schema,
-                  itemType.schemaFieldRoles,
-                  'profileIcon',
-                  data,
-                );
-
-                const allMedia = job.payload.allMediaItems;
-                const media = await Promise.all(
-                  decision.reportedMedia.map(async (it) => {
-                    const reportedItem = allMedia.find(
-                      (payloadMedia) =>
-                        payloadMedia.contentItem.itemId === it.id,
-                    );
-                    if (reportedItem === undefined) {
-                      throw new Error(
-                        'Unable to find reported media in job payload',
-                      );
-                    }
-                    const itemType =
-                      await container.getItemTypeEventuallyConsistent({
-                        orgId,
-                        typeSelector:
-                          reportedItem.contentItem.itemTypeIdentifier,
-                      });
-                    if (itemType === undefined) {
-                      throw new Error(
-                        'Unable to find item type for reported media',
-                      );
-                    }
-
-                    const createdAt =
-                      getFieldValueForRole(
-                        itemType.schema,
-                        itemType.schemaFieldRoles,
-                        'createdAt',
-                        reportedItem.contentItem.data,
-                      ) ?? makeDateString(new Date().toISOString());
-                    if (createdAt === undefined) {
-                      throw new Error('No created at for reported media');
-                    }
-
-                    return {
-                      id: it.id,
-                      typeId: it.typeId,
-                      url: it.url,
-                      createdAt,
-                      industryClassification: it.industryClassification,
-                      fileAnnotations: it.fileAnnotations,
-                    };
-                  }),
-                );
+                const reportParams = await buildSubmitReportParamsFromDecision({
+                  orgId,
+                  reviewerId,
+                  reportedItemId: itemId,
+                  reportedItemTypeId: itemTypeIdentifier.id,
+                  reportedUserItemType: itemType,
+                  reportedUserData: data,
+                  allMediaItems: job.payload.allMediaItems,
+                  decisionComponent: decision,
+                  jobId: job.id,
+                  getItemTypeEventuallyConsistent:
+                    container.getItemTypeEventuallyConsistent,
+                });
                 // Submissions go to the NCMEC test endpoint
                 // (exttest.cybertip.org) unless the deployment is explicitly
                 // configured for production via NCMEC_ENV=production. Operators
@@ -1203,35 +1158,7 @@ export default async function getBottle() {
                 // configured in Settings → NCMEC are production or test
                 // credentials issued by NCMEC.
                 const isTest = process.env.NCMEC_ENV !== 'production';
-                await container.NcmecService.submitReport(
-                  {
-                    reportedUser: {
-                      id: itemId,
-                      typeId: itemTypeIdentifier.id,
-                      ...(displayName ? { displayName } : {}),
-                      ...(profilePicUrl
-                        ? { profilePicture: profilePicUrl.url }
-                        : {}),
-                    },
-                    threads: decision.reportedMessages,
-                    orgId,
-                    media,
-                    reviewerId,
-                    incidentType: decision.incidentType,
-                    ...(decision.escalateToHighPriority != null &&
-                    decision.escalateToHighPriority.trim() !== ''
-                      ? {
-                          escalateToHighPriority:
-                            decision.escalateToHighPriority.trim(),
-                        }
-                      : {}),
-                    ...(decision.additionalInfo != null &&
-                    decision.additionalInfo.trim() !== ''
-                      ? { additionalInfo: decision.additionalInfo.trim() }
-                      : {}),
-                  },
-                  isTest,
-                );
+                await container.NcmecService.submitReport(reportParams, isTest);
                 const actionAndPolicy =
                   await container.NcmecService.getNCMECActionsToRunAndPolicies(
                     orgId,

--- a/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.test.ts
+++ b/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.test.ts
@@ -141,3 +141,90 @@ describe('ClickhouseActionExecutionsAdapter.findInferredUserIdentity', () => {
     expect(sentSql).toContain('org-99');
   });
 });
+
+describe('ClickhouseActionExecutionsAdapter.findContentCreatorIdentity', () => {
+  it('returns null when no rows match', async () => {
+    const { adapter } = makeAdapter([]);
+
+    const result = await adapter.findContentCreatorIdentity({
+      orgId: 'org-1',
+      itemId: 'content-1',
+      itemTypeId: 'content-type-1',
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('projects the creator id + type id from the most-recent CONTENT row', async () => {
+    const ts = '2026-05-10T12:00:00.000Z';
+    const { adapter } = makeAdapter([
+      {
+        ts,
+        item_creator_id: 'user-42',
+        item_creator_type_id: 'user-type-A',
+      },
+    ]);
+
+    const result = await adapter.findContentCreatorIdentity({
+      orgId: 'org-1',
+      itemId: 'content-1',
+      itemTypeId: 'content-type-1',
+    });
+
+    expect(result).toEqual({
+      creatorId: 'user-42',
+      creatorTypeId: 'user-type-A',
+      lastSeenAt: new Date(ts),
+    });
+  });
+
+  it('returns null when the row has empty creator fields', async () => {
+    const { adapter } = makeAdapter([
+      {
+        ts: '2026-05-10T12:00:00.000Z',
+        item_creator_id: null,
+        item_creator_type_id: 'user-type-A',
+      },
+    ]);
+
+    const result = await adapter.findContentCreatorIdentity({
+      orgId: 'org-1',
+      itemId: 'content-1',
+      itemTypeId: 'content-type-1',
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('filters to CONTENT rows with non-empty creator columns and uses LIMIT 1', async () => {
+    const { adapter, query } = makeAdapter([]);
+
+    await adapter.findContentCreatorIdentity({
+      orgId: 'org-1',
+      itemId: 'content-1',
+      itemTypeId: 'content-type-1',
+    });
+
+    const sentSql = query.mock.calls[0][0];
+    expect(sentSql).toContain('analytics.ACTION_EXECUTIONS');
+    expect(sentSql).toContain("item_type_kind = 'CONTENT'");
+    expect(sentSql).toContain('item_creator_id IS NOT NULL');
+    expect(sentSql).toContain("item_creator_id != ''");
+    expect(sentSql).toContain('item_creator_type_id IS NOT NULL');
+    expect(sentSql).toContain("item_creator_type_id != ''");
+    expect(sentSql).toContain('LIMIT 1');
+  });
+
+  it('passes the item type id to disambiguate from other content with the same id', async () => {
+    const { adapter, query } = makeAdapter([]);
+
+    await adapter.findContentCreatorIdentity({
+      orgId: 'org-1',
+      itemId: 'content-1',
+      itemTypeId: 'content-type-PHOTO',
+    });
+
+    const sentSql = query.mock.calls[0][0];
+    expect(sentSql).toContain('content-type-PHOTO');
+  });
+});

--- a/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.ts
+++ b/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.ts
@@ -4,6 +4,8 @@ import type SafeTracer from '../../../utils/SafeTracer.js';
 import { SIX_MONTHS_MS } from '../../../utils/time.js';
 import { formatClickhouseQuery } from '../utils/clickhouseSql.js';
 import {
+  type ContentCreatorIdentityInput,
+  type ContentCreatorIdentityRecord,
   type IActionExecutionsAdapter,
   type InferredUserIdentityInput,
   type InferredUserIdentityRecord,
@@ -203,6 +205,64 @@ export class ClickhouseActionExecutionsAdapter implements IActionExecutionsAdapt
 
     return {
       itemTypeId: userTypeId,
+      lastSeenAt: new Date(row.ts),
+    };
+  }
+
+  async findContentCreatorIdentity(
+    input: ContentCreatorIdentityInput,
+  ): Promise<ContentCreatorIdentityRecord | null> {
+    const {
+      orgId,
+      itemId,
+      itemTypeId,
+      lookbackWindowMs = SIX_MONTHS_MS,
+    } = input;
+
+    const lookbackStart = new Date(Date.now() - Math.max(1, lookbackWindowMs));
+    const lookbackStartDate = lookbackStart.toISOString().slice(0, 10);
+
+    // Filter empty creator rows in SQL so LIMIT 1 always returns a usable row
+    // when one exists; otherwise the most recent action on this content could
+    // legitimately have no creator and hide older rows that do.
+    const sql = `
+      SELECT
+        ts,
+        item_creator_id,
+        item_creator_type_id
+      FROM analytics.ACTION_EXECUTIONS
+      WHERE org_id = ?
+        AND ds >= toDate(?)
+        AND lower(item_id) = lower(?)
+        AND item_type_id = ?
+        AND item_type_kind = 'CONTENT'
+        AND item_creator_id IS NOT NULL
+        AND item_creator_id != ''
+        AND item_creator_type_id IS NOT NULL
+        AND item_creator_type_id != ''
+      ORDER BY ts DESC
+      LIMIT 1
+    `;
+
+    const rows = await this.query<ClickhouseActionExecutionRow>(sql, [
+      orgId,
+      lookbackStartDate,
+      itemId,
+      itemTypeId,
+    ]);
+
+    if (rows.length === 0) {
+      return null;
+    }
+
+    const row = rows[0];
+    if (!row.item_creator_id || !row.item_creator_type_id) {
+      return null;
+    }
+
+    return {
+      creatorId: row.item_creator_id,
+      creatorTypeId: row.item_creator_type_id,
       lastSeenAt: new Date(row.ts),
     };
   }

--- a/server/plugins/warehouse/queries/IActionExecutionsAdapter.ts
+++ b/server/plugins/warehouse/queries/IActionExecutionsAdapter.ts
@@ -46,6 +46,21 @@ export interface InferredUserIdentityRecord {
   lastSeenAt: Date;
 }
 
+export interface ContentCreatorIdentityInput {
+  orgId: string;
+  /** Id of the content item whose creator we want to resolve. */
+  itemId: string;
+  /** Type id of the content item; required to disambiguate id collisions. */
+  itemTypeId: string;
+  lookbackWindowMs?: number;
+}
+
+export interface ContentCreatorIdentityRecord {
+  creatorId: string;
+  creatorTypeId: string;
+  lastSeenAt: Date;
+}
+
 export interface IActionExecutionsAdapter {
   getItemActionHistory(
     input: ItemActionHistoryInput,
@@ -59,4 +74,14 @@ export interface IActionExecutionsAdapter {
   findInferredUserIdentity(
     input: InferredUserIdentityInput,
   ): Promise<InferredUserIdentityRecord | null>;
+
+  /**
+   * Resolve the creator `(id, typeId)` for a CONTENT item by finding the
+   * most-recent action-execution row matching `(item_id, item_type_id)` and
+   * projecting its creator columns. Returns `null` when no row has non-empty
+   * creator fields.
+   */
+  findContentCreatorIdentity(
+    input: ContentCreatorIdentityInput,
+  ): Promise<ContentCreatorIdentityRecord | null>;
 }

--- a/server/rule_engine/ActionPublisher.test.ts
+++ b/server/rule_engine/ActionPublisher.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable max-lines -- scenarios share the `makeIsolatedPublisher`
+ * harness; splitting would duplicate ~100 lines of setup. */
 /**
  * Unit tests for ActionPublisher to verify action execution logging behavior.
  *
@@ -10,58 +12,57 @@ import getBottle, { type Dependencies } from '../iocContainer/index.js';
 import { ActionType } from '../services/moderationConfigService/index.js';
 import { type CorrelationId } from '../utils/correlationIds.js';
 import { jsonParse } from '../utils/encoding.js';
-import ActionPublisherDefault, {
-  type ActionPublisher,
-} from './ActionPublisher.js';
+import { ActionPublisher } from './ActionPublisher.js';
 import { RuleEnvironment } from './RuleEngine.js';
 
-// Hand-rolled mocks for `makeIsolatedPublisher` below — used by tests that
-// need to inspect outgoing webhook bodies without mutating the bottle's
-// shared `ActionPublisher` instance.
-type SpanLike = {
-  setAttribute: () => void;
-  recordException: () => void;
-  isRecording: () => boolean;
-};
-type TracerLike = {
-  addActiveSpan: (_meta: unknown, fn: (span: SpanLike) => unknown) => unknown;
-  getActiveSpan: () => undefined;
+type IsolatedPublisherOptions = {
+  fetchHTTP: jest.Mock;
+  manualReviewToolService?: Partial<Dependencies['ManualReviewToolService']>;
+  ncmecService?: Partial<Dependencies['NcmecService']>;
+  itemInvestigationService?: Partial<Dependencies['ItemInvestigationService']>;
+  getItemTypeEventuallyConsistent?: Dependencies['getItemTypeEventuallyConsistent'];
 };
 
-function makeIsolatedPublisher(opts: { fetchHTTP: jest.Mock }) {
-  const tracer: TracerLike = {
-    addActiveSpan: (_meta, fn) =>
+function makeNoopTracer(): Dependencies['Tracer'] {
+  return {
+    addActiveSpan: (_meta: unknown, fn: (span: unknown) => unknown) =>
       fn({
         setAttribute: () => {},
         recordException: () => {},
         isRecording: () => false,
       }),
     getActiveSpan: () => undefined,
-  };
-  const PublisherCtor = ActionPublisherDefault as unknown as new (
-    actionExecutionLogger: { logActionExecutions: jest.Mock },
-    tracer: TracerLike,
-    fetchHTTP: jest.Mock,
-    signingKeyPairService: { sign: jest.Mock },
-    manualReviewToolService: object,
-    ncmecService: object,
-    itemInvestigationService: { getItemByIdentifier: jest.Mock },
-    userStrikeService: { applyUserStrikeFromPublishedActions: jest.Mock },
-  ) => ActionPublisher;
+  } as unknown as Dependencies['Tracer'];
+}
+
+function makeIsolatedPublisher(opts: IsolatedPublisherOptions) {
   const logActionExecutions = jest.fn().mockResolvedValue(undefined);
-  const publisher = new PublisherCtor(
-    { logActionExecutions },
-    tracer,
+  const actionExecutionLogger = {
+    logActionExecutions,
+  } as unknown as Dependencies['ActionExecutionLogger'];
+  const signingKeyPairService = {
+    sign: jest.fn().mockResolvedValue(undefined),
+  } as unknown as Dependencies['SigningKeyPairService'];
+  const itemInvestigationService = (opts.itemInvestigationService ?? {
+    getItemByIdentifier: jest.fn().mockResolvedValue(undefined),
+  }) as Dependencies['ItemInvestigationService'];
+  const userStrikeService = {
+    applyUserStrikeFromPublishedActions: jest.fn().mockResolvedValue(undefined),
+  } as unknown as Dependencies['UserStrikeService'];
+  const getItemTypeEventuallyConsistent =
+    opts.getItemTypeEventuallyConsistent ??
+    jest.fn().mockResolvedValue(undefined);
+  const publisher = new ActionPublisher(
+    actionExecutionLogger,
+    makeNoopTracer(),
     opts.fetchHTTP,
-    { sign: jest.fn().mockResolvedValue(undefined) },
-    {},
-    {},
-    { getItemByIdentifier: jest.fn().mockResolvedValue(undefined) },
-    {
-      applyUserStrikeFromPublishedActions: jest
-        .fn()
-        .mockResolvedValue(undefined),
-    },
+    signingKeyPairService,
+    (opts.manualReviewToolService ??
+      {}) as Dependencies['ManualReviewToolService'],
+    (opts.ncmecService ?? {}) as Dependencies['NcmecService'],
+    itemInvestigationService,
+    userStrikeService,
+    getItemTypeEventuallyConsistent,
   );
   return { publisher, logActionExecutions };
 }
@@ -185,9 +186,7 @@ describe('ActionPublisher', () => {
     });
 
     it('builds the CUSTOM_ACTION webhook body with parameters merged into `custom` and actorNote at the top level', async () => {
-      const fetchHTTP = jest
-        .fn()
-        .mockResolvedValue({ status: 200, ok: true });
+      const fetchHTTP = jest.fn().mockResolvedValue({ status: 200, ok: true });
       const { publisher } = makeIsolatedPublisher({ fetchHTTP });
 
       await publisher.publishActions(
@@ -248,9 +247,7 @@ describe('ActionPublisher', () => {
     });
 
     it('omits actorNote from the webhook body entirely when no note is supplied', async () => {
-      const fetchHTTP = jest
-        .fn()
-        .mockResolvedValue({ status: 200, ok: true });
+      const fetchHTTP = jest.fn().mockResolvedValue({ status: 200, ok: true });
       const { publisher } = makeIsolatedPublisher({ fetchHTTP });
 
       await publisher.publishActions(
@@ -354,6 +351,288 @@ describe('ActionPublisher', () => {
       expect(logged?.actorNote).toBe('Repeat offender');
 
       logSpy.mockRestore();
+    });
+
+    it('enqueues to NCMEC for a synthetic USER target with no item submission record', async () => {
+      const enqueueForHumanReviewIfApplicable = jest
+        .fn()
+        .mockResolvedValue({ status: 'ENQUEUED' });
+      const userItemType = {
+        id: 'user-type-1',
+        kind: 'USER' as const,
+        name: 'User',
+        version: '1',
+        schemaVariant: 'DEFAULT',
+        schema: [],
+        schemaFieldRoles: {},
+      };
+      const getItemTypeEventuallyConsistent = jest
+        .fn()
+        .mockResolvedValue(userItemType);
+      const { publisher, logActionExecutions } = makeIsolatedPublisher({
+        fetchHTTP: jest.fn(),
+        ncmecService: { enqueueForHumanReviewIfApplicable },
+        itemInvestigationService: {
+          getItemByIdentifier: jest.fn().mockResolvedValue(undefined),
+        },
+        getItemTypeEventuallyConsistent,
+      });
+
+      const results = await publisher.publishActions(
+        [
+          {
+            action: {
+              id: 'action-ncmec',
+              orgId: 'org-synth',
+              name: 'Enqueue for NCMEC Review',
+              description: null,
+              applyUserStrikes: false,
+              penalty: 'NONE' as const,
+              actionType: ActionType.ENQUEUE_TO_NCMEC,
+            },
+            policies: [],
+            matchingRules: undefined,
+            ruleEnvironment: undefined,
+          },
+        ],
+        {
+          orgId: 'org-synth',
+          correlationId:
+            'manual-action-run:synthetic-ncmec' as CorrelationId<'manual-action-run'>,
+          targetItem: {
+            itemId: 'synthetic-user-id',
+            itemType: {
+              id: 'user-type-1',
+              kind: 'USER' as const,
+              name: 'User',
+            },
+          },
+        },
+      );
+
+      expect(results).toEqual([
+        expect.objectContaining({ success: true, actionId: 'action-ncmec' }),
+      ]);
+      expect(enqueueForHumanReviewIfApplicable).toHaveBeenCalledTimes(1);
+      const enqueueArg = enqueueForHumanReviewIfApplicable.mock.calls[0]?.[0];
+      expect(enqueueArg.item.itemId).toBe('synthetic-user-id');
+      expect(enqueueArg.item.itemTypeIdentifier.id).toBe('user-type-1');
+      expect(logActionExecutions).toHaveBeenCalledWith(
+        expect.objectContaining({ failed: false }),
+      );
+    });
+
+    it('enqueues to MRT for a synthetic USER target with no submission record', async () => {
+      const enqueue = jest.fn().mockResolvedValue(undefined);
+      const userItemType = {
+        id: 'user-type-2',
+        kind: 'USER' as const,
+        name: 'User',
+        version: '1',
+        schemaVariant: 'DEFAULT',
+        schema: [],
+        schemaFieldRoles: {},
+      };
+      const getItemTypeEventuallyConsistent = jest
+        .fn()
+        .mockResolvedValue(userItemType);
+      const { publisher, logActionExecutions } = makeIsolatedPublisher({
+        fetchHTTP: jest.fn(),
+        manualReviewToolService: { enqueue },
+        itemInvestigationService: {
+          getItemByIdentifier: jest.fn().mockResolvedValue(undefined),
+        },
+        getItemTypeEventuallyConsistent,
+      });
+
+      const results = await publisher.publishActions(
+        [
+          {
+            action: {
+              id: 'action-mrt',
+              orgId: 'org-synth',
+              name: 'Enqueue to MRT',
+              description: null,
+              applyUserStrikes: false,
+              penalty: 'NONE' as const,
+              actionType: ActionType.ENQUEUE_TO_MRT,
+            },
+            policies: [],
+            matchingRules: undefined,
+            ruleEnvironment: undefined,
+          },
+        ],
+        {
+          orgId: 'org-synth',
+          correlationId:
+            'manual-action-run:synthetic-mrt' as CorrelationId<'manual-action-run'>,
+          targetItem: {
+            itemId: 'synthetic-user-id',
+            itemType: {
+              id: 'user-type-2',
+              kind: 'USER' as const,
+              name: 'User',
+            },
+          },
+        },
+      );
+
+      expect(results).toEqual([
+        expect.objectContaining({ success: true, actionId: 'action-mrt' }),
+      ]);
+      expect(enqueue).toHaveBeenCalledTimes(1);
+      expect(logActionExecutions).toHaveBeenCalledWith(
+        expect.objectContaining({ failed: false }),
+      );
+    });
+
+    it('infers the creator and enqueues to NCMEC for a CONTENT target with no submission', async () => {
+      const enqueueForHumanReviewIfApplicable = jest
+        .fn()
+        .mockResolvedValue({ status: 'ENQUEUED' });
+      const userItemType = {
+        id: 'user-type-3',
+        kind: 'USER' as const,
+        name: 'User',
+        version: '1',
+        schemaVariant: 'DEFAULT',
+        schema: [],
+        schemaFieldRoles: {},
+      };
+      // The real helper resolves the creator id from ACTION_EXECUTIONS and
+      // then synthesizes a submission keyed on *the creator's* id (not the
+      // content's id). The mock mirrors that shape so the test exercises a
+      // payload production can actually produce.
+      const synthesizeUserItemFromContentTarget = jest.fn().mockResolvedValue({
+        latestSubmission: {
+          itemId: 'creator-user-id-7',
+          itemType: userItemType,
+          data: {},
+          submissionId: 'synthetic:creator-user-id-7',
+          submissionTime: undefined,
+          creator: undefined,
+        },
+      });
+      const { publisher, logActionExecutions } = makeIsolatedPublisher({
+        fetchHTTP: jest.fn(),
+        ncmecService: { enqueueForHumanReviewIfApplicable },
+        itemInvestigationService: {
+          getItemByIdentifier: jest.fn().mockResolvedValue(undefined),
+          synthesizeUserItemFromContentTarget,
+        },
+      });
+
+      const results = await publisher.publishActions(
+        [
+          {
+            action: {
+              id: 'action-ncmec-inferred',
+              orgId: 'org-synth',
+              name: 'Enqueue for NCMEC Review',
+              description: null,
+              applyUserStrikes: false,
+              penalty: 'NONE' as const,
+              actionType: ActionType.ENQUEUE_TO_NCMEC,
+            },
+            policies: [],
+            matchingRules: undefined,
+            ruleEnvironment: undefined,
+          },
+        ],
+        {
+          orgId: 'org-synth',
+          correlationId:
+            'manual-action-run:inferred-ncmec' as CorrelationId<'manual-action-run'>,
+          targetItem: {
+            itemId: 'phantom-content-id',
+            itemType: {
+              id: 'content-type-1',
+              kind: 'CONTENT' as const,
+              name: 'Post',
+            },
+          },
+        },
+      );
+
+      expect(results).toEqual([expect.objectContaining({ success: true })]);
+      expect(synthesizeUserItemFromContentTarget).toHaveBeenCalledWith({
+        orgId: 'org-synth',
+        itemId: 'phantom-content-id',
+        itemTypeId: 'content-type-1',
+      });
+      expect(enqueueForHumanReviewIfApplicable).toHaveBeenCalledTimes(1);
+      const enqueueArg = enqueueForHumanReviewIfApplicable.mock.calls[0]?.[0];
+      expect(enqueueArg.item.itemId).toBe('creator-user-id-7');
+      expect(enqueueArg.item.itemTypeIdentifier.id).toBe('user-type-3');
+      expect(logActionExecutions).toHaveBeenCalledWith(
+        expect.objectContaining({ failed: false }),
+      );
+    });
+
+    it('fails loudly when ENQUEUE_TO_NCMEC targets a CONTENT item with no submission and no inferable creator', async () => {
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const enqueueForHumanReviewIfApplicable = jest.fn();
+      const synthesizeUserItemFromContentTarget = jest
+        .fn()
+        .mockResolvedValue(null);
+      const { publisher, logActionExecutions } = makeIsolatedPublisher({
+        fetchHTTP: jest.fn(),
+        ncmecService: { enqueueForHumanReviewIfApplicable },
+        itemInvestigationService: {
+          getItemByIdentifier: jest.fn().mockResolvedValue(undefined),
+          synthesizeUserItemFromContentTarget,
+        },
+      });
+
+      const results = await publisher.publishActions(
+        [
+          {
+            action: {
+              id: 'action-ncmec-content',
+              orgId: 'org-synth',
+              name: 'Enqueue for NCMEC Review',
+              description: null,
+              applyUserStrikes: false,
+              penalty: 'NONE' as const,
+              actionType: ActionType.ENQUEUE_TO_NCMEC,
+            },
+            policies: [],
+            matchingRules: undefined,
+            ruleEnvironment: undefined,
+          },
+        ],
+        {
+          orgId: 'org-synth',
+          correlationId:
+            'manual-action-run:synthetic-ncmec-content' as CorrelationId<'manual-action-run'>,
+          targetItem: {
+            itemId: 'phantom-content-id',
+            itemType: {
+              id: 'content-type-1',
+              kind: 'CONTENT' as const,
+              name: 'Post',
+            },
+          },
+        },
+      );
+
+      expect(results).toEqual([expect.objectContaining({ success: false })]);
+      expect(synthesizeUserItemFromContentTarget).toHaveBeenCalled();
+      expect(enqueueForHumanReviewIfApplicable).not.toHaveBeenCalled();
+      expect(logActionExecutions).toHaveBeenCalledWith(
+        expect.objectContaining({ failed: true }),
+      );
+      expect(consoleSpy).toHaveBeenCalled();
+      const loggedLine = consoleSpy.mock.calls[0]?.[0];
+      expect(loggedLine).toEqual(
+        expect.stringContaining('action-ncmec-content'),
+      );
+      expect(loggedLine).toEqual(
+        expect.stringContaining('actionPublisher.publishAction.failed'),
+      );
+      consoleSpy.mockRestore();
     });
   });
 });

--- a/server/rule_engine/ActionPublisher.ts
+++ b/server/rule_engine/ActionPublisher.ts
@@ -11,6 +11,7 @@ import {
   type MatchingRule,
   type Policy,
 } from '../services/analyticsLoggers/index.js';
+import { makeSyntheticUserSubmission } from '../services/itemInvestigationService/index.js';
 import {
   getFieldValueForRole,
   itemSubmissionToItemSubmissionWithTypeIdentifier,
@@ -121,6 +122,7 @@ class ActionPublisher {
     private ncmecService: Dependencies['NcmecService'],
     private itemInvestigationService: Dependencies['ItemInvestigationService'],
     private userStrikeService: Dependencies['UserStrikeService'],
+    private getItemTypeEventuallyConsistent: Dependencies['getItemTypeEventuallyConsistent'],
   ) {}
 
   /**
@@ -325,6 +327,50 @@ class ActionPublisher {
             })
           )?.latestSubmission;
         };
+
+        // USER target with no record: synthesize a minimal submission from
+        // the id. Returns undefined for non-USER targets — MRT needs the
+        // real content submission, so it must fail loudly for CONTENT.
+        const getFullItemOrSyntheticUserForUserTarget = async () => {
+          const fullItem = await getFullItem();
+          if (fullItem) {
+            return fullItem;
+          }
+          if (targetItem.itemType.kind !== 'USER') {
+            return undefined;
+          }
+          const userItemType = await this.getItemTypeEventuallyConsistent({
+            orgId,
+            typeSelector: { id: targetItem.itemType.id },
+          });
+          if (!userItemType || userItemType.kind !== 'USER') {
+            return undefined;
+          }
+          return makeSyntheticUserSubmission(targetItem.itemId, userItemType);
+        };
+
+        // NCMEC fallback: USER target → synthetic user (as above); CONTENT
+        // target → resolve the creator via ACTION_EXECUTIONS and synthesize a
+        // user submission keyed on the creator id. THREAD has no single
+        // owner, so we refuse.
+        const getFullItemOrSyntheticUserForNcmec = async () => {
+          const userTarget = await getFullItemOrSyntheticUserForUserTarget();
+          if (userTarget) {
+            return userTarget;
+          }
+          if (targetItem.itemType.kind !== 'CONTENT') {
+            return undefined;
+          }
+          const inferred =
+            await this.itemInvestigationService.synthesizeUserItemFromContentTarget(
+              {
+                orgId,
+                itemId: targetItem.itemId,
+                itemTypeId: targetItem.itemType.id,
+              },
+            );
+          return inferred?.latestSubmission;
+        };
         const actionSource = getSourceType(
           correlationId,
         ) as ActionExecutionSourceType;
@@ -389,11 +435,14 @@ class ActionPublisher {
               }
 
               return true;
-            case ActionType.ENQUEUE_TO_MRT:
-              const fullItemForMrt = await getFullItem();
+            case ActionType.ENQUEUE_TO_MRT: {
+              const fullItemForMrt =
+                await getFullItemOrSyntheticUserForUserTarget();
               if (!fullItemForMrt) {
                 throw new Error(
-                  "Actions without full item submissions can't be enqueued to MRT yet",
+                  `Cannot enqueue to MRT: no submission record for ${targetItem.itemType.kind} ` +
+                    `item ${targetItem.itemId} (type ${targetItem.itemType.id}). ` +
+                    `POST the item to the items endpoint first.`,
                 );
               }
 
@@ -430,11 +479,15 @@ class ActionPublisher {
               });
 
               return true;
-            case ActionType.ENQUEUE_TO_NCMEC:
-              const fullItemForNcmec = await getFullItem();
+            }
+            case ActionType.ENQUEUE_TO_NCMEC: {
+              const fullItemForNcmec =
+                await getFullItemOrSyntheticUserForNcmec();
               if (!fullItemForNcmec) {
                 throw new Error(
-                  "Actions without full item submissions can't be enqueued to NCMEC yet",
+                  `Cannot enqueue to NCMEC: no submission record for ${targetItem.itemType.kind} ` +
+                    `item ${targetItem.itemId} (type ${targetItem.itemType.id}). ` +
+                    `POST the item to the items endpoint first.`,
                 );
               }
 
@@ -463,6 +516,7 @@ class ActionPublisher {
               });
 
               return true;
+            }
             case ActionType.ENQUEUE_AUTHOR_TO_MRT:
               const fullItemForAuthor = await getFullItem();
               if (
@@ -573,6 +627,23 @@ class ActionPublisher {
           }
         } catch (e) {
           span.recordException(e as Exception);
+          // Log to stderr so operators see action failures without having
+          // to pull traces. Identifiers only, no item `data`.
+          // eslint-disable-next-line no-console
+          console.error(
+            jsonStringify({
+              event: 'actionPublisher.publishAction.failed',
+              orgId,
+              actionId: action.id,
+              actionName: action.name,
+              actionType: action.actionType,
+              itemId: targetItem.itemId,
+              itemTypeId: targetItem.itemType.id,
+              itemTypeKind: targetItem.itemType.kind,
+              correlationId,
+              error: e instanceof Error ? e.message : String(e),
+            }),
+          );
           return false;
         }
       },
@@ -590,6 +661,7 @@ export default inject(
     'NcmecService',
     'ItemInvestigationService',
     'UserStrikeService',
+    'getItemTypeEventuallyConsistent',
   ],
   ActionPublisher,
 );

--- a/server/services/itemInvestigationService/index.ts
+++ b/server/services/itemInvestigationService/index.ts
@@ -2,3 +2,4 @@ export {
   ItemInvestigationServiceAdapter as ItemInvestigationService,
   RETURN_UNLIMITED_RESULTS_AND_POTENTIALLY_HANG_DB,
 } from './itemInvestigationServiceAdapter.js';
+export { makeSyntheticUserSubmission } from './synthesizeUserItemFromCreatorReferences.js';

--- a/server/services/itemInvestigationService/itemInvestigationServiceAdapter.ts
+++ b/server/services/itemInvestigationService/itemInvestigationServiceAdapter.ts
@@ -25,6 +25,7 @@ import {
   ItemInvestigationService,
   type SubmissionsForItemWithTypeIdentifier,
 } from './itemInvestigationService.js';
+import { synthesizeUserItemFromContentTarget } from './synthesizeUserItemFromContentTarget.js';
 import { synthesizeUserItemFromCreatorReferences } from './synthesizeUserItemFromCreatorReferences.js';
 
 type AdaptedReturnType<T extends PublicMethodNames<ItemInvestigationService>> =
@@ -286,6 +287,22 @@ export class ItemInvestigationServiceAdapter {
     knownUserTypeId?: string;
   }): Promise<SubmissionsForItem | null> {
     return synthesizeUserItemFromCreatorReferences({
+      ...opts,
+      scyllaCreatorRefExists: async (input) =>
+        this.#hasAnySubmissionsCreatedBy(input.orgId, input.creatorIdentifier),
+      actionExecutionsAdapter: this.actionExecutionsAdapter,
+      contentApiRequestsAdapter: this.contentApiRequestsAdapter,
+      moderationConfigService: this.moderationConfigService,
+    });
+  }
+
+  /** See `synthesizeUserItemFromContentTarget.ts`. */
+  async synthesizeUserItemFromContentTarget(opts: {
+    orgId: string;
+    itemId: string;
+    itemTypeId: string;
+  }): Promise<SubmissionsForItem | null> {
+    return synthesizeUserItemFromContentTarget({
       ...opts,
       scyllaCreatorRefExists: async (input) =>
         this.#hasAnySubmissionsCreatedBy(input.orgId, input.creatorIdentifier),

--- a/server/services/itemInvestigationService/synthesizeUserItemFromContentTarget.ts
+++ b/server/services/itemInvestigationService/synthesizeUserItemFromContentTarget.ts
@@ -1,0 +1,66 @@
+import { type Dependencies } from '../../iocContainer/index.js';
+import { type IActionExecutionsAdapter } from '../../plugins/warehouse/queries/IActionExecutionsAdapter.js';
+import { type IContentApiRequestsAdapter } from '../../plugins/warehouse/queries/IContentApiRequestsAdapter.js';
+import {
+  synthesizeUserItemFromCreatorReferences,
+  type SyntheticUserItemSubmissionsForItem,
+} from './synthesizeUserItemFromCreatorReferences.js';
+
+/**
+ * Resolve a synthetic `UserItem` submission for the *creator* of a CONTENT
+ * item whose own submission record is missing. Looks up the most-recent
+ * `(creator_id, creator_type_id)` for `(itemId, itemTypeId)` in
+ * `ACTION_EXECUTIONS`, then delegates to
+ * `synthesizeUserItemFromCreatorReferences` with the resolved user id so the
+ * returned submission is keyed on the creator (not the content).
+ */
+export async function synthesizeUserItemFromContentTarget(opts: {
+  orgId: string;
+  itemId: string;
+  itemTypeId: string;
+  actionExecutionsAdapter: Pick<
+    IActionExecutionsAdapter,
+    'findContentCreatorIdentity' | 'findInferredUserIdentity'
+  >;
+  contentApiRequestsAdapter: Pick<
+    IContentApiRequestsAdapter,
+    'findInferredUserIdentityFromCreators'
+  >;
+  scyllaCreatorRefExists: Parameters<
+    typeof synthesizeUserItemFromCreatorReferences
+  >[0]['scyllaCreatorRefExists'];
+  moderationConfigService: Pick<
+    Dependencies['ModerationConfigService'],
+    'getItemType' | 'getItemTypes'
+  >;
+}): Promise<SyntheticUserItemSubmissionsForItem | null> {
+  const {
+    orgId,
+    itemId,
+    itemTypeId,
+    actionExecutionsAdapter,
+    contentApiRequestsAdapter,
+    scyllaCreatorRefExists,
+    moderationConfigService,
+  } = opts;
+
+  const creator = await actionExecutionsAdapter.findContentCreatorIdentity({
+    orgId,
+    itemId,
+    itemTypeId,
+  });
+
+  if (!creator) {
+    return null;
+  }
+
+  return synthesizeUserItemFromCreatorReferences({
+    orgId,
+    itemId: creator.creatorId,
+    knownUserTypeId: creator.creatorTypeId,
+    scyllaCreatorRefExists,
+    actionExecutionsAdapter,
+    contentApiRequestsAdapter,
+    moderationConfigService,
+  });
+}

--- a/server/services/manualReviewToolService/manualReviewToolService.ts
+++ b/server/services/manualReviewToolService/manualReviewToolService.ts
@@ -1174,6 +1174,17 @@ export class ManualReviewToolService {
     return this.jobDecisioning.getNcmecDecisions(opts);
   }
 
+  async getNcmecDecisionsForOrg(opts: { orgId: string; limit?: number }) {
+    return this.jobDecisioning.getNcmecDecisionsForOrg(opts);
+  }
+
+  async getNcmecDecisionByIdForOrg(opts: {
+    orgId: string;
+    decisionId: string;
+  }) {
+    return this.jobDecisioning.getNcmecDecisionByIdForOrg(opts);
+  }
+
   async upsertDefaultSettings(opts: { orgId: string }) {
     return this.manualReviewToolSettings.upsertDefaultSettings(opts);
   }

--- a/server/services/manualReviewToolService/modules/JobDecisioning.ts
+++ b/server/services/manualReviewToolService/modules/JobDecisioning.ts
@@ -470,6 +470,85 @@ export default class JobDecisioning {
     );
   }
 
+  async getNcmecDecisionsForOrg(opts: { orgId: string; limit?: number }) {
+    const { orgId, limit = 500 } = opts;
+    const allNcmecDecisions = await this.pgQuery
+      .selectFrom('manual_review_tool.manual_review_decisions')
+      .where('org_id', '=', orgId)
+      .where(({ eb, selectFrom }) => {
+        return eb.exists(
+          selectFrom(
+            sql`unnest(manual_review_tool.manual_review_decisions.decision_components)`.as(
+              'decision_component',
+            ),
+          )
+            .selectAll()
+            .where(
+              sql<string>`decision_component->>'type'`,
+              '=',
+              'SUBMIT_NCMEC_REPORT',
+            ),
+        );
+      })
+      .select([
+        'org_id',
+        'decision_components',
+        'job_payload',
+        'id',
+        'queue_id',
+        'reviewer_id',
+        'created_at',
+      ])
+      .orderBy('created_at', 'desc')
+      .limit(limit)
+      .execute();
+    return filterNullOrUndefined(
+      allNcmecDecisions.map((it) => {
+        if (
+          'policyIds' in it.job_payload &&
+          'submissionId' in it.job_payload.payload.item
+        ) {
+          return { ...it, job_payload: it.job_payload };
+        }
+        return undefined;
+      }),
+    );
+  }
+
+  /** Single-decision lookup gated on the caller's org. Returns `undefined` if
+   * the decision doesn't exist or belongs to a different org (callers should
+   * treat both cases as "not found" — never confirm cross-org existence). */
+  async getNcmecDecisionByIdForOrg(opts: {
+    orgId: string;
+    decisionId: string;
+  }) {
+    const { orgId, decisionId } = opts;
+    const row = await this.pgQuery
+      .selectFrom('manual_review_tool.manual_review_decisions')
+      .where('id', '=', decisionId)
+      .where('org_id', '=', orgId)
+      .select([
+        'org_id',
+        'decision_components',
+        'job_payload',
+        'id',
+        'queue_id',
+        'reviewer_id',
+        'created_at',
+      ])
+      .executeTakeFirst();
+    if (!row) {
+      return undefined;
+    }
+    if (
+      !('policyIds' in row.job_payload) ||
+      !('submissionId' in row.job_payload.payload.item)
+    ) {
+      return undefined;
+    }
+    return { ...row, job_payload: row.job_payload };
+  }
+
   async getIgnoreCallbackForOrg(orgId: string): Promise<string | undefined> {
     const settings = await this.pgQuery
       .selectFrom('manual_review_tool.manual_review_tool_settings')

--- a/server/services/manualReviewToolService/modules/JobDecisioning.ts
+++ b/server/services/manualReviewToolService/modules/JobDecisioning.ts
@@ -471,7 +471,15 @@ export default class JobDecisioning {
   }
 
   async getNcmecDecisionsForOrg(opts: { orgId: string; limit?: number }) {
-    const { orgId, limit = 500 } = opts;
+    const { orgId } = opts;
+    // Clamp `limit` so callers can't request an unreasonable number of rows;
+    // default of 500 matches the previous behavior. Non-numeric values fall
+    // back to the default via Number.isFinite.
+    const requestedLimit = opts.limit ?? 500;
+    const safeLimit =
+      Number.isFinite(requestedLimit) && requestedLimit > 0
+        ? Math.min(Math.floor(requestedLimit), 500)
+        : 500;
     const allNcmecDecisions = await this.pgQuery
       .selectFrom('manual_review_tool.manual_review_decisions')
       .where('org_id', '=', orgId)
@@ -500,7 +508,7 @@ export default class JobDecisioning {
         'created_at',
       ])
       .orderBy('created_at', 'desc')
-      .limit(limit)
+      .limit(safeLimit)
       .execute();
     return filterNullOrUndefined(
       allNcmecDecisions.map((it) => {
@@ -538,6 +546,15 @@ export default class JobDecisioning {
       ])
       .executeTakeFirst();
     if (!row) {
+      return undefined;
+    }
+    // Only return decisions that actually contain a SUBMIT_NCMEC_REPORT
+    // component so callers get the same `not_found` shape for both
+    // "wrong-org" and "wrong-decision-type" lookups.
+    const hasNcmecComponent = row.decision_components.some(
+      (component) => component.type === 'SUBMIT_NCMEC_REPORT',
+    );
+    if (!hasNcmecComponent) {
       return undefined;
     }
     if (

--- a/server/services/ncmecService/buildSubmitReportParamsFromDecision.ts
+++ b/server/services/ncmecService/buildSubmitReportParamsFromDecision.ts
@@ -8,6 +8,11 @@ import {
 import { type UserItemType } from '../moderationConfigService/types/itemTypes.js';
 import { type NCMECReportParams } from './ncmecReporting.js';
 
+/** NCMEC's accepted "Incident Type Category" string used as a safe fallback
+ * for legacy decisions whose DB row predates the `incidentType` column. */
+export const LEGACY_FALLBACK_INCIDENT_TYPE =
+  'Child Pornography (possession, manufacture, and distribution)';
+
 /** Single source of truth for assembling the NCMEC `submitReport` payload
  * from a SUBMIT_NCMEC_REPORT decision component. Three call sites use this:
  *  - the IoC `onRecordDecision` flow (initial submission after a reviewer's
@@ -52,7 +57,10 @@ export interface BuildSubmitReportParamsInput {
       fileAnnotations: NCMECReportParams['media'][number]['fileAnnotations'];
     }>;
     reportedMessages: NCMECReportParams['threads'];
-    incidentType: string;
+    /** Optional because legacy DB rows predate the `incidentType` column on
+     * `decision_components`; callers should pass `fallbackIncidentType` when
+     * they want a safe default. */
+    incidentType?: string;
     escalateToHighPriority?: string;
     additionalInfo?: string;
   };
@@ -112,6 +120,10 @@ export async function buildSubmitReportParamsFromDecision(
       if (mediaItemType === undefined) {
         throw new Error('Unable to find item type for reported media');
       }
+      // Fall back to "now" when the source row is missing `createdAt`.
+      // This keeps retries submittable for legacy data (predates the field)
+      // better to send the retry timestamp than to permanently block the
+      // report from being submitted to NCMEC at all.
       const createdAt =
         getFieldValueForRole(
           mediaItemType.schema,
@@ -133,9 +145,10 @@ export async function buildSubmitReportParamsFromDecision(
     }),
   );
 
+  const trimmedIncidentType = (decisionComponent.incidentType ?? '').trim();
   const incidentType =
-    decisionComponent.incidentType.trim() !== ''
-      ? decisionComponent.incidentType
+    trimmedIncidentType !== ''
+      ? trimmedIncidentType
       : (fallbackIncidentType ?? '');
 
   return {

--- a/server/services/ncmecService/buildSubmitReportParamsFromDecision.ts
+++ b/server/services/ncmecService/buildSubmitReportParamsFromDecision.ts
@@ -1,0 +1,166 @@
+import { makeDateString } from '@roostorg/types';
+
+import { type Dependencies } from '../../iocContainer/index.js';
+import {
+  getFieldValueForRole,
+  type NormalizedItemData,
+} from '../itemProcessingService/index.js';
+import { type UserItemType } from '../moderationConfigService/types/itemTypes.js';
+import { type NCMECReportParams } from './ncmecReporting.js';
+
+/** Single source of truth for assembling the NCMEC `submitReport` payload
+ * from a SUBMIT_NCMEC_REPORT decision component. Three call sites use this:
+ *  - the IoC `onRecordDecision` flow (initial submission after a reviewer's
+ *    decision)
+ *  - the background `RetryFailedNcmecDecisionsJob`
+ *  - the user-initiated `retryNcmecSubmission` GraphQL mutation
+ *
+ * Centralising the assembly here means each site behaves identically: the
+ * reviewer's `escalateToHighPriority` and `additionalInfo` are preserved on
+ * retry, and any future field added to the decision component is delivered to
+ * NCMEC from every code path. */
+export interface BuildSubmitReportParamsInput {
+  orgId: string;
+  reviewerId: string;
+  /** ID of the reported user item (the subject of the report). */
+  reportedItemId: string;
+  /** Item-type ID of the reported user item. */
+  reportedItemTypeId: string;
+  /** USER-kind item type, already resolved by the caller. The caller is
+   * responsible for ensuring `itemType.kind === 'USER'` (this helper does
+   * not re-validate); narrowing the type here gives us proper typing for
+   * the schema-field-role lookups below. */
+  reportedUserItemType: Readonly<UserItemType>;
+  /** Raw item data for the reported user (used to read displayName / icon). */
+  reportedUserData: NormalizedItemData;
+  /** All media items attached to the MRT job; used to resolve each reported
+   * media id to its full content item (so we can read its createdAt etc). */
+  allMediaItems: ReadonlyArray<{
+    contentItem: {
+      itemId: string;
+      itemTypeIdentifier: { id: string; name?: string };
+      data: NormalizedItemData;
+    };
+  }>;
+  /** The SUBMIT_NCMEC_REPORT decision component. */
+  decisionComponent: {
+    reportedMedia: ReadonlyArray<{
+      id: string;
+      typeId: string;
+      url: string;
+      industryClassification: NCMECReportParams['media'][number]['industryClassification'];
+      fileAnnotations: NCMECReportParams['media'][number]['fileAnnotations'];
+    }>;
+    reportedMessages: NCMECReportParams['threads'];
+    incidentType: string;
+    escalateToHighPriority?: string;
+    additionalInfo?: string;
+  };
+  /** Optional fallback used when `decisionComponent.incidentType` is empty
+   * (legacy DB rows). Callers that don't want a fallback should omit this. */
+  fallbackIncidentType?: string;
+  /** MRT decision id; forwarded to `NCMECReportParams.jobId` for failure recording. */
+  jobId?: string;
+  getItemTypeEventuallyConsistent: Dependencies['getItemTypeEventuallyConsistent'];
+}
+
+export async function buildSubmitReportParamsFromDecision(
+  input: BuildSubmitReportParamsInput,
+): Promise<NCMECReportParams> {
+  const {
+    orgId,
+    reviewerId,
+    reportedItemId,
+    reportedItemTypeId,
+    reportedUserItemType,
+    reportedUserData,
+    allMediaItems,
+    decisionComponent,
+    fallbackIncidentType,
+    jobId,
+    getItemTypeEventuallyConsistent,
+  } = input;
+
+  // Reading these via getFieldValueForRole keeps the helper agnostic to the
+  // org's field-naming conventions; if the role isn't mapped, the field is
+  // simply omitted from the report.
+  const displayName = getFieldValueForRole(
+    reportedUserItemType.schema,
+    reportedUserItemType.schemaFieldRoles,
+    'displayName',
+    reportedUserData,
+  );
+  const profilePicUrl = getFieldValueForRole(
+    reportedUserItemType.schema,
+    reportedUserItemType.schemaFieldRoles,
+    'profileIcon',
+    reportedUserData,
+  );
+
+  const media = await Promise.all(
+    decisionComponent.reportedMedia.map(async (it) => {
+      const reportedItem = allMediaItems.find(
+        (m) => m.contentItem.itemId === it.id,
+      );
+      if (reportedItem === undefined) {
+        throw new Error('Unable to find reported media in job payload');
+      }
+      const mediaItemType = await getItemTypeEventuallyConsistent({
+        orgId,
+        typeSelector: reportedItem.contentItem.itemTypeIdentifier,
+      });
+      if (mediaItemType === undefined) {
+        throw new Error('Unable to find item type for reported media');
+      }
+      const createdAt =
+        getFieldValueForRole(
+          mediaItemType.schema,
+          mediaItemType.schemaFieldRoles,
+          'createdAt',
+          reportedItem.contentItem.data,
+        ) ?? makeDateString(new Date().toISOString());
+      if (createdAt === undefined) {
+        throw new Error('No created at for reported media');
+      }
+      return {
+        id: it.id,
+        typeId: it.typeId,
+        url: it.url,
+        createdAt,
+        industryClassification: it.industryClassification,
+        fileAnnotations: it.fileAnnotations,
+      };
+    }),
+  );
+
+  const incidentType =
+    decisionComponent.incidentType.trim() !== ''
+      ? decisionComponent.incidentType
+      : (fallbackIncidentType ?? '');
+
+  return {
+    reportedUser: {
+      id: reportedItemId,
+      typeId: reportedItemTypeId,
+      ...(displayName ? { displayName } : {}),
+      ...(profilePicUrl ? { profilePicture: profilePicUrl.url } : {}),
+    },
+    orgId,
+    media,
+    reviewerId,
+    threads: decisionComponent.reportedMessages,
+    incidentType,
+    ...(decisionComponent.escalateToHighPriority != null &&
+    decisionComponent.escalateToHighPriority.trim() !== ''
+      ? {
+          escalateToHighPriority:
+            decisionComponent.escalateToHighPriority.trim(),
+        }
+      : {}),
+    ...(decisionComponent.additionalInfo != null &&
+    decisionComponent.additionalInfo.trim() !== ''
+      ? { additionalInfo: decisionComponent.additionalInfo.trim() }
+      : {}),
+    ...(jobId !== undefined ? { jobId } : {}),
+  };
+}

--- a/server/services/ncmecService/index.ts
+++ b/server/services/ncmecService/index.ts
@@ -5,4 +5,7 @@ export {
 
 export { NCMECIncidentType } from './ncmecReporting.js';
 export { filterDecisionsToFailedSubmissions } from './ncmecSubmissionFilters.js';
-export { buildSubmitReportParamsFromDecision } from './buildSubmitReportParamsFromDecision.js';
+export {
+  buildSubmitReportParamsFromDecision,
+  LEGACY_FALLBACK_INCIDENT_TYPE,
+} from './buildSubmitReportParamsFromDecision.js';

--- a/server/services/ncmecService/index.ts
+++ b/server/services/ncmecService/index.ts
@@ -4,3 +4,5 @@ export {
 } from './ncmecService.js';
 
 export { NCMECIncidentType } from './ncmecReporting.js';
+export { filterDecisionsToFailedSubmissions } from './ncmecSubmissionFilters.js';
+export { buildSubmitReportParamsFromDecision } from './buildSubmitReportParamsFromDecision.js';

--- a/server/services/ncmecService/ncmecReporting.ts
+++ b/server/services/ncmecService/ncmecReporting.ts
@@ -189,6 +189,8 @@ export type NCMECReportParams = {
   escalateToHighPriority?: string;
   /** Optional free-text notes; if present must be non-blank and max 3000 chars. */
   additionalInfo?: string;
+  /** MRT decision id; when set, failures are recorded to `ncmec_reports_errors`. */
+  jobId?: string;
 };
 
 // Key insertion order in these object literals must match the NCMEC XSD
@@ -1651,6 +1653,17 @@ export default class NcmecReporting {
             message: jsonStringify({ reportParams, isTest }),
           });
           span.recordException(e as Exception);
+          if (reportParams.jobId !== undefined) {
+            await this.#recordSubmissionError({
+              jobId: reportParams.jobId,
+              userId: reportParams.reportedUser.id,
+              userTypeId: reportParams.reportedUser.typeId,
+              error:
+                e instanceof Error
+                  ? e.message
+                  : 'Unknown NCMEC submission error',
+            });
+          }
           return 'FAILURE';
         }
       },
@@ -2059,6 +2072,56 @@ export default class NcmecReporting {
 
     const responseJson = response.body as CyberTipFinishResponse;
     return responseJson.reportDoneResponse.reportId;
+  }
+
+  /** Best-effort write of a failed-submission row. Swallows its own DB errors
+   * so a follow-on failure can't turn a NCMEC FAILURE into an unhandled
+   * exception. */
+  async #recordSubmissionError(opts: {
+    jobId: string;
+    userId: string;
+    userTypeId: string;
+    error: string;
+  }) {
+    try {
+      // user_id/user_type_id are varchar(255); trim so an over-long org id
+      // can't make this failure-recording write itself fail.
+      const safeUserId = opts.userId.slice(0, 255);
+      const safeUserTypeId = opts.userTypeId.slice(0, 255);
+      const retryCountRow = await this.pgQuery
+        .selectFrom('ncmec_reporting.ncmec_reports_errors')
+        .select('retry_count')
+        .where('job_id', '=', opts.jobId)
+        .executeTakeFirst();
+      const nextRetryCount = retryCountRow ? retryCountRow.retry_count + 1 : 1;
+      await this.pgQuery
+        .insertInto('ncmec_reporting.ncmec_reports_errors')
+        .values({
+          job_id: opts.jobId,
+          user_id: safeUserId,
+          user_type_id: safeUserTypeId,
+          status: 'RETRYABLE_ERROR',
+          last_error: opts.error,
+          retry_count: nextRetryCount,
+        })
+        .onConflict((oc) =>
+          oc.columns(['job_id']).doUpdateSet({
+            retry_count: nextRetryCount,
+            last_error: opts.error,
+            status: 'RETRYABLE_ERROR',
+          }),
+        )
+        .execute();
+    } catch (e: unknown) {
+      // eslint-disable-next-line no-restricted-syntax
+      logErrorJson({
+        error: e,
+        message: jsonStringify({
+          context: 'recordSubmissionError',
+          jobId: opts.jobId,
+        }),
+      });
+    }
   }
 
   async #sendCyberTipRequest(input: {

--- a/server/services/ncmecService/ncmecReporting.ts
+++ b/server/services/ncmecService/ncmecReporting.ts
@@ -2,7 +2,7 @@
 import type { Exception } from '@opentelemetry/api';
 import { makeEnumLike, type ItemIdentifier } from '@roostorg/types';
 import _Ajv from 'ajv';
-import { type Kysely } from 'kysely';
+import { sql, type Kysely } from 'kysely';
 import _ from 'lodash';
 import { FormData } from 'undici';
 import { js2xml } from 'xml-js';
@@ -2088,12 +2088,8 @@ export default class NcmecReporting {
       // can't make this failure-recording write itself fail.
       const safeUserId = opts.userId.slice(0, 255);
       const safeUserTypeId = opts.userTypeId.slice(0, 255);
-      const retryCountRow = await this.pgQuery
-        .selectFrom('ncmec_reporting.ncmec_reports_errors')
-        .select('retry_count')
-        .where('job_id', '=', opts.jobId)
-        .executeTakeFirst();
-      const nextRetryCount = retryCountRow ? retryCountRow.retry_count + 1 : 1;
+      // Atomic increment in `doUpdateSet` avoids the read-modify-write race
+      // when two retries land on the same job_id concurrently.
       await this.pgQuery
         .insertInto('ncmec_reporting.ncmec_reports_errors')
         .values({
@@ -2102,11 +2098,11 @@ export default class NcmecReporting {
           user_type_id: safeUserTypeId,
           status: 'RETRYABLE_ERROR',
           last_error: opts.error,
-          retry_count: nextRetryCount,
+          retry_count: 1,
         })
         .onConflict((oc) =>
           oc.columns(['job_id']).doUpdateSet({
-            retry_count: nextRetryCount,
+            retry_count: sql`ncmec_reporting.ncmec_reports_errors.retry_count + 1`,
             last_error: opts.error,
             status: 'RETRYABLE_ERROR',
           }),

--- a/server/services/ncmecService/ncmecService.ts
+++ b/server/services/ncmecService/ncmecService.ts
@@ -1,6 +1,6 @@
 import { type ItemIdentifier } from '@roostorg/types';
 import _Ajv from 'ajv-draft-04';
-import { type Kysely } from 'kysely';
+import { sql, type Kysely } from 'kysely';
 
 import { inject, type Dependencies } from '../../iocContainer/index.js';
 import { type ActionExecutionCorrelationId } from '../analyticsLoggers/ActionExecutionLogger.js';
@@ -76,8 +76,6 @@ export class NcmecService {
         manualReviewToolService: this.manualReviewToolService,
         ncmecReporting: this.ncmecReporting,
         getItemTypeEventuallyConsistent: this.getItemTypeEventuallyConsistent,
-        insertOrUpdateNcmecReportError: async (errOpts) =>
-          this.insertOrUpdateNcmecReportError(errOpts),
       },
       opts,
     );
@@ -192,11 +190,9 @@ export class NcmecService {
     // can't make this failure-recording write itself fail.
     const safeUserId = opts.userId.slice(0, 255);
     const safeUserTypeId = opts.userTypeId.slice(0, 255);
-    const retryCountRow = await this.pqQueryReadReplica
-      .selectFrom('ncmec_reporting.ncmec_reports_errors')
-      .select('retry_count')
-      .where('job_id', '=', opts.jobId)
-      .executeTakeFirst();
+    // Atomic increment in `doUpdateSet` avoids the read-modify-write race
+    // when two callers (e.g. background retry job + user-clicked Retry)
+    // attempt to record an error for the same job_id concurrently.
     return this.pgQuery
       .insertInto('ncmec_reporting.ncmec_reports_errors')
       .values({
@@ -205,11 +201,11 @@ export class NcmecService {
         user_type_id: safeUserTypeId,
         status: opts.status,
         last_error: opts.error,
-        retry_count: retryCountRow ? retryCountRow.retry_count + 1 : 1,
+        retry_count: 1,
       })
       .onConflict((oc) =>
         oc.columns(['job_id']).doUpdateSet({
-          retry_count: retryCountRow ? retryCountRow.retry_count + 1 : 1,
+          retry_count: sql`ncmec_reporting.ncmec_reports_errors.retry_count + 1`,
           last_error: opts.error,
           status: opts.status,
         }),

--- a/server/services/ncmecService/ncmecService.ts
+++ b/server/services/ncmecService/ncmecService.ts
@@ -1,4 +1,4 @@
-import type { ItemIdentifier } from '@roostorg/types';
+import { type ItemIdentifier } from '@roostorg/types';
 import _Ajv from 'ajv-draft-04';
 import { type Kysely } from 'kysely';
 
@@ -18,6 +18,10 @@ import {
 import { type NcmecReportingServicePg } from './dbTypes.js';
 import NcmecEnqueueToMrt from './ncmecEnqueueToMrt.js';
 import NcmecReporting, { type NCMECReportParams } from './ncmecReporting.js';
+import {
+  retryNcmecSubmission,
+  type RetryNcmecSubmissionResult,
+} from './retryNcmecSubmission.js';
 
 export class NcmecService {
   private readonly ncmecReporting: NcmecReporting;
@@ -57,6 +61,26 @@ export class NcmecService {
 
   async submitReport(reportParams: NCMECReportParams, isTest: boolean) {
     return this.ncmecReporting.submitReport(reportParams, isTest);
+  }
+
+  /** Org-scoped retry for a previously-failed NCMEC submission. See
+   * `retryNcmecSubmission.ts` for the orchestration; this is a thin wrapper
+   * that supplies dependencies. */
+  async retrySubmission(opts: {
+    orgId: string;
+    decisionId: string;
+    requestingReviewerId: string;
+  }): Promise<RetryNcmecSubmissionResult> {
+    return retryNcmecSubmission(
+      {
+        manualReviewToolService: this.manualReviewToolService,
+        ncmecReporting: this.ncmecReporting,
+        getItemTypeEventuallyConsistent: this.getItemTypeEventuallyConsistent,
+        insertOrUpdateNcmecReportError: async (errOpts) =>
+          this.insertOrUpdateNcmecReportError(errOpts),
+      },
+      opts,
+    );
   }
 
   async hasNCMECReportingEnabled(orgId: string) {
@@ -128,10 +152,32 @@ export class NcmecService {
   }
 
   async getNcmecErrorsForJobIds(jobIds: string[]) {
+    if (jobIds.length === 0) {
+      return [];
+    }
     return this.pqQueryReadReplica
       .selectFrom('ncmec_reporting.ncmec_reports_errors')
-      .select(['job_id', 'retry_count', 'user_id', 'user_type_id', 'status'])
+      .select([
+        'job_id',
+        'retry_count',
+        'user_id',
+        'user_type_id',
+        'status',
+        'last_error',
+      ])
       .where('job_id', 'in', jobIds)
+      .execute();
+  }
+
+  /** Returns the `(user_id, user_item_type_id)` pairs that already have a
+   * successful NCMEC submission for this org. Used to filter MRT decisions
+   * down to "failed" submissions (those without a matching report row). */
+  async getSuccessfulSubmissionKeysForOrg(orgId: string) {
+    return this.pqQueryReadReplica
+      .selectFrom('ncmec_reporting.ncmec_reports')
+      .select(['user_id as userId', 'user_item_type_id as userItemTypeId'])
+      .where('org_id', '=', orgId)
+      .groupBy(['user_id', 'user_item_type_id'])
       .execute();
   }
 
@@ -142,6 +188,10 @@ export class NcmecService {
     status: 'RETRYABLE_ERROR' | 'PERMANENT_ERROR';
     error: string;
   }) {
+    // user_id/user_type_id are varchar(255); trim so an over-long org id
+    // can't make this failure-recording write itself fail.
+    const safeUserId = opts.userId.slice(0, 255);
+    const safeUserTypeId = opts.userTypeId.slice(0, 255);
     const retryCountRow = await this.pqQueryReadReplica
       .selectFrom('ncmec_reporting.ncmec_reports_errors')
       .select('retry_count')
@@ -151,8 +201,8 @@ export class NcmecService {
       .insertInto('ncmec_reporting.ncmec_reports_errors')
       .values({
         job_id: opts.jobId,
-        user_id: opts.userId,
-        user_type_id: opts.userTypeId,
+        user_id: safeUserId,
+        user_type_id: safeUserTypeId,
         status: opts.status,
         last_error: opts.error,
         retry_count: retryCountRow ? retryCountRow.retry_count + 1 : 1,

--- a/server/services/ncmecService/ncmecSubmissionFilters.test.ts
+++ b/server/services/ncmecService/ncmecSubmissionFilters.test.ts
@@ -1,0 +1,66 @@
+import { filterDecisionsToFailedSubmissions } from './ncmecSubmissionFilters.js';
+
+describe('filterDecisionsToFailedSubmissions', () => {
+  it('returns all decisions when no submissions are successful', () => {
+    const decisions = [
+      { userId: 'u1', userItemTypeId: 't1', payload: 'a' },
+      { userId: 'u2', userItemTypeId: 't1', payload: 'b' },
+    ];
+    expect(filterDecisionsToFailedSubmissions(decisions, [])).toEqual(
+      decisions,
+    );
+  });
+
+  it('removes decisions that match a successful (userId, userItemTypeId) pair', () => {
+    const decisions = [
+      { userId: 'u1', userItemTypeId: 't1', payload: 'a' },
+      { userId: 'u2', userItemTypeId: 't1', payload: 'b' },
+      { userId: 'u3', userItemTypeId: 't2', payload: 'c' },
+    ];
+    const successful = [{ userId: 'u2', userItemTypeId: 't1' }];
+    expect(filterDecisionsToFailedSubmissions(decisions, successful)).toEqual([
+      { userId: 'u1', userItemTypeId: 't1', payload: 'a' },
+      { userId: 'u3', userItemTypeId: 't2', payload: 'c' },
+    ]);
+  });
+
+  it('does NOT match across different userItemTypeIds when userId is the same', () => {
+    // Same user id under a different type identifier counts as a different
+    // submission and should remain in the failed list.
+    const decisions = [
+      { userId: 'u1', userItemTypeId: 't1', payload: 'a' },
+      { userId: 'u1', userItemTypeId: 't2', payload: 'b' },
+    ];
+    const successful = [{ userId: 'u1', userItemTypeId: 't1' }];
+    expect(filterDecisionsToFailedSubmissions(decisions, successful)).toEqual([
+      { userId: 'u1', userItemTypeId: 't2', payload: 'b' },
+    ]);
+  });
+
+  it('returns empty when every decision has a corresponding successful submission', () => {
+    const decisions = [
+      { userId: 'u1', userItemTypeId: 't1' },
+      { userId: 'u2', userItemTypeId: 't1' },
+    ];
+    const successful = [
+      { userId: 'u1', userItemTypeId: 't1' },
+      { userId: 'u2', userItemTypeId: 't1' },
+    ];
+    expect(filterDecisionsToFailedSubmissions(decisions, successful)).toEqual(
+      [],
+    );
+  });
+
+  it('does not collide when userId+userItemTypeId concatenation is ambiguous', () => {
+    // Without a delimiter, ('a', 'bc') and ('ab', 'c') would collide. The
+    // helper uses NUL as a delimiter, so these stay distinct.
+    const decisions = [
+      { userId: 'a', userItemTypeId: 'bc', payload: '1' },
+      { userId: 'ab', userItemTypeId: 'c', payload: '2' },
+    ];
+    const successful = [{ userId: 'a', userItemTypeId: 'bc' }];
+    expect(filterDecisionsToFailedSubmissions(decisions, successful)).toEqual([
+      { userId: 'ab', userItemTypeId: 'c', payload: '2' },
+    ]);
+  });
+});

--- a/server/services/ncmecService/ncmecSubmissionFilters.ts
+++ b/server/services/ncmecService/ncmecSubmissionFilters.ts
@@ -1,0 +1,23 @@
+/** Pure helpers for filtering NCMEC submission lists. Lives in its own file
+ * (no deps on the wider service container) so it can be unit-tested without
+ * pulling in DB clients or the IoC bottle. */
+
+/** Subtracts the set of successful submission keys from a list of NCMEC
+ * decisions, returning only decisions whose `(userId, userItemTypeId)` pair
+ * does NOT have a corresponding successful report row. */
+export function filterDecisionsToFailedSubmissions<
+  D extends { userId: string; userItemTypeId: string },
+>(
+  decisions: readonly D[],
+  successfulKeys: readonly { userId: string; userItemTypeId: string }[],
+): D[] {
+  // NUL is a delimiter chosen because real userId / userItemTypeId values
+  // never contain it; this avoids ambiguity between e.g. ('a','bc') and
+  // ('ab','c') that a naive concatenation would conflate.
+  const successfulKeySet = new Set(
+    successfulKeys.map((k) => `${k.userId}\u0000${k.userItemTypeId}`),
+  );
+  return decisions.filter(
+    (d) => !successfulKeySet.has(`${d.userId}\u0000${d.userItemTypeId}`),
+  );
+}

--- a/server/services/ncmecService/retryNcmecSubmission.test.ts
+++ b/server/services/ncmecService/retryNcmecSubmission.test.ts
@@ -17,12 +17,7 @@ function makeDeps(overrides: Partial<RetryDeps> = {}): RetryDeps {
     ncmecReporting: {
       submitReport: fail('submitReport'),
     } as unknown as RetryDeps['ncmecReporting'],
-    getItemTypeEventuallyConsistent: fail(
-      'getItemTypeEventuallyConsistent',
-    ),
-    insertOrUpdateNcmecReportError: fail(
-      'insertOrUpdateNcmecReportError',
-    ),
+    getItemTypeEventuallyConsistent: fail('getItemTypeEventuallyConsistent'),
     ...overrides,
   };
 }

--- a/server/services/ncmecService/retryNcmecSubmission.test.ts
+++ b/server/services/ncmecService/retryNcmecSubmission.test.ts
@@ -1,0 +1,98 @@
+import {
+  retryNcmecSubmission,
+  type RetryDeps,
+} from './retryNcmecSubmission.js';
+
+/** Helper that builds a `RetryDeps` mock with sensible defaults. Each test
+ * overrides only the fields it cares about; everything else throws if invoked
+ * unexpectedly so missing assertions surface as failures. */
+function makeDeps(overrides: Partial<RetryDeps> = {}): RetryDeps {
+  const fail = (name: string) => () => {
+    throw new Error(`Unexpected call to ${name}`);
+  };
+  return {
+    manualReviewToolService: {
+      getNcmecDecisionByIdForOrg: fail('getNcmecDecisionByIdForOrg'),
+    } as unknown as RetryDeps['manualReviewToolService'],
+    ncmecReporting: {
+      submitReport: fail('submitReport'),
+    } as unknown as RetryDeps['ncmecReporting'],
+    getItemTypeEventuallyConsistent: fail(
+      'getItemTypeEventuallyConsistent',
+    ),
+    insertOrUpdateNcmecReportError: fail(
+      'insertOrUpdateNcmecReportError',
+    ),
+    ...overrides,
+  };
+}
+
+describe('retryNcmecSubmission', () => {
+  // SECURITY: a decision belonging to a different org must look identical to
+  // a missing decision so that callers cannot probe cross-org existence. The
+  // SQL-level filter in getNcmecDecisionByIdForOrg returns undefined for
+  // cross-org IDs; this test pins that behavior at the orchestration layer.
+  it('returns not_found when the underlying lookup returns undefined (cross-org or missing)', async () => {
+    const deps = makeDeps({
+      manualReviewToolService: {
+        getNcmecDecisionByIdForOrg: async () => undefined,
+      } as unknown as RetryDeps['manualReviewToolService'],
+    });
+    const result = await retryNcmecSubmission(deps, {
+      orgId: 'org-A',
+      decisionId: 'decision-belonging-to-org-B',
+      requestingReviewerId: 'reviewer-1',
+    });
+    expect(result).toEqual({ kind: 'not_found' });
+  });
+
+  it('returns permanent_error when the decision lacks an NCMEC component', async () => {
+    const deps = makeDeps({
+      manualReviewToolService: {
+        getNcmecDecisionByIdForOrg: async () => ({
+          id: 'd1',
+          org_id: 'org-A',
+          decision_components: [{ type: 'TAKE_USER_ACTION' }],
+          job_payload: { payload: { kind: 'NCMEC' } },
+          reviewer_id: 'r1',
+          queue_id: 'q1',
+          created_at: new Date(),
+        }),
+      } as unknown as RetryDeps['manualReviewToolService'],
+    });
+    const result = await retryNcmecSubmission(deps, {
+      orgId: 'org-A',
+      decisionId: 'd1',
+      requestingReviewerId: 'reviewer-1',
+    });
+    expect(result.kind).toBe('permanent_error');
+    if (result.kind === 'permanent_error') {
+      expect(result.error).toMatch(/NCMEC report component/i);
+    }
+  });
+
+  it('returns permanent_error when the job payload is not an NCMEC payload', async () => {
+    const deps = makeDeps({
+      manualReviewToolService: {
+        getNcmecDecisionByIdForOrg: async () => ({
+          id: 'd1',
+          org_id: 'org-A',
+          decision_components: [{ type: 'SUBMIT_NCMEC_REPORT' }],
+          job_payload: { payload: { kind: 'OTHER' } },
+          reviewer_id: 'r1',
+          queue_id: 'q1',
+          created_at: new Date(),
+        }),
+      } as unknown as RetryDeps['manualReviewToolService'],
+    });
+    const result = await retryNcmecSubmission(deps, {
+      orgId: 'org-A',
+      decisionId: 'd1',
+      requestingReviewerId: 'reviewer-1',
+    });
+    expect(result.kind).toBe('permanent_error');
+    if (result.kind === 'permanent_error') {
+      expect(result.error).toMatch(/NCMEC payload/i);
+    }
+  });
+});

--- a/server/services/ncmecService/retryNcmecSubmission.ts
+++ b/server/services/ncmecService/retryNcmecSubmission.ts
@@ -1,6 +1,9 @@
 import { type Dependencies } from '../../iocContainer/index.js';
 import { type ManualReviewToolService } from '../manualReviewToolService/manualReviewToolService.js';
-import { buildSubmitReportParamsFromDecision } from './buildSubmitReportParamsFromDecision.js';
+import {
+  buildSubmitReportParamsFromDecision,
+  LEGACY_FALLBACK_INCIDENT_TYPE,
+} from './buildSubmitReportParamsFromDecision.js';
 import type NcmecReporting from './ncmecReporting.js';
 
 /** Result of a retry attempt. Distinct cases let the GraphQL layer return a
@@ -17,13 +20,6 @@ export interface RetryDeps {
   manualReviewToolService: ManualReviewToolService;
   ncmecReporting: NcmecReporting;
   getItemTypeEventuallyConsistent: Dependencies['getItemTypeEventuallyConsistent'];
-  insertOrUpdateNcmecReportError: (opts: {
-    jobId: string;
-    userId: string;
-    userTypeId: string;
-    status: 'RETRYABLE_ERROR' | 'PERMANENT_ERROR';
-    error: string;
-  }) => Promise<unknown>;
 }
 
 /** Retries a previously-failed NCMEC submission for the given decision.
@@ -98,10 +94,7 @@ export async function retryNcmecSubmission(
       reportedUserData: decisionRow.job_payload.payload.item.data,
       allMediaItems: decisionRow.job_payload.payload.allMediaItems,
       decisionComponent: submitNcmecReportComponent,
-      // Mirror the legacy retry-job behaviour for old DB rows that predate
-      // the incidentType column.
-      fallbackIncidentType:
-        'Child Pornography (possession, manufacture, and distribution)',
+      fallbackIncidentType: LEGACY_FALLBACK_INCIDENT_TYPE,
       jobId: decisionRow.job_payload.id,
       getItemTypeEventuallyConsistent: deps.getItemTypeEventuallyConsistent,
     });
@@ -112,25 +105,15 @@ export async function retryNcmecSubmission(
   }
 
   const isTest = process.env.NCMEC_ENV !== 'production';
-  // submitReport never throws and records its own errors via jobId; we just
-  // translate the result code and upgrade UNSUPPORTED_ORG/ALL_MEDIA_MISSING
-  // to PERMANENT_ERROR.
+  // submitReport records its own RETRYABLE_ERROR row via jobId when it throws
+  // and returns 'FAILURE' / 'UNSUPPORTED_ORG' / 'ALL_MEDIA_MISSING' for
+  // explicit non-success cases. The defensive try/catch here only translates
+  // those outcomes for the caller — error persistence stays centralized in
+  // submitReport so we never double-write or downgrade RETRYABLE to PERMANENT.
   try {
     const result = await deps.ncmecReporting.submitReport(reportParams, isTest);
     if (result === 'SUCCESS') {
       return { kind: 'success' };
-    }
-    try {
-      await deps.insertOrUpdateNcmecReportError({
-        jobId: decisionRow.job_payload.id,
-        userId: itemId,
-        userTypeId: itemTypeId,
-        status: 'PERMANENT_ERROR',
-        error: result,
-      });
-    } catch {
-      // Already logged in the service; swallow so the user sees the NCMEC
-      // error rather than a raw Postgres message.
     }
     return { kind: 'permanent_error', error: result };
   } catch (e: unknown) {

--- a/server/services/ncmecService/retryNcmecSubmission.ts
+++ b/server/services/ncmecService/retryNcmecSubmission.ts
@@ -1,0 +1,140 @@
+import { type Dependencies } from '../../iocContainer/index.js';
+import { type ManualReviewToolService } from '../manualReviewToolService/manualReviewToolService.js';
+import { buildSubmitReportParamsFromDecision } from './buildSubmitReportParamsFromDecision.js';
+import type NcmecReporting from './ncmecReporting.js';
+
+/** Result of a retry attempt. Distinct cases let the GraphQL layer return a
+ * uniform error message for cross-org `not_found` (no information disclosure)
+ * while still differentiating retryable vs permanent failures internally for
+ * logging / `ncmec_reports_errors` updates. */
+export type RetryNcmecSubmissionResult =
+  | { kind: 'success' }
+  | { kind: 'not_found' }
+  | { kind: 'permanent_error'; error: string }
+  | { kind: 'retryable_error'; error: string };
+
+export interface RetryDeps {
+  manualReviewToolService: ManualReviewToolService;
+  ncmecReporting: NcmecReporting;
+  getItemTypeEventuallyConsistent: Dependencies['getItemTypeEventuallyConsistent'];
+  insertOrUpdateNcmecReportError: (opts: {
+    jobId: string;
+    userId: string;
+    userTypeId: string;
+    status: 'RETRYABLE_ERROR' | 'PERMANENT_ERROR';
+    error: string;
+  }) => Promise<unknown>;
+}
+
+/** Retries a previously-failed NCMEC submission for the given decision.
+ *
+ * Org-scoped: the caller's `orgId` is forwarded to
+ * `getNcmecDecisionByIdForOrg`, which filters on `org_id` at the SQL level.
+ * Cross-org callers (or callers with an unknown decisionId) get the same
+ * `not_found` response — never confirm cross-org existence. */
+export async function retryNcmecSubmission(
+  deps: RetryDeps,
+  opts: {
+    orgId: string;
+    decisionId: string;
+    requestingReviewerId: string;
+  },
+): Promise<RetryNcmecSubmissionResult> {
+  const { orgId, decisionId, requestingReviewerId } = opts;
+
+  const decisionRow =
+    await deps.manualReviewToolService.getNcmecDecisionByIdForOrg({
+      orgId,
+      decisionId,
+    });
+  if (!decisionRow) {
+    return { kind: 'not_found' };
+  }
+
+  const submitNcmecReportComponent = decisionRow.decision_components.find(
+    (c) => c.type === 'SUBMIT_NCMEC_REPORT',
+  );
+  if (submitNcmecReportComponent === undefined) {
+    return {
+      kind: 'permanent_error',
+      error: 'Decision does not contain an NCMEC report component',
+    };
+  }
+  if (decisionRow.job_payload.payload.kind !== 'NCMEC') {
+    return {
+      kind: 'permanent_error',
+      error: 'Decision job payload is not an NCMEC payload',
+    };
+  }
+
+  // Use the original reviewer when available so the resulting report keeps
+  // its provenance; otherwise attribute to the user clicking Retry.
+  const reviewerId = decisionRow.reviewer_id ?? requestingReviewerId;
+
+  const itemId = decisionRow.job_payload.payload.item.itemId;
+  const itemTypeIdentifier =
+    decisionRow.job_payload.payload.item.itemTypeIdentifier;
+  const itemTypeId = itemTypeIdentifier.id;
+
+  const itemType = await deps.getItemTypeEventuallyConsistent({
+    orgId,
+    typeSelector: itemTypeIdentifier,
+  });
+  if (itemType === undefined || itemType.kind !== 'USER') {
+    return {
+      kind: 'permanent_error',
+      error: 'Reported item type is missing or not a USER type',
+    };
+  }
+
+  let reportParams;
+  try {
+    reportParams = await buildSubmitReportParamsFromDecision({
+      orgId,
+      reviewerId,
+      reportedItemId: itemId,
+      reportedItemTypeId: itemTypeId,
+      reportedUserItemType: itemType,
+      reportedUserData: decisionRow.job_payload.payload.item.data,
+      allMediaItems: decisionRow.job_payload.payload.allMediaItems,
+      decisionComponent: submitNcmecReportComponent,
+      // Mirror the legacy retry-job behaviour for old DB rows that predate
+      // the incidentType column.
+      fallbackIncidentType:
+        'Child Pornography (possession, manufacture, and distribution)',
+      jobId: decisionRow.job_payload.id,
+      getItemTypeEventuallyConsistent: deps.getItemTypeEventuallyConsistent,
+    });
+  } catch (e: unknown) {
+    const error =
+      e instanceof Error ? e.message : 'Failed to assemble reported media';
+    return { kind: 'permanent_error', error };
+  }
+
+  const isTest = process.env.NCMEC_ENV !== 'production';
+  // submitReport never throws and records its own errors via jobId; we just
+  // translate the result code and upgrade UNSUPPORTED_ORG/ALL_MEDIA_MISSING
+  // to PERMANENT_ERROR.
+  try {
+    const result = await deps.ncmecReporting.submitReport(reportParams, isTest);
+    if (result === 'SUCCESS') {
+      return { kind: 'success' };
+    }
+    try {
+      await deps.insertOrUpdateNcmecReportError({
+        jobId: decisionRow.job_payload.id,
+        userId: itemId,
+        userTypeId: itemTypeId,
+        status: 'PERMANENT_ERROR',
+        error: result,
+      });
+    } catch {
+      // Already logged in the service; swallow so the user sees the NCMEC
+      // error rather than a raw Postgres message.
+    }
+    return { kind: 'permanent_error', error: result };
+  } catch (e: unknown) {
+    const error = e instanceof Error ? e.message : 'Unknown error';
+    return { kind: 'retryable_error', error };
+  }
+}

--- a/server/workers_jobs/RetryFailedNcmecDecisionsJob.ts
+++ b/server/workers_jobs/RetryFailedNcmecDecisionsJob.ts
@@ -1,9 +1,8 @@
-import { makeDateString } from '@roostorg/types';
 import _ from 'lodash';
 import { v1 as uuidv1 } from 'uuid';
 
 import { inject } from '../iocContainer/utils.js';
-import { getFieldValueForRole } from '../services/itemProcessingService/index.js';
+import { buildSubmitReportParamsFromDecision } from '../services/ncmecService/index.js';
 import { toCorrelationId } from '../utils/correlationIds.js';
 
 export default inject(
@@ -97,76 +96,24 @@ export default inject(
         return;
       }
       try {
-        const displayName = getFieldValueForRole(
-          itemType.schema,
-          itemType.schemaFieldRoles,
-          'displayName',
-          data,
-        );
-        const profilePicUrl = getFieldValueForRole(
-          itemType.schema,
-          itemType.schemaFieldRoles,
-          'profileIcon',
-          data,
-        );
-
-        const allMedia = row.job_payload.payload.allMediaItems;
-        const media = await Promise.all(
-          submitNcmecReportDecisionComponent.reportedMedia.map(async (it) => {
-            const reportedItem = allMedia.find(
-              (payloadMedia) => payloadMedia.contentItem.itemId === it.id,
-            );
-            if (reportedItem === undefined) {
-              throw new Error('Unable to find reported media in job payload');
-            }
-            const itemType = await getItemTypeEventuallyConsistent({
-              orgId,
-              typeSelector: reportedItem.contentItem.itemTypeIdentifier,
-            });
-            if (itemType === undefined) {
-              throw new Error('Unable to find item type for reported media');
-            }
-
-            const createdAt =
-              getFieldValueForRole(
-                itemType.schema,
-                itemType.schemaFieldRoles,
-                'createdAt',
-                reportedItem.contentItem.data,
-              ) ?? makeDateString(new Date().toISOString());
-            if (createdAt === undefined) {
-              throw new Error('No created at for reported media');
-            }
-
-            return {
-              id: it.id,
-              typeId: it.typeId,
-              url: it.url,
-              createdAt,
-              industryClassification: it.industryClassification,
-              fileAnnotations: it.fileAnnotations,
-            };
-          }),
-        );
+        const reportParams = await buildSubmitReportParamsFromDecision({
+          orgId,
+          reviewerId: row.reviewer_id,
+          reportedItemId: itemId,
+          reportedItemTypeId: itemTypeId,
+          reportedUserItemType: itemType,
+          reportedUserData: data,
+          allMediaItems: row.job_payload.payload.allMediaItems,
+          decisionComponent: submitNcmecReportDecisionComponent,
+          // Old decisions predate the incidentType column; fall back to the
+          // most common incident type so they remain submittable on retry.
+          fallbackIncidentType:
+            'Child Pornography (possession, manufacture, and distribution)',
+          jobId: row.job_payload.id,
+          getItemTypeEventuallyConsistent,
+        });
         const reportResult = await ncmecService.submitReport(
-          {
-            reportedUser: {
-              id: itemId,
-              typeId: itemTypeId,
-              ...(displayName ? { displayName } : {}),
-              ...(profilePicUrl ? { profilePicture: profilePicUrl.url } : {}),
-            },
-            orgId,
-            media,
-            reviewerId: row.reviewer_id,
-            threads: submitNcmecReportDecisionComponent.reportedMessages,
-            // Use the stored incidentType if available, otherwise default to the most common one
-            // The type says it's required, but old decisions in the DB won't have it
-
-            incidentType:
-              submitNcmecReportDecisionComponent.incidentType ||
-              'Child Pornography (possession, manufacture, and distribution)',
-          },
+          reportParams,
           false,
         );
         if (

--- a/server/workers_jobs/RetryFailedNcmecDecisionsJob.ts
+++ b/server/workers_jobs/RetryFailedNcmecDecisionsJob.ts
@@ -2,7 +2,10 @@ import _ from 'lodash';
 import { v1 as uuidv1 } from 'uuid';
 
 import { inject } from '../iocContainer/utils.js';
-import { buildSubmitReportParamsFromDecision } from '../services/ncmecService/index.js';
+import {
+  buildSubmitReportParamsFromDecision,
+  LEGACY_FALLBACK_INCIDENT_TYPE,
+} from '../services/ncmecService/index.js';
 import { toCorrelationId } from '../utils/correlationIds.js';
 
 export default inject(
@@ -105,10 +108,7 @@ export default inject(
           reportedUserData: data,
           allMediaItems: row.job_payload.payload.allMediaItems,
           decisionComponent: submitNcmecReportDecisionComponent,
-          // Old decisions predate the incidentType column; fall back to the
-          // most common incident type so they remain submittable on retry.
-          fallbackIncidentType:
-            'Child Pornography (possession, manufacture, and distribution)',
+          fallbackIncidentType: LEGACY_FALLBACK_INCIDENT_TYPE,
           jobId: row.job_payload.id,
           getItemTypeEventuallyConsistent,
         });


### PR DESCRIPTION
Fixes #491

## Context & Requests for Reviewers

Stacked on #477 (`fix-ncmec-reporting-unordered-reports`). 

Today, when an MRT decision triggers a NCMEC submission and NCMEC rejects it (auth, schema, transient outage, etc.), the failure is logged server-side and silently dropped. 

The reviewer sees no UI feedback, the decision row has no associated `ncmec_reports` row, and the only path back to a successful report is the nightly background retry job which itself had a latent bug that dropped the reviewer's `escalateToHighPriority` and `additionalInfo` fields when re-submitting.

This PR closes the loop: failed submissions are now persisted, visible on the existing **NCMEC Reports** dashboard, and retryable from the UI without losing reviewer-supplied context.


<img width="1928" height="725" alt="Screenshot 2026-05-15 at 8 56 42 PM" src="https://github.com/user-attachments/assets/5ed8186f-4acf-4c1e-a8b1-3c44957431ad" />
<img width="1950" height="734" alt="Screenshot 2026-05-15 at 8 56 08 PM" src="https://github.com/user-attachments/assets/79bc1ab5-1a43-4eed-a6b7-67d10ad571e7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Failed NCMEC submissions now appear alongside successful reports with a retry option per row.
  * Column visibility can be toggled in the NCMEC reports table; preferences are automatically saved.

* **Improvements**
  * Enhanced dashboard layout and scrollbar styling for improved content visibility and navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/492?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->