### PR TITLE
Playbook Agent: grounded confidence engine (5/8)

### DIFF
--- a/server/services/playbookAgentService/confidenceEngine.test.ts
+++ b/server/services/playbookAgentService/confidenceEngine.test.ts
@@ -1,0 +1,182 @@
+import { computeConfidence } from './confidenceEngine.js';
+import type {
+  ConfidenceComputation,
+  Playbook,
+  PlaybookVerdict,
+  QueryResults,
+} from './playbookTypes.js';
+
+function makePlaybook(
+  overrides: Partial<ConfidenceComputation> = {},
+): Playbook {
+  return {
+    useCaseId: 'test_use_case',
+    version: { major: 1, minor: 0, patch: 0 },
+    displayName: 'Test',
+    description: 'Test playbook',
+    inputContext: [],
+    evidenceOntology: {
+      version: { major: 1, minor: 0, patch: 0 },
+      evidenceTypes: [],
+    },
+    baselineCatalogRefs: [
+      { catalogId: 'query_a', version: { major: 1, minor: 0, patch: 0 }, catalogType: 'query' },
+      { catalogId: 'query_b', version: { major: 1, minor: 0, patch: 0 }, catalogType: 'query' },
+    ],
+    allowedCatalogRefs: [
+      { catalogId: 'query_a', version: { major: 1, minor: 0, patch: 0 }, catalogType: 'query' },
+      { catalogId: 'query_b', version: { major: 1, minor: 0, patch: 0 }, catalogType: 'query' },
+      { catalogId: 'query_c', version: { major: 1, minor: 0, patch: 0 }, catalogType: 'query' },
+    ],
+    evidenceRequestPolicy: {
+      querySelectionMode: 'query_id',
+      maxRounds: 3,
+      targetConfidence: 0.75,
+      maxAdditionalQueries: 5,
+      stopIfNoNewEvidence: true,
+    },
+    labels: [],
+    decisionLogic: { hardRules: [], scoringGuidance: [], defaultLabel: 'SAFE' },
+    confidenceComputation: {
+      evidenceCompletenessWeight: 0.35,
+      signalStrengthWeight: 0.25,
+      signalAgreementWeight: 0.25,
+      dataQualityWeight: 0.15,
+      llmUncertaintyAlpha: 0.4,
+      baseCoverageWeight: 0.7,
+      additionalCoverageWeight: 0.3,
+      criticalEvidenceMissingPenalty: 0.3,
+      additionalQueryBonusMax: 0.2,
+      ...overrides,
+    },
+    outputContract: {
+      version: { major: 1, minor: 0, patch: 0 },
+      requiredFields: ['verdict', 'rationale', 'confidence_score'],
+    },
+  };
+}
+
+function makeVerdict(overrides: Partial<PlaybookVerdict> = {}): PlaybookVerdict {
+  return {
+    verdict: 'RISKY',
+    rationale: 'Test rationale',
+    confidenceScore: 4,
+    uLlm: 0.1,
+    queriesExecuted: ['query_a', 'query_b'],
+    supportingEvidence: ['evidence_1', 'evidence_2'],
+    contradictingEvidence: [],
+    criticalEvidenceMissing: false,
+    hasContradictorySignals: false,
+    ...overrides,
+  };
+}
+
+function makeQueryResults(
+  results: Record<string, { success: boolean; data: Record<string, unknown>[] }>,
+): QueryResults {
+  return { results };
+}
+
+describe('confidenceEngine', () => {
+  it('computes high confidence when all evidence is present and agrees', () => {
+    const playbook = makePlaybook();
+    const verdict = makeVerdict({ uLlm: 0.05, queriesExecuted: ['query_a', 'query_b', 'query_c'] });
+    const queryResults = makeQueryResults({
+      query_a: { success: true, data: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }] },
+      query_b: { success: true, data: [{ id: 6 }, { id: 7 }, { id: 8 }, { id: 9 }, { id: 10 }] },
+      query_c: { success: true, data: [{ id: 11 }] },
+    });
+
+    const result = computeConfidence(verdict, queryResults, playbook);
+
+    expect(result.confidenceScore0To1).toBeGreaterThan(0.9);
+    expect(result.confidenceScore1To5).toBe(5);
+    expect(result.cGround).toBeGreaterThan(0.9);
+    expect(result.baseCoverage).toBe(1.0);
+  });
+
+  it('reduces confidence when critical evidence is missing', () => {
+    const playbook = makePlaybook();
+    const verdict = makeVerdict({ criticalEvidenceMissing: true });
+    const queryResults = makeQueryResults({
+      query_a: { success: true, data: [{ id: 1 }] },
+      query_b: { success: true, data: [] },
+    });
+
+    const result = computeConfidence(verdict, queryResults, playbook);
+
+    expect(result.confidenceScore0To1).toBeLessThan(0.8);
+    expect(result.evidenceCompleteness).toBeLessThan(0.7);
+  });
+
+  it('penalizes contradictory signals', () => {
+    const playbook = makePlaybook();
+
+    const noContradiction = makeVerdict({
+      supportingEvidence: ['a', 'b', 'c'],
+      contradictingEvidence: [],
+      hasContradictorySignals: false,
+    });
+    const withContradiction = makeVerdict({
+      supportingEvidence: ['a', 'b'],
+      contradictingEvidence: ['c'],
+      hasContradictorySignals: true,
+    });
+
+    const qr = makeQueryResults({
+      query_a: { success: true, data: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }] },
+      query_b: { success: true, data: [{ id: 6 }, { id: 7 }, { id: 8 }, { id: 9 }, { id: 10 }] },
+    });
+
+    const resultClean = computeConfidence(noContradiction, qr, playbook);
+    const resultDirty = computeConfidence(withContradiction, qr, playbook);
+
+    expect(resultDirty.signalAgreement).toBeLessThan(resultClean.signalAgreement);
+    expect(resultDirty.confidenceScore0To1).toBeLessThan(resultClean.confidenceScore0To1);
+  });
+
+  it('LLM uncertainty can only reduce confidence', () => {
+    const playbook = makePlaybook();
+    const qr = makeQueryResults({
+      query_a: { success: true, data: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }] },
+      query_b: { success: true, data: [{ id: 6 }, { id: 7 }, { id: 8 }, { id: 9 }, { id: 10 }] },
+    });
+
+    const lowUncertainty = computeConfidence(makeVerdict({ uLlm: 0.05 }), qr, playbook);
+    const highUncertainty = computeConfidence(makeVerdict({ uLlm: 0.9 }), qr, playbook);
+
+    // Same C_ground, different u_llm → higher uncertainty = lower C_final
+    expect(lowUncertainty.cGround).toBeCloseTo(highUncertainty.cGround, 2);
+    expect(highUncertainty.confidenceScore0To1).toBeLessThan(lowUncertainty.confidenceScore0To1);
+  });
+
+  it('handles query failures gracefully', () => {
+    const playbook = makePlaybook();
+    const verdict = makeVerdict({ queriesExecuted: ['query_a'] });
+    const queryResults = makeQueryResults({
+      query_a: { success: true, data: [{ id: 1 }] },
+      query_b: { success: false, data: [] },
+    });
+
+    const result = computeConfidence(verdict, queryResults, playbook);
+
+    expect(result.dataQuality).toBeLessThan(1.0);
+    expect(result.confidenceScore0To1).toBeGreaterThan(0);
+    expect(result.confidenceScore0To1).toBeLessThan(1);
+  });
+
+  it('produces valid 1–5 bucket scores', () => {
+    const playbook = makePlaybook();
+    const qr = makeQueryResults({
+      query_a: { success: true, data: [{ id: 1 }] },
+      query_b: { success: true, data: [{ id: 2 }] },
+    });
+
+    for (const uLlm of [0.0, 0.25, 0.5, 0.75, 1.0]) {
+      const result = computeConfidence(makeVerdict({ uLlm }), qr, playbook);
+      expect(result.confidenceScore1To5).toBeGreaterThanOrEqual(1);
+      expect(result.confidenceScore1To5).toBeLessThanOrEqual(5);
+      expect(Number.isInteger(result.confidenceScore1To5)).toBe(true);
+    }
+  });
+});

