### PR TITLE
Make NCMEC and MRT enqueue work for users with no submission record

### DIFF
--- a/client/src/components/ItemAction.tsx
+++ b/client/src/components/ItemAction.tsx
@@ -1,21 +1,21 @@
-import ActionParametersModal, {
-  defaultValuesForParameters,
-} from '@/components/ActionParametersModal';
-import { type ActionParameterValues } from '@/components/ActionParameterInputs';
-import { type JsonObject } from 'type-fest';
 import {
-  type GQLActionParameter,
   namedOperations,
   useGQLBulkActionExecutionMutation,
   useGQLBulkActionsFormDataQuery,
+  type GQLActionParameter,
 } from '@/graphql/generated';
 import { stripTypename } from '@/graphql/inputHelpers';
-import { ItemIdentifier } from '@roostorg/types';
 import Pencil from '@/icons/lni/Education/pencil.svg?react';
+import { ItemIdentifier } from '@roostorg/types';
 import { Button, Input, Select } from 'antd';
 import orderBy from 'lodash/orderBy';
 import { useCallback, useMemo, useState } from 'react';
+import { type JsonObject } from 'type-fest';
 
+import { type ActionParameterValues } from '@/components/ActionParameterInputs';
+import ActionParametersModal, {
+  defaultValuesForParameters,
+} from '@/components/ActionParametersModal';
 import { selectFilterByLabelOption } from '@/webpages/dashboard/components/antDesignUtils';
 import CoopButton from '@/webpages/dashboard/components/CoopButton';
 import CoopModal from '@/webpages/dashboard/components/CoopModal';
@@ -50,7 +50,9 @@ export default function ItemAction(props: {
       const anyFailed = results.some((r) => r.success === false);
       if (anyFailed) {
         setModalBody(
-          'One or more actions failed. The callback URL may have returned an error. If your org requires a policy for decisions, select a policy and try again.',
+          'One or more actions failed. Check server logs for details. ' +
+            'If the action posts to a callback URL, the URL may have returned an error. ' +
+            'If your org requires a policy for decisions, select a policy and try again.',
         );
       } else {
         setModalBody('Actions submitted successfully.');
@@ -76,7 +78,9 @@ export default function ItemAction(props: {
   const [moderatorNote, setModeratorNote] = useState<string>('');
 
   const eligibleActions: EligibleAction[] = (queryData?.myOrg?.actions ?? [])
-    .filter((it) => it.itemTypes.map((t) => t.id).includes(itemIdentifier.typeId))
+    .filter((it) =>
+      it.itemTypes.map((t) => t.id).includes(itemIdentifier.typeId),
+    )
     .map((it) => ({
       id: it.id,
       name: it.name,
@@ -211,7 +215,8 @@ export default function ItemAction(props: {
               Object.keys(parametersByActionId).length > 0
                 ? (parametersByActionId as unknown as JsonObject)
                 : undefined,
-            note: moderatorNote.trim() === '' ? undefined : moderatorNote.trim(),
+            note:
+              moderatorNote.trim() === '' ? undefined : moderatorNote.trim(),
           },
         },
       }),

--- a/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.test.ts
+++ b/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.test.ts
@@ -141,3 +141,90 @@ describe('ClickhouseActionExecutionsAdapter.findInferredUserIdentity', () => {
     expect(sentSql).toContain('org-99');
   });
 });
+
+describe('ClickhouseActionExecutionsAdapter.findContentCreatorIdentity', () => {
+  it('returns null when no rows match', async () => {
+    const { adapter } = makeAdapter([]);
+
+    const result = await adapter.findContentCreatorIdentity({
+      orgId: 'org-1',
+      itemId: 'content-1',
+      itemTypeId: 'content-type-1',
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('projects the creator id + type id from the most-recent CONTENT row', async () => {
+    const ts = '2026-05-10T12:00:00.000Z';
+    const { adapter } = makeAdapter([
+      {
+        ts,
+        item_creator_id: 'user-42',
+        item_creator_type_id: 'user-type-A',
+      },
+    ]);
+
+    const result = await adapter.findContentCreatorIdentity({
+      orgId: 'org-1',
+      itemId: 'content-1',
+      itemTypeId: 'content-type-1',
+    });
+
+    expect(result).toEqual({
+      creatorId: 'user-42',
+      creatorTypeId: 'user-type-A',
+      lastSeenAt: new Date(ts),
+    });
+  });
+
+  it('returns null when the row has empty creator fields', async () => {
+    const { adapter } = makeAdapter([
+      {
+        ts: '2026-05-10T12:00:00.000Z',
+        item_creator_id: null,
+        item_creator_type_id: 'user-type-A',
+      },
+    ]);
+
+    const result = await adapter.findContentCreatorIdentity({
+      orgId: 'org-1',
+      itemId: 'content-1',
+      itemTypeId: 'content-type-1',
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('filters to CONTENT rows with non-empty creator columns and uses LIMIT 1', async () => {
+    const { adapter, query } = makeAdapter([]);
+
+    await adapter.findContentCreatorIdentity({
+      orgId: 'org-1',
+      itemId: 'content-1',
+      itemTypeId: 'content-type-1',
+    });
+
+    const sentSql = query.mock.calls[0][0];
+    expect(sentSql).toContain('analytics.ACTION_EXECUTIONS');
+    expect(sentSql).toContain("item_type_kind = 'CONTENT'");
+    expect(sentSql).toContain('item_creator_id IS NOT NULL');
+    expect(sentSql).toContain("item_creator_id != ''");
+    expect(sentSql).toContain('item_creator_type_id IS NOT NULL');
+    expect(sentSql).toContain("item_creator_type_id != ''");
+    expect(sentSql).toContain('LIMIT 1');
+  });
+
+  it('passes the item type id to disambiguate from other content with the same id', async () => {
+    const { adapter, query } = makeAdapter([]);
+
+    await adapter.findContentCreatorIdentity({
+      orgId: 'org-1',
+      itemId: 'content-1',
+      itemTypeId: 'content-type-PHOTO',
+    });
+
+    const sentSql = query.mock.calls[0][0];
+    expect(sentSql).toContain('content-type-PHOTO');
+  });
+});

--- a/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.ts
+++ b/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.ts
@@ -4,6 +4,8 @@ import type SafeTracer from '../../../utils/SafeTracer.js';
 import { SIX_MONTHS_MS } from '../../../utils/time.js';
 import { formatClickhouseQuery } from '../utils/clickhouseSql.js';
 import {
+  type ContentCreatorIdentityInput,
+  type ContentCreatorIdentityRecord,
   type IActionExecutionsAdapter,
   type InferredUserIdentityInput,
   type InferredUserIdentityRecord,
@@ -203,6 +205,64 @@ export class ClickhouseActionExecutionsAdapter implements IActionExecutionsAdapt
 
     return {
       itemTypeId: userTypeId,
+      lastSeenAt: new Date(row.ts),
+    };
+  }
+
+  async findContentCreatorIdentity(
+    input: ContentCreatorIdentityInput,
+  ): Promise<ContentCreatorIdentityRecord | null> {
+    const {
+      orgId,
+      itemId,
+      itemTypeId,
+      lookbackWindowMs = SIX_MONTHS_MS,
+    } = input;
+
+    const lookbackStart = new Date(Date.now() - Math.max(1, lookbackWindowMs));
+    const lookbackStartDate = lookbackStart.toISOString().slice(0, 10);
+
+    // Filter empty creator rows in SQL so LIMIT 1 always returns a usable row
+    // when one exists; otherwise the most recent action on this content could
+    // legitimately have no creator and hide older rows that do.
+    const sql = `
+      SELECT
+        ts,
+        item_creator_id,
+        item_creator_type_id
+      FROM analytics.ACTION_EXECUTIONS
+      WHERE org_id = ?
+        AND ds >= toDate(?)
+        AND lower(item_id) = lower(?)
+        AND item_type_id = ?
+        AND item_type_kind = 'CONTENT'
+        AND item_creator_id IS NOT NULL
+        AND item_creator_id != ''
+        AND item_creator_type_id IS NOT NULL
+        AND item_creator_type_id != ''
+      ORDER BY ts DESC
+      LIMIT 1
+    `;
+
+    const rows = await this.query<ClickhouseActionExecutionRow>(sql, [
+      orgId,
+      lookbackStartDate,
+      itemId,
+      itemTypeId,
+    ]);
+
+    if (rows.length === 0) {
+      return null;
+    }
+
+    const row = rows[0];
+    if (!row.item_creator_id || !row.item_creator_type_id) {
+      return null;
+    }
+
+    return {
+      creatorId: row.item_creator_id,
+      creatorTypeId: row.item_creator_type_id,
       lastSeenAt: new Date(row.ts),
     };
   }

--- a/server/plugins/warehouse/queries/IActionExecutionsAdapter.ts
+++ b/server/plugins/warehouse/queries/IActionExecutionsAdapter.ts
@@ -46,6 +46,21 @@ export interface InferredUserIdentityRecord {
   lastSeenAt: Date;
 }
 
+export interface ContentCreatorIdentityInput {
+  orgId: string;
+  /** Id of the content item whose creator we want to resolve. */
+  itemId: string;
+  /** Type id of the content item; required to disambiguate id collisions. */
+  itemTypeId: string;
+  lookbackWindowMs?: number;
+}
+
+export interface ContentCreatorIdentityRecord {
+  creatorId: string;
+  creatorTypeId: string;
+  lastSeenAt: Date;
+}
+
 export interface IActionExecutionsAdapter {
   getItemActionHistory(
     input: ItemActionHistoryInput,
@@ -59,4 +74,14 @@ export interface IActionExecutionsAdapter {
   findInferredUserIdentity(
     input: InferredUserIdentityInput,
   ): Promise<InferredUserIdentityRecord | null>;
+
+  /**
+   * Resolve the creator `(id, typeId)` for a CONTENT item by finding the
+   * most-recent action-execution row matching `(item_id, item_type_id)` and
+   * projecting its creator columns. Returns `null` when no row has non-empty
+   * creator fields.
+   */
+  findContentCreatorIdentity(
+    input: ContentCreatorIdentityInput,
+  ): Promise<ContentCreatorIdentityRecord | null>;
 }

--- a/server/rule_engine/ActionPublisher.test.ts
+++ b/server/rule_engine/ActionPublisher.test.ts
@@ -1,4 +1,5 @@
-/* eslint-disable max-lines */
+/* eslint-disable max-lines -- scenarios share the `makeIsolatedPublisher`
+ * harness; splitting would duplicate ~100 lines of setup. */
 /**
  * Unit tests for ActionPublisher to verify action execution logging behavior.
  *

--- a/server/rule_engine/ActionPublisher.test.ts
+++ b/server/rule_engine/ActionPublisher.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 /**
  * Unit tests for ActionPublisher to verify action execution logging behavior.
  *
@@ -10,58 +11,61 @@ import getBottle, { type Dependencies } from '../iocContainer/index.js';
 import { ActionType } from '../services/moderationConfigService/index.js';
 import { type CorrelationId } from '../utils/correlationIds.js';
 import { jsonParse } from '../utils/encoding.js';
-import ActionPublisherDefault, {
-  type ActionPublisher,
-} from './ActionPublisher.js';
+import { ActionPublisher } from './ActionPublisher.js';
 import { RuleEnvironment } from './RuleEngine.js';
 
-// Hand-rolled mocks for `makeIsolatedPublisher` below — used by tests that
-// need to inspect outgoing webhook bodies without mutating the bottle's
-// shared `ActionPublisher` instance.
-type SpanLike = {
-  setAttribute: () => void;
-  recordException: () => void;
-  isRecording: () => boolean;
-};
-type TracerLike = {
-  addActiveSpan: (_meta: unknown, fn: (span: SpanLike) => unknown) => unknown;
-  getActiveSpan: () => undefined;
+type IsolatedPublisherOptions = {
+  fetchHTTP: jest.Mock;
+  manualReviewToolService?: Partial<Dependencies['ManualReviewToolService']>;
+  ncmecService?: Partial<Dependencies['NcmecService']>;
+  itemInvestigationService?: Partial<Dependencies['ItemInvestigationService']>;
+  getItemTypeEventuallyConsistent?: Dependencies['getItemTypeEventuallyConsistent'];
 };
 
-function makeIsolatedPublisher(opts: { fetchHTTP: jest.Mock }) {
-  const tracer: TracerLike = {
-    addActiveSpan: (_meta, fn) =>
+function makeNoopTracer(): Dependencies['Tracer'] {
+  return {
+    addActiveSpan: (_meta: unknown, fn: (span: unknown) => unknown) =>
       fn({
         setAttribute: () => {},
         recordException: () => {},
         isRecording: () => false,
       }),
     getActiveSpan: () => undefined,
-  };
-  const PublisherCtor = ActionPublisherDefault as unknown as new (
-    actionExecutionLogger: { logActionExecutions: jest.Mock },
-    tracer: TracerLike,
-    fetchHTTP: jest.Mock,
-    signingKeyPairService: { sign: jest.Mock },
-    manualReviewToolService: object,
-    ncmecService: object,
-    itemInvestigationService: { getItemByIdentifier: jest.Mock },
-    userStrikeService: { applyUserStrikeFromPublishedActions: jest.Mock },
-  ) => ActionPublisher;
+  } as unknown as Dependencies['Tracer'];
+}
+
+function makeIsolatedPublisher(opts: IsolatedPublisherOptions) {
   const logActionExecutions = jest.fn().mockResolvedValue(undefined);
-  const publisher = new PublisherCtor(
-    { logActionExecutions },
-    tracer,
+  const actionExecutionLogger = {
+    logActionExecutions,
+  } as unknown as Dependencies['ActionExecutionLogger'];
+  const signingKeyPairService = {
+    sign: jest.fn().mockResolvedValue(undefined),
+  } as unknown as Dependencies['SigningKeyPairService'];
+  const itemInvestigationService = (opts.itemInvestigationService ?? {
+    getItemByIdentifier: jest.fn().mockResolvedValue(undefined),
+  }) as Dependencies['ItemInvestigationService'];
+  const userStrikeService = {
+    applyUserStrikeFromPublishedActions: jest.fn().mockResolvedValue(undefined),
+  } as unknown as Dependencies['UserStrikeService'];
+  const getItemTypeEventuallyConsistent =
+    opts.getItemTypeEventuallyConsistent ??
+    (jest
+      .fn()
+      .mockResolvedValue(
+        undefined,
+      ));
+  const publisher = new ActionPublisher(
+    actionExecutionLogger,
+    makeNoopTracer(),
     opts.fetchHTTP,
-    { sign: jest.fn().mockResolvedValue(undefined) },
-    {},
-    {},
-    { getItemByIdentifier: jest.fn().mockResolvedValue(undefined) },
-    {
-      applyUserStrikeFromPublishedActions: jest
-        .fn()
-        .mockResolvedValue(undefined),
-    },
+    signingKeyPairService,
+    (opts.manualReviewToolService ??
+      {}) as Dependencies['ManualReviewToolService'],
+    (opts.ncmecService ?? {}) as Dependencies['NcmecService'],
+    itemInvestigationService,
+    userStrikeService,
+    getItemTypeEventuallyConsistent,
   );
   return { publisher, logActionExecutions };
 }
@@ -185,9 +189,7 @@ describe('ActionPublisher', () => {
     });
 
     it('builds the CUSTOM_ACTION webhook body with parameters merged into `custom` and actorNote at the top level', async () => {
-      const fetchHTTP = jest
-        .fn()
-        .mockResolvedValue({ status: 200, ok: true });
+      const fetchHTTP = jest.fn().mockResolvedValue({ status: 200, ok: true });
       const { publisher } = makeIsolatedPublisher({ fetchHTTP });
 
       await publisher.publishActions(
@@ -248,9 +250,7 @@ describe('ActionPublisher', () => {
     });
 
     it('omits actorNote from the webhook body entirely when no note is supplied', async () => {
-      const fetchHTTP = jest
-        .fn()
-        .mockResolvedValue({ status: 200, ok: true });
+      const fetchHTTP = jest.fn().mockResolvedValue({ status: 200, ok: true });
       const { publisher } = makeIsolatedPublisher({ fetchHTTP });
 
       await publisher.publishActions(
@@ -354,6 +354,200 @@ describe('ActionPublisher', () => {
       expect(logged?.actorNote).toBe('Repeat offender');
 
       logSpy.mockRestore();
+    });
+
+    it('enqueues to NCMEC for a synthetic USER target with no item submission record', async () => {
+      const enqueueForHumanReviewIfApplicable = jest
+        .fn()
+        .mockResolvedValue({ status: 'ENQUEUED' });
+      const userItemType = {
+        id: 'user-type-1',
+        kind: 'USER' as const,
+        name: 'User',
+        version: '1',
+        schemaVariant: 'DEFAULT',
+        schema: [],
+        schemaFieldRoles: {},
+      };
+      const getItemTypeEventuallyConsistent = jest
+        .fn()
+        .mockResolvedValue(userItemType);
+      const { publisher, logActionExecutions } = makeIsolatedPublisher({
+        fetchHTTP: jest.fn(),
+        ncmecService: { enqueueForHumanReviewIfApplicable },
+        itemInvestigationService: {
+          getItemByIdentifier: jest.fn().mockResolvedValue(undefined),
+        },
+        getItemTypeEventuallyConsistent,
+      });
+
+      const results = await publisher.publishActions(
+        [
+          {
+            action: {
+              id: 'action-ncmec',
+              orgId: 'org-synth',
+              name: 'Enqueue for NCMEC Review',
+              description: null,
+              applyUserStrikes: false,
+              penalty: 'NONE' as const,
+              actionType: ActionType.ENQUEUE_TO_NCMEC,
+            },
+            policies: [],
+            matchingRules: undefined,
+            ruleEnvironment: undefined,
+          },
+        ],
+        {
+          orgId: 'org-synth',
+          correlationId:
+            'manual-action-run:synthetic-ncmec' as CorrelationId<'manual-action-run'>,
+          targetItem: {
+            itemId: 'synthetic-user-id',
+            itemType: {
+              id: 'user-type-1',
+              kind: 'USER' as const,
+              name: 'User',
+            },
+          },
+        },
+      );
+
+      expect(results).toEqual([
+        expect.objectContaining({ success: true, actionId: 'action-ncmec' }),
+      ]);
+      expect(enqueueForHumanReviewIfApplicable).toHaveBeenCalledTimes(1);
+      const enqueueArg = enqueueForHumanReviewIfApplicable.mock.calls[0]?.[0];
+      expect(enqueueArg.item.itemId).toBe('synthetic-user-id');
+      expect(enqueueArg.item.itemTypeIdentifier.id).toBe('user-type-1');
+      expect(logActionExecutions).toHaveBeenCalledWith(
+        expect.objectContaining({ failed: false }),
+      );
+    });
+
+    it('enqueues to MRT for a synthetic USER target with no submission record', async () => {
+      const enqueue = jest.fn().mockResolvedValue(undefined);
+      const userItemType = {
+        id: 'user-type-2',
+        kind: 'USER' as const,
+        name: 'User',
+        version: '1',
+        schemaVariant: 'DEFAULT',
+        schema: [],
+        schemaFieldRoles: {},
+      };
+      const getItemTypeEventuallyConsistent = jest
+        .fn()
+        .mockResolvedValue(userItemType);
+      const { publisher, logActionExecutions } = makeIsolatedPublisher({
+        fetchHTTP: jest.fn(),
+        manualReviewToolService: { enqueue },
+        itemInvestigationService: {
+          getItemByIdentifier: jest.fn().mockResolvedValue(undefined),
+        },
+        getItemTypeEventuallyConsistent,
+      });
+
+      const results = await publisher.publishActions(
+        [
+          {
+            action: {
+              id: 'action-mrt',
+              orgId: 'org-synth',
+              name: 'Enqueue to MRT',
+              description: null,
+              applyUserStrikes: false,
+              penalty: 'NONE' as const,
+              actionType: ActionType.ENQUEUE_TO_MRT,
+            },
+            policies: [],
+            matchingRules: undefined,
+            ruleEnvironment: undefined,
+          },
+        ],
+        {
+          orgId: 'org-synth',
+          correlationId:
+            'manual-action-run:synthetic-mrt' as CorrelationId<'manual-action-run'>,
+          targetItem: {
+            itemId: 'synthetic-user-id',
+            itemType: {
+              id: 'user-type-2',
+              kind: 'USER' as const,
+              name: 'User',
+            },
+          },
+        },
+      );
+
+      expect(results).toEqual([
+        expect.objectContaining({ success: true, actionId: 'action-mrt' }),
+      ]);
+      expect(enqueue).toHaveBeenCalledTimes(1);
+      expect(logActionExecutions).toHaveBeenCalledWith(
+        expect.objectContaining({ failed: false }),
+      );
+    });
+
+    it('fails loudly when ENQUEUE_TO_NCMEC targets a CONTENT item with no submission', async () => {
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const enqueueForHumanReviewIfApplicable = jest.fn();
+      const { publisher, logActionExecutions } = makeIsolatedPublisher({
+        fetchHTTP: jest.fn(),
+        ncmecService: { enqueueForHumanReviewIfApplicable },
+        itemInvestigationService: {
+          getItemByIdentifier: jest.fn().mockResolvedValue(undefined),
+        },
+      });
+
+      const results = await publisher.publishActions(
+        [
+          {
+            action: {
+              id: 'action-ncmec-content',
+              orgId: 'org-synth',
+              name: 'Enqueue for NCMEC Review',
+              description: null,
+              applyUserStrikes: false,
+              penalty: 'NONE' as const,
+              actionType: ActionType.ENQUEUE_TO_NCMEC,
+            },
+            policies: [],
+            matchingRules: undefined,
+            ruleEnvironment: undefined,
+          },
+        ],
+        {
+          orgId: 'org-synth',
+          correlationId:
+            'manual-action-run:synthetic-ncmec-content' as CorrelationId<'manual-action-run'>,
+          targetItem: {
+            itemId: 'phantom-content-id',
+            itemType: {
+              id: 'content-type-1',
+              kind: 'CONTENT' as const,
+              name: 'Post',
+            },
+          },
+        },
+      );
+
+      expect(results).toEqual([expect.objectContaining({ success: false })]);
+      expect(enqueueForHumanReviewIfApplicable).not.toHaveBeenCalled();
+      expect(logActionExecutions).toHaveBeenCalledWith(
+        expect.objectContaining({ failed: true }),
+      );
+      expect(consoleSpy).toHaveBeenCalled();
+      const loggedLine = consoleSpy.mock.calls[0]?.[0];
+      expect(loggedLine).toEqual(
+        expect.stringContaining('action-ncmec-content'),
+      );
+      expect(loggedLine).toEqual(
+        expect.stringContaining('actionPublisher.publishAction.failed'),
+      );
+      consoleSpy.mockRestore();
     });
   });
 });

--- a/server/rule_engine/ActionPublisher.test.ts
+++ b/server/rule_engine/ActionPublisher.test.ts
@@ -499,24 +499,26 @@ describe('ActionPublisher', () => {
         schema: [],
         schemaFieldRoles: {},
       };
-      const synthesizeUserItemFromCreatorReferences = jest
-        .fn()
-        .mockResolvedValue({
-          latestSubmission: {
-            itemId: 'inferred-creator-id',
-            itemType: userItemType,
-            data: {},
-            submissionId: 'synthetic:inferred-creator-id',
-            submissionTime: undefined,
-            creator: undefined,
-          },
-        });
+      // The real helper resolves the creator id from ACTION_EXECUTIONS and
+      // then synthesizes a submission keyed on *the creator's* id (not the
+      // content's id). The mock mirrors that shape so the test exercises a
+      // payload production can actually produce.
+      const synthesizeUserItemFromContentTarget = jest.fn().mockResolvedValue({
+        latestSubmission: {
+          itemId: 'creator-user-id-7',
+          itemType: userItemType,
+          data: {},
+          submissionId: 'synthetic:creator-user-id-7',
+          submissionTime: undefined,
+          creator: undefined,
+        },
+      });
       const { publisher, logActionExecutions } = makeIsolatedPublisher({
         fetchHTTP: jest.fn(),
         ncmecService: { enqueueForHumanReviewIfApplicable },
         itemInvestigationService: {
           getItemByIdentifier: jest.fn().mockResolvedValue(undefined),
-          synthesizeUserItemFromCreatorReferences,
+          synthesizeUserItemFromContentTarget,
         },
       });
 
@@ -553,13 +555,14 @@ describe('ActionPublisher', () => {
       );
 
       expect(results).toEqual([expect.objectContaining({ success: true })]);
-      expect(synthesizeUserItemFromCreatorReferences).toHaveBeenCalledWith({
+      expect(synthesizeUserItemFromContentTarget).toHaveBeenCalledWith({
         orgId: 'org-synth',
         itemId: 'phantom-content-id',
+        itemTypeId: 'content-type-1',
       });
       expect(enqueueForHumanReviewIfApplicable).toHaveBeenCalledTimes(1);
       const enqueueArg = enqueueForHumanReviewIfApplicable.mock.calls[0]?.[0];
-      expect(enqueueArg.item.itemId).toBe('inferred-creator-id');
+      expect(enqueueArg.item.itemId).toBe('creator-user-id-7');
       expect(enqueueArg.item.itemTypeIdentifier.id).toBe('user-type-3');
       expect(logActionExecutions).toHaveBeenCalledWith(
         expect.objectContaining({ failed: false }),
@@ -571,7 +574,7 @@ describe('ActionPublisher', () => {
         .spyOn(console, 'error')
         .mockImplementation(() => {});
       const enqueueForHumanReviewIfApplicable = jest.fn();
-      const synthesizeUserItemFromCreatorReferences = jest
+      const synthesizeUserItemFromContentTarget = jest
         .fn()
         .mockResolvedValue(null);
       const { publisher, logActionExecutions } = makeIsolatedPublisher({
@@ -579,7 +582,7 @@ describe('ActionPublisher', () => {
         ncmecService: { enqueueForHumanReviewIfApplicable },
         itemInvestigationService: {
           getItemByIdentifier: jest.fn().mockResolvedValue(undefined),
-          synthesizeUserItemFromCreatorReferences,
+          synthesizeUserItemFromContentTarget,
         },
       });
 
@@ -616,7 +619,7 @@ describe('ActionPublisher', () => {
       );
 
       expect(results).toEqual([expect.objectContaining({ success: false })]);
-      expect(synthesizeUserItemFromCreatorReferences).toHaveBeenCalled();
+      expect(synthesizeUserItemFromContentTarget).toHaveBeenCalled();
       expect(enqueueForHumanReviewIfApplicable).not.toHaveBeenCalled();
       expect(logActionExecutions).toHaveBeenCalledWith(
         expect.objectContaining({ failed: true }),

--- a/server/rule_engine/ActionPublisher.test.ts
+++ b/server/rule_engine/ActionPublisher.test.ts
@@ -50,11 +50,7 @@ function makeIsolatedPublisher(opts: IsolatedPublisherOptions) {
   } as unknown as Dependencies['UserStrikeService'];
   const getItemTypeEventuallyConsistent =
     opts.getItemTypeEventuallyConsistent ??
-    (jest
-      .fn()
-      .mockResolvedValue(
-        undefined,
-      ));
+    jest.fn().mockResolvedValue(undefined);
   const publisher = new ActionPublisher(
     actionExecutionLogger,
     makeNoopTracer(),
@@ -489,16 +485,100 @@ describe('ActionPublisher', () => {
       );
     });
 
-    it('fails loudly when ENQUEUE_TO_NCMEC targets a CONTENT item with no submission', async () => {
-      const consoleSpy = jest
-        .spyOn(console, 'error')
-        .mockImplementation(() => {});
-      const enqueueForHumanReviewIfApplicable = jest.fn();
+    it('infers the creator and enqueues to NCMEC for a CONTENT target with no submission', async () => {
+      const enqueueForHumanReviewIfApplicable = jest
+        .fn()
+        .mockResolvedValue({ status: 'ENQUEUED' });
+      const userItemType = {
+        id: 'user-type-3',
+        kind: 'USER' as const,
+        name: 'User',
+        version: '1',
+        schemaVariant: 'DEFAULT',
+        schema: [],
+        schemaFieldRoles: {},
+      };
+      const synthesizeUserItemFromCreatorReferences = jest
+        .fn()
+        .mockResolvedValue({
+          latestSubmission: {
+            itemId: 'inferred-creator-id',
+            itemType: userItemType,
+            data: {},
+            submissionId: 'synthetic:inferred-creator-id',
+            submissionTime: undefined,
+            creator: undefined,
+          },
+        });
       const { publisher, logActionExecutions } = makeIsolatedPublisher({
         fetchHTTP: jest.fn(),
         ncmecService: { enqueueForHumanReviewIfApplicable },
         itemInvestigationService: {
           getItemByIdentifier: jest.fn().mockResolvedValue(undefined),
+          synthesizeUserItemFromCreatorReferences,
+        },
+      });
+
+      const results = await publisher.publishActions(
+        [
+          {
+            action: {
+              id: 'action-ncmec-inferred',
+              orgId: 'org-synth',
+              name: 'Enqueue for NCMEC Review',
+              description: null,
+              applyUserStrikes: false,
+              penalty: 'NONE' as const,
+              actionType: ActionType.ENQUEUE_TO_NCMEC,
+            },
+            policies: [],
+            matchingRules: undefined,
+            ruleEnvironment: undefined,
+          },
+        ],
+        {
+          orgId: 'org-synth',
+          correlationId:
+            'manual-action-run:inferred-ncmec' as CorrelationId<'manual-action-run'>,
+          targetItem: {
+            itemId: 'phantom-content-id',
+            itemType: {
+              id: 'content-type-1',
+              kind: 'CONTENT' as const,
+              name: 'Post',
+            },
+          },
+        },
+      );
+
+      expect(results).toEqual([expect.objectContaining({ success: true })]);
+      expect(synthesizeUserItemFromCreatorReferences).toHaveBeenCalledWith({
+        orgId: 'org-synth',
+        itemId: 'phantom-content-id',
+      });
+      expect(enqueueForHumanReviewIfApplicable).toHaveBeenCalledTimes(1);
+      const enqueueArg = enqueueForHumanReviewIfApplicable.mock.calls[0]?.[0];
+      expect(enqueueArg.item.itemId).toBe('inferred-creator-id');
+      expect(enqueueArg.item.itemTypeIdentifier.id).toBe('user-type-3');
+      expect(logActionExecutions).toHaveBeenCalledWith(
+        expect.objectContaining({ failed: false }),
+      );
+    });
+
+    it('fails loudly when ENQUEUE_TO_NCMEC targets a CONTENT item with no submission and no inferable creator', async () => {
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const enqueueForHumanReviewIfApplicable = jest.fn();
+      const synthesizeUserItemFromCreatorReferences = jest
+        .fn()
+        .mockResolvedValue(null);
+      const { publisher, logActionExecutions } = makeIsolatedPublisher({
+        fetchHTTP: jest.fn(),
+        ncmecService: { enqueueForHumanReviewIfApplicable },
+        itemInvestigationService: {
+          getItemByIdentifier: jest.fn().mockResolvedValue(undefined),
+          synthesizeUserItemFromCreatorReferences,
         },
       });
 
@@ -535,6 +615,7 @@ describe('ActionPublisher', () => {
       );
 
       expect(results).toEqual([expect.objectContaining({ success: false })]);
+      expect(synthesizeUserItemFromCreatorReferences).toHaveBeenCalled();
       expect(enqueueForHumanReviewIfApplicable).not.toHaveBeenCalled();
       expect(logActionExecutions).toHaveBeenCalledWith(
         expect.objectContaining({ failed: true }),

--- a/server/rule_engine/ActionPublisher.ts
+++ b/server/rule_engine/ActionPublisher.ts
@@ -328,24 +328,36 @@ class ActionPublisher {
           )?.latestSubmission;
         };
 
-        // Recover when no submission exists for the target. USER: synthesize
-        // a minimal submission from the id alone. CONTENT: infer the creator
-        // via warehouse references so we can still enqueue the right user.
-        // THREAD has no single "owner" so we refuse.
-        const getFullItemOrSyntheticUser = async () => {
+        // USER target with no record: synthesize a minimal submission from
+        // the id. Returns undefined for non-USER targets — callers acting on
+        // the content itself (e.g., MRT) must not substitute a user.
+        const getFullItemOrSyntheticUserForUserTarget = async () => {
+          const fullItem = await getFullItem();
+          if (fullItem) {
+            return fullItem;
+          }
+          if (targetItem.itemType.kind !== 'USER') {
+            return undefined;
+          }
+          const userItemType = await this.getItemTypeEventuallyConsistent({
+            orgId,
+            typeSelector: { id: targetItem.itemType.id },
+          });
+          if (!userItemType || userItemType.kind !== 'USER') {
+            return undefined;
+          }
+          return makeSyntheticUserSubmission(targetItem.itemId, userItemType);
+        };
+
+        // NCMEC-only: also infers the creator for CONTENT targets so the
+        // report is filed against the right user. THREAD has no owner.
+        const getFullItemOrSyntheticUserForNcmec = async () => {
           const fullItem = await getFullItem();
           if (fullItem) {
             return fullItem;
           }
           if (targetItem.itemType.kind === 'USER') {
-            const userItemType = await this.getItemTypeEventuallyConsistent({
-              orgId,
-              typeSelector: { id: targetItem.itemType.id },
-            });
-            if (!userItemType || userItemType.kind !== 'USER') {
-              return undefined;
-            }
-            return makeSyntheticUserSubmission(targetItem.itemId, userItemType);
+            return getFullItemOrSyntheticUserForUserTarget();
           }
           if (targetItem.itemType.kind === 'CONTENT') {
             const inferred =
@@ -420,8 +432,9 @@ class ActionPublisher {
               }
 
               return true;
-            case ActionType.ENQUEUE_TO_MRT:
-              const fullItemForMrt = await getFullItemOrSyntheticUser();
+            case ActionType.ENQUEUE_TO_MRT: {
+              const fullItemForMrt =
+                await getFullItemOrSyntheticUserForUserTarget();
               if (!fullItemForMrt) {
                 throw new Error(
                   `Cannot enqueue to MRT: no submission record for ${targetItem.itemType.kind} ` +
@@ -463,8 +476,10 @@ class ActionPublisher {
               });
 
               return true;
-            case ActionType.ENQUEUE_TO_NCMEC:
-              const fullItemForNcmec = await getFullItemOrSyntheticUser();
+            }
+            case ActionType.ENQUEUE_TO_NCMEC: {
+              const fullItemForNcmec =
+                await getFullItemOrSyntheticUserForNcmec();
               if (!fullItemForNcmec) {
                 throw new Error(
                   `Cannot enqueue to NCMEC: no submission record for ${targetItem.itemType.kind} ` +
@@ -498,6 +513,7 @@ class ActionPublisher {
               });
 
               return true;
+            }
             case ActionType.ENQUEUE_AUTHOR_TO_MRT:
               const fullItemForAuthor = await getFullItem();
               if (

--- a/server/rule_engine/ActionPublisher.ts
+++ b/server/rule_engine/ActionPublisher.ts
@@ -329,8 +329,8 @@ class ActionPublisher {
         };
 
         // USER target with no record: synthesize a minimal submission from
-        // the id. Returns undefined for non-USER targets — callers acting on
-        // the content itself (e.g., MRT) must not substitute a user.
+        // the id. Returns undefined for non-USER targets — MRT needs the
+        // real content submission, so it must fail loudly for CONTENT.
         const getFullItemOrSyntheticUserForUserTarget = async () => {
           const fullItem = await getFullItem();
           if (fullItem) {
@@ -349,24 +349,27 @@ class ActionPublisher {
           return makeSyntheticUserSubmission(targetItem.itemId, userItemType);
         };
 
-        // NCMEC-only: also infers the creator for CONTENT targets so the
-        // report is filed against the right user. THREAD has no owner.
+        // NCMEC fallback: USER target → synthetic user (as above); CONTENT
+        // target → resolve the creator via ACTION_EXECUTIONS and synthesize a
+        // user submission keyed on the creator id. THREAD has no single
+        // owner, so we refuse.
         const getFullItemOrSyntheticUserForNcmec = async () => {
-          const fullItem = await getFullItem();
-          if (fullItem) {
-            return fullItem;
+          const userTarget = await getFullItemOrSyntheticUserForUserTarget();
+          if (userTarget) {
+            return userTarget;
           }
-          if (targetItem.itemType.kind === 'USER') {
-            return getFullItemOrSyntheticUserForUserTarget();
+          if (targetItem.itemType.kind !== 'CONTENT') {
+            return undefined;
           }
-          if (targetItem.itemType.kind === 'CONTENT') {
-            const inferred =
-              await this.itemInvestigationService.synthesizeUserItemFromCreatorReferences(
-                { orgId, itemId: targetItem.itemId },
-              );
-            return inferred?.latestSubmission;
-          }
-          return undefined;
+          const inferred =
+            await this.itemInvestigationService.synthesizeUserItemFromContentTarget(
+              {
+                orgId,
+                itemId: targetItem.itemId,
+                itemTypeId: targetItem.itemType.id,
+              },
+            );
+          return inferred?.latestSubmission;
         };
         const actionSource = getSourceType(
           correlationId,

--- a/server/rule_engine/ActionPublisher.ts
+++ b/server/rule_engine/ActionPublisher.ts
@@ -328,25 +328,33 @@ class ActionPublisher {
           )?.latestSubmission;
         };
 
-        // Synthesize a minimal USER submission when no prior submission
-        // exists. CONTENT/THREAD enqueues need real `data` to resolve the
-        // creator, so they fall through to the existing error path.
+        // Recover when no submission exists for the target. USER: synthesize
+        // a minimal submission from the id alone. CONTENT: infer the creator
+        // via warehouse references so we can still enqueue the right user.
+        // THREAD has no single "owner" so we refuse.
         const getFullItemOrSyntheticUser = async () => {
           const fullItem = await getFullItem();
           if (fullItem) {
             return fullItem;
           }
-          if (targetItem.itemType.kind !== 'USER') {
-            return undefined;
+          if (targetItem.itemType.kind === 'USER') {
+            const userItemType = await this.getItemTypeEventuallyConsistent({
+              orgId,
+              typeSelector: { id: targetItem.itemType.id },
+            });
+            if (!userItemType || userItemType.kind !== 'USER') {
+              return undefined;
+            }
+            return makeSyntheticUserSubmission(targetItem.itemId, userItemType);
           }
-          const userItemType = await this.getItemTypeEventuallyConsistent({
-            orgId,
-            typeSelector: { id: targetItem.itemType.id },
-          });
-          if (!userItemType || userItemType.kind !== 'USER') {
-            return undefined;
+          if (targetItem.itemType.kind === 'CONTENT') {
+            const inferred =
+              await this.itemInvestigationService.synthesizeUserItemFromCreatorReferences(
+                { orgId, itemId: targetItem.itemId },
+              );
+            return inferred?.latestSubmission;
           }
-          return makeSyntheticUserSubmission(targetItem.itemId, userItemType);
+          return undefined;
         };
         const actionSource = getSourceType(
           correlationId,

--- a/server/rule_engine/ActionPublisher.ts
+++ b/server/rule_engine/ActionPublisher.ts
@@ -11,6 +11,7 @@ import {
   type MatchingRule,
   type Policy,
 } from '../services/analyticsLoggers/index.js';
+import { makeSyntheticUserSubmission } from '../services/itemInvestigationService/index.js';
 import {
   getFieldValueForRole,
   itemSubmissionToItemSubmissionWithTypeIdentifier,
@@ -121,6 +122,7 @@ class ActionPublisher {
     private ncmecService: Dependencies['NcmecService'],
     private itemInvestigationService: Dependencies['ItemInvestigationService'],
     private userStrikeService: Dependencies['UserStrikeService'],
+    private getItemTypeEventuallyConsistent: Dependencies['getItemTypeEventuallyConsistent'],
   ) {}
 
   /**
@@ -325,6 +327,27 @@ class ActionPublisher {
             })
           )?.latestSubmission;
         };
+
+        // Synthesize a minimal USER submission when no prior submission
+        // exists. CONTENT/THREAD enqueues need real `data` to resolve the
+        // creator, so they fall through to the existing error path.
+        const getFullItemOrSyntheticUser = async () => {
+          const fullItem = await getFullItem();
+          if (fullItem) {
+            return fullItem;
+          }
+          if (targetItem.itemType.kind !== 'USER') {
+            return undefined;
+          }
+          const userItemType = await this.getItemTypeEventuallyConsistent({
+            orgId,
+            typeSelector: { id: targetItem.itemType.id },
+          });
+          if (!userItemType || userItemType.kind !== 'USER') {
+            return undefined;
+          }
+          return makeSyntheticUserSubmission(targetItem.itemId, userItemType);
+        };
         const actionSource = getSourceType(
           correlationId,
         ) as ActionExecutionSourceType;
@@ -390,10 +413,12 @@ class ActionPublisher {
 
               return true;
             case ActionType.ENQUEUE_TO_MRT:
-              const fullItemForMrt = await getFullItem();
+              const fullItemForMrt = await getFullItemOrSyntheticUser();
               if (!fullItemForMrt) {
                 throw new Error(
-                  "Actions without full item submissions can't be enqueued to MRT yet",
+                  `Cannot enqueue to MRT: no submission record for ${targetItem.itemType.kind} ` +
+                    `item ${targetItem.itemId} (type ${targetItem.itemType.id}). ` +
+                    `POST the item to the items endpoint first.`,
                 );
               }
 
@@ -431,10 +456,12 @@ class ActionPublisher {
 
               return true;
             case ActionType.ENQUEUE_TO_NCMEC:
-              const fullItemForNcmec = await getFullItem();
+              const fullItemForNcmec = await getFullItemOrSyntheticUser();
               if (!fullItemForNcmec) {
                 throw new Error(
-                  "Actions without full item submissions can't be enqueued to NCMEC yet",
+                  `Cannot enqueue to NCMEC: no submission record for ${targetItem.itemType.kind} ` +
+                    `item ${targetItem.itemId} (type ${targetItem.itemType.id}). ` +
+                    `POST the item to the items endpoint first.`,
                 );
               }
 
@@ -573,6 +600,23 @@ class ActionPublisher {
           }
         } catch (e) {
           span.recordException(e as Exception);
+          // Log to stderr so operators see action failures without having
+          // to pull traces. Identifiers only, no item `data`.
+          // eslint-disable-next-line no-console
+          console.error(
+            jsonStringify({
+              event: 'actionPublisher.publishAction.failed',
+              orgId,
+              actionId: action.id,
+              actionName: action.name,
+              actionType: action.actionType,
+              itemId: targetItem.itemId,
+              itemTypeId: targetItem.itemType.id,
+              itemTypeKind: targetItem.itemType.kind,
+              correlationId,
+              error: e instanceof Error ? e.message : String(e),
+            }),
+          );
           return false;
         }
       },
@@ -590,6 +634,7 @@ export default inject(
     'NcmecService',
     'ItemInvestigationService',
     'UserStrikeService',
+    'getItemTypeEventuallyConsistent',
   ],
   ActionPublisher,
 );

--- a/server/services/itemInvestigationService/index.ts
+++ b/server/services/itemInvestigationService/index.ts
@@ -2,3 +2,4 @@ export {
   ItemInvestigationServiceAdapter as ItemInvestigationService,
   RETURN_UNLIMITED_RESULTS_AND_POTENTIALLY_HANG_DB,
 } from './itemInvestigationServiceAdapter.js';
+export { makeSyntheticUserSubmission } from './synthesizeUserItemFromCreatorReferences.js';

--- a/server/services/itemInvestigationService/itemInvestigationServiceAdapter.ts
+++ b/server/services/itemInvestigationService/itemInvestigationServiceAdapter.ts
@@ -25,6 +25,7 @@ import {
   ItemInvestigationService,
   type SubmissionsForItemWithTypeIdentifier,
 } from './itemInvestigationService.js';
+import { synthesizeUserItemFromContentTarget } from './synthesizeUserItemFromContentTarget.js';
 import { synthesizeUserItemFromCreatorReferences } from './synthesizeUserItemFromCreatorReferences.js';
 
 type AdaptedReturnType<T extends PublicMethodNames<ItemInvestigationService>> =
@@ -286,6 +287,22 @@ export class ItemInvestigationServiceAdapter {
     knownUserTypeId?: string;
   }): Promise<SubmissionsForItem | null> {
     return synthesizeUserItemFromCreatorReferences({
+      ...opts,
+      scyllaCreatorRefExists: async (input) =>
+        this.#hasAnySubmissionsCreatedBy(input.orgId, input.creatorIdentifier),
+      actionExecutionsAdapter: this.actionExecutionsAdapter,
+      contentApiRequestsAdapter: this.contentApiRequestsAdapter,
+      moderationConfigService: this.moderationConfigService,
+    });
+  }
+
+  /** See `synthesizeUserItemFromContentTarget.ts`. */
+  async synthesizeUserItemFromContentTarget(opts: {
+    orgId: string;
+    itemId: string;
+    itemTypeId: string;
+  }): Promise<SubmissionsForItem | null> {
+    return synthesizeUserItemFromContentTarget({
       ...opts,
       scyllaCreatorRefExists: async (input) =>
         this.#hasAnySubmissionsCreatedBy(input.orgId, input.creatorIdentifier),

--- a/server/services/itemInvestigationService/synthesizeUserItemFromContentTarget.ts
+++ b/server/services/itemInvestigationService/synthesizeUserItemFromContentTarget.ts
@@ -1,0 +1,66 @@
+import { type Dependencies } from '../../iocContainer/index.js';
+import { type IActionExecutionsAdapter } from '../../plugins/warehouse/queries/IActionExecutionsAdapter.js';
+import { type IContentApiRequestsAdapter } from '../../plugins/warehouse/queries/IContentApiRequestsAdapter.js';
+import {
+  synthesizeUserItemFromCreatorReferences,
+  type SyntheticUserItemSubmissionsForItem,
+} from './synthesizeUserItemFromCreatorReferences.js';
+
+/**
+ * Resolve a synthetic `UserItem` submission for the *creator* of a CONTENT
+ * item whose own submission record is missing. Looks up the most-recent
+ * `(creator_id, creator_type_id)` for `(itemId, itemTypeId)` in
+ * `ACTION_EXECUTIONS`, then delegates to
+ * `synthesizeUserItemFromCreatorReferences` with the resolved user id so the
+ * returned submission is keyed on the creator (not the content).
+ */
+export async function synthesizeUserItemFromContentTarget(opts: {
+  orgId: string;
+  itemId: string;
+  itemTypeId: string;
+  actionExecutionsAdapter: Pick<
+    IActionExecutionsAdapter,
+    'findContentCreatorIdentity' | 'findInferredUserIdentity'
+  >;
+  contentApiRequestsAdapter: Pick<
+    IContentApiRequestsAdapter,
+    'findInferredUserIdentityFromCreators'
+  >;
+  scyllaCreatorRefExists: Parameters<
+    typeof synthesizeUserItemFromCreatorReferences
+  >[0]['scyllaCreatorRefExists'];
+  moderationConfigService: Pick<
+    Dependencies['ModerationConfigService'],
+    'getItemType' | 'getItemTypes'
+  >;
+}): Promise<SyntheticUserItemSubmissionsForItem | null> {
+  const {
+    orgId,
+    itemId,
+    itemTypeId,
+    actionExecutionsAdapter,
+    contentApiRequestsAdapter,
+    scyllaCreatorRefExists,
+    moderationConfigService,
+  } = opts;
+
+  const creator = await actionExecutionsAdapter.findContentCreatorIdentity({
+    orgId,
+    itemId,
+    itemTypeId,
+  });
+
+  if (!creator) {
+    return null;
+  }
+
+  return synthesizeUserItemFromCreatorReferences({
+    orgId,
+    itemId: creator.creatorId,
+    knownUserTypeId: creator.creatorTypeId,
+    scyllaCreatorRefExists,
+    actionExecutionsAdapter,
+    contentApiRequestsAdapter,
+    moderationConfigService,
+  });
+}


### PR DESCRIPTION
## Context & Requests for Reviewers

Moderators triaging a user the integration never POSTed (a "synthetic" user surfaced by Item Investigation) could not enqueue them for NCMEC review or MRT. The action returned success: false with a misleading "callback URL may have returned an error" toast and nothing in server logs, while still creating an audit row in `analytics.ACTION_EXECUTIONS` so every retry looked like a new entry in Recent Actions on this User despite none of them taking effect.

`ActionPublisher.publishAction` now synthesizes a minimal `UserItem` submission via `makeSyntheticUserSubmission` when the target is a USER and `getItemByIdentifier` returns nothing, so `ENQUEUE_TO_NCMEC` and `ENQUEUE_TO_MRT` enqueue successfully. The downstream `NcmecEnqueueToMrt` service already handles minimal user submissions.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bulk-action failure messaging to include server log guidance and clearer callback URL / retry guidance.
  * Action publishing now fails more clearly with structured error output when target submission cannot be recovered.

* **New Features**
  * Improved recovery so actions can be enqueued even when submission records are missing, including inferring a content creator to allow reporting to downstream receivers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/494?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->