### PR TITLE
docs: add Partial Items API

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -35,6 +35,7 @@
   - [User Scores](api/user-scores.md)
   - [GDPR Deletion](api/gdpr.md)
   - [Handling Actions](api/actions.md)
+  - [Partial Items](api/partial-items.md)
   - [Errors](api/errors.md)
 
 ---

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -20,4 +20,8 @@ You can find or rotate your API key under **Settings** → **API Keys** in the C
 | `GET /api/v1/user_scores`    | [User Scores](user-scores.md): fetch a user's moderation score |
 | `POST /api/v1/gdpr/delete`   | [GDPR Deletion](gdpr.md): delete a user's data                 |
 
-See [Handling Actions](actions.md) for information about receiving action webhooks from Coop. See [Errors](errors.md) for information error responses from Coop.
+See also:
+
+- [Handling Actions](actions.md): information about receiving action webhooks from Coop
+- [Partial Items API](../api/partial-items.md): support Coop fetching Items and their attributes on demand
+- [Errors](errors.md): details of error responses from Coop

--- a/docs/api/actions.md
+++ b/docs/api/actions.md
@@ -6,7 +6,7 @@ When Coop triggers an Action—either through an automated rule or a moderator's
 
 For each Action you define in Coop, provide a publicly accessible callback URL and any authentication headers your endpoint requires (e.g. an API key Coop should send). Coop includes these headers on every outgoing request to that endpoint.
 