--- a/server/services/playbookAgentService/confidenceEngine.ts
+++ b/server/services/playbookAgentService/confidenceEngine.ts
@@ -1,0 +1,198 @@
+/**
+ * Confidence Engine — Grounded confidence scoring.
+ *
+ * Implements the playbook-driven confidence formula:
+ *   C_final = C_ground * (1 - alpha * u_llm)
+ *
+ * Where:
+ *   C_ground: Computed from objective, query-backed factors
+ *     1. Evidence completeness (required evidence present vs missing)
+ *     2. Signal strength (data volume and investigation depth)
+ *     3. Signal agreement (supporting vs contradicting evidence)
+ *     4. Data quality (query success rate and result quality)
+ *
+ *   u_llm: LLM's self-reported uncertainty (0–1)
+ *   alpha: Playbook-configured uncertainty weight
+ *
+ * The LLM can only REDUCE confidence — it can never inflate it.
+ *
+ * @license Apache-2.0
+ */
+
+import type {
+  ConfidenceBreakdown,
+  Playbook,
+  PlaybookVerdict,
+  QueryResults,
+} from './playbookTypes.js';
+
+/**
+ * Compute grounded confidence score from objective evidence factors.
+ *
+ * Takes the LLM's u_llm, computes C_ground from query results,
+ * and applies the playbook formula: C_final = C_ground * (1 - alpha * u_llm)
+ */
+export function computeConfidence(
+  verdict: PlaybookVerdict,
+  queryResults: QueryResults,
+  playbook: Playbook,
+): ConfidenceBreakdown {
+  const cc = playbook.confidenceComputation;
+  const alpha = clamp(Number.isFinite(cc.llmUncertaintyAlpha) ? cc.llmUncertaintyAlpha : 0.4, 0, 1);
+  const uLlm = clamp(Number.isFinite(verdict.uLlm) ? verdict.uLlm : 0.5, 0, 1);
+
+  // Identify baseline vs additional query IDs
+  const baselineQueryIds = new Set(
+    playbook.baselineCatalogRefs.map((ref) => ref.catalogId),
+  );
+  const allowedQueryIds = new Set(
+    playbook.allowedCatalogRefs.map((ref) => ref.catalogId),
+  );
+  const additionalQueryIds = new Set(
+    [...allowedQueryIds].filter((id) => !baselineQueryIds.has(id)),
+  );
+
+  const queriesExecuted = new Set(verdict.queriesExecuted);
+  const additionalQueriesExecuted = new Set(
+    [...queriesExecuted].filter((id) => additionalQueryIds.has(id)),
+  );
+
+  // ── 1. Evidence completeness ──────────────────────────────────────────
+  const baseQueriesTotal = baselineQueryIds.size;
+  let baseQueriesWithData = 0;
+  for (const [queryId, result] of Object.entries(queryResults.results)) {
+    if (
+      baselineQueryIds.has(queryId) &&
+      result.success &&
+      result.data.length > 0
+    ) {
+      baseQueriesWithData++;
+    }
+  }
+  const baseCoverage =
+    baseQueriesTotal > 0 ? baseQueriesWithData / baseQueriesTotal : 0.0;
+
+  const additionalQueriesTotal = additionalQueryIds.size;
+  const additionalCoverage =
+    additionalQueriesTotal > 0
+      ? additionalQueriesExecuted.size / additionalQueriesTotal
+      : 0.0;
+
+  // Weighted average using playbook config
+  let baseWeight = cc.baseCoverageWeight;
+  let additionalWeight = cc.additionalCoverageWeight;
+  const totalWeight = baseWeight + additionalWeight;
+  if (totalWeight > 0) {
+    baseWeight = baseWeight / totalWeight;
+    additionalWeight = additionalWeight / totalWeight;
+  } else {
+    baseWeight = 0.7;
+    additionalWeight = 0.3;
+  }
+
+  let evidenceCompleteness =
+    baseWeight * baseCoverage + additionalWeight * additionalCoverage;
+
+  // Penalty for missing critical evidence
+  if (verdict.criticalEvidenceMissing) {
+    evidenceCompleteness *= 1.0 - cc.criticalEvidenceMissingPenalty;
+  }
+
+  // ── 2. Signal strength ────────────────────────────────────────────────
+  let totalRows = 0;
+  for (const result of Object.values(queryResults.results)) {
+    if (result.success) {
+      totalRows += result.data.length;
+    }
+  }
+  let signalStrength = Math.min(1.0, totalRows / 10.0);
+
+  // Bonus for additional queries indicating deeper investigation
+  if (additionalQueriesTotal > 0) {
+    const bonus = Math.min(
+      cc.additionalQueryBonusMax,
+      (additionalQueriesExecuted.size / additionalQueriesTotal) *
+        cc.additionalQueryBonusMax,
+    );
+    signalStrength = Math.min(1.0, signalStrength + bonus);
+  }
+
+  // ── 3. Signal agreement ───────────────────────────────────────────────
+  const supportingCount = verdict.supportingEvidence.length;
+  const contradictingCount = verdict.contradictingEvidence.length;
+  const totalEvidence = supportingCount + contradictingCount;
+
+  let signalAgreement =
+    totalEvidence > 0 ? supportingCount / totalEvidence : 0.5;
+
+  if (verdict.hasContradictorySignals) {
+    signalAgreement *= 0.5;
+  }
+
+  // ── 4. Data quality ───────────────────────────────────────────────────
+  let baseQueriesSuccessful = 0;
+  for (const [queryId, result] of Object.entries(queryResults.results)) {
+    if (baselineQueryIds.has(queryId) && result.success) {
+      baseQueriesSuccessful++;
+    }
+  }
+  const failedQueries = baseQueriesTotal - baseQueriesSuccessful;
+  let dataQuality = Math.max(0.0, 1.0 - failedQueries * 0.2);
+
+  // Penalty for empty results
+  let emptyResults = 0;
+  for (const result of Object.values(queryResults.results)) {
+    if (result.success && result.data.length === 0) {
+      emptyResults++;
+    }
+  }
+  if (emptyResults > 0 && baseQueriesTotal > 0) {
+    const emptyPenalty = Math.min(
+      0.3,
+      (emptyResults / baseQueriesTotal) * 0.3,
+    );
+    dataQuality *= 1.0 - emptyPenalty;
+  }
+
+  // Penalty for edge cases
+  if (verdict.isEdgeCase) {
+    dataQuality *= 0.8;
+  }
+
+  // ── Compute C_ground ──────────────────────────────────────────────────
+  let cGround =
+    cc.evidenceCompletenessWeight * evidenceCompleteness +
+    cc.signalStrengthWeight * signalStrength +
+    cc.signalAgreementWeight * signalAgreement +
+    cc.dataQualityWeight * dataQuality;
+  cGround = clamp(cGround, 0.0, 1.0);
+
+  // ── Apply formula: C_final = C_ground * (1 - alpha * u_llm) ──────────
+  let cFinal = cGround * (1.0 - alpha * uLlm);
+  cFinal = clamp(cFinal, 0.0, 1.0);
+
+  // Bucket into 1–5 scale
+  const cFinal1To5 = 1 + Math.min(4, Math.floor(cFinal * 5));
+
+  return {
+    confidenceScore0To1: round4(cFinal),
+    confidenceScore1To5: cFinal1To5,
+    cGround: round4(cGround),
+    uLlm: round4(uLlm),
+    alpha,
+    evidenceCompleteness: round4(evidenceCompleteness),
+    signalStrength: round4(signalStrength),
+    signalAgreement: round4(signalAgreement),
+    dataQuality: round4(dataQuality),
+    baseCoverage: round4(baseCoverage),
+    additionalCoverage: round4(additionalCoverage),
+  };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function round4(value: number): number {
+  return Math.round(value * 10000) / 10000;
+}

--- a/server/services/playbookAgentService/hardRuleEngine.test.ts
+++ b/server/services/playbookAgentService/hardRuleEngine.test.ts
@@ -1,0 +1,119 @@
+import { evaluateHardRules } from './hardRuleEngine.js';
+import type { HardRule, QueryResult } from './playbookTypes.js';
+
+function makeResult(
+  data: Record<string, unknown>[],
+  success = true,
+): QueryResult {
+  return { success, data };
+}
+
+describe('evaluateHardRules', () => {
+  const rules: HardRule[] = [
+    {
+      ruleId: 'auto_report_critical',
+      description: 'Auto-report on known CSAM series',
+      condition: "hash_match_history.severity_tier == 'CRITICAL'",
+      outcome: 'REPORT_AND_REMOVE',
+      bypassLlm: true,
+    },
+    {
+      ruleId: 'escalate_high_count',
+      description: 'Escalate when many matches',
+      condition: 'hash_match_history.total_matches >= 5',
+      outcome: 'ESCALATE_FOR_REVIEW',
+      bypassLlm: false,
+    },
+  ];
+
+  it('returns first matching rule', () => {
+    const queryResults = {
+      hash_match_history: makeResult([
+        { severity_tier: 'CRITICAL', total_matches: 10 },
+      ]),
+    };
+
+    const match = evaluateHardRules(rules, queryResults);
+    expect(match).toBeDefined();
+    expect(match!.ruleId).toBe('auto_report_critical');
+    expect(match!.outcome).toBe('REPORT_AND_REMOVE');
+    expect(match!.bypassLlm).toBe(true);
+    expect(match!.matchedValue).toBe('CRITICAL');
+  });
+
+  it('returns second rule when first does not match', () => {
+    const queryResults = {
+      hash_match_history: makeResult([
+        { severity_tier: 'HIGH', total_matches: 7 },
+      ]),
+    };
+
+    const match = evaluateHardRules(rules, queryResults);
+    expect(match).toBeDefined();
+    expect(match!.ruleId).toBe('escalate_high_count');
+    expect(match!.outcome).toBe('ESCALATE_FOR_REVIEW');
+  });
+
+  it('returns undefined when no rules match', () => {
+    const queryResults = {
+      hash_match_history: makeResult([
+        { severity_tier: 'LOW', total_matches: 1 },
+      ]),
+    };
+
+    const match = evaluateHardRules(rules, queryResults);
+    expect(match).toBeUndefined();
+  });
+
+  it('handles missing query results gracefully', () => {
+    const match = evaluateHardRules(rules, {});
+    expect(match).toBeUndefined();
+  });
+
+  it('handles failed queries gracefully', () => {
+    const queryResults = {
+      hash_match_history: makeResult([], false),
+    };
+
+    const match = evaluateHardRules(rules, queryResults);
+    expect(match).toBeUndefined();
+  });
+
+  it('matches across any row in the result set', () => {
+    const queryResults = {
+      hash_match_history: makeResult([
+        { severity_tier: 'LOW', total_matches: 1 },
+        { severity_tier: 'CRITICAL', total_matches: 1 },
+      ]),
+    };
+
+    const match = evaluateHardRules(rules, queryResults);
+    expect(match).toBeDefined();
+    expect(match!.ruleId).toBe('auto_report_critical');
+  });
+
+  it('handles != operator', () => {
+    const notNullRule: HardRule[] = [
+      {
+        ruleId: 'not_null_check',
+        description: 'Check field is not null',
+        condition: "data.status != 'inactive'",
+        outcome: 'FLAG',
+        bypassLlm: false,
+      },
+    ];
+
+    const queryResults = {
+      data: makeResult([{ status: 'active' }]),
+    };
+
+    const match = evaluateHardRules(notNullRule, queryResults);
+    expect(match).toBeDefined();
+    expect(match!.ruleId).toBe('not_null_check');
+  });
+
+  it('returns empty array for empty rules', () => {
+    const match = evaluateHardRules([], { some_query: makeResult([{ a: 1 }]) });
+    expect(match).toBeUndefined();
+  });
+});

--- a/server/services/playbookAgentService/hardRuleEngine.ts
+++ b/server/services/playbookAgentService/hardRuleEngine.ts
@@ -1,0 +1,139 @@
+/**
+ * Hard Rule Engine — Deterministic rules evaluated before the LLM.
+ *
+ * Hard rules provide guardrails for critical cases that must never be left
+ * to probabilistic reasoning. When a hard rule fires, its outcome is locked
+ * and the LLM verdict cannot override it.
+ *
+ * Example: A known CSAM series hash match always results in REPORT_AND_REMOVE,
+ * regardless of what the LLM produces.
+ *
+ * @license Apache-2.0
+ */
+
+import type { HardRule, QueryResult } from './playbookTypes.js';
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export type HardRuleMatch = {
+  readonly ruleId: string;
+  readonly outcome: string;
+  readonly bypassLlm: boolean;
+  readonly matchedCondition: string;
+  readonly matchedValue: unknown;
+};
+
+// ── Expression evaluation ───────────────────────────────────────────────────
+
+/**
+ * Evaluate a hard rule condition against query results.
+ *
+ * Conditions use a simple dot-path expression format:
+ *   "catalog_id.field_name == 'VALUE'"
+ *   "catalog_id.field_name >= 3"
+ *   "catalog_id.field_name != null"
+ *
+ * The left side is a dot-path into the query results (catalog_id.column).
+ * The right side is a literal value (string, number, boolean, null).
+ */
+function evaluateCondition(
+  condition: string,
+  queryResults: Readonly<Record<string, QueryResult | undefined>>,
+): { readonly matched: boolean; readonly matchedValue: unknown } {
+  // Parse condition: "catalog_id.field == 'VALUE'"
+  const match = condition.match(
+    /^(\w+)\.(\w+)\s*(==|!=|>=|<=|>|<)\s*(.+)$/,
+  );
+  if (!match) {
+    return { matched: false, matchedValue: undefined };
+  }
+
+  const [, catalogId, fieldName, operator, rawExpected] = match;
+  const result = queryResults[catalogId];
+
+  if (!result?.success || result.data.length === 0) {
+    return { matched: false, matchedValue: undefined };
+  }
+
+  // Parse the expected value
+  const expected = parseExpectedValue(rawExpected.trim());
+
+  // Check if ANY row in the result matches
+  for (const row of result.data) {
+    const actual = row[fieldName];
+    if (compare(actual, operator, expected)) {
+      return { matched: true, matchedValue: actual };
+    }
+  }
+
+  return { matched: false, matchedValue: undefined };
+}
+
+function parseExpectedValue(raw: string): unknown {
+  // String literal: 'VALUE' or "VALUE"
+  if (
+    (raw.startsWith("'") && raw.endsWith("'")) ||
+    (raw.startsWith('"') && raw.endsWith('"'))
+  ) {
+    return raw.slice(1, -1);
+  }
+  // null
+  if (raw === 'null') return null;
+  // boolean
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  // number
+  const num = Number(raw);
+  if (!Number.isNaN(num)) return num;
+  // fallback to string
+  return raw;
+}
+
+function compare(actual: unknown, operator: string, expected: unknown): boolean {
+  switch (operator) {
+    case '==':
+      return actual === expected;
+    case '!=':
+      return actual !== expected;
+    case '>=':
+      return typeof actual === 'number' && typeof expected === 'number' && actual >= expected;
+    case '<=':
+      return typeof actual === 'number' && typeof expected === 'number' && actual <= expected;
+    case '>':
+      return typeof actual === 'number' && typeof expected === 'number' && actual > expected;
+    case '<':
+      return typeof actual === 'number' && typeof expected === 'number' && actual < expected;
+    default:
+      return false;
+  }
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Evaluate all hard rules against query results.
+ *
+ * Returns the first matching rule (rules are evaluated in order).
+ * If no rule matches, returns undefined and the LLM verdict is used.
+ */
+export function evaluateHardRules(
+  hardRules: readonly HardRule[],
+  queryResults: Readonly<Record<string, QueryResult | undefined>>,
+): HardRuleMatch | undefined {
+  for (const rule of hardRules) {
+    const { matched, matchedValue } = evaluateCondition(
+      rule.condition,
+      queryResults,
+    );
+    if (matched) {
+      return {
+        ruleId: rule.ruleId,
+        outcome: rule.outcome,
+        bypassLlm: rule.bypassLlm,
+        matchedCondition: rule.condition,
+        matchedValue,
+      };
+    }
+  }
+  return undefined;
+}

--- a/server/services/playbookAgentService/interfaces.ts
+++ b/server/services/playbookAgentService/interfaces.ts
@@ -1,0 +1,92 @@
+/**
+ * Abstract interfaces for the Playbook Agent framework.
+ *
+ * Organizations bring their own infrastructure by implementing these interfaces.
+ * The framework handles orchestration, safety constraints, and audit trail.
+ *
+ * @license Apache-2.0
+ */
+
+import type { PlaybookResult, QueryResult } from './playbookTypes.js';
+
+// ── LLM Adapter ─────────────────────────────────────────────────────────────
+
+export type LLMRequest = {
+  readonly systemPrompt: string;
+  readonly userPrompt: string;
+  readonly outputSchema?: Record<string, unknown>;
+  readonly maxTokens?: number;
+  readonly temperature?: number;
+};
+
+export type LLMResponse = {
+  readonly content: string;
+  readonly usage?: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  };
+};
+
+/**
+ * Adapter for LLM providers.
+ *
+ * Implementations may use OpenAI, Anthropic, local models, etc.
+ * The framework never calls the LLM directly — all calls go through this interface.
+ */
+export interface ILLMAdapter {
+  complete(request: LLMRequest): Promise<LLMResponse>;
+}
+
+// ── Evidence Store ──────────────────────────────────────────────────────────
+
+export type EvidenceQuery = {
+  readonly catalogId: string;
+  readonly version: string;
+  readonly parameters: Record<string, unknown>;
+};
+
+/**
+ * Adapter for executing pre-approved evidence queries.
+ *
+ * Implementations execute catalog-referenced queries against the org's database.
+ * The agent never writes SQL — it requests evidence by catalog ID.
+ */
+export interface IEvidenceStore {
+  executeQuery(query: EvidenceQuery): Promise<QueryResult>;
+}
+
+// ── Artifact Store ──────────────────────────────────────────────────────────
+
+export type PlaybookArtifact = {
+  readonly sessionId: string;
+  readonly playbookId: string;
+  readonly artifactType: 'verdict' | 'evidence' | 'query_result' | 'confidence';
+  readonly data: Record<string, unknown>;
+  readonly createdAt: Date;
+};
+
+/**
+ * Adapter for storing investigation artifacts.
+ *
+ * Artifacts are insert-only for compliance — they form an immutable evidence chain
+ * for law enforcement referrals and audit purposes.
+ */
+export interface IArtifactStore {
+  store(artifact: PlaybookArtifact): Promise<void>;
+  getBySessionId(sessionId: string): Promise<readonly PlaybookArtifact[]>;
+}
+
+// ── Playbook Runner Interface ───────────────────────────────────────────────
+
+export type PlaybookRunInput = {
+  readonly playbookId: string;
+  readonly inputContext: Record<string, unknown>;
+  readonly sessionId?: string;
+};
+
+/**
+ * Core runner interface that orchestrates a playbook investigation.
+ */
+export interface IPlaybookRunner {
+  run(input: PlaybookRunInput): Promise<PlaybookResult>;
+}

--- a/server/services/playbookAgentService/playbookLoader.test.ts
+++ b/server/services/playbookAgentService/playbookLoader.test.ts
@@ -1,0 +1,157 @@
+import { parsePlaybook } from './playbookLoader.js';
+
+const MINIMAL_PLAYBOOK = {
+  use_case_id: 'test_investigation',
+  version: '1.0.0',
+  display_name: 'Test Investigation',
+  description: 'A test playbook',
+  input_context: [
+    {
+      field_name: 'account_id',
+      field_type: 'string',
+      required: true,
+      description: 'Account to investigate',
+    },
+  ],
+  evidence_ontology: {
+    version: '1.0.0',
+    evidence_types: [
+      {
+        evidence_id: 'login_patterns',
+        display_name: 'Login Patterns',
+        description: 'Login frequency analysis',
+        quality: { minimum_confidence: 0.7, minimum_num_required_sources: 1 },
+      },
+    ],
+  },
+  baseline_catalog_refs: [
+    { catalog_id: 'login_patterns', version: '1.0.0', catalog_type: 'query' },
+  ],
+  allowed_catalog_refs: [
+    { catalog_id: 'login_patterns', version: '1.0.0', catalog_type: 'query' },
+    { catalog_id: 'device_info', version: '1.0.0', catalog_type: 'query' },
+  ],
+  evidence_request_policy: {
+    query_selection_mode: 'query_id',
+    max_rounds: 3,
+    target_confidence: 0.75,
+    max_additional_queries: 5,
+    stop_if_no_new_evidence: true,
+  },
+  labels: [
+    { label_id: 'RISKY', display_name: 'Risky', description: 'Account is risky' },
+    { label_id: 'SAFE', display_name: 'Safe', description: 'Account is safe' },
+  ],
+  decision_logic: {
+    hard_rules: [],
+    default_label: 'SAFE',
+  },
+  confidence_computation: {
+    evidence_completeness_weight: 0.35,
+    signal_strength_weight: 0.25,
+    signal_agreement_weight: 0.25,
+    data_quality_weight: 0.15,
+    llm_uncertainty_alpha: 0.4,
+  },
+  output_contract: {
+    version: '1.0.0',
+    required_fields: ['verdict', 'rationale', 'confidence_score'],
+  },
+};
+
+describe('parsePlaybook', () => {
+  it('parses a valid playbook', () => {
+    const playbook = parsePlaybook(MINIMAL_PLAYBOOK);
+
+    expect(playbook.useCaseId).toBe('test_investigation');
+    expect(playbook.version).toEqual({ major: 1, minor: 0, patch: 0 });
+    expect(playbook.baselineCatalogRefs).toHaveLength(1);
+    expect(playbook.allowedCatalogRefs).toHaveLength(2);
+    expect(playbook.labels).toHaveLength(2);
+    expect(playbook.confidenceComputation.llmUncertaintyAlpha).toBe(0.4);
+  });
+
+  it('applies default values for optional confidence fields', () => {
+    const playbook = parsePlaybook(MINIMAL_PLAYBOOK);
+
+    expect(playbook.confidenceComputation.baseCoverageWeight).toBe(0.7);
+    expect(playbook.confidenceComputation.additionalCoverageWeight).toBe(0.3);
+    expect(playbook.confidenceComputation.criticalEvidenceMissingPenalty).toBe(0.3);
+    expect(playbook.confidenceComputation.additionalQueryBonusMax).toBe(0.2);
+  });
+
+  it('rejects baseline ref not in allowed set', () => {
+    const bad = {
+      ...MINIMAL_PLAYBOOK,
+      baseline_catalog_refs: [
+        { catalog_id: 'unknown_query', version: '1.0.0', catalog_type: 'query' },
+      ],
+    };
+
+    expect(() => parsePlaybook(bad)).toThrow('not found in allowed_catalog_refs');
+  });
+
+  it('rejects invalid default label', () => {
+    const bad = {
+      ...MINIMAL_PLAYBOOK,
+      decision_logic: {
+        hard_rules: [],
+        default_label: 'NONEXISTENT',
+      },
+    };
+
+    expect(() => parsePlaybook(bad)).toThrow("'NONEXISTENT' is not a valid label");
+  });
+
+  it('rejects confidence weights that do not sum to ~1.0', () => {
+    const bad = {
+      ...MINIMAL_PLAYBOOK,
+      confidence_computation: {
+        ...MINIMAL_PLAYBOOK.confidence_computation,
+        evidence_completeness_weight: 0.5,
+        signal_strength_weight: 0.5,
+        signal_agreement_weight: 0.5,
+        data_quality_weight: 0.5,
+      },
+    };
+
+    expect(() => parsePlaybook(bad)).toThrow('weights sum to');
+  });
+
+  it('rejects invalid semantic version', () => {
+    const bad = { ...MINIMAL_PLAYBOOK, version: 'not-a-version' };
+    expect(() => parsePlaybook(bad)).toThrow('Invalid semantic version');
+  });
+
+  it('rejects forbidden catalog IDs', () => {
+    const bad = {
+      ...MINIMAL_PLAYBOOK,
+      allowed_catalog_refs: [
+        ...MINIMAL_PLAYBOOK.allowed_catalog_refs,
+        { catalog_id: 'latest', version: '1.0.0', catalog_type: 'query' },
+      ],
+    };
+
+    expect(() => parsePlaybook(bad)).toThrow("cannot be 'latest'");
+  });
+
+  it('validates hard rule outcomes against labels', () => {
+    const bad = {
+      ...MINIMAL_PLAYBOOK,
+      decision_logic: {
+        hard_rules: [
+          {
+            rule_id: 'test_rule',
+            description: 'Test',
+            condition: "data.field == 'value'",
+            outcome: 'NONEXISTENT_LABEL',
+            bypass_llm: true,
+          },
+        ],
+        default_label: 'SAFE',
+      },
+    };
+
+    expect(() => parsePlaybook(bad)).toThrow("'NONEXISTENT_LABEL' is not a valid label");
+  });
+});

--- a/server/services/playbookAgentService/playbookLoader.ts
+++ b/server/services/playbookAgentService/playbookLoader.ts
@@ -1,0 +1,417 @@
+/**
+ * Playbook Loader — Load and validate investigation playbooks from YAML.
+ *
+ * Handles parsing, validation, and cross-reference checking of playbook configs.
+ * Ensures baseline_catalog_refs is a subset of allowed_catalog_refs,
+ * deep-dive query refs are in allowed set, and all label references are valid.
+ *
+ * @license Apache-2.0
+ */
+
+import {
+  type CatalogReference,
+  type CatalogType,
+  type ConfidenceComputation,
+  type DecisionLogic,
+  type DeepDiveModule,
+  type EvidenceOntology,
+  type EvidenceRequestPolicy,
+  type HardRule,
+  type InputContextField,
+  type InputFieldType,
+  type LabelDefinition,
+  type OutputContract,
+  type PhaseBudget,
+  type Playbook,
+  formatCatalogReference,
+  parseSemanticVersion,
+  validateCatalogReference,
+} from './playbookTypes.js';
+
+// ── Raw YAML types (snake_case as authored) ─────────────────────────────────
+
+type RawCatalogRef = {
+  catalog_id: string;
+  version: string;
+  catalog_type: string;
+};
+
+type RawPlaybook = {
+  use_case_id: string;
+  version: string;
+  display_name: string;
+  description: string;
+  input_context: Array<{
+    field_name: string;
+    field_type: string;
+    required: boolean;
+    description: string;
+    default?: unknown;
+    validation_pattern?: string;
+    catalog_parameter_name?: string;
+  }>;
+  evidence_ontology: {
+    version: string;
+    evidence_types: Array<{
+      evidence_id: string;
+      display_name: string;
+      description: string;
+      quality?: {
+        freshness_max_age_ms?: number;
+        minimum_confidence?: number;
+        minimum_num_required_sources?: number;
+      };
+    }>;
+  };
+  baseline_catalog_refs: RawCatalogRef[];
+  allowed_catalog_refs: RawCatalogRef[];
+  evidence_request_policy: {
+    query_selection_mode: string;
+    max_rounds: number;
+    target_confidence: number;
+    max_additional_queries: number;
+    stop_if_no_new_evidence: boolean;
+    trigger_deep_dive_if?: string;
+    stop_investigation_if?: string;
+    guidance?: string;
+  };
+  deep_dive_modules?: Array<{
+    module_id: string;
+    display_name: string;
+    description: string;
+    entry_conditions: Array<{
+      condition_id: string;
+      description: string;
+      expression: string;
+    }>;
+    exit_conditions: Array<{
+      condition_id: string;
+      description: string;
+      expression: string;
+    }>;
+    query_refs: RawCatalogRef[];
+  }>;
+  labels: Array<{
+    label_id: string;
+    display_name: string;
+    description: string;
+    severity?: string;
+  }>;
+  decision_logic: {
+    hard_rules: Array<{
+      rule_id: string;
+      description: string;
+      condition: string;
+      outcome: string;
+      bypass_llm: boolean;
+    }>;
+    scoring_guidance?: Array<{
+      guidance_id: string;
+      description: string;
+    }>;
+    default_label: string;
+  };
+  confidence_computation: {
+    evidence_completeness_weight: number;
+    signal_strength_weight: number;
+    signal_agreement_weight: number;
+    data_quality_weight: number;
+    llm_uncertainty_alpha: number;
+    base_coverage_weight?: number;
+    additional_coverage_weight?: number;
+    critical_evidence_missing_penalty?: number;
+    additional_query_bonus_max?: number;
+  };
+  phase_budget?: {
+    max_queries: number;
+    max_llm_calls: number;
+    max_duration_ms: number;
+  };
+  output_contract: {
+    version: string;
+    required_fields: string[];
+    schema?: Record<string, unknown>;
+  };
+};
+
+// ── Conversion helpers ──────────────────────────────────────────────────────
+
+function toCatalogReference(raw: RawCatalogRef): CatalogReference {
+  const ref: CatalogReference = {
+    catalogId: raw.catalog_id,
+    version: parseSemanticVersion(raw.version),
+    catalogType: raw.catalog_type as CatalogType,
+  };
+  validateCatalogReference(ref);
+  return ref;
+}
+
+const VALID_INPUT_FIELD_TYPES = new Set([
+  'string',
+  'integer',
+  'float',
+  'boolean',
+  'date',
+  'datetime',
+]);
+
+const VALID_SEVERITIES = new Set([
+  'CRITICAL',
+  'HIGH',
+  'MEDIUM',
+  'LOW',
+  'INFO',
+]);
+
+// ── Validation ──────────────────────────────────────────────────────────────
+
+export type PlaybookValidationError = {
+  readonly field: string;
+  readonly message: string;
+};
+
+function validatePlaybookCrossRefs(playbook: Playbook): PlaybookValidationError[] {
+  const errors: PlaybookValidationError[] = [];
+
+  // baseline_catalog_refs must be a subset of allowed_catalog_refs
+  const allowedIds = new Set(
+    playbook.allowedCatalogRefs.map(formatCatalogReference),
+  );
+  for (const ref of playbook.baselineCatalogRefs) {
+    const refStr = formatCatalogReference(ref);
+    if (!allowedIds.has(refStr)) {
+      errors.push({
+        field: 'baselineCatalogRefs',
+        message: `Baseline ref '${refStr}' not found in allowed_catalog_refs`,
+      });
+    }
+  }
+
+  // deep-dive query refs must be in allowed set
+  if (playbook.deepDiveModules) {
+    for (const mod of playbook.deepDiveModules) {
+      for (const ref of mod.queryRefs) {
+        const refStr = formatCatalogReference(ref);
+        if (!allowedIds.has(refStr)) {
+          errors.push({
+            field: `deepDiveModules.${mod.moduleId}`,
+            message: `Deep-dive ref '${refStr}' not found in allowed_catalog_refs`,
+          });
+        }
+      }
+    }
+  }
+
+  // hard rule outcomes must reference valid labels
+  const labelIds = new Set(playbook.labels.map((l) => l.labelId));
+  for (const rule of playbook.decisionLogic.hardRules) {
+    if (!labelIds.has(rule.outcome)) {
+      errors.push({
+        field: `decisionLogic.hardRules.${rule.ruleId}`,
+        message: `Hard rule outcome '${rule.outcome}' is not a valid label`,
+      });
+    }
+  }
+
+  // default label must be valid
+  if (!labelIds.has(playbook.decisionLogic.defaultLabel)) {
+    errors.push({
+      field: 'decisionLogic.defaultLabel',
+      message: `Default label '${playbook.decisionLogic.defaultLabel}' is not a valid label`,
+    });
+  }
+
+  // confidence weights should sum to ~1.0
+  const cc = playbook.confidenceComputation;
+  const weightSum =
+    cc.evidenceCompletenessWeight +
+    cc.signalStrengthWeight +
+    cc.signalAgreementWeight +
+    cc.dataQualityWeight;
+  if (Math.abs(weightSum - 1.0) > 0.01) {
+    errors.push({
+      field: 'confidenceComputation',
+      message: `Confidence weights sum to ${weightSum}, expected ~1.0`,
+    });
+  }
+
+  return errors;
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Parse a raw YAML-deserialized object into a validated Playbook.
+ *
+ * Call this with the result of `yaml.load(...)` or `JSON.parse(...)`.
+ * Throws on invalid structure or cross-reference violations.
+ */
+export function parsePlaybook(raw: unknown): Playbook {
+  const r = raw as Partial<RawPlaybook>;
+
+  if (
+    typeof r.use_case_id !== 'string' ||
+    typeof r.version !== 'string' ||
+    typeof r.display_name !== 'string' ||
+    typeof r.description !== 'string' ||
+    r.evidence_ontology == null ||
+    !Array.isArray(r.baseline_catalog_refs) ||
+    !Array.isArray(r.allowed_catalog_refs) ||
+    r.evidence_request_policy == null ||
+    !Array.isArray(r.labels) ||
+    r.decision_logic == null ||
+    r.confidence_computation == null ||
+    r.output_contract == null
+  ) {
+    throw new Error('Playbook is missing required top-level fields');
+  }
+
+  const inputContext: InputContextField[] = (r.input_context ?? []).map(
+    (f) => {
+      if (!VALID_INPUT_FIELD_TYPES.has(f.field_type)) {
+        throw new Error(`Invalid field_type '${f.field_type}' for input '${f.field_name}'`);
+      }
+      return {
+        fieldName: f.field_name,
+        fieldType: f.field_type as InputFieldType,
+        required: f.required,
+        description: f.description,
+        default: f.default,
+        validationPattern: f.validation_pattern,
+        catalogParameterName: f.catalog_parameter_name,
+      };
+    },
+  );
+
+  const evidenceOntology: EvidenceOntology = {
+    version: parseSemanticVersion(r.evidence_ontology.version),
+    evidenceTypes: r.evidence_ontology.evidence_types.map((et) => ({
+      evidenceId: et.evidence_id,
+      displayName: et.display_name,
+      description: et.description,
+      quality: {
+        freshnessMaxAgeMs: et.quality?.freshness_max_age_ms,
+        minimumConfidence: et.quality?.minimum_confidence ?? 0.0,
+        minimumNumRequiredSources: et.quality?.minimum_num_required_sources ?? 1,
+      },
+    })),
+  };
+
+  const baselineCatalogRefs = r.baseline_catalog_refs.map(toCatalogReference);
+  const allowedCatalogRefs = r.allowed_catalog_refs.map(toCatalogReference);
+
+  const evidenceRequestPolicy: EvidenceRequestPolicy = {
+    querySelectionMode: 'query_id',
+    maxRounds: r.evidence_request_policy.max_rounds,
+    targetConfidence: r.evidence_request_policy.target_confidence,
+    maxAdditionalQueries: r.evidence_request_policy.max_additional_queries,
+    stopIfNoNewEvidence: r.evidence_request_policy.stop_if_no_new_evidence,
+    triggerDeepDiveIf: r.evidence_request_policy.trigger_deep_dive_if,
+    stopInvestigationIf: r.evidence_request_policy.stop_investigation_if,
+    guidance: r.evidence_request_policy.guidance,
+  };
+
+  const deepDiveModules: DeepDiveModule[] | undefined =
+    r.deep_dive_modules?.map((m) => ({
+      moduleId: m.module_id,
+      displayName: m.display_name,
+      description: m.description,
+      entryConditions: m.entry_conditions.map((c) => ({
+        conditionId: c.condition_id,
+        description: c.description,
+        expression: c.expression,
+      })),
+      exitConditions: m.exit_conditions.map((c) => ({
+        conditionId: c.condition_id,
+        description: c.description,
+        expression: c.expression,
+      })),
+      queryRefs: m.query_refs.map(toCatalogReference),
+    }));
+
+  const labels: LabelDefinition[] = r.labels.map((l) => {
+    if (l.severity && !VALID_SEVERITIES.has(l.severity)) {
+      throw new Error(
+        `Invalid severity '${l.severity}' for label '${l.label_id}'`,
+      );
+    }
+    return {
+      labelId: l.label_id,
+      displayName: l.display_name,
+      description: l.description,
+      severity: l.severity as LabelDefinition['severity'],
+    };
+  });
+
+  const hardRules: HardRule[] = r.decision_logic.hard_rules.map((hr) => ({
+    ruleId: hr.rule_id,
+    description: hr.description,
+    condition: hr.condition,
+    outcome: hr.outcome,
+    bypassLlm: hr.bypass_llm,
+  }));
+
+  const decisionLogic: DecisionLogic = {
+    hardRules,
+    scoringGuidance: (r.decision_logic.scoring_guidance ?? []).map((sg) => ({
+      guidanceId: sg.guidance_id,
+      description: sg.description,
+    })),
+    defaultLabel: r.decision_logic.default_label,
+  };
+
+  const cc = r.confidence_computation;
+  const confidenceComputation: ConfidenceComputation = {
+    evidenceCompletenessWeight: cc.evidence_completeness_weight,
+    signalStrengthWeight: cc.signal_strength_weight,
+    signalAgreementWeight: cc.signal_agreement_weight,
+    dataQualityWeight: cc.data_quality_weight,
+    llmUncertaintyAlpha: cc.llm_uncertainty_alpha,
+    baseCoverageWeight: cc.base_coverage_weight ?? 0.7,
+    additionalCoverageWeight: cc.additional_coverage_weight ?? 0.3,
+    criticalEvidenceMissingPenalty: cc.critical_evidence_missing_penalty ?? 0.3,
+    additionalQueryBonusMax: cc.additional_query_bonus_max ?? 0.2,
+  };
+
+  const phaseBudget: PhaseBudget | undefined = r.phase_budget
+    ? {
+        maxQueries: r.phase_budget.max_queries,
+        maxLlmCalls: r.phase_budget.max_llm_calls,
+        maxDurationMs: r.phase_budget.max_duration_ms,
+      }
+    : undefined;
+
+  const outputContract: OutputContract = {
+    version: parseSemanticVersion(r.output_contract.version),
+    requiredFields: r.output_contract.required_fields,
+    schema: r.output_contract.schema,
+  };
+
+  const playbook: Playbook = {
+    useCaseId: r.use_case_id,
+    version: parseSemanticVersion(r.version),
+    displayName: r.display_name,
+    description: r.description,
+    inputContext,
+    evidenceOntology,
+    baselineCatalogRefs,
+    allowedCatalogRefs,
+    evidenceRequestPolicy,
+    deepDiveModules,
+    labels,
+    decisionLogic,
+    confidenceComputation,
+    phaseBudget,
+    outputContract,
+  };
+
+  const errors = validatePlaybookCrossRefs(playbook);
+  if (errors.length > 0) {
+    const details = errors
+      .map((e) => `  - ${e.field}: ${e.message}`)
+      .join('\n');
+    throw new Error(`Playbook validation failed:\n${details}`);
+  }
+
+  return playbook;
+}

--- a/server/services/playbookAgentService/playbookTypes.ts
+++ b/server/services/playbookAgentService/playbookTypes.ts
@@ -1,0 +1,285 @@
+/**
+ * Playbook Schema Types — Declarative configs for risk investigation use cases.
+ *
+ * Playbooks are versioned, declarative configurations that define investigation
+ * workflows, evidence requirements, decision logic, and output contracts.
+ *
+ * Key design principles:
+ *   - Versioned using semantic versioning for reproducibility
+ *   - Declarative: define requirements, not implementation
+ *   - Catalog-based: reference queries by ID + version, never contain SQL
+ *   - Deterministic: same input + same playbook version = same behavior
+ *
+ * @license Apache-2.0
+ */
+
+// ── Semantic Versioning ─────────────────────────────────────────────────────
+
+export type SemanticVersion = {
+  readonly major: number;
+  readonly minor: number;
+  readonly patch: number;
+};
+
+export function parseSemanticVersion(input: string): SemanticVersion {
+  const parts = input.split('.');
+  if (parts.length !== 3) {
+    throw new Error(
+      `Invalid semantic version format: '${input}'. Expected format: 'X.Y.Z'`,
+    );
+  }
+  const [major, minor, patch] = parts.map(Number);
+  if ([major, minor, patch].some((n) => !Number.isInteger(n) || n < 0)) {
+    throw new Error(
+      `Invalid semantic version format: '${input}'. All parts must be non-negative integers.`,
+    );
+  }
+  return { major, minor, patch };
+}
+
+export function formatSemanticVersion(v: SemanticVersion): string {
+  return `${v.major}.${v.minor}.${v.patch}`;
+}
+
+// ── Catalog References ──────────────────────────────────────────────────────
+
+const FORBIDDEN_CATALOG_IDS = [
+  'latest',
+  'head',
+  'main',
+  'master',
+  'current',
+] as const;
+
+const CATALOG_ID_PATTERN = /^[a-z0-9_]+$/;
+
+export type CatalogType = 'query' | 'query_bundle';
+
+export type CatalogReference = {
+  readonly catalogId: string;
+  readonly version: SemanticVersion;
+  readonly catalogType: CatalogType;
+};
+
+export function validateCatalogReference(ref: CatalogReference): void {
+  if (!CATALOG_ID_PATTERN.test(ref.catalogId)) {
+    throw new Error(
+      `Invalid catalog ID '${ref.catalogId}': must match /^[a-z0-9_]+$/`,
+    );
+  }
+  if (
+    FORBIDDEN_CATALOG_IDS.includes(
+      ref.catalogId.toLowerCase() as (typeof FORBIDDEN_CATALOG_IDS)[number],
+    )
+  ) {
+    throw new Error(
+      `Catalog ID cannot be '${ref.catalogId}' — use specific versioned IDs`,
+    );
+  }
+}
+
+export function formatCatalogReference(ref: CatalogReference): string {
+  return `${ref.catalogId}@${formatSemanticVersion(ref.version)}`;
+}
+
+// ── Input Context ───────────────────────────────────────────────────────────
+
+export type InputFieldType =
+  | 'string'
+  | 'integer'
+  | 'float'
+  | 'boolean'
+  | 'date'
+  | 'datetime';
+
+export type InputContextField = {
+  readonly fieldName: string;
+  readonly fieldType: InputFieldType;
+  readonly required: boolean;
+  readonly description: string;
+  readonly default?: unknown;
+  readonly validationPattern?: string;
+  readonly catalogParameterName?: string;
+};
+
+// ── Evidence Ontology ───────────────────────────────────────────────────────
+
+export type EvidenceQuality = {
+  readonly freshnessMaxAgeMs?: number;
+  readonly minimumConfidence: number;
+  readonly minimumNumRequiredSources: number;
+};
+
+export type EvidenceType = {
+  readonly evidenceId: string;
+  readonly displayName: string;
+  readonly description: string;
+  readonly quality: EvidenceQuality;
+};
+
+export type EvidenceOntology = {
+  readonly version: SemanticVersion;
+  readonly evidenceTypes: readonly EvidenceType[];
+};
+
+// ── Evidence Request Policy ─────────────────────────────────────────────────
+
+export type EvidenceRequestPolicy = {
+  readonly querySelectionMode: 'query_id';
+  readonly maxRounds: number;
+  readonly targetConfidence: number;
+  readonly maxAdditionalQueries: number;
+  readonly stopIfNoNewEvidence: boolean;
+  readonly triggerDeepDiveIf?: string;
+  readonly stopInvestigationIf?: string;
+  readonly guidance?: string;
+};
+
+// ── Deep-Dive Modules ───────────────────────────────────────────────────────
+
+export type DeepDiveCondition = {
+  readonly conditionId: string;
+  readonly description: string;
+  readonly expression: string;
+};
+
+export type DeepDiveModule = {
+  readonly moduleId: string;
+  readonly displayName: string;
+  readonly description: string;
+  readonly entryConditions: readonly DeepDiveCondition[];
+  readonly exitConditions: readonly DeepDiveCondition[];
+  readonly queryRefs: readonly CatalogReference[];
+};
+
+// ── Labels & Decision Logic ─────────────────────────────────────────────────
+
+export type LabelDefinition = {
+  readonly labelId: string;
+  readonly displayName: string;
+  readonly description: string;
+  readonly severity?: 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW' | 'INFO';
+};
+
+export type HardRule = {
+  readonly ruleId: string;
+  readonly description: string;
+  readonly condition: string;
+  readonly outcome: string;
+  readonly bypassLlm: boolean;
+};
+
+export type ScoringGuidance = {
+  readonly guidanceId: string;
+  readonly description: string;
+};
+
+export type DecisionLogic = {
+  readonly hardRules: readonly HardRule[];
+  readonly scoringGuidance: readonly ScoringGuidance[];
+  readonly defaultLabel: string;
+};
+
+// ── Confidence Computation ──────────────────────────────────────────────────
+
+export type ConfidenceComputation = {
+  readonly evidenceCompletenessWeight: number;
+  readonly signalStrengthWeight: number;
+  readonly signalAgreementWeight: number;
+  readonly dataQualityWeight: number;
+  readonly llmUncertaintyAlpha: number;
+  readonly baseCoverageWeight: number;
+  readonly additionalCoverageWeight: number;
+  readonly criticalEvidenceMissingPenalty: number;
+  readonly additionalQueryBonusMax: number;
+};
+
+// ── Phase Budget ────────────────────────────────────────────────────────────
+
+export type PhaseBudget = {
+  readonly maxQueries: number;
+  readonly maxLlmCalls: number;
+  readonly maxDurationMs: number;
+};
+
+// ── Output Contract ─────────────────────────────────────────────────────────
+
+export type OutputContract = {
+  readonly version: SemanticVersion;
+  readonly requiredFields: readonly string[];
+  readonly schema?: Record<string, unknown>;
+};
+
+// ── Playbook (top-level) ────────────────────────────────────────────────────
+
+export type Playbook = {
+  readonly useCaseId: string;
+  readonly version: SemanticVersion;
+  readonly displayName: string;
+  readonly description: string;
+  readonly inputContext: readonly InputContextField[];
+  readonly evidenceOntology: EvidenceOntology;
+  readonly baselineCatalogRefs: readonly CatalogReference[];
+  readonly allowedCatalogRefs: readonly CatalogReference[];
+  readonly evidenceRequestPolicy: EvidenceRequestPolicy;
+  readonly deepDiveModules?: readonly DeepDiveModule[];
+  readonly labels: readonly LabelDefinition[];
+  readonly decisionLogic: DecisionLogic;
+  readonly confidenceComputation: ConfidenceComputation;
+  readonly phaseBudget?: PhaseBudget;
+  readonly outputContract: OutputContract;
+};
+
+// ── Verdict & Results ───────────────────────────────────────────────────────
+
+export type PlaybookVerdict = {
+  readonly verdict: string;
+  readonly rationale: string;
+  readonly confidenceScore: number;
+  readonly uLlm: number;
+  readonly ncmecReportRequired?: boolean;
+  readonly contentRemovalRequired?: boolean;
+  readonly queriesExecuted: readonly string[];
+  readonly supportingEvidence: readonly string[];
+  readonly contradictingEvidence: readonly string[];
+  readonly criticalEvidenceMissing: boolean;
+  readonly hasContradictorySignals: boolean;
+  readonly isEdgeCase?: boolean;
+};
+
+export type ConfidenceBreakdown = {
+  readonly confidenceScore0To1: number;
+  readonly confidenceScore1To5: number;
+  readonly cGround: number;
+  readonly uLlm: number;
+  readonly alpha: number;
+  readonly evidenceCompleteness: number;
+  readonly signalStrength: number;
+  readonly signalAgreement: number;
+  readonly dataQuality: number;
+  readonly baseCoverage: number;
+  readonly additionalCoverage: number;
+};
+
+export type QueryResult = {
+  readonly success: boolean;
+  readonly data: readonly Record<string, unknown>[];
+  readonly error?: string;
+};
+
+export type QueryResults = {
+  readonly results: Record<string, QueryResult>;
+};
+
+export type PlaybookResult = {
+  readonly playbookId: string;
+  readonly playbookVersion: string;
+  readonly verdict: PlaybookVerdict;
+  readonly confidence: ConfidenceBreakdown;
+  readonly hardRuleTriggered?: string;
+  readonly evidence: readonly Record<string, unknown>[];
+  readonly queriesExecuted: readonly string[];
+  readonly ranAt: Date;
+  readonly durationMs: number;
+  readonly sessionId: string;
+};

--- a/server/services/playbookAgentService/queryCatalog.test.ts
+++ b/server/services/playbookAgentService/queryCatalog.test.ts
@@ -1,0 +1,107 @@
+import QueryCatalog, { parseCatalogEntry } from './queryCatalog.js';
+
+describe('parseCatalogEntry', () => {
+  it('parses a SQL template with metadata comments', () => {
+    const sql = `-- catalog_id: login_patterns
+-- version: 1.0.0
+-- description: Login frequency analysis
+-- Human-authored, versioned, pre-approved
+
+SELECT
+    DATE(login_timestamp) AS login_date,
+    COUNT(*) AS login_count
+FROM account_logins
+WHERE account_id = :account_id
+  AND login_timestamp >= DATEADD(day, -:lookback_days, :alert_timestamp)
+LIMIT 30;`;
+
+    const entry = parseCatalogEntry(sql);
+    expect(entry.catalogId).toBe('login_patterns');
+    expect(entry.version).toBe('1.0.0');
+    expect(entry.description).toBe('Login frequency analysis');
+    expect(entry.parameters).toEqual(
+      expect.arrayContaining(['account_id', 'lookback_days', 'alert_timestamp']),
+    );
+    expect(entry.sql).toContain('SELECT');
+    expect(entry.sql).toContain(':account_id');
+  });
+
+  it('throws on missing catalog_id', () => {
+    const sql = `-- version: 1.0.0
+SELECT 1;`;
+    expect(() => parseCatalogEntry(sql)).toThrow('catalog_id');
+  });
+
+  it('throws on missing version', () => {
+    const sql = `-- catalog_id: test_query
+SELECT 1;`;
+    expect(() => parseCatalogEntry(sql)).toThrow('version');
+  });
+
+  it('deduplicates parameters', () => {
+    const sql = `-- catalog_id: test
+-- version: 1.0.0
+SELECT * FROM t WHERE a = :id AND b = :id;`;
+
+    const entry = parseCatalogEntry(sql);
+    // :id appears twice but should be deduplicated
+    expect(entry.parameters.filter((p) => p === 'id')).toHaveLength(1);
+  });
+});
+
+describe('QueryCatalog', () => {
+  const entries = [
+    {
+      catalogId: 'query_a',
+      version: '1.0.0',
+      description: 'Query A',
+      sql: 'SELECT * FROM a WHERE id = :id',
+      parameters: ['id'],
+    },
+    {
+      catalogId: 'query_b',
+      version: '2.0.0',
+      description: 'Query B',
+      sql: 'SELECT * FROM b WHERE x = :x AND y = :y',
+      parameters: ['x', 'y'],
+    },
+  ];
+
+  it('resolves by CatalogReference', () => {
+    const catalog = new QueryCatalog(entries);
+    const result = catalog.resolve({
+      catalogId: 'query_a',
+      version: { major: 1, minor: 0, patch: 0 },
+      catalogType: 'query',
+    });
+    expect(result).toBeDefined();
+    expect(result!.catalogId).toBe('query_a');
+  });
+
+  it('resolves by string', () => {
+    const catalog = new QueryCatalog(entries);
+    expect(catalog.resolveByString('query_b@2.0.0')).toBeDefined();
+    expect(catalog.resolveByString('query_b@1.0.0')).toBeUndefined();
+  });
+
+  it('renders SQL with positional parameters', () => {
+    const catalog = new QueryCatalog(entries);
+    const entry = catalog.resolveByString('query_b@2.0.0')!;
+
+    const { sql, bindings } = catalog.renderSql(entry, { x: 'hello', y: 42 });
+    expect(sql).toBe('SELECT * FROM b WHERE x = $1 AND y = $2');
+    expect(bindings).toEqual(['hello', 42]);
+  });
+
+  it('throws on missing parameter', () => {
+    const catalog = new QueryCatalog(entries);
+    const entry = catalog.resolveByString('query_b@2.0.0')!;
+
+    expect(() => catalog.renderSql(entry, { x: 'hello' })).toThrow("Missing required parameter 'y'");
+  });
+
+  it('reports catalog size', () => {
+    const catalog = new QueryCatalog(entries);
+    expect(catalog.size).toBe(2);
+  });
+});

--- a/server/services/playbookAgentService/queryCatalog.ts
+++ b/server/services/playbookAgentService/queryCatalog.ts
@@ -1,0 +1,165 @@
+/**
+ * Query Catalog — Pre-approved SQL template loader and resolver.
+ *
+ * The agent requests evidence by catalog_id@version. It never writes SQL
+ * or sees table names. The catalog resolves IDs to pre-approved, parameterized
+ * SQL templates that are executed by the evidence store.
+ *
+ * Template format:
+ *   -- catalog_id: login_patterns
+ *   -- version: 1.0.0
+ *   -- description: Login frequency analysis
+ *   SELECT ... WHERE account_id = :account_id
+ *
+ * Parameters use `:field_name` syntax for safe substitution.
+ *
+ * @license Apache-2.0
+ */
+
+import {
+  type CatalogReference,
+  type Playbook,
+  formatCatalogReference,
+} from './playbookTypes.js';
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export type CatalogEntry = {
+  readonly catalogId: string;
+  readonly version: string;
+  readonly description: string;
+  readonly sql: string;
+  readonly parameters: readonly string[];
+};
+
+export type CatalogEntryMap = ReadonlyMap<string, CatalogEntry>;
+
+// ── Parsing ─────────────────────────────────────────────────────────────────
+
+const METADATA_PATTERN =
+  /^--\s*(catalog_id|version|description):\s*(.+)$/;
+const PARAMETER_PATTERN = /:([a-z_][a-z0-9_]*)/g;
+
+/**
+ * Parse a SQL template file into a CatalogEntry.
+ *
+ * Extracts metadata from comment headers and discovers parameters
+ * from `:field_name` tokens in the SQL body.
+ */
+export function parseCatalogEntry(sql: string): CatalogEntry {
+  const lines = sql.split('\n');
+  const metadata: Record<string, string> = {};
+  const sqlLines: string[] = [];
+
+  for (const line of lines) {
+    const match = METADATA_PATTERN.exec(line.trim());
+    if (match) {
+      metadata[match[1]] = match[2].trim();
+    } else if (!line.trim().startsWith('--') || sqlLines.length > 0) {
+      // Once we hit non-comment lines, include everything (including inline comments)
+      sqlLines.push(line);
+    }
+  }
+
+  const sqlBody = sqlLines.join('\n').trim();
+
+  if (!metadata['catalog_id']) {
+    throw new Error('SQL template missing required "catalog_id" metadata comment');
+  }
+  if (!metadata['version']) {
+    throw new Error(
+      `SQL template '${metadata['catalog_id']}' missing required "version" metadata comment`,
+    );
+  }
+
+  // Extract parameter names from :field_name tokens
+  const parameterMatches = sqlBody.matchAll(PARAMETER_PATTERN);
+  const parameters = [...new Set([...parameterMatches].map((m) => m[1]))];
+
+  return {
+    catalogId: metadata['catalog_id'],
+    version: metadata['version'],
+    description: metadata['description'] ?? '',
+    sql: sqlBody,
+    parameters,
+  };
+}
+
+// ── Query Catalog ───────────────────────────────────────────────────────────
+
+export default class QueryCatalog {
+  readonly #entries: Map<string, CatalogEntry>;
+
+  constructor(entries: readonly CatalogEntry[]) {
+    this.#entries = new Map(
+      entries.map((e) => [`${e.catalogId}@${e.version}`, e]),
+    );
+  }
+
+  /**
+   * Resolve a catalog reference to a SQL template.
+   *
+   * Returns undefined if the reference is not found.
+   */
+  resolve(ref: CatalogReference): CatalogEntry | undefined {
+    const key = formatCatalogReference(ref);
+    return this.#entries.get(key);
+  }
+
+  /**
+   * Resolve a catalog_id@version string to a SQL template.
+   */
+  resolveByString(refString: string): CatalogEntry | undefined {
+    return this.#entries.get(refString);
+  }
+
+  /**
+   * Validate that a catalog reference is in the playbook's allowed set.
+   *
+   * Returns true only if the ref exists in the catalog AND is listed
+   * in the playbook's allowed_catalog_refs.
+   */
+  isAllowed(refString: string, playbook: Playbook): boolean {
+    const allowedKeys = new Set(
+      playbook.allowedCatalogRefs.map(formatCatalogReference),
+    );
+    return allowedKeys.has(refString) && this.#entries.has(refString);
+  }
+
+  /**
+   * Render a SQL template by substituting parameters.
+   *
+   * Uses parameterized substitution (not string interpolation) to prevent injection.
+   * Returns the SQL string with `:param` tokens replaced by their values.
+   *
+   * Throws if a required parameter is missing.
+   */
+  renderSql(
+    entry: CatalogEntry,
+    parameters: Record<string, unknown>,
+  ): { readonly sql: string; readonly bindings: readonly unknown[] } {
+    // Build ordered bindings array and replace :param with $N positional params
+    const bindings: unknown[] = [];
+    let paramIndex = 0;
+    const renderedSql = entry.sql.replace(PARAMETER_PATTERN, (_match, name: string) => {
+      if (!(name in parameters)) {
+        throw new Error(
+          `Missing required parameter '${name}' for query '${entry.catalogId}'`,
+        );
+      }
+      bindings.push(parameters[name]);
+      paramIndex++;
+      return `$${paramIndex}`;
+    });
+
+    return { sql: renderedSql, bindings };
+  }
+
+  get size(): number {
+    return this.#entries.size;
+  }
+
+  get catalogIds(): string[] {
+    return [...this.#entries.keys()];
+  }
+}


### PR DESCRIPTION
- depends on #572
- depends on #573
- depends on #574
- depends on #575

## Summary

Grounded confidence scoring where the LLM can only **reduce** confidence — never inflate it.

**Part 5 of 8** — depends on #575 (hard rule engine).

### Formula
```
C_final = C_ground * (1 - alpha * u_llm)
```

### C_ground components (objective, query-backed)
| Component | What it measures |
|-----------|-----------------|
| Evidence completeness | Required vs optional query coverage |
| Signal strength | Data volume and investigation depth |
| Signal agreement | Supporting vs contradicting evidence ratio |
| Data quality | Query success rate, empty results, edge cases |

Each weighted by playbook-configured values (must sum to ~1.0). The LLM's `u_llm` is discounted by alpha (typically 0.35-0.5).

### `confidenceEngine.ts`
- `computeConfidence()`: full formula with all 4 components
- Configurable penalties for critical missing evidence, contradictions, failures
- Outputs raw 0-1 score and bucketed 1-5 score

### `confidenceEngine.test.ts` — 6 tests
- High confidence when all evidence present and agrees
- Reduces confidence for critical missing evidence
- Penalizes contradictory signals
- Proves LLM can only reduce (same C_ground, higher u_llm = lower C_final)
- Handles query failures gracefully
- Valid 1-5 buckets across full u_llm range

## Test plan
- [ ] `npm test -- --testPathPattern=confidenceEngine` passes (6 tests)

> Depends on [#575 Hard rule engine](https://github.com/roostorg/coop/pull/575). Merge #572, #573, #574, #575 first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced playbook-driven investigation framework with validated playbook loading and semantic-versioned references
  * Added rich playbook schema/types, a query catalog for reusable evidence queries, a deterministic hard-rule engine, and a grounded confidence scoring system (0–1 + 1–5 buckets)

* **Tests**
  * Comprehensive test coverage for playbook parsing/validation, query catalog, hard-rule evaluation, and confidence computation behaviors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/576?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Part of #659