### PR TITLE
docs: use Funnel Display and Funnel Sans

### DIFF
--- a/docs/theme/fonts/fonts.css
+++ b/docs/theme/fonts/fonts.css
@@ -1,0 +1,19 @@
+@import url('https://fonts.googleapis.com/css2?family=Funnel+Display:wght@300..800&family=Funnel+Sans:ital,wght@0,300..800;1,300..800&display=swap');
+
+:root {
+  font-family: "Funnel Sans", sans-serif;
+  font-optical-sizing: auto;
+  font-weight: 400;
+  font-style: normal;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: "Funnel Display", sans-serif;
+  font-optical-sizing: auto;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.content a {
+  text-decoration: underline;
+}


### PR DESCRIPTION
I've gotten lots of positive feedback about the typography on the community docs, so I wanted to bring that here as well. However, rather than going with a full custom theme (yellow is hard…), this retains the existing built-in mdBook color schemes and just updates the typography to use ROOST brand fonts.

Also a small accessibility win by making links underlined by default.

Before | After
------ | -----
![Before](https://github.com/user-attachments/assets/cb545db8-6960-4b64-9117-2c4d2ff3d926) | ![After](https://github.com/user-attachments/assets/3135e49c-7eeb-4f00-a535-9eb3c694c2aa)
![Before](https://github.com/user-attachments/assets/e1ba1f66-a5e5-4b4d-88d8-672de65fba77) | ![After](https://github.com/user-attachments/assets/6a34020e-a4bc-4a1d-aa03-a810c2016e9c)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Updated application typography with new font families for enhanced visual design
* Improved heading and link styling for better visual consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/525?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->