### PR TITLE
docs: explicitly point to GitHub repo/README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,8 @@
 # Welcome
 
-Welcome to the Coop documentation! These docs are split into a few guides, depending on who you are and what you're looking for:
+Welcome to the Coop documentation! For the Coop source code and basic information, [check out Coop on GitHub](https://github.com/roostorg/coop).
+
+These docs are split into a few guides, depending on who you are and what you're looking for:
 
 - [User Guide](user/): learn about Coop, its functionality, and the user interface
 - [Development Guide](development/): get Coop running and learn how to navigate the code


### PR DESCRIPTION
I realized this wasn't actually that prominent, even if it's in the header. We should link to the GitHub repo right away in case someone lands here before seeing the project on GitHub.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README welcome section to direct readers to the Coop GitHub repository for source code and additional information.
  * Adjusted the introductory paragraph explaining how the documentation is organized and structured.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/511?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->