### PR TITLE
Playbook Agent: playbook loader with validation (2/8)

### DIFF
--- a/server/services/playbookAgentService/interfaces.ts
+++ b/server/services/playbookAgentService/interfaces.ts
@@ -1,0 +1,92 @@
+/**
+ * Abstract interfaces for the Playbook Agent framework.
+ *
+ * Organizations bring their own infrastructure by implementing these interfaces.
+ * The framework handles orchestration, safety constraints, and audit trail.
+ *
+ * @license Apache-2.0
+ */
+
+import type { PlaybookResult, QueryResult } from './playbookTypes.js';
+
+// ── LLM Adapter ─────────────────────────────────────────────────────────────
+
+export type LLMRequest = {
+  readonly systemPrompt: string;
+  readonly userPrompt: string;
+  readonly outputSchema?: Record<string, unknown>;
+  readonly maxTokens?: number;
+  readonly temperature?: number;
+};
+
+export type LLMResponse = {
+  readonly content: string;
+  readonly usage?: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  };
+};
+
+/**
+ * Adapter for LLM providers.
+ *
+ * Implementations may use OpenAI, Anthropic, local models, etc.
+ * The framework never calls the LLM directly — all calls go through this interface.
+ */
+export interface ILLMAdapter {
+  complete(request: LLMRequest): Promise<LLMResponse>;
+}
+
+// ── Evidence Store ──────────────────────────────────────────────────────────
+
+export type EvidenceQuery = {
+  readonly catalogId: string;
+  readonly version: string;
+  readonly parameters: Record<string, unknown>;
+};
+
+/**
+ * Adapter for executing pre-approved evidence queries.
+ *
+ * Implementations execute catalog-referenced queries against the org's database.
+ * The agent never writes SQL — it requests evidence by catalog ID.
+ */
+export interface IEvidenceStore {
+  executeQuery(query: EvidenceQuery): Promise<QueryResult>;
+}
+
+// ── Artifact Store ──────────────────────────────────────────────────────────
+
+export type PlaybookArtifact = {
+  readonly sessionId: string;
+  readonly playbookId: string;
+  readonly artifactType: 'verdict' | 'evidence' | 'query_result' | 'confidence';
+  readonly data: Record<string, unknown>;
+  readonly createdAt: Date;
+};
+
+/**
+ * Adapter for storing investigation artifacts.
+ *
+ * Artifacts are insert-only for compliance — they form an immutable evidence chain
+ * for law enforcement referrals and audit purposes.
+ */
+export interface IArtifactStore {
+  store(artifact: PlaybookArtifact): Promise<void>;
+  getBySessionId(sessionId: string): Promise<readonly PlaybookArtifact[]>;
+}
+
+// ── Playbook Runner Interface ───────────────────────────────────────────────
+
+export type PlaybookRunInput = {
+  readonly playbookId: string;
+  readonly inputContext: Record<string, unknown>;
+  readonly sessionId?: string;
+};
+
+/**
+ * Core runner interface that orchestrates a playbook investigation.
+ */
+export interface IPlaybookRunner {
+  run(input: PlaybookRunInput): Promise<PlaybookResult>;
+}

