### PR TITLE
docs: correct site-url

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -8,6 +8,7 @@ src = "."
 build-dir = "./book"
 
 [output.html]
+site-url = "/coop/latest/"
 edit-url-template = "https://github.com/roostorg/coop/edit/main/docs/{path}"
 git-repository-url = "https://github.com/roostorg/coop"
 


### PR DESCRIPTION
Apparently needed to fix the broken 404 page styling (and maybe other things): https://rust-lang.github.io/mdBook/continuous-integration.html#404-handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation site URL configuration to reflect the latest deployment path.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/510?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->