-To verify that an incoming request actually came from Coop, check the `Coop-Signature` header. See [API Keys & Authentication](../development/api-auth.md) for the signature verification algorithm.
+To verify that an incoming request actually came from Coop, check the `Coop-Signature` header. See [API Keys & Authentication](../development/api-auth.md#verifying-incoming-requests-from-coop) for the signature verification algorithm and a code example.
 
 Failed deliveries are retried up to five times with exponential backoff.
 
@@ -58,7 +58,7 @@ Failed deliveries are retried up to five times with exponential backoff.
 | `id`   | String | Coop's unique rule ID |
 | `name` | String | Rule name             |
 
-## Appeal Decision Callback
+## Appeal decision callback
 
 When a moderator reviews an appeal in the Review Console and makes a decision, Coop sends a POST request to the Appeal callback URL configured in your Appeals Dashboard.
 

--- a/docs/api/items.md
+++ b/docs/api/items.md
@@ -1,8 +1,8 @@
 # Submit Items API
 
-Send content to Coop for automated rule evaluation. Every time you submit an item, Coop runs it through all your configured [Automated Rules](../user/rules.md).
+Send [Items](../user/concepts.md#item) to Coop for automated rule evaluation. Every time you submit an item, Coop runs it through all your configured [Proactive Rules](../user/rules.md#proactive-rules).
 
-Submit items when they are created, edited, reported, or otherwise need to be re-evaluated. You should also submit items retroactively if you configure new rules after launch.
+Submit items when they are created, edited, reported, or otherwise need to be re-evaluated. You should also submit items retroactively if you configure new rules after launch. To support Coop fetching Items and their attributes on demand, see the [Partial Items API](../api/partial-items.md).
 
 ## Endpoint
 

--- a/docs/api/partial-items.md
+++ b/docs/api/partial-items.md
@@ -2,12 +2,18 @@
 
 Enable Coop to fetch [Items](../user/concepts.md#item) and their details from your platform. Used to backfill historical data, fetch related items in the review console that haven't yet been sent to Coop, and ensure items are up-to-date when viewed.
 
+## Setting up your endpoint
+
+To use this API, your platform must provide a Partial Items API endpoint that can receive POST requests from Coop. When Coop needs to get information about a particular item from your platform, it sends a POST request to the endpoint with the requested item's unique ID.
+
+To verify that an incoming request actually came from Coop, check the `Coop-Signature` header. See [API Keys & Authentication](../development/api-auth.md#verifying-incoming-requests-from-coop) for the signature verification algorithm and a code example.
+
 > [!IMPORTANT]
 > **It is not yet possible to configure this from the Coop UI**, so you'll have to manage it in code. See [roostorg/coop#378](https://github.com/roostorg/coop/issues/378) for details.
 
-To use this API, your platform must provide a Partial Items API endpoint that can receive POST requests from Coop. When Coop needs to get information about a particular item from your platform, it sends a POST request to the endpoint with the requested item's unique ID. You'll need to update your Coop instance's code with the endpoint URL and any required headers so it can make the HTTP requests.
+You'll need to update your Coop instance's code with the endpoint URL and any required headers (including any additional authentication, such as an API key) so it can make the HTTP requests.
 
-## REST API Example
+## REST API example
 
 Here's an example of a POST request that Coop would send to this endpoint:
 
@@ -38,7 +44,7 @@ In each object in the `items` array, Coop expects the following fields:
 | `id`     | `String` | Your unique identifier for this Item                                                                                                                                                                   |
 | `typeId` | `String` | The ID of the [Item Type](../user/concepts.md#item-type) that corresponds to the Item. This will exactly match the ID of one of the Item Types you've [defined](../user/administration.md#item-types). |
 
-## Example Response
+## Example response
 
 Your platform returns information about the item to Coop in its response. Even if it can't fetch _all_ attributes of the item (perhaps because of some limitations in your data model or query latency), your platform can just return as many attributes as you have access to. In other words, you can return a _partial_ version of the Item, even if some attributes are missing.
 
@@ -59,3 +65,9 @@ Coop expects a response in the following format:
   ]
 }
 ```
+
+Coop expects a `2xx` HTTP status from your endpoint. If it receives any non-2xx response, it treats the request as failed and the on-demand item fetch will not succeed for the user.
+
+If your platform can't find or return a particular item, omit it from the `items` array in your response rather than returning an error status. Coop won't treat a missing item as a failure; it simply won't have data for that item.
+
+The response body must be valid JSON with a top-level `items` array. A malformed response is also treated as a failure.

--- a/docs/api/partial-items.md
+++ b/docs/api/partial-items.md
@@ -53,7 +53,7 @@ Coop expects a response in the following format:
 
 ```json
 {
-  items: [
+  "items": [
     {
       "id": "abc123", // the `id` Coop provided in the request body
       "typeId": "def456", // the `typeId` Coop provided in the request body

--- a/docs/api/partial-items.md
+++ b/docs/api/partial-items.md
@@ -21,6 +21,7 @@ Here's an example of a POST request that Coop would send to this endpoint:
 curl --request POST \
     --url https://your-platform.example.com/partial-items \
     --header 'Content-Type: application/json' \
+    --header 'Coop-Signature: t=1234567890,v1=5f7d8e9...' \
     --data '{
         "items": [
             {
@@ -50,14 +51,14 @@ Your platform returns information about the item to Coop in its response. Even i
 
 Coop expects a response in the following format:
 
-```ts
+```json
 {
   items: [
     {
-      id: "abc123", // the `id` Coop provided in the request body
-      typeId: "def456", // the `typeId` Coop provided in the request body
-      data: { // the same `data` JSON object you'd provide if you had sent this Item via the Items API
-        text: "some text uploaded by a user"
+      "id": "abc123", // the `id` Coop provided in the request body
+      "typeId": "def456", // the `typeId` Coop provided in the request body
+      "data": { // the same `data` JSON object you'd provide if you had sent this Item via the Items API
+        "text": "some text uploaded by a user"
         // ... all other fields in your Item Type
       },
     },

--- a/docs/api/partial-items.md
+++ b/docs/api/partial-items.md
@@ -1,0 +1,61 @@
+# Partial Items API
+
+Enable Coop to fetch [Items](../user/concepts.md#item) and their details from your platform. Used to backfill historical data, fetch related items in the review console that haven't yet been sent to Coop, and ensure items are up-to-date when viewed.
+
+> [!IMPORTANT]
+> **It is not yet possible to configure this from the Coop UI**, so you'll have to manage it in code. See [roostorg/coop#378](https://github.com/roostorg/coop/issues/378) for details.
+
+To use this API, your platform must provide a Partial Items API endpoint that can receive POST requests from Coop. When Coop needs to get information about a particular item from your platform, it sends a POST request to the endpoint with the requested item's unique ID. You'll need to update your Coop instance's code with the endpoint URL and any required headers so it can make the HTTP requests.
+
+## REST API Example
+
+Here's an example of a POST request that Coop would send to this endpoint:
+
+```sh
+curl --request POST \
+    --url https://your-platform.example.com/partial-items \
+    --header 'Content-Type: application/json' \
+    --data '{
+        "items": [
+            {
+                "id": "abc123",
+                "typeId": "def456"
+            },
+            {
+                "id": "xyz789",
+                "typeId": "def456"
+            }
+        ]
+    }'
+```
+
+In the body of the request, there is only one top-level property called `items`, which is an array of objects representing the Items about which Coop needs more information. This property is an array so that Coop can request batches of multiple Items within a single API request, when needed.
+
+In each object in the `items` array, Coop expects the following fields:
+
+| Property | Type     | Description                                                                                                                                                                                            |
+| :------- | :------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`     | `String` | Your unique identifier for this Item                                                                                                                                                                   |
+| `typeId` | `String` | The ID of the [Item Type](../user/concepts.md#item-type) that corresponds to the Item. This will exactly match the ID of one of the Item Types you've [defined](../user/administration.md#item-types). |
+
+## Example Response
+
+Your platform returns information about the item to Coop in its response. Even if it can't fetch _all_ attributes of the item (perhaps because of some limitations in your data model or query latency), your platform can just return as many attributes as you have access to. In other words, you can return a _partial_ version of the Item, even if some attributes are missing.
+
+Coop expects a response in the following format:
+
+```ts
+{
+  items: [
+    {
+      id: "abc123", // the `id` Coop provided in the request body
+      typeId: "def456", // the `typeId` Coop provided in the request body
+      data: { // the same `data` JSON object you'd provide if you had sent this Item via the Items API
+        text: "some text uploaded by a user"
+        // ... all other fields in your Item Type
+      },
+    },
+    ... // other items
+  ]
+}
+```

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -78,6 +78,8 @@ See the [API Reference](../api/) for details including all endpoints and request
 
 Content comes into Coop via a platform sending items to the [Items API](../api/items.md) for automated enforcement, and user reports to the [Report API](../api/report.md) to be routed to the Review Console.
 
+To backfill historical data, fetch related items in the review console that haven't yet been sent to Coop, and ensure items are up-to-date when viewed, platforms can use the [Partial Items API](../api/partial-items.md).
+
 ### Actions from Coop
 
 When an action is triggered by a proactive rule or moderator decision, Coop sends a webhook back to the organization's platform. See [Handling Actions](../api/actions.md) for details on the webhook format and how to process it.


### PR DESCRIPTION
Fixes #501. A little awkward because the API still requires code changes in a deployed Coop instance, but it's better than nothing! Fleshing out the front-end for the API is tracked in #378.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Partial Items API docs describing request/response format, verification, partial-response behavior, and error handling
  * Added navigation entry for Partial Items
  * Clarified Submit Items API intro; renamed “Automated Rules” to “Proactive Rules”
  * Added “See also” cross-references to related API pages and a backfill workflow note
  * Clarified Actions callback verification reference and standardized “Appeal decision callback” heading

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/523?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->