--- a/server/services/playbookAgentService/playbookLoader.test.ts
+++ b/server/services/playbookAgentService/playbookLoader.test.ts
@@ -1,0 +1,157 @@
+import { parsePlaybook } from './playbookLoader.js';
+
+const MINIMAL_PLAYBOOK = {
+  use_case_id: 'test_investigation',
+  version: '1.0.0',
+  display_name: 'Test Investigation',
+  description: 'A test playbook',
+  input_context: [
+    {
+      field_name: 'account_id',
+      field_type: 'string',
+      required: true,
+      description: 'Account to investigate',
+    },
+  ],
+  evidence_ontology: {
+    version: '1.0.0',
+    evidence_types: [
+      {
+        evidence_id: 'login_patterns',
+        display_name: 'Login Patterns',
+        description: 'Login frequency analysis',
+        quality: { minimum_confidence: 0.7, minimum_num_required_sources: 1 },
+      },
+    ],
+  },
+  baseline_catalog_refs: [
+    { catalog_id: 'login_patterns', version: '1.0.0', catalog_type: 'query' },
+  ],
+  allowed_catalog_refs: [
+    { catalog_id: 'login_patterns', version: '1.0.0', catalog_type: 'query' },
+    { catalog_id: 'device_info', version: '1.0.0', catalog_type: 'query' },
+  ],
+  evidence_request_policy: {
+    query_selection_mode: 'query_id',
+    max_rounds: 3,
+    target_confidence: 0.75,
+    max_additional_queries: 5,
+    stop_if_no_new_evidence: true,
+  },
+  labels: [
+    { label_id: 'RISKY', display_name: 'Risky', description: 'Account is risky' },
+    { label_id: 'SAFE', display_name: 'Safe', description: 'Account is safe' },
+  ],
+  decision_logic: {
+    hard_rules: [],
+    default_label: 'SAFE',
+  },
+  confidence_computation: {
+    evidence_completeness_weight: 0.35,
+    signal_strength_weight: 0.25,
+    signal_agreement_weight: 0.25,
+    data_quality_weight: 0.15,
+    llm_uncertainty_alpha: 0.4,
+  },
+  output_contract: {
+    version: '1.0.0',
+    required_fields: ['verdict', 'rationale', 'confidence_score'],
+  },
+};
+
+describe('parsePlaybook', () => {
+  it('parses a valid playbook', () => {
+    const playbook = parsePlaybook(MINIMAL_PLAYBOOK);
+
+    expect(playbook.useCaseId).toBe('test_investigation');
+    expect(playbook.version).toEqual({ major: 1, minor: 0, patch: 0 });
+    expect(playbook.baselineCatalogRefs).toHaveLength(1);
+    expect(playbook.allowedCatalogRefs).toHaveLength(2);
+    expect(playbook.labels).toHaveLength(2);
+    expect(playbook.confidenceComputation.llmUncertaintyAlpha).toBe(0.4);
+  });
+
+  it('applies default values for optional confidence fields', () => {
+    const playbook = parsePlaybook(MINIMAL_PLAYBOOK);
+
+    expect(playbook.confidenceComputation.baseCoverageWeight).toBe(0.7);
+    expect(playbook.confidenceComputation.additionalCoverageWeight).toBe(0.3);
+    expect(playbook.confidenceComputation.criticalEvidenceMissingPenalty).toBe(0.3);
+    expect(playbook.confidenceComputation.additionalQueryBonusMax).toBe(0.2);
+  });
+
+  it('rejects baseline ref not in allowed set', () => {
+    const bad = {
+      ...MINIMAL_PLAYBOOK,
+      baseline_catalog_refs: [
+        { catalog_id: 'unknown_query', version: '1.0.0', catalog_type: 'query' },
+      ],
+    };
+
+    expect(() => parsePlaybook(bad)).toThrow('not found in allowed_catalog_refs');
+  });
+
+  it('rejects invalid default label', () => {
+    const bad = {
+      ...MINIMAL_PLAYBOOK,
+      decision_logic: {
+        hard_rules: [],
+        default_label: 'NONEXISTENT',
+      },
+    };
+
+    expect(() => parsePlaybook(bad)).toThrow("'NONEXISTENT' is not a valid label");
+  });
+
+  it('rejects confidence weights that do not sum to ~1.0', () => {
+    const bad = {
+      ...MINIMAL_PLAYBOOK,
+      confidence_computation: {
+        ...MINIMAL_PLAYBOOK.confidence_computation,
+        evidence_completeness_weight: 0.5,
+        signal_strength_weight: 0.5,
+        signal_agreement_weight: 0.5,
+        data_quality_weight: 0.5,
+      },
+    };
+
+    expect(() => parsePlaybook(bad)).toThrow('weights sum to');
+  });
+
+  it('rejects invalid semantic version', () => {
+    const bad = { ...MINIMAL_PLAYBOOK, version: 'not-a-version' };
+    expect(() => parsePlaybook(bad)).toThrow('Invalid semantic version');
+  });
+
+  it('rejects forbidden catalog IDs', () => {
+    const bad = {
+      ...MINIMAL_PLAYBOOK,
+      allowed_catalog_refs: [
+        ...MINIMAL_PLAYBOOK.allowed_catalog_refs,
+        { catalog_id: 'latest', version: '1.0.0', catalog_type: 'query' },
+      ],
+    };
+
+    expect(() => parsePlaybook(bad)).toThrow("cannot be 'latest'");
+  });
+
+  it('validates hard rule outcomes against labels', () => {
+    const bad = {
+      ...MINIMAL_PLAYBOOK,
+      decision_logic: {
+        hard_rules: [
+          {
+            rule_id: 'test_rule',
+            description: 'Test',
+            condition: "data.field == 'value'",
+            outcome: 'NONEXISTENT_LABEL',
+            bypass_llm: true,
+          },
+        ],
+        default_label: 'SAFE',
+      },
+    };
+
+    expect(() => parsePlaybook(bad)).toThrow("'NONEXISTENT_LABEL' is not a valid label");
+  });
+});

