### PR TITLE
client: Strip Cove marketing and tracking from index

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -10,21 +10,15 @@
     <title>Coop</title>
     <meta
       name="description"
-      content="Coop is an open source content moderation and trust & safety review tool by ROOST."
+      content="Coop is an open source review tool for moderation and online safety by ROOST."
     />
     <meta property="og:title" content="Coop" />
     <meta
       property="og:description"
-      content="Coop is an open source content moderation and trust & safety review tool by ROOST."
+      content="Coop is an open source review tool for moderation and online safety by ROOST."
     />
     <meta property="og:url" content="https://roost.tools/coop" />
     <meta property="og:type" content="website" />
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:title" content="Coop" />
-    <meta
-      name="twitter:description"
-      content="Coop is an open source content moderation and trust & safety review tool by ROOST."
-    />
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/client/index.html
+++ b/client/index.html
@@ -17,7 +17,6 @@
       property="og:description"
       content="Coop is an open source review tool for moderation and online safety by ROOST."
     />
-    <meta property="og:url" content="https://roost.tools/coop" />
     <meta property="og:type" content="website" />
   </head>
   <body>

--- a/client/index.html
+++ b/client/index.html
@@ -1,82 +1,34 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <script
-      id="cookieyes"
-      type="text/javascript"
-      src="https://cdn-cookieyes.com/client_data/dc1f6469ed06cb8b7d7dc617/script.js"
-    ></script>
     <meta charset="utf-8" />
-    <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
+    <link rel="icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" href="/logo192.png" />
+    <link rel="manifest" href="/manifest.json" />
+    <title>Coop</title>
     <meta
       name="description"
-      content="A no-code platform for Trust and Safety"
+      content="Coop is an open source content moderation and trust & safety review tool by ROOST."
     />
-    <link rel="apple-touch-icon" href="/logo192.png" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="/manifest.json" />
-    <style>
-      @import url('https://fonts.googleapis.com/css2?family=Manrope:wght@200;300;400;500;600;700;800&display=swap');
-    </style>
-    <title>Coop</title>
-    <!-- Google tag (gtag.js) -->
-    <script
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=AW-11326070039"
-    ></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag('js', new Date());
-
-      gtag('config', 'AW-11326070039');
-    </script>
-    <meta property="og:title" content="Coop | AI-Powered Trust & Safety" />
+    <meta property="og:title" content="Coop" />
     <meta
       property="og:description"
-      content="Coop is the new standard for modern Trust & Safety. Move faster,
-    reduce spend, and maintain full control without writing code. Easily
-    customize AI models and policy enforcement workflows to fit your needs."
+      content="Coop is an open source content moderation and trust & safety review tool by ROOST."
     />
-    <meta
-      property="og:image"
-      content="http://getcoop.com/graphics/coop-opengraph.png"
-    />
-    <meta property="og:url" content="https://www.getcoop.com/" />
+    <meta property="og:url" content="https://roost.tools/coop" />
     <meta property="og:type" content="website" />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@coopsoftware" />
-    <meta name="twitter:title" content="Coop | AI-Powered Trust & Safety" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Coop" />
     <meta
       name="twitter:description"
-      content="Coop is the new standard for modern Trust & Safety. Move faster, reduce spend, and maintain full control without writing code. Easily customize AI models and policy enforcement workflows to fit your needs."
-    />
-    <meta
-      name="twitter:image"
-      content="http://getcoop.com/graphics/coop-opengraph-twitter.png"
+      content="Coop is an open source content moderation and trust & safety review tool by ROOST."
     />
   </head>
-
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <script type="module" src="/src/index.tsx"></script>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>


### PR DESCRIPTION
## Context & Requests for Reviewers

Closes #166. The client entry HTML carried Cove SaaS leftovers that both misrepresented self-hosted Coop and had old code related to non-active tracking and cookie services.

### Removed

- **CookieYes cookie-consent script** keyed to a Cove `client_data` ID — every visitor to any Coop deployment was hitting Cove's CookieYes subscription (no longer active)
- **Google Ads `gtag` ** — Cove's conversion-tracking pixel. Same problem.
- **Marketing meta tags** written for a Cove sales page:
  - `description` ("A no-code platform for Trust and Safety")
  - `og:title` / `og:description` / `og:image` / `og:url` (the latter two pointed at the nonexistent `getcoop.com`)
  - Twitter cards including `@coopsoftware` (Cove's handle, not ROOST's) and Cove marketing copy
- **Google Fonts `@import` for Manrope** — redundant; the font already ships from `client/src/fonts/Manrope-VariableFont_wght.ttf` and is wired up by `client/src/styles/globals.css` and `Dashboard.css`. Net effect of removal: one fewer call to `fonts.googleapis.com` per page load.
- **Twitter** - now X

### Kept (the minimum Vite needs + accurate share preview)

- doctype, `<html lang="en">`, `<head>`, `<body>`
- charset, viewport, theme-color
- favicon / apple-touch-icon / manifest
- `<title>Coop</title>`
- root `<div id="root"></div>` and `<script type="module" src="/src/index.tsx">`
- Updated `description` / `og:*` / `twitter:*` tags pointing at `https://roost.tools/coop` with the wording: _"Coop is an open source moderation and trust & safety review tool by ROOST."_

Net diff: `1 file changed, 10 insertions(+), 58 deletions(-)`.

## Tests

- `cd client && npm run build` succeeds (Vite build, 6.83s). The root div + module script are unchanged, so the app still mounts.
- No automated test added — there's no existing test harness for `client/index.html` and the change is purely declarative content. Manual smoke: load the running client, view source, confirm no `cookieyes.com` / `googletagmanager.com` / `getcoop.com` references remain.

Reviewer checks:

- [ ] `cd client && npm run build` succeeds
- [ ] Diff is content-only; no Vite wiring touched
- [ ] No remaining references to `cookieyes`, `gtag`, `getcoop.com`, or `@coopsoftware` in `client/index.html`

## AGENTS.md callout

This isn't in any of AGENTS.md's "human-approval-required" buckets (not auth, not migrations, not deploy, not GraphQL types, not IoC, not deps). Still:

- **Small, focused diff** per AGENTS.md's general guidance.
- **No new dependencies** — only removals (CookieYes, gtag, Google Fonts).
- **Tracking/data-flow change worth flagging:** visitors to any Coop deployment will no longer load resources from `cdn-cookieyes.com`, `googletagmanager.com`, or `fonts.googleapis.com`. That's a privacy improvement for end users and a slight breakage for any operator who was depending on the Cove tracking (extremely unlikely). Adjacent SaaS-remnant findings from #487 (the hardcoded `getcoop.com` SSO bypass, the bogus blocked-hostnames list) are tracked separately — this PR doesn't touch those.

## (Optional) Rollout Plan

None required. HTML template change applies on next deploy. No data migrations, no config changes, no env vars. If a deployment had grown to depend on the Cove analytics IDs (extremely unlikely for a self-hosted ROOST tool), they can re-add their own tracking after the fact — but they should not be inheriting Cove's IDs in the first place.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed analytics and cookie-consent embeds and the Google tracking script from the page head.
  * Eliminated the Google Fonts import and other nonessential head assets.
  * Replaced verbose metadata and social preview tags with a concise set (charset, viewport, theme, icons, manifest), a short site description, and minimal OpenGraph fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/509?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->