### PR TITLE
docs: correct links in user README

### DIFF
--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -21,8 +21,8 @@ We recommend beginning by familiarizing yourself with Coop's [basic concepts](co
 
 2. Define your [Item Types](administration.md#item-types); the kinds of content or users on your platform (posts, comments, profiles, etc.)
 
-3. Define your [Actions](administration.md#actions) and expose callback endpoints so Coop can trigger enforcement on your platform; see [Handle Actions](../api/actions.md) for the webhook format
+3. Define your [Actions](administration.md#actions) and expose callback endpoints so Coop can trigger enforcement on your platform; see [Handling Actions](../api/actions.md) for the webhook format
 
 4. Begin submitting items to Coop via the [Items API](../api/items.md) so they run through your proactive rules
 
-5. Submit user reports via the [Reports API](../api/reports.md) to route them into review queues for your moderators
+5. Submit user reports via the [Report API](../api/report.md) to route them into review queues for your moderators


### PR DESCRIPTION
Reports → Report, and correct a link title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the admin getting started guide with corrected documentation links for configuring Actions and managing user reports through the Report API.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/515?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->