### PR TITLE
chore(client): migrate test setup to Vitest 4

### DIFF
--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -10,3 +10,4 @@
 !tailwind.config.js
 !tsconfig.json
 !nginx.conf
+!tsconfig.test.json

--- a/client/.eslintrc.cjs
+++ b/client/.eslintrc.cjs
@@ -23,7 +23,7 @@ module.exports = {
   extends: ['plugin:react/recommended', 'plugin:react-hooks/recommended'],
   parser: '@typescript-eslint/parser',
   parserOptions: {
-    project: ['./tsconfig.json'],
+    project: ['./tsconfig.json', './tsconfig.test.json'],
     tsconfigRootDir: __dirname,
   },
   ignorePatterns: [

--- a/client/eslint/__tests__/customRules.test.js
+++ b/client/eslint/__tests__/customRules.test.js
@@ -1,5 +1,6 @@
-import { Linter } from 'eslint';
 import tsParser from '@typescript-eslint/parser';
+import { Linter } from 'eslint';
+
 import rule from '../no-casting-in-getFieldValueForRole.js';
 
 const linter = new Linter({ configType: 'flat' });
@@ -7,7 +8,9 @@ const linter = new Linter({ configType: 'flat' });
 const runLint = (code) => {
   const messages = linter.verify(code, [
     {
-      plugins: { local: { rules: { 'no-casting-in-getFieldValueForRole': rule } } },
+      plugins: {
+        local: { rules: { 'no-casting-in-getFieldValueForRole': rule } },
+      },
       rules: { 'local/no-casting-in-getFieldValueForRole': 'error' },
       languageOptions: {
         parser: tsParser,

--- a/client/eslint/__tests__/customRules.test.js
+++ b/client/eslint/__tests__/customRules.test.js
@@ -2,7 +2,7 @@ import { Linter } from 'eslint';
 import tsParser from '@typescript-eslint/parser';
 import rule from '../no-casting-in-getFieldValueForRole.js';
 
-const linter = new Linter();
+const linter = new Linter({ configType: 'flat' });
 
 const runLint = (code) => {
   const messages = linter.verify(code, [

--- a/client/eslint/__tests__/customRules.test.js
+++ b/client/eslint/__tests__/customRules.test.js
@@ -1,22 +1,21 @@
-const { Linter } = require('eslint');
-const rule = require('../no-casting-in-getFieldValueForRole');
+import { Linter } from 'eslint';
+import tsParser from '@typescript-eslint/parser';
+import rule from '../no-casting-in-getFieldValueForRole.js';
 
 const linter = new Linter();
 
 const runLint = (code) => {
-  const messages = linter.verify(code, {
-    plugins: {
-      custom: {
-        rules: {
-          'no-casting-in-getFieldValueForRole': rule,
-        },
+  const messages = linter.verify(code, [
+    {
+      plugins: { local: { rules: { 'no-casting-in-getFieldValueForRole': rule } } },
+      rules: { 'local/no-casting-in-getFieldValueForRole': 'error' },
+      languageOptions: {
+        parser: tsParser,
+        ecmaVersion: 2015,
+        sourceType: 'module',
       },
     },
-    rules: {
-      'custom/no-casting-in-getFieldValueForRole': 'error',
-    },
-    languageOptions: { ecmaVersion: 2015, sourceType: 'module' },
-  });
+  ]);
   return messages;
 };
 

--- a/client/package.json
+++ b/client/package.json
@@ -9,7 +9,7 @@
     "test": "vitest --passWithNoTests",
     "test:prepush": "vitest run --passWithNoTests",
     "check:prepush": "npm run build && npm run test:prepush",
-    "lint": "tsc --noEmit && eslint ./src",
+    "lint": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json && eslint ./src",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "knip": "knip"

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
     "start": "vite --port 3000",
     "build": "vite build",
     "test": "vitest --passWithNoTests",
-    "test:prepush": "vitest --watchAll=false --passWithNoTests",
+    "test:prepush": "vitest run --passWithNoTests",
     "check:prepush": "npm run build && npm run test:prepush",
     "lint": "tsc --noEmit && eslint ./src",
     "storybook": "storybook dev -p 6006",

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "target": "ESNext",
-    "types": ["vite/client", "vite-plugin-svgr/client"],
+    "types": ["vite/client", "vite-plugin-svgr/client", "vitest/globals"],
     "module": "esnext",
     "strict": true,
     "esModuleInterop": true,

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "target": "ESNext",
-    "types": ["vite/client", "vite-plugin-svgr/client", "vitest/globals"],
+    "types": ["vite/client", "vite-plugin-svgr/client"],
     "module": "esnext",
     "strict": true,
     "esModuleInterop": true,
@@ -21,5 +21,12 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx",
+    "src/setupTests.ts"
+  ]
 }

--- a/client/tsconfig.test.json
+++ b/client/tsconfig.test.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["vite/client", "vite-plugin-svgr/client", "vitest/globals", "node"]
+  },
+  "include": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx",
+    "src/setupTests.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/client/tsconfig.test.json
+++ b/client/tsconfig.test.json
@@ -1,7 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "types": ["vite/client", "vite-plugin-svgr/client", "vitest/globals", "node"]
+    "types": [
+      "vite/client",
+      "vite-plugin-svgr/client",
+      "vitest/globals",
+      "node"
+    ]
   },
   "include": [
     "src/**/*.test.ts",

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -34,5 +34,8 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './src/setupTests.ts',
+    typecheck: {
+      tsconfig: './tsconfig.test.json',
+    },
   },
 });


### PR DESCRIPTION
## Context & Requests for Reviewers

Follow-up to the client's Vitest 4 migration (`vitest ^4.1.0` is already on `main`). Three Jest-era leftovers remained, one of which breaks a pre-push gate:

- **`npm run test:prepush` is broken on `main`** — it passes Jest's `--watchAll=false` flag, which Vitest rejects (`CACError: Unknown option --watchAll`), so `check:prepush` can't run at all. Fixed to `vitest run`.
- **`eslint/__tests__/customRules.test.js`** (the test for our in-repo custom ESLint rule) was still CommonJS and used the legacy `Linter` config shape with no TypeScript parser — meaning the rule's `as`-cast scenarios were never actually parsed as TS. Rewritten to ESM + ESLint 9 flat-config API (`new Linter({ configType: 'flat' })`) with `@typescript-eslint/parser`.
- **Test files were not type-checked anywhere**, and `vitest/globals` types leaked into the app's tsconfig. Added a dedicated `tsconfig.test.json` (extends the app config, adds `vitest/globals` + `node`); the app `tsconfig.json` now excludes test files, so production code can no longer silently reference test globals. `npm run lint` gains a `tsc --noEmit -p tsconfig.test.json` gate, and the new config is wired into `vite.config.ts`, `.eslintrc.cjs`, and `.dockerignore`.

**Note for reviewers:** the full client suite has 6 failures that also fail on pristine `main` (Sidebar ×3, Calendar ×2, MergedReportsComponent ×1) — pre-existing and out of scope for this PR.

## Tests

```bash
cd client && npm install
npm run lint          # includes the new tsc -p tsconfig.test.json gate — 0 errors
npm run test:prepush  # now actually runs; only the 6 pre-existing main failures
```

For contrast: on `main`, `npm run test:prepush` exits immediately with `CACError: Unknown option --watchAll`.

### 🤖 AI Usage Disclosure

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test runner setup with one-time execution and TypeScript type checking for tests.
  * Updated ESLint test coverage to work with the latest configuration style.

* **Bug Fixes**
  * Reduced false positives in linting and type checking by separating app and test TypeScript settings.
  * Prevented test files from being included in regular app builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
