### PR TITLE
Add IP_ADDRESS scalar to @roostorg/types (v2.1.0)

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -30,6 +30,10 @@ export const ScalarTypes = makeEnumLike([
   'RELATED_ITEM',
   'URL',
   'POLICY_ID',
+  // Stored as a string at runtime. The dedicated scalar lets Coop tag a
+  // schema field as an IP address so it can be surfaced as an identifier in
+  // moderation flows (see UserSchemaFieldRoles.ipAddress et al.).
+  'IP_ADDRESS',
 ]);
 export type ScalarTypes = typeof ScalarTypes;
 export type ScalarType = keyof typeof ScalarTypes;
@@ -55,6 +59,7 @@ type ScalarTypeRuntimeTypeMapping = Satisfies<
     [ScalarTypes.VIDEO]: { url: string };
     [ScalarTypes.RELATED_ITEM]: RelatedItem;
     [ScalarTypes.POLICY_ID]: string;
+    [ScalarTypes.IP_ADDRESS]: string;
   },
   { [K in ScalarType]: unknown }
 >;

--- a/types/index.ts
+++ b/types/index.ts
@@ -32,7 +32,7 @@ export const ScalarTypes = makeEnumLike([
   'POLICY_ID',
   // Stored as a string at runtime. The dedicated scalar lets Coop tag a
   // schema field as an IP address so it can be surfaced as an identifier in
-  // moderation flows (see UserSchemaFieldRoles.ipAddress et al.).
+  // moderation flows (e.g., via schema-field role metadata).
   'IP_ADDRESS',
 ]);
 export type ScalarTypes = typeof ScalarTypes;

--- a/types/package-lock.json
+++ b/types/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@roostorg/types",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@roostorg/types",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
         "date-fns": "^2.29.3",

--- a/types/package.json
+++ b/types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@roostorg/types",
   "type": "module",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Shared types across Coop services",
   "module": "transpiled/index.js",
   "typings": "./transpiled/index.d.ts",


### PR DESCRIPTION
Part of #468 

## Context & Requests for Reviewers

Adds a dedicated IP_ADDRESS entry to the ScalarTypes enum and maps it to `string` in ScalarTypeRuntimeTypeMapping. This lets Coop tag a schema field as an IP address so it can be surfaced as an identifier in moderation flows alongside creator / title / parent / thread roles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an IP Address scalar type with runtime mapping to string, enabling enhanced validation and consistent handling of IP address fields across the app.

* **Chores**
  * Bumped types package version to 2.1.0; no breaking changes introduced.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->