--- a/server/services/playbookAgentService/playbookLoader.ts
+++ b/server/services/playbookAgentService/playbookLoader.ts
@@ -1,0 +1,438 @@
+/**
+ * Playbook Loader — Load and validate investigation playbooks from YAML.
+ *
+ * Handles parsing, validation, and cross-reference checking of playbook configs.
+ * Ensures baseline_catalog_refs is a subset of allowed_catalog_refs,
+ * deep-dive query refs are in allowed set, and all label references are valid.
+ *
+ * @license Apache-2.0
+ */
+
+import {
+  type CatalogReference,
+  type CatalogType,
+  type ConfidenceComputation,
+  type DecisionLogic,
+  type DeepDiveModule,
+  type EvidenceOntology,
+  type EvidenceRequestPolicy,
+  type HardRule,
+  type InputContextField,
+  type InputFieldType,
+  type LabelDefinition,
+  type OutputContract,
+  type PhaseBudget,
+  type Playbook,
+  formatCatalogReference,
+  parseSemanticVersion,
+  validateCatalogReference,
+} from './playbookTypes.js';
+
+// ── Raw YAML types (snake_case as authored) ─────────────────────────────────
+
+type RawCatalogRef = {
+  catalog_id: string;
+  version: string;
+  catalog_type: string;
+};
+
+type RawPlaybook = {
+  use_case_id: string;
+  version: string;
+  display_name: string;
+  description: string;
+  input_context: Array<{
+    field_name: string;
+    field_type: string;
+    required: boolean;
+    description: string;
+    default?: unknown;
+    validation_pattern?: string;
+    catalog_parameter_name?: string;
+  }>;
+  evidence_ontology: {
+    version: string;
+    evidence_types: Array<{
+      evidence_id: string;
+      display_name: string;
+      description: string;
+      quality?: {
+        freshness_max_age_ms?: number;
+        minimum_confidence?: number;
+        minimum_num_required_sources?: number;
+      };
+    }>;
+  };
+  baseline_catalog_refs: RawCatalogRef[];
+  allowed_catalog_refs: RawCatalogRef[];
+  evidence_request_policy: {
+    query_selection_mode: string;
+    max_rounds: number;
+    target_confidence: number;
+    max_additional_queries: number;
+    stop_if_no_new_evidence: boolean;
+    trigger_deep_dive_if?: string;
+    stop_investigation_if?: string;
+    guidance?: string;
+  };
+  deep_dive_modules?: Array<{
+    module_id: string;
+    display_name: string;
+    description: string;
+    entry_conditions: Array<{
+      condition_id: string;
+      description: string;
+      expression: string;
+    }>;
+    exit_conditions: Array<{
+      condition_id: string;
+      description: string;
+      expression: string;
+    }>;
+    query_refs: RawCatalogRef[];
+  }>;
+  labels: Array<{
+    label_id: string;
+    display_name: string;
+    description: string;
+    severity?: string;
+  }>;
+  decision_logic: {
+    hard_rules: Array<{
+      rule_id: string;
+      description: string;
+      condition: string;
+      outcome: string;
+      bypass_llm: boolean;
+    }>;
+    scoring_guidance?: Array<{
+      guidance_id: string;
+      description: string;
+    }>;
+    default_label: string;
+  };
+  confidence_computation: {
+    evidence_completeness_weight: number;
+    signal_strength_weight: number;
+    signal_agreement_weight: number;
+    data_quality_weight: number;
+    llm_uncertainty_alpha: number;
+    base_coverage_weight?: number;
+    additional_coverage_weight?: number;
+    critical_evidence_missing_penalty?: number;
+    additional_query_bonus_max?: number;
+  };
+  phase_budget?: {
+    max_queries: number;
+    max_llm_calls: number;
+    max_duration_ms: number;
+  };
+  output_contract: {
+    version: string;
+    required_fields: string[];
+    schema?: Record<string, unknown>;
+  };
+};
+
+// ── Conversion helpers ──────────────────────────────────────────────────────
+
+const VALID_CATALOG_TYPES = new Set<string>(['query', 'query_bundle']);
+
+function toCatalogReference(raw: RawCatalogRef): CatalogReference {
+  if (!VALID_CATALOG_TYPES.has(raw.catalog_type)) {
+    throw new Error(
+      `Invalid catalog_type '${raw.catalog_type}' for catalog '${raw.catalog_id}'. Must be one of: ${[...VALID_CATALOG_TYPES].join(', ')}`,
+    );
+  }
+  const ref: CatalogReference = {
+    catalogId: raw.catalog_id,
+    version: parseSemanticVersion(raw.version),
+    catalogType: raw.catalog_type as CatalogType,
+  };
+  validateCatalogReference(ref);
+  return ref;
+}
+
+const VALID_INPUT_FIELD_TYPES = new Set([
+  'string',
+  'integer',
+  'float',
+  'boolean',
+  'date',
+  'datetime',
+]);
+
+const VALID_SEVERITIES = new Set([
+  'CRITICAL',
+  'HIGH',
+  'MEDIUM',
+  'LOW',
+  'INFO',
+]);
+
+// ── Validation ──────────────────────────────────────────────────────────────
+
+export type PlaybookValidationError = {
+  readonly field: string;
+  readonly message: string;
+};
+
+function validatePlaybookCrossRefs(playbook: Playbook): PlaybookValidationError[] {
+  const errors: PlaybookValidationError[] = [];
+
+  // baseline_catalog_refs must be a subset of allowed_catalog_refs
+  const allowedIds = new Set(
+    playbook.allowedCatalogRefs.map(formatCatalogReference),
+  );
+  for (const ref of playbook.baselineCatalogRefs) {
+    const refStr = formatCatalogReference(ref);
+    if (!allowedIds.has(refStr)) {
+      errors.push({
+        field: 'baselineCatalogRefs',
+        message: `Baseline ref '${refStr}' not found in allowed_catalog_refs`,
+      });
+    }
+  }
+
+  // deep-dive query refs must be in allowed set
+  if (playbook.deepDiveModules) {
+    for (const mod of playbook.deepDiveModules) {
+      for (const ref of mod.queryRefs) {
+        const refStr = formatCatalogReference(ref);
+        if (!allowedIds.has(refStr)) {
+          errors.push({
+            field: `deepDiveModules.${mod.moduleId}`,
+            message: `Deep-dive ref '${refStr}' not found in allowed_catalog_refs`,
+          });
+        }
+      }
+    }
+  }
+
+  // hard rule outcomes must reference valid labels
+  const labelIds = new Set(playbook.labels.map((l) => l.labelId));
+  for (const rule of playbook.decisionLogic.hardRules) {
+    if (!labelIds.has(rule.outcome)) {
+      errors.push({
+        field: `decisionLogic.hardRules.${rule.ruleId}`,
+        message: `Hard rule outcome '${rule.outcome}' is not a valid label`,
+      });
+    }
+  }
+
+  // default label must be valid
+  if (!labelIds.has(playbook.decisionLogic.defaultLabel)) {
+    errors.push({
+      field: 'decisionLogic.defaultLabel',
+      message: `Default label '${playbook.decisionLogic.defaultLabel}' is not a valid label`,
+    });
+  }
+
+  // confidence weights should sum to ~1.0
+  const cc = playbook.confidenceComputation;
+  const weightSum =
+    cc.evidenceCompletenessWeight +
+    cc.signalStrengthWeight +
+    cc.signalAgreementWeight +
+    cc.dataQualityWeight;
+  if (Math.abs(weightSum - 1.0) > 0.01) {
+    errors.push({
+      field: 'confidenceComputation',
+      message: `Confidence weights sum to ${weightSum}, expected ~1.0`,
+    });
+  }
+
+  return errors;
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Parse a raw YAML-deserialized object into a validated Playbook.
+ *
+ * Call this with the result of `yaml.load(...)` or `JSON.parse(...)`.
+ * Throws on invalid structure or cross-reference violations.
+ */
+export function parsePlaybook(raw: unknown): Playbook {
+  const r = raw as Partial<RawPlaybook>;
+
+  if (
+    typeof r.use_case_id !== 'string' ||
+    typeof r.version !== 'string' ||
+    typeof r.display_name !== 'string' ||
+    typeof r.description !== 'string' ||
+    r.evidence_ontology == null ||
+    !Array.isArray(r.baseline_catalog_refs) ||
+    !Array.isArray(r.allowed_catalog_refs) ||
+    r.evidence_request_policy == null ||
+    !Array.isArray(r.labels) ||
+    r.decision_logic == null ||
+    r.confidence_computation == null ||
+    r.output_contract == null
+  ) {
+    throw new Error('Playbook is missing required top-level fields');
+  }
+
+  const inputContext: InputContextField[] = (r.input_context ?? []).map(
+    (f) => {
+      if (!VALID_INPUT_FIELD_TYPES.has(f.field_type)) {
+        throw new Error(`Invalid field_type '${f.field_type}' for input '${f.field_name}'`);
+      }
+      return {
+        fieldName: f.field_name,
+        fieldType: f.field_type as InputFieldType,
+        required: f.required,
+        description: f.description,
+        default: f.default,
+        validationPattern: f.validation_pattern,
+        catalogParameterName: f.catalog_parameter_name,
+      };
+    },
+  );
+
+  const evidenceOntology: EvidenceOntology = {
+    version: parseSemanticVersion(r.evidence_ontology.version),
+    evidenceTypes: r.evidence_ontology.evidence_types.map((et) => ({
+      evidenceId: et.evidence_id,
+      displayName: et.display_name,
+      description: et.description,
+      quality: {
+        freshnessMaxAgeMs: et.quality?.freshness_max_age_ms,
+        minimumConfidence: et.quality?.minimum_confidence ?? 0.0,
+        minimumNumRequiredSources: et.quality?.minimum_num_required_sources ?? 1,
+      },
+    })),
+  };
+
+  const baselineCatalogRefs = r.baseline_catalog_refs.map(toCatalogReference);
+  const allowedCatalogRefs = r.allowed_catalog_refs.map(toCatalogReference);
+
+  const evidenceRequestPolicy: EvidenceRequestPolicy = {
+    querySelectionMode: 'query_id',
+    maxRounds: r.evidence_request_policy.max_rounds,
+    targetConfidence: r.evidence_request_policy.target_confidence,
+    maxAdditionalQueries: r.evidence_request_policy.max_additional_queries,
+    stopIfNoNewEvidence: r.evidence_request_policy.stop_if_no_new_evidence,
+    triggerDeepDiveIf: r.evidence_request_policy.trigger_deep_dive_if,
+    stopInvestigationIf: r.evidence_request_policy.stop_investigation_if,
+    guidance: r.evidence_request_policy.guidance,
+  };
+
+  const deepDiveModules: DeepDiveModule[] | undefined =
+    r.deep_dive_modules?.map((m) => ({
+      moduleId: m.module_id,
+      displayName: m.display_name,
+      description: m.description,
+      entryConditions: m.entry_conditions.map((c) => ({
+        conditionId: c.condition_id,
+        description: c.description,
+        expression: c.expression,
+      })),
+      exitConditions: m.exit_conditions.map((c) => ({
+        conditionId: c.condition_id,
+        description: c.description,
+        expression: c.expression,
+      })),
+      queryRefs: m.query_refs.map(toCatalogReference),
+    }));
+
+  const labels: LabelDefinition[] = r.labels.map((l) => {
+    if (l.severity && !VALID_SEVERITIES.has(l.severity)) {
+      throw new Error(
+        `Invalid severity '${l.severity}' for label '${l.label_id}'`,
+      );
+    }
+    return {
+      labelId: l.label_id,
+      displayName: l.display_name,
+      description: l.description,
+      severity: l.severity as LabelDefinition['severity'],
+    };
+  });
+
+  const hardRules: HardRule[] = r.decision_logic.hard_rules.map((hr) => ({
+    ruleId: hr.rule_id,
+    description: hr.description,
+    condition: hr.condition,
+    outcome: hr.outcome,
+    bypassLlm: hr.bypass_llm,
+  }));
+
+  const decisionLogic: DecisionLogic = {
+    hardRules,
+    scoringGuidance: (r.decision_logic.scoring_guidance ?? []).map((sg) => ({
+      guidanceId: sg.guidance_id,
+      description: sg.description,
+    })),
+    defaultLabel: r.decision_logic.default_label,
+  };
+
+  const cc = r.confidence_computation;
+
+  function validateRange(value: number, name: string): void {
+    if (!Number.isFinite(value) || value < 0 || value > 1) {
+      throw new Error(
+        `Invalid ${name}: ${value}. Must be a finite number in [0, 1].`,
+      );
+    }
+  }
+  validateRange(cc.llm_uncertainty_alpha, 'llm_uncertainty_alpha');
+  validateRange(cc.evidence_completeness_weight, 'evidence_completeness_weight');
+  validateRange(cc.signal_strength_weight, 'signal_strength_weight');
+  validateRange(cc.signal_agreement_weight, 'signal_agreement_weight');
+  validateRange(cc.data_quality_weight, 'data_quality_weight');
+
+  const confidenceComputation: ConfidenceComputation = {
+    evidenceCompletenessWeight: cc.evidence_completeness_weight,
+    signalStrengthWeight: cc.signal_strength_weight,
+    signalAgreementWeight: cc.signal_agreement_weight,
+    dataQualityWeight: cc.data_quality_weight,
+    llmUncertaintyAlpha: cc.llm_uncertainty_alpha,
+    baseCoverageWeight: cc.base_coverage_weight ?? 0.7,
+    additionalCoverageWeight: cc.additional_coverage_weight ?? 0.3,
+    criticalEvidenceMissingPenalty: cc.critical_evidence_missing_penalty ?? 0.3,
+    additionalQueryBonusMax: cc.additional_query_bonus_max ?? 0.2,
+  };
+
+  const phaseBudget: PhaseBudget | undefined = r.phase_budget
+    ? {
+        maxQueries: r.phase_budget.max_queries,
+        maxLlmCalls: r.phase_budget.max_llm_calls,
+        maxDurationMs: r.phase_budget.max_duration_ms,
+      }
+    : undefined;
+
+  const outputContract: OutputContract = {
+    version: parseSemanticVersion(r.output_contract.version),
+    requiredFields: r.output_contract.required_fields,
+    schema: r.output_contract.schema,
+  };
+
+  const playbook: Playbook = {
+    useCaseId: r.use_case_id,
+    version: parseSemanticVersion(r.version),
+    displayName: r.display_name,
+    description: r.description,
+    inputContext,
+    evidenceOntology,
+    baselineCatalogRefs,
+    allowedCatalogRefs,
+    evidenceRequestPolicy,
+    deepDiveModules,
+    labels,
+    decisionLogic,
+    confidenceComputation,
+    phaseBudget,
+    outputContract,
+  };
+
+  const errors = validatePlaybookCrossRefs(playbook);
+  if (errors.length > 0) {
+    const details = errors
+      .map((e) => `  - ${e.field}: ${e.message}`)
+      .join('\n');
+    throw new Error(`Playbook validation failed:\n${details}`);
+  }
+
+  return playbook;
+}

--- a/server/services/playbookAgentService/playbookTypes.ts
+++ b/server/services/playbookAgentService/playbookTypes.ts
@@ -1,0 +1,278 @@
+/**
+ * Playbook Schema Types — Declarative configs for risk investigation use cases.
+ *
+ * Playbooks are versioned, declarative configurations that define investigation
+ * workflows, evidence requirements, decision logic, and output contracts.
+ *
+ * Key design principles:
+ *   - Versioned using semantic versioning for reproducibility
+ *   - Declarative: define requirements, not implementation
+ *   - Catalog-based: reference queries by ID + version, never contain SQL
+ *   - Deterministic: same input + same playbook version = same behavior
+ *
+ * @license Apache-2.0
+ */
+
+// ── Semantic Versioning ─────────────────────────────────────────────────────
+
+export type SemanticVersion = {
+  readonly major: number;
+  readonly minor: number;
+  readonly patch: number;
+};
+
+export function parseSemanticVersion(input: string): SemanticVersion {
+  const match = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.exec(input);
+  if (!match) {
+    throw new Error(
+      `Invalid semantic version format: '${input}'. Expected format: 'X.Y.Z' with no leading zeros.`,
+    );
+  }
+  return { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]) };
+}
+
+export function formatSemanticVersion(v: SemanticVersion): string {
+  return `${v.major}.${v.minor}.${v.patch}`;
+}
+
+// ── Catalog References ──────────────────────────────────────────────────────
+
+const FORBIDDEN_CATALOG_IDS = [
+  'latest',
+  'head',
+  'main',
+  'master',
+  'current',
+] as const;
+
+const CATALOG_ID_PATTERN = /^[a-z0-9_]+$/;
+
+export type CatalogType = 'query' | 'query_bundle';
+
+export type CatalogReference = {
+  readonly catalogId: string;
+  readonly version: SemanticVersion;
+  readonly catalogType: CatalogType;
+};
+
+export function validateCatalogReference(ref: CatalogReference): void {
+  if (!CATALOG_ID_PATTERN.test(ref.catalogId)) {
+    throw new Error(
+      `Invalid catalog ID '${ref.catalogId}': must match /^[a-z0-9_]+$/`,
+    );
+  }
+  if (
+    (FORBIDDEN_CATALOG_IDS as readonly string[]).includes(ref.catalogId)
+  ) {
+    throw new Error(
+      `Catalog ID cannot be '${ref.catalogId}' — use specific versioned IDs`,
+    );
+  }
+}
+
+export function formatCatalogReference(ref: CatalogReference): string {
+  return `${ref.catalogId}@${formatSemanticVersion(ref.version)}`;
+}
+
+// ── Input Context ───────────────────────────────────────────────────────────
+
+export type InputFieldType =
+  | 'string'
+  | 'integer'
+  | 'float'
+  | 'boolean'
+  | 'date'
+  | 'datetime';
+
+export type InputContextField = {
+  readonly fieldName: string;
+  readonly fieldType: InputFieldType;
+  readonly required: boolean;
+  readonly description: string;
+  readonly default?: unknown;
+  readonly validationPattern?: string;
+  readonly catalogParameterName?: string;
+};
+
+// ── Evidence Ontology ───────────────────────────────────────────────────────
+
+export type EvidenceQuality = {
+  readonly freshnessMaxAgeMs?: number;
+  readonly minimumConfidence: number;
+  readonly minimumNumRequiredSources: number;
+};
+
+export type EvidenceType = {
+  readonly evidenceId: string;
+  readonly displayName: string;
+  readonly description: string;
+  readonly quality: EvidenceQuality;
+};
+
+export type EvidenceOntology = {
+  readonly version: SemanticVersion;
+  readonly evidenceTypes: readonly EvidenceType[];
+};
+
+// ── Evidence Request Policy ─────────────────────────────────────────────────
+
+export type EvidenceRequestPolicy = {
+  readonly querySelectionMode: 'query_id';
+  readonly maxRounds: number;
+  readonly targetConfidence: number;
+  readonly maxAdditionalQueries: number;
+  readonly stopIfNoNewEvidence: boolean;
+  readonly triggerDeepDiveIf?: string;
+  readonly stopInvestigationIf?: string;
+  readonly guidance?: string;
+};
+
+// ── Deep-Dive Modules ───────────────────────────────────────────────────────
+
+export type DeepDiveCondition = {
+  readonly conditionId: string;
+  readonly description: string;
+  readonly expression: string;
+};
+
+export type DeepDiveModule = {
+  readonly moduleId: string;
+  readonly displayName: string;
+  readonly description: string;
+  readonly entryConditions: readonly DeepDiveCondition[];
+  readonly exitConditions: readonly DeepDiveCondition[];
+  readonly queryRefs: readonly CatalogReference[];
+};
+
+// ── Labels & Decision Logic ─────────────────────────────────────────────────
+
+export type LabelDefinition = {
+  readonly labelId: string;
+  readonly displayName: string;
+  readonly description: string;
+  readonly severity?: 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW' | 'INFO';
+};
+
+export type HardRule = {
+  readonly ruleId: string;
+  readonly description: string;
+  readonly condition: string;
+  readonly outcome: string;
+  readonly bypassLlm: boolean;
+};
+
+export type ScoringGuidance = {
+  readonly guidanceId: string;
+  readonly description: string;
+};
+
+export type DecisionLogic = {
+  readonly hardRules: readonly HardRule[];
+  readonly scoringGuidance: readonly ScoringGuidance[];
+  readonly defaultLabel: string;
+};
+
+// ── Confidence Computation ──────────────────────────────────────────────────
+
+export type ConfidenceComputation = {
+  readonly evidenceCompletenessWeight: number;
+  readonly signalStrengthWeight: number;
+  readonly signalAgreementWeight: number;
+  readonly dataQualityWeight: number;
+  readonly llmUncertaintyAlpha: number;
+  readonly baseCoverageWeight: number;
+  readonly additionalCoverageWeight: number;
+  readonly criticalEvidenceMissingPenalty: number;
+  readonly additionalQueryBonusMax: number;
+};
+
+// ── Phase Budget ────────────────────────────────────────────────────────────
+
+export type PhaseBudget = {
+  readonly maxQueries: number;
+  readonly maxLlmCalls: number;
+  readonly maxDurationMs: number;
+};
+
+// ── Output Contract ─────────────────────────────────────────────────────────
+
+export type OutputContract = {
+  readonly version: SemanticVersion;
+  readonly requiredFields: readonly string[];
+  readonly schema?: Record<string, unknown>;
+};
+
+// ── Playbook (top-level) ────────────────────────────────────────────────────
+
+export type Playbook = {
+  readonly useCaseId: string;
+  readonly version: SemanticVersion;
+  readonly displayName: string;
+  readonly description: string;
+  readonly inputContext: readonly InputContextField[];
+  readonly evidenceOntology: EvidenceOntology;
+  readonly baselineCatalogRefs: readonly CatalogReference[];
+  readonly allowedCatalogRefs: readonly CatalogReference[];
+  readonly evidenceRequestPolicy: EvidenceRequestPolicy;
+  readonly deepDiveModules?: readonly DeepDiveModule[];
+  readonly labels: readonly LabelDefinition[];
+  readonly decisionLogic: DecisionLogic;
+  readonly confidenceComputation: ConfidenceComputation;
+  readonly phaseBudget?: PhaseBudget;
+  readonly outputContract: OutputContract;
+};
+
+// ── Verdict & Results ───────────────────────────────────────────────────────
+
+export type PlaybookVerdict = {
+  readonly verdict: string;
+  readonly rationale: string;
+  readonly confidenceScore: number;
+  /** LLM self-reported uncertainty (0–1). Higher = less certain. */
+  readonly uLlm: number;
+  /** Domain-specific outputs defined by the playbook's output_contract. */
+  readonly additionalOutputs?: Record<string, unknown>;
+  readonly queriesExecuted: readonly string[];
+  readonly supportingEvidence: readonly string[];
+  readonly contradictingEvidence: readonly string[];
+  readonly criticalEvidenceMissing: boolean;
+  readonly hasContradictorySignals: boolean;
+  readonly isEdgeCase?: boolean;
+};
+
+export type ConfidenceBreakdown = {
+  readonly confidenceScore0To1: number;
+  readonly confidenceScore1To5: number;
+  readonly cGround: number;
+  readonly uLlm: number;
+  readonly alpha: number;
+  readonly evidenceCompleteness: number;
+  readonly signalStrength: number;
+  readonly signalAgreement: number;
+  readonly dataQuality: number;
+  readonly baseCoverage: number;
+  readonly additionalCoverage: number;
+};
+
+export type QueryResult = {
+  readonly success: boolean;
+  readonly data: readonly Record<string, unknown>[];
+  readonly error?: string;
+};
+
+export type QueryResults = {
+  readonly results: Record<string, QueryResult>;
+};
+
+export type PlaybookResult = {
+  readonly playbookId: string;
+  readonly playbookVersion: string;
+  readonly verdict: PlaybookVerdict;
+  readonly confidence: ConfidenceBreakdown;
+  readonly hardRuleTriggered?: string;
+  readonly evidence: readonly Record<string, unknown>[];
+  readonly queriesExecuted: readonly string[];
+  readonly ranAt: Date;
+  readonly durationMs: number;
+  readonly sessionId: string;
+};


### PR DESCRIPTION
- depends on #572

## Summary

Playbook loader that converts raw YAML/JSON configs into validated TypeScript `Playbook` objects with comprehensive cross-reference checking.

**Part 2 of 8** — depends on #572 (types and interfaces).

### `playbookLoader.ts`
- `parsePlaybook()`: snake_case YAML input to camelCase TypeScript output
- Cross-reference validation at load time:
  - `baseline_catalog_refs` must be a subset of `allowed_catalog_refs`
  - Deep-dive module query refs must be in the allowed set
  - Hard rule outcomes must reference valid label IDs
  - Default label must exist in labels
  - Confidence weights must sum to ~1.0
- Rejects forbidden floating versions (`latest`, `head`, `main`)

### `playbookLoader.test.ts` — 7 tests
- Parses valid playbook with correct type conversion
- Applies default values for optional confidence fields
- Rejects baseline ref not in allowed set
- Rejects invalid default label
- Rejects confidence weights that don't sum to ~1.0
- Rejects invalid semantic versions
- Validates hard rule outcomes against labels

## Test plan
- [ ] `npm test -- --testPathPattern=playbookLoader` passes (7 tests)

> Depends on [#572 Types and interfaces](https://github.com/roostorg/coop/pull/572). Merge #572 first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Playbook Agent framework for structured investigation workflows with playbook parsing, validation, and result types.
  * Added semantic versioning and catalog reference validation for playbooks.
  * Added configurable decision logic, confidence computation, hard rules, evidence policies, and output contracts.

* **Tests**
  * Added unit tests validating playbook parsing, schema enforcement, cross-reference checks, and error reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/573?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Part of #659