### PR TITLE
Playbook Agent: examples and component walkthrough (8/8)

### DIFF
--- a/server/services/playbookAgentService/componentWalkthrough.test.ts
+++ b/server/services/playbookAgentService/componentWalkthrough.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Component walkthrough — exercises every component in the playbook agent
+ * framework through two end-to-end scenarios:
+ *
+ *   1. Account Takeover (LLM decides) — no hard rules, LLM produces verdict
+ *      from messy text, QueryCatalog parses SQL template, confidence is grounded
+ *
+ *   2. CSAM Triage (hard rule decides) — deterministic rule overrides LLM,
+ *      artifact store captures immutable evidence chain
+ *
+ * Components exercised:
+ *   - PlaybookLoader (parsePlaybook)
+ *   - QueryCatalog (parseCatalogEntry, resolve, renderSql)
+ *   - HardRuleEngine (evaluateHardRules)
+ *   - JsonExtractor (extractVerdict from raw LLM text)
+ *   - ConfidenceEngine (computeConfidence)
+ *   - PlaybookRunner (full pipeline via PlaybookAgentService)
+ *   - Interfaces (ILLMAdapter, IEvidenceStore, IArtifactStore)
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { tryJsonParse } from '../../utils/encoding.js';
+import { computeConfidence } from './confidenceEngine.js';
+import { evaluateHardRules } from './hardRuleEngine.js';
+import type {
+  IArtifactStore,
+  IEvidenceStore,
+  ILLMAdapter,
+  PlaybookArtifact,
+} from './interfaces.js';
+import { extractVerdict } from './jsonExtractor.js';
+import { PlaybookAgentService } from './playbookAgentService.js';
+import { parsePlaybook } from './playbookLoader.js';
+import type { Playbook, PlaybookVerdict, QueryResults } from './playbookTypes.js';
+import QueryCatalog, { parseCatalogEntry } from './queryCatalog.js';
+
+const examplesDir = join(dirname(fileURLToPath(import.meta.url)), 'examples');
+
+function readExample(filename: string): Record<string, unknown> {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  const raw = readFileSync(join(examplesDir, filename), 'utf-8');
+  const parsed = tryJsonParse(raw);
+  if (typeof parsed !== 'object' || parsed == null || Array.isArray(parsed)) {
+    throw new Error(`Example '${filename}' must be a JSON object`);
+  }
+  return parsed;
+}
+
+function readSql(filename: string): string {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  return readFileSync(join(examplesDir, filename), 'utf-8');
+}
+
+// ── Scenario 1: Account Takeover (LLM decides, no hard rules) ──────────────
+
+describe('Scenario: Account Takeover — LLM decides verdict', () => {
+  let playbook: Playbook;
+
+  beforeAll(() => {
+    playbook = parsePlaybook(
+      readExample('account_takeover_triage.playbook.json'),
+    );
+  });
+
+  it('PlaybookLoader: parses the ATO playbook with no hard rules', () => {
+    expect(playbook.useCaseId).toBe('account_takeover_triage');
+    expect(playbook.decisionLogic.hardRules).toHaveLength(0);
+    expect(playbook.labels).toHaveLength(3);
+    expect(playbook.labels.map((l) => l.labelId)).toEqual([
+      'ATO_CONFIRMED',
+      'ATO_SUSPECTED',
+      'LEGITIMATE',
+    ]);
+    expect(playbook.decisionLogic.defaultLabel).toBe('LEGITIMATE');
+  });
+
+  it('QueryCatalog: parses SQL template and renders with parameters', () => {
+    const sql = readSql('account_takeover_triage.catalog.sql');
+    const entry = parseCatalogEntry(sql);
+
+    expect(entry.catalogId).toBe('login_patterns');
+    expect(entry.version).toBe('1.0.0');
+    expect(entry.parameters).toContain('account_id');
+    expect(entry.parameters).toContain('lookback_days');
+    expect(entry.sql).toContain(':account_id');
+
+    const catalog = new QueryCatalog([entry]);
+    const resolved = catalog.resolve(playbook.baselineCatalogRefs[0]!);
+    expect(resolved).toBeDefined();
+
+    const { sql: rendered, bindings } = catalog.renderSql(resolved!, {
+      account_id: 'acc_12345',
+      lookback_days: 30,
+    });
+
+    expect(rendered).toContain('$1'); // account_id
+    expect(rendered).toContain('$2'); // lookback_days
+    expect(rendered).not.toContain(':account_id');
+    expect(bindings).toEqual(['acc_12345', 30]);
+  });
+
+  it('HardRuleEngine: no rules fire (empty hard_rules list)', () => {
+    const queryResults = {
+      login_patterns: {
+        success: true,
+        data: [
+          { login_date: '2026-05-20', login_count: 15, failed_logins: 12, distinct_ips: 8, distinct_countries: 4 },
+        ],
+      },
+    };
+
+    const match = evaluateHardRules(playbook.decisionLogic.hardRules, queryResults);
+    expect(match).toBeUndefined();
+  });
+
+  it('JsonExtractor: extracts verdict from messy LLM output with surrounding text', () => {
+    const messyLlmOutput = `
+Based on my analysis of the login patterns, I've identified several concerning signals.
+
+The account shows 12 failed logins from 8 different IPs across 4 countries in a single day,
+which is consistent with credential stuffing followed by a successful compromise.
+
+Here is my structured assessment:
+
+\`\`\`json
+{"verdict": "ATO_CONFIRMED", "rationale": "12 failed logins from 8 IPs across 4 countries in 24h is consistent with credential stuffing. The successful login from a new device in a 5th country 2 hours later confirms compromise.", "confidence_score": 4, "u_llm": 0.15, "queries_executed": ["login_patterns"], "supporting_evidence": ["geo_impossible_travel", "credential_stuffing_pattern", "new_device_after_failures"], "contradicting_evidence": [], "critical_evidence_missing": false, "has_contradictory_signals": false}
+\`\`\`
+
+I recommend immediate account lockout and password reset.
+    `;
+
+    const verdict = extractVerdict(messyLlmOutput, playbook.outputContract);
+
+    expect(verdict).toBeDefined();
+    expect(verdict!.verdict).toBe('ATO_CONFIRMED');
+    expect(verdict!.uLlm).toBe(0.15);
+    expect(verdict!.supportingEvidence).toHaveLength(3);
+    expect(verdict!.contradictingEvidence).toHaveLength(0);
+    expect(verdict!.rationale).toContain('credential stuffing');
+  });
+
+  it('ConfidenceEngine: computes grounded score for LLM verdict', () => {
+    const verdict: PlaybookVerdict = {
+      verdict: 'ATO_CONFIRMED',
+      rationale: 'Credential stuffing pattern detected.',
+      confidenceScore: 4,
+      uLlm: 0.15,
+      queriesExecuted: ['login_patterns'],
+      supportingEvidence: ['geo_impossible', 'credential_stuffing', 'new_device'],
+      contradictingEvidence: [],
+      criticalEvidenceMissing: false,
+      hasContradictorySignals: false,
+    };
+
+    const queryResults: QueryResults = {
+      results: {
+        login_patterns: {
+          success: true,
+          data: [
+            { login_date: '2026-05-20', login_count: 15, failed_logins: 12, distinct_ips: 8 },
+            { login_date: '2026-05-19', login_count: 3, failed_logins: 0, distinct_ips: 1 },
+          ],
+        },
+      },
+    };
+
+    const confidence = computeConfidence(verdict, queryResults, playbook);
+
+    // LLM uncertainty is low (0.15) so it barely reduces confidence
+    expect(confidence.uLlm).toBe(0.15);
+    expect(confidence.alpha).toBe(0.4);
+    expect(confidence.confidenceScore0To1).toBeGreaterThan(0);
+    expect(confidence.confidenceScore0To1).toBeLessThanOrEqual(1);
+    expect(confidence.confidenceScore1To5).toBeGreaterThanOrEqual(1);
+    expect(confidence.confidenceScore1To5).toBeLessThanOrEqual(5);
+    // C_final = C_ground * (1 - 0.4 * 0.15) = C_ground * 0.94
+    expect(confidence.confidenceScore0To1).toBeCloseTo(
+      confidence.cGround * (1 - 0.4 * 0.15),
+      3,
+    );
+  });
+
+  it('PlaybookAgentService: full pipeline — LLM verdict is used (no hard rule)', async () => {
+    const artifacts: PlaybookArtifact[] = [];
+
+    const service = new PlaybookAgentService({
+      llmAdapter: {
+        async complete() {
+          return {
+            content: JSON.stringify({
+              verdict: 'ATO_SUSPECTED',
+              rationale: 'Suspicious login pattern from multiple countries.',
+              confidence_score: 3,
+              u_llm: 0.3,
+              queries_executed: ['login_patterns'],
+              supporting_evidence: ['multi_country_logins'],
+              contradicting_evidence: ['known_vpn_usage'],
+              critical_evidence_missing: false,
+              has_contradictory_signals: true,
+            }),
+          };
+        },
+      } satisfies ILLMAdapter,
+      evidenceStore: {
+        async executeQuery() {
+          return {
+            success: true,
+            data: [
+              { login_date: '2026-05-20', login_count: 5, failed_logins: 2, distinct_countries: 3 },
+            ],
+          };
+        },
+      } satisfies IEvidenceStore,
+      artifactStore: {
+        async store(artifact) { artifacts.push(artifact); },
+        async getBySessionId(sid) { return artifacts.filter((a) => a.sessionId === sid); },
+      } satisfies IArtifactStore,
+      playbooks: new Map([[playbook.useCaseId, playbook]]),
+      queuePlaybookMapping: new Map([['ato-review-queue', playbook.useCaseId]]),
+    });
+
+    const result = await service.runForJob({
+      orgId: 'org-1',
+      queueId: 'ato-review-queue',
+      itemId: 'user_abc',
+      itemTypeId: 'user',
+      itemData: { account_id: 'acc_12345', lookback_days: 30 },
+    });
+
+    // LLM verdict is used (no hard rule override)
+    expect(result).toBeDefined();
+    expect(result!.verdict.verdict).toBe('ATO_SUSPECTED');
+    expect(result!.hardRuleTriggered).toBeUndefined();
+    expect(result!.verdict.hasContradictorySignals).toBe(true);
+
+    // Confidence is penalized for contradictory signals
+    expect(result!.confidence.signalAgreement).toBeLessThan(1.0);
+
+    // Artifacts stored
+    expect(artifacts).toHaveLength(2);
+    expect(artifacts.map((a) => a.artifactType).sort()).toEqual(['confidence', 'verdict']);
+  });
+});
+
+// ── Scenario 2: CSAM Triage (hard rule overrides LLM) ──────────────────────
+
+describe('Scenario: CSAM Triage — hard rule overrides LLM', () => {
+  let playbook: Playbook;
+
+  beforeAll(() => {
+    playbook = parsePlaybook(
+      readExample('dummy_csam_triage.playbook.json'),
+    );
+  });
+
+  it('HardRuleEngine: critical hash match fires deterministic rule', () => {
+    const queryResults = {
+      hash_match_history: {
+        success: true,
+        data: [{ severity_tier: 'CRITICAL', total_matches: 1 }],
+      },
+    };
+
+    const match = evaluateHardRules(playbook.decisionLogic.hardRules, queryResults);
+    expect(match).toBeDefined();
+    expect(match!.ruleId).toBe('known_critical_hash');
+    expect(match!.outcome).toBe('REPORT_AND_REMOVE');
+    expect(match!.bypassLlm).toBe(true);
+  });
+
+  it('PlaybookAgentService: hard rule overrides LLM even when LLM says NO_ACTION', async () => {
+    const service = new PlaybookAgentService({
+      llmAdapter: {
+        async complete() {
+          return {
+            content: JSON.stringify({
+              verdict: 'NO_ACTION',
+              rationale: 'LLM incorrectly says no action needed.',
+              confidence_score: 5,
+              u_llm: 0.01,
+              queries_executed: ['hash_match_history'],
+              supporting_evidence: [],
+              contradicting_evidence: [],
+              critical_evidence_missing: false,
+              has_contradictory_signals: false,
+            }),
+          };
+        },
+      } satisfies ILLMAdapter,
+      evidenceStore: {
+        async executeQuery() {
+          return {
+            success: true,
+            data: [{ severity_tier: 'CRITICAL', total_matches: 1 }],
+          };
+        },
+      } satisfies IEvidenceStore,
+      artifactStore: {
+        async store() {},
+        async getBySessionId() { return []; },
+      } satisfies IArtifactStore,
+      playbooks: new Map([[playbook.useCaseId, playbook]]),
+      queuePlaybookMapping: new Map([['csam-queue', playbook.useCaseId]]),
+    });
+
+    const result = await service.runForJob({
+      orgId: 'org-1',
+      queueId: 'csam-queue',
+      itemId: 'item-999',
+      itemTypeId: 'content',
+      itemData: {},
+    });
+
+    // Hard rule overrides the LLM's NO_ACTION
+    expect(result!.verdict.verdict).toBe('REPORT_AND_REMOVE');
+    expect(result!.hardRuleTriggered).toBe('known_critical_hash');
+    // LLM rationale is preserved even though verdict was overridden
+    expect(result!.verdict.rationale).toContain('no action');
+  });
+});

--- a/server/services/playbookAgentService/confidenceEngine.test.ts
+++ b/server/services/playbookAgentService/confidenceEngine.test.ts
@@ -1,0 +1,182 @@
+import { computeConfidence } from './confidenceEngine.js';
+import type {
+  ConfidenceComputation,
+  Playbook,
+  PlaybookVerdict,
+  QueryResults,
+} from './playbookTypes.js';
+
+function makePlaybook(
+  overrides: Partial<ConfidenceComputation> = {},
+): Playbook {
+  return {
+    useCaseId: 'test_use_case',
+    version: { major: 1, minor: 0, patch: 0 },
+    displayName: 'Test',
+    description: 'Test playbook',
+    inputContext: [],
+    evidenceOntology: {
+      version: { major: 1, minor: 0, patch: 0 },
+      evidenceTypes: [],
+    },
+    baselineCatalogRefs: [
+      { catalogId: 'query_a', version: { major: 1, minor: 0, patch: 0 }, catalogType: 'query' },
+      { catalogId: 'query_b', version: { major: 1, minor: 0, patch: 0 }, catalogType: 'query' },
+    ],
+    allowedCatalogRefs: [
+      { catalogId: 'query_a', version: { major: 1, minor: 0, patch: 0 }, catalogType: 'query' },
+      { catalogId: 'query_b', version: { major: 1, minor: 0, patch: 0 }, catalogType: 'query' },
+      { catalogId: 'query_c', version: { major: 1, minor: 0, patch: 0 }, catalogType: 'query' },
+    ],
+    evidenceRequestPolicy: {
+      querySelectionMode: 'query_id',
+      maxRounds: 3,
+      targetConfidence: 0.75,
+      maxAdditionalQueries: 5,
+      stopIfNoNewEvidence: true,
+    },
+    labels: [],
+    decisionLogic: { hardRules: [], scoringGuidance: [], defaultLabel: 'SAFE' },
+    confidenceComputation: {
+      evidenceCompletenessWeight: 0.35,
+      signalStrengthWeight: 0.25,
+      signalAgreementWeight: 0.25,
+      dataQualityWeight: 0.15,
+      llmUncertaintyAlpha: 0.4,
+      baseCoverageWeight: 0.7,
+      additionalCoverageWeight: 0.3,
+      criticalEvidenceMissingPenalty: 0.3,
+      additionalQueryBonusMax: 0.2,
+      ...overrides,
+    },
+    outputContract: {
+      version: { major: 1, minor: 0, patch: 0 },
+      requiredFields: ['verdict', 'rationale', 'confidence_score'],
+    },
+  };
+}
+
+function makeVerdict(overrides: Partial<PlaybookVerdict> = {}): PlaybookVerdict {
+  return {
+    verdict: 'RISKY',
+    rationale: 'Test rationale',
+    confidenceScore: 4,
+    uLlm: 0.1,
+    queriesExecuted: ['query_a', 'query_b'],
+    supportingEvidence: ['evidence_1', 'evidence_2'],
+    contradictingEvidence: [],
+    criticalEvidenceMissing: false,
+    hasContradictorySignals: false,
+    ...overrides,
+  };
+}
+
+function makeQueryResults(
+  results: Record<string, { success: boolean; data: Record<string, unknown>[] }>,
+): QueryResults {
+  return { results };
+}
+
+describe('confidenceEngine', () => {
+  it('computes high confidence when all evidence is present and agrees', () => {
+    const playbook = makePlaybook();
+    const verdict = makeVerdict({ uLlm: 0.05, queriesExecuted: ['query_a', 'query_b', 'query_c'] });
+    const queryResults = makeQueryResults({
+      query_a: { success: true, data: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }] },
+      query_b: { success: true, data: [{ id: 6 }, { id: 7 }, { id: 8 }, { id: 9 }, { id: 10 }] },
+      query_c: { success: true, data: [{ id: 11 }] },
+    });
+
+    const result = computeConfidence(verdict, queryResults, playbook);
+
+    expect(result.confidenceScore0To1).toBeGreaterThan(0.9);
+    expect(result.confidenceScore1To5).toBe(5);
+    expect(result.cGround).toBeGreaterThan(0.9);
+    expect(result.baseCoverage).toBe(1.0);
+  });
+
+  it('reduces confidence when critical evidence is missing', () => {
+    const playbook = makePlaybook();
+    const verdict = makeVerdict({ criticalEvidenceMissing: true });
+    const queryResults = makeQueryResults({
+      query_a: { success: true, data: [{ id: 1 }] },
+      query_b: { success: true, data: [] },
+    });
+
+    const result = computeConfidence(verdict, queryResults, playbook);
+
+    expect(result.confidenceScore0To1).toBeLessThan(0.8);
+    expect(result.evidenceCompleteness).toBeLessThan(0.7);
+  });
+
+  it('penalizes contradictory signals', () => {
+    const playbook = makePlaybook();
+
+    const noContradiction = makeVerdict({
+      supportingEvidence: ['a', 'b', 'c'],
+      contradictingEvidence: [],
+      hasContradictorySignals: false,
+    });
+    const withContradiction = makeVerdict({
+      supportingEvidence: ['a', 'b'],
+      contradictingEvidence: ['c'],
+      hasContradictorySignals: true,
+    });
+
+    const qr = makeQueryResults({
+      query_a: { success: true, data: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }] },
+      query_b: { success: true, data: [{ id: 6 }, { id: 7 }, { id: 8 }, { id: 9 }, { id: 10 }] },
+    });
+
+    const resultClean = computeConfidence(noContradiction, qr, playbook);
+    const resultDirty = computeConfidence(withContradiction, qr, playbook);
+
+    expect(resultDirty.signalAgreement).toBeLessThan(resultClean.signalAgreement);
+    expect(resultDirty.confidenceScore0To1).toBeLessThan(resultClean.confidenceScore0To1);
+  });
+
+  it('LLM uncertainty can only reduce confidence', () => {
+    const playbook = makePlaybook();
+    const qr = makeQueryResults({
+      query_a: { success: true, data: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }] },
+      query_b: { success: true, data: [{ id: 6 }, { id: 7 }, { id: 8 }, { id: 9 }, { id: 10 }] },
+    });
+
+    const lowUncertainty = computeConfidence(makeVerdict({ uLlm: 0.05 }), qr, playbook);
+    const highUncertainty = computeConfidence(makeVerdict({ uLlm: 0.9 }), qr, playbook);
+
+    // Same C_ground, different u_llm → higher uncertainty = lower C_final
+    expect(lowUncertainty.cGround).toBeCloseTo(highUncertainty.cGround, 2);
+    expect(highUncertainty.confidenceScore0To1).toBeLessThan(lowUncertainty.confidenceScore0To1);
+  });
+
+  it('handles query failures gracefully', () => {
+    const playbook = makePlaybook();
+    const verdict = makeVerdict({ queriesExecuted: ['query_a'] });
+    const queryResults = makeQueryResults({
+      query_a: { success: true, data: [{ id: 1 }] },
+      query_b: { success: false, data: [] },
+    });
+
+    const result = computeConfidence(verdict, queryResults, playbook);
+
+    expect(result.dataQuality).toBeLessThan(1.0);
+    expect(result.confidenceScore0To1).toBeGreaterThan(0);
+    expect(result.confidenceScore0To1).toBeLessThan(1);
+  });
+
+  it('produces valid 1–5 bucket scores', () => {
+    const playbook = makePlaybook();
+    const qr = makeQueryResults({
+      query_a: { success: true, data: [{ id: 1 }] },
+      query_b: { success: true, data: [{ id: 2 }] },
+    });
+
+    for (const uLlm of [0.0, 0.25, 0.5, 0.75, 1.0]) {
+      const result = computeConfidence(makeVerdict({ uLlm }), qr, playbook);
+      expect(result.confidenceScore1To5).toBeGreaterThanOrEqual(1);
+      expect(result.confidenceScore1To5).toBeLessThanOrEqual(5);
+      expect(Number.isInteger(result.confidenceScore1To5)).toBe(true);
+    }
+  });
+});

--- a/server/services/playbookAgentService/confidenceEngine.ts
+++ b/server/services/playbookAgentService/confidenceEngine.ts
@@ -1,0 +1,198 @@
+/**
+ * Confidence Engine — Grounded confidence scoring.
+ *
+ * Implements the playbook-driven confidence formula:
+ *   C_final = C_ground * (1 - alpha * u_llm)
+ *
+ * Where:
+ *   C_ground: Computed from objective, query-backed factors
+ *     1. Evidence completeness (required evidence present vs missing)
+ *     2. Signal strength (data volume and investigation depth)
+ *     3. Signal agreement (supporting vs contradicting evidence)
+ *     4. Data quality (query success rate and result quality)
+ *
+ *   u_llm: LLM's self-reported uncertainty (0–1)
+ *   alpha: Playbook-configured uncertainty weight
+ *
+ * The LLM can only REDUCE confidence — it can never inflate it.
+ *
+ * @license Apache-2.0
+ */
+
+import type {
+  ConfidenceBreakdown,
+  Playbook,
+  PlaybookVerdict,
+  QueryResults,
+} from './playbookTypes.js';
+
+/**
+ * Compute grounded confidence score from objective evidence factors.
+ *
+ * Takes the LLM's u_llm, computes C_ground from query results,
+ * and applies the playbook formula: C_final = C_ground * (1 - alpha * u_llm)
+ */
+export function computeConfidence(
+  verdict: PlaybookVerdict,
+  queryResults: QueryResults,
+  playbook: Playbook,
+): ConfidenceBreakdown {
+  const cc = playbook.confidenceComputation;
+  const alpha = cc.llmUncertaintyAlpha;
+  const uLlm = verdict.uLlm;
+
+  // Identify baseline vs additional query IDs
+  const baselineQueryIds = new Set(
+    playbook.baselineCatalogRefs.map((ref) => ref.catalogId),
+  );
+  const allowedQueryIds = new Set(
+    playbook.allowedCatalogRefs.map((ref) => ref.catalogId),
+  );
+  const additionalQueryIds = new Set(
+    [...allowedQueryIds].filter((id) => !baselineQueryIds.has(id)),
+  );
+
+  const queriesExecuted = new Set(verdict.queriesExecuted);
+  const additionalQueriesExecuted = new Set(
+    [...queriesExecuted].filter((id) => additionalQueryIds.has(id)),
+  );
+
+  // ── 1. Evidence completeness ──────────────────────────────────────────
+  const baseQueriesTotal = baselineQueryIds.size;
+  let baseQueriesWithData = 0;
+  for (const [queryId, result] of Object.entries(queryResults.results)) {
+    if (
+      baselineQueryIds.has(queryId) &&
+      result.success &&
+      result.data.length > 0
+    ) {
+      baseQueriesWithData++;
+    }
+  }
+  const baseCoverage =
+    baseQueriesTotal > 0 ? baseQueriesWithData / baseQueriesTotal : 0.0;
+
+  const additionalQueriesTotal = additionalQueryIds.size;
+  const additionalCoverage =
+    additionalQueriesTotal > 0
+      ? additionalQueriesExecuted.size / additionalQueriesTotal
+      : 0.0;
+
+  // Weighted average using playbook config
+  let baseWeight = cc.baseCoverageWeight;
+  let additionalWeight = cc.additionalCoverageWeight;
+  const totalWeight = baseWeight + additionalWeight;
+  if (totalWeight > 0) {
+    baseWeight = baseWeight / totalWeight;
+    additionalWeight = additionalWeight / totalWeight;
+  } else {
+    baseWeight = 0.7;
+    additionalWeight = 0.3;
+  }
+
+  let evidenceCompleteness =
+    baseWeight * baseCoverage + additionalWeight * additionalCoverage;
+
+  // Penalty for missing critical evidence
+  if (verdict.criticalEvidenceMissing) {
+    evidenceCompleteness *= 1.0 - cc.criticalEvidenceMissingPenalty;
+  }
+
+  // ── 2. Signal strength ────────────────────────────────────────────────
+  let totalRows = 0;
+  for (const result of Object.values(queryResults.results)) {
+    if (result.success) {
+      totalRows += result.data.length;
+    }
+  }
+  let signalStrength = Math.min(1.0, totalRows / 10.0);
+
+  // Bonus for additional queries indicating deeper investigation
+  if (additionalQueriesTotal > 0) {
+    const bonus = Math.min(
+      cc.additionalQueryBonusMax,
+      (additionalQueriesExecuted.size / additionalQueriesTotal) *
+        cc.additionalQueryBonusMax,
+    );
+    signalStrength = Math.min(1.0, signalStrength + bonus);
+  }
+
+  // ── 3. Signal agreement ───────────────────────────────────────────────
+  const supportingCount = verdict.supportingEvidence.length;
+  const contradictingCount = verdict.contradictingEvidence.length;
+  const totalEvidence = supportingCount + contradictingCount;
+
+  let signalAgreement =
+    totalEvidence > 0 ? supportingCount / totalEvidence : 0.5;
+
+  if (verdict.hasContradictorySignals) {
+    signalAgreement *= 0.5;
+  }
+
+  // ── 4. Data quality ───────────────────────────────────────────────────
+  let baseQueriesSuccessful = 0;
+  for (const [queryId, result] of Object.entries(queryResults.results)) {
+    if (baselineQueryIds.has(queryId) && result.success) {
+      baseQueriesSuccessful++;
+    }
+  }
+  const failedQueries = baseQueriesTotal - baseQueriesSuccessful;
+  let dataQuality = Math.max(0.0, 1.0 - failedQueries * 0.2);
+
+  // Penalty for empty results
+  let emptyResults = 0;
+  for (const result of Object.values(queryResults.results)) {
+    if (result.success && result.data.length === 0) {
+      emptyResults++;
+    }
+  }
+  if (emptyResults > 0 && baseQueriesTotal > 0) {
+    const emptyPenalty = Math.min(
+      0.3,
+      (emptyResults / baseQueriesTotal) * 0.3,
+    );
+    dataQuality *= 1.0 - emptyPenalty;
+  }
+
+  // Penalty for edge cases
+  if (verdict.isEdgeCase) {
+    dataQuality *= 0.8;
+  }
+
+  // ── Compute C_ground ──────────────────────────────────────────────────
+  let cGround =
+    cc.evidenceCompletenessWeight * evidenceCompleteness +
+    cc.signalStrengthWeight * signalStrength +
+    cc.signalAgreementWeight * signalAgreement +
+    cc.dataQualityWeight * dataQuality;
+  cGround = clamp(cGround, 0.0, 1.0);
+
+  // ── Apply formula: C_final = C_ground * (1 - alpha * u_llm) ──────────
+  let cFinal = cGround * (1.0 - alpha * uLlm);
+  cFinal = clamp(cFinal, 0.0, 1.0);
+
+  // Bucket into 1–5 scale
+  const cFinal1To5 = 1 + Math.min(4, Math.floor(cFinal * 5));
+
+  return {
+    confidenceScore0To1: round4(cFinal),
+    confidenceScore1To5: cFinal1To5,
+    cGround: round4(cGround),
+    uLlm: round4(uLlm),
+    alpha,
+    evidenceCompleteness: round4(evidenceCompleteness),
+    signalStrength: round4(signalStrength),
+    signalAgreement: round4(signalAgreement),
+    dataQuality: round4(dataQuality),
+    baseCoverage: round4(baseCoverage),
+    additionalCoverage: round4(additionalCoverage),
+  };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function round4(value: number): number {
+  return Math.round(value * 10000) / 10000;
+}

--- a/server/services/playbookAgentService/confidenceEngine.ts
+++ b/server/services/playbookAgentService/confidenceEngine.ts
@@ -38,8 +38,8 @@ export function computeConfidence(
   playbook: Playbook,
 ): ConfidenceBreakdown {
   const cc = playbook.confidenceComputation;
-  const alpha = cc.llmUncertaintyAlpha;
-  const uLlm = verdict.uLlm;
+  const alpha = clamp(Number.isFinite(cc.llmUncertaintyAlpha) ? cc.llmUncertaintyAlpha : 0.4, 0, 1);
+  const uLlm = clamp(Number.isFinite(verdict.uLlm) ? verdict.uLlm : 0.5, 0, 1);
 
   // Identify baseline vs additional query IDs
   const baselineQueryIds = new Set(

--- a/server/services/playbookAgentService/examples.test.ts
+++ b/server/services/playbookAgentService/examples.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { tryJsonParse } from '../../utils/encoding.js';
+import { parsePlaybook } from './playbookLoader.js';
+
+const examplesDir = join(dirname(fileURLToPath(import.meta.url)), 'examples');
+
+function readExampleJson(filename: string): Record<string, unknown> {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  const raw = readFileSync(join(examplesDir, filename), 'utf-8');
+  const parsed = tryJsonParse(raw);
+  if (typeof parsed !== 'object' || parsed == null || Array.isArray(parsed)) {
+    throw new Error(`Example '${filename}' must contain a JSON object`);
+  }
+  return parsed;
+}
+
+describe('playbook examples', () => {
+  it('keeps the dummy playbook sample parseable', () => {
+    const playbook = parsePlaybook(
+      readExampleJson('dummy_csam_triage.playbook.json'),
+    );
+
+    expect(playbook.useCaseId).toBe('dummy_csam_triage');
+    expect(playbook.baselineCatalogRefs).toHaveLength(1);
+    expect(playbook.baselineCatalogRefs[0]?.catalogId).toBe(
+      'hash_match_history',
+    );
+    expect(playbook.decisionLogic.hardRules[0]?.ruleId).toBe(
+      'known_critical_hash',
+    );
+  });
+
+  it('keeps the dummy evidence and result samples aligned', () => {
+    const evidence = readExampleJson('dummy_csam_triage.evidence.json');
+    const result = readExampleJson('dummy_csam_triage.result.json');
+
+    expect(result['hardRuleTriggered']).toBe('known_critical_hash');
+    expect(result['queriesExecuted']).toEqual(['hash_match_history']);
+    expect(result['artifactTypesStored']).toEqual(['verdict', 'confidence']);
+
+    const query = evidence['query'];
+    const verdict = result['verdict'];
+    expect(query).toMatchObject({
+      catalog_id: 'hash_match_history',
+      version: '1.0.0',
+    });
+    expect(verdict).toMatchObject({
+      verdict: 'REPORT_AND_REMOVE',
+    });
+  });
+});

--- a/server/services/playbookAgentService/examples/README.md
+++ b/server/services/playbookAgentService/examples/README.md
@@ -1,0 +1,55 @@
+# Dummy CSAM Triage Example
+
+This directory defines a concrete sample for the Playbook Agent backend. It is
+not wired into the product UI yet; it documents the contract that a future MRT
+or Investigation UI can render.
+
+## Files
+
+- `dummy_csam_triage.playbook.json`: authored playbook config in the same
+  snake_case shape a YAML playbook would use.
+- `dummy_csam_triage.evidence.json`: sample pre-approved evidence query request
+  and result.
+- `dummy_csam_triage.result.json`: representative backend result after the
+  playbook runner applies hard rules and confidence scoring.
+
+## Backend Flow
+
+1. Queue `dummy-queue` maps to playbook `dummy_csam_triage`.
+2. The runner executes baseline catalog query `hash_match_history@1.0.0`.
+3. Evidence returns `severity_tier: CRITICAL`.
+4. Hard rule `known_critical_hash` locks the verdict to
+   `REPORT_AND_REMOVE`.
+5. The LLM can still provide rationale, but it cannot override the hard-rule
+   verdict.
+6. The confidence engine returns a grounded score and stores `verdict` and
+   `confidence` artifacts.
+
+## UI Target
+
+A future UI panel should be able to render the expected result like this:
+
+```text
+Playbook Investigation
+
+Verdict      REPORT_AND_REMOVE
+Confidence   4/5 (0.713)
+Hard rule    known_critical_hash
+
+Evidence
+- hash_match_history@1.0.0
+  - severity_tier: CRITICAL
+  - total_matches: 1
+
+Rationale
+The model tried to choose NO_ACTION, but the hard rule should override this
+verdict.
+
+Audit artifacts
+- verdict
+- confidence
+```
+
+The important behavior is that the deterministic hard rule wins over the LLM
+verdict while still preserving the LLM rationale and grounded confidence
+breakdown for review.

--- a/server/services/playbookAgentService/examples/account_takeover_triage.catalog.sql
+++ b/server/services/playbookAgentService/examples/account_takeover_triage.catalog.sql
@@ -1,0 +1,16 @@
+-- catalog_id: login_patterns
+-- version: 1.0.0
+-- description: Login frequency and geographic anomaly analysis
+
+SELECT
+    DATE(login_timestamp) AS login_date,
+    COUNT(*) AS login_count,
+    SUM(CASE WHEN success = false THEN 1 ELSE 0 END) AS failed_logins,
+    COUNT(DISTINCT ip_address) AS distinct_ips,
+    COUNT(DISTINCT country_code) AS distinct_countries
+FROM account_logins
+WHERE account_id = :account_id
+  AND login_timestamp >= DATEADD(day, -:lookback_days, CURRENT_TIMESTAMP)
+GROUP BY DATE(login_timestamp)
+ORDER BY login_date DESC
+LIMIT 30;

--- a/server/services/playbookAgentService/examples/account_takeover_triage.playbook.json
+++ b/server/services/playbookAgentService/examples/account_takeover_triage.playbook.json
@@ -1,0 +1,131 @@
+{
+  "use_case_id": "account_takeover_triage",
+  "version": "1.0.0",
+  "display_name": "Account Takeover Triage",
+  "description": "Investigate suspicious login patterns to determine if an account has been compromised. No hard rules — the LLM decides the verdict based on evidence.",
+  "input_context": [
+    {
+      "field_name": "account_id",
+      "field_type": "string",
+      "required": true,
+      "description": "Account under investigation."
+    },
+    {
+      "field_name": "lookback_days",
+      "field_type": "integer",
+      "required": false,
+      "description": "How far back to look.",
+      "default": 30
+    }
+  ],
+  "evidence_ontology": {
+    "version": "1.0.0",
+    "evidence_types": [
+      {
+        "evidence_id": "login_pattern_changes",
+        "display_name": "Login Pattern Analysis",
+        "description": "Login frequency, failure rate, and geographic anomalies.",
+        "quality": {
+          "minimum_confidence": 0.7,
+          "minimum_num_required_sources": 1
+        }
+      },
+      {
+        "evidence_id": "device_fingerprints",
+        "display_name": "Device Fingerprints",
+        "description": "New or unrecognized devices used for login.",
+        "quality": {
+          "minimum_confidence": 0.5,
+          "minimum_num_required_sources": 1
+        }
+      }
+    ]
+  },
+  "baseline_catalog_refs": [
+    {
+      "catalog_id": "login_patterns",
+      "version": "1.0.0",
+      "catalog_type": "query"
+    }
+  ],
+  "allowed_catalog_refs": [
+    {
+      "catalog_id": "login_patterns",
+      "version": "1.0.0",
+      "catalog_type": "query"
+    },
+    {
+      "catalog_id": "device_fingerprints",
+      "version": "1.0.0",
+      "catalog_type": "query"
+    }
+  ],
+  "evidence_request_policy": {
+    "query_selection_mode": "query_id",
+    "max_rounds": 2,
+    "target_confidence": 0.75,
+    "max_additional_queries": 1,
+    "stop_if_no_new_evidence": true,
+    "trigger_deep_dive_if": "Failed login rate > 50% or logins from 3+ countries in 24h",
+    "guidance": "Look for geographic impossibility, sudden device changes, and credential stuffing patterns."
+  },
+  "labels": [
+    {
+      "label_id": "ATO_CONFIRMED",
+      "display_name": "ATO Confirmed",
+      "description": "Strong evidence of account takeover.",
+      "severity": "CRITICAL"
+    },
+    {
+      "label_id": "ATO_SUSPECTED",
+      "display_name": "ATO Suspected",
+      "description": "Suspicious patterns but not conclusive.",
+      "severity": "HIGH"
+    },
+    {
+      "label_id": "LEGITIMATE",
+      "display_name": "Legitimate Activity",
+      "description": "Login patterns are consistent with account owner.",
+      "severity": "INFO"
+    }
+  ],
+  "decision_logic": {
+    "hard_rules": [],
+    "scoring_guidance": [
+      {
+        "guidance_id": "geo_impossible",
+        "description": "Logins from 2+ countries within 1 hour with >5000km distance is strong ATO signal."
+      },
+      {
+        "guidance_id": "credential_stuffing",
+        "description": "10+ failed logins followed by a success from a new device suggests credential stuffing."
+      }
+    ],
+    "default_label": "LEGITIMATE"
+  },
+  "confidence_computation": {
+    "evidence_completeness_weight": 0.35,
+    "signal_strength_weight": 0.25,
+    "signal_agreement_weight": 0.25,
+    "data_quality_weight": 0.15,
+    "llm_uncertainty_alpha": 0.4,
+    "base_coverage_weight": 0.7,
+    "additional_coverage_weight": 0.3,
+    "critical_evidence_missing_penalty": 0.3,
+    "additional_query_bonus_max": 0.2
+  },
+  "output_contract": {
+    "version": "1.0.0",
+    "required_fields": [
+      "verdict",
+      "rationale",
+      "confidence_score",
+      "u_llm",
+      "queries_executed",
+      "supporting_evidence",
+      "contradicting_evidence",
+      "critical_evidence_missing",
+      "has_contradictory_signals"
+    ]
+  }
+}

--- a/server/services/playbookAgentService/examples/dummy_csam_triage.evidence.json
+++ b/server/services/playbookAgentService/examples/dummy_csam_triage.evidence.json
@@ -1,0 +1,22 @@
+{
+  "query": {
+    "catalog_id": "hash_match_history",
+    "version": "1.0.0",
+    "parameters": {
+      "org_id": "org-1",
+      "item_id": "dummy-item-123",
+      "item_type_id": "content-type"
+    }
+  },
+  "result": {
+    "success": true,
+    "data": [
+      {
+        "item_id": "dummy-item-123",
+        "severity_tier": "CRITICAL",
+        "total_matches": 1,
+        "matched_bank": "known-critical-hash-bank"
+      }
+    ]
+  }
+}

--- a/server/services/playbookAgentService/examples/dummy_csam_triage.playbook.json
+++ b/server/services/playbookAgentService/examples/dummy_csam_triage.playbook.json
@@ -1,0 +1,144 @@
+{
+  "use_case_id": "dummy_csam_triage",
+  "version": "1.0.0",
+  "display_name": "Dummy CSAM Triage",
+  "description": "Example playbook showing deterministic escalation for a known critical hash match.",
+  "input_context": [
+    {
+      "field_name": "org_id",
+      "field_type": "string",
+      "required": true,
+      "description": "Organization id for the job."
+    },
+    {
+      "field_name": "item_id",
+      "field_type": "string",
+      "required": true,
+      "description": "Submitted item id."
+    },
+    {
+      "field_name": "item_type_id",
+      "field_type": "string",
+      "required": true,
+      "description": "Submitted item type id."
+    }
+  ],
+  "evidence_ontology": {
+    "version": "1.0.0",
+    "evidence_types": [
+      {
+        "evidence_id": "hash_match",
+        "display_name": "Hash Match",
+        "description": "Known media hash match evidence.",
+        "quality": {
+          "minimum_confidence": 1,
+          "minimum_num_required_sources": 1
+        }
+      }
+    ]
+  },
+  "baseline_catalog_refs": [
+    {
+      "catalog_id": "hash_match_history",
+      "version": "1.0.0",
+      "catalog_type": "query"
+    }
+  ],
+  "allowed_catalog_refs": [
+    {
+      "catalog_id": "hash_match_history",
+      "version": "1.0.0",
+      "catalog_type": "query"
+    }
+  ],
+  "evidence_request_policy": {
+    "query_selection_mode": "query_id",
+    "max_rounds": 1,
+    "target_confidence": 0.8,
+    "max_additional_queries": 0,
+    "stop_if_no_new_evidence": true,
+    "guidance": "Use only the supplied catalog evidence."
+  },
+  "labels": [
+    {
+      "label_id": "NO_ACTION",
+      "display_name": "No Action",
+      "description": "No enforcement needed.",
+      "severity": "INFO"
+    },
+    {
+      "label_id": "ESCALATE_FOR_REVIEW",
+      "display_name": "Escalate for Review",
+      "description": "Needs human review before enforcement.",
+      "severity": "HIGH"
+    },
+    {
+      "label_id": "REPORT_AND_REMOVE",
+      "display_name": "Report and Remove",
+      "description": "Known critical hash match requires reporting and removal.",
+      "severity": "CRITICAL"
+    }
+  ],
+  "decision_logic": {
+    "hard_rules": [
+      {
+        "rule_id": "known_critical_hash",
+        "description": "Critical hash matches are deterministic.",
+        "condition": "hash_match_history.severity_tier == 'CRITICAL'",
+        "outcome": "REPORT_AND_REMOVE",
+        "bypass_llm": true
+      }
+    ],
+    "scoring_guidance": [
+      {
+        "guidance_id": "known_hash",
+        "description": "Treat verified critical hash matches as conclusive."
+      }
+    ],
+    "default_label": "NO_ACTION"
+  },
+  "confidence_computation": {
+    "evidence_completeness_weight": 0.35,
+    "signal_strength_weight": 0.25,
+    "signal_agreement_weight": 0.25,
+    "data_quality_weight": 0.15,
+    "llm_uncertainty_alpha": 0.4,
+    "base_coverage_weight": 1,
+    "additional_coverage_weight": 0,
+    "critical_evidence_missing_penalty": 0.3,
+    "additional_query_bonus_max": 0
+  },
+  "phase_budget": {
+    "max_queries": 1,
+    "max_llm_calls": 1,
+    "max_duration_ms": 30000
+  },
+  "output_contract": {
+    "version": "1.0.0",
+    "required_fields": [
+      "verdict",
+      "rationale",
+      "confidence_score",
+      "u_llm",
+      "queries_executed",
+      "supporting_evidence",
+      "contradicting_evidence",
+      "critical_evidence_missing",
+      "has_contradictory_signals"
+    ],
+    "schema": {
+      "type": "object",
+      "required": [
+        "verdict",
+        "rationale",
+        "confidence_score",
+        "u_llm",
+        "queries_executed",
+        "supporting_evidence",
+        "contradicting_evidence",
+        "critical_evidence_missing",
+        "has_contradictory_signals"
+      ]
+    }
+  }
+}

--- a/server/services/playbookAgentService/examples/dummy_csam_triage.result.json
+++ b/server/services/playbookAgentService/examples/dummy_csam_triage.result.json
@@ -1,0 +1,52 @@
+{
+  "playbookId": "dummy_csam_triage",
+  "playbookVersion": "1.0.0",
+  "verdict": {
+    "verdict": "REPORT_AND_REMOVE",
+    "rationale": "The model tried to choose NO_ACTION, but the hard rule should override this verdict.",
+    "confidenceScore": 2,
+    "uLlm": 0.2,
+    "queriesExecuted": [
+      "hash_match_history"
+    ],
+    "supportingEvidence": [
+      "hash_match_history.severity_tier=CRITICAL"
+    ],
+    "contradictingEvidence": [],
+    "criticalEvidenceMissing": false,
+    "hasContradictorySignals": false
+  },
+  "confidence": {
+    "confidenceScore0To1": 0.713,
+    "confidenceScore1To5": 4,
+    "cGround": 0.775,
+    "uLlm": 0.2,
+    "alpha": 0.4,
+    "evidenceCompleteness": 1,
+    "signalStrength": 0.1,
+    "signalAgreement": 1,
+    "dataQuality": 1,
+    "baseCoverage": 1,
+    "additionalCoverage": 0
+  },
+  "hardRuleTriggered": "known_critical_hash",
+  "evidence": [
+    {
+      "item_id": "dummy-item-123",
+      "severity_tier": "CRITICAL",
+      "total_matches": 1,
+      "matched_bank": "known-critical-hash-bank",
+      "_catalogId": "hash_match_history"
+    }
+  ],
+  "queriesExecuted": [
+    "hash_match_history"
+  ],
+  "ranAt": "2026-05-22T00:00:00.000Z",
+  "durationMs": 12,
+  "sessionId": "example-session-id",
+  "artifactTypesStored": [
+    "verdict",
+    "confidence"
+  ]
+}

--- a/server/services/playbookAgentService/hardRuleEngine.test.ts
+++ b/server/services/playbookAgentService/hardRuleEngine.test.ts
@@ -112,7 +112,7 @@ describe('evaluateHardRules', () => {
     expect(match!.ruleId).toBe('not_null_check');
   });
 
-  it('returns empty array for empty rules', () => {
+  it('returns undefined for empty rules', () => {
     const match = evaluateHardRules([], { some_query: makeResult([{ a: 1 }]) });
     expect(match).toBeUndefined();
   });

--- a/server/services/playbookAgentService/hardRuleEngine.test.ts
+++ b/server/services/playbookAgentService/hardRuleEngine.test.ts
@@ -1,0 +1,119 @@
+import { evaluateHardRules } from './hardRuleEngine.js';
+import type { HardRule, QueryResult } from './playbookTypes.js';
+
+function makeResult(
+  data: Record<string, unknown>[],
+  success = true,
+): QueryResult {
+  return { success, data };
+}
+
+describe('evaluateHardRules', () => {
+  const rules: HardRule[] = [
+    {
+      ruleId: 'auto_report_critical',
+      description: 'Auto-report on known CSAM series',
+      condition: "hash_match_history.severity_tier == 'CRITICAL'",
+      outcome: 'REPORT_AND_REMOVE',
+      bypassLlm: true,
+    },
+    {
+      ruleId: 'escalate_high_count',
+      description: 'Escalate when many matches',
+      condition: 'hash_match_history.total_matches >= 5',
+      outcome: 'ESCALATE_FOR_REVIEW',
+      bypassLlm: false,
+    },
+  ];
+
+  it('returns first matching rule', () => {
+    const queryResults = {
+      hash_match_history: makeResult([
+        { severity_tier: 'CRITICAL', total_matches: 10 },
+      ]),
+    };
+
+    const match = evaluateHardRules(rules, queryResults);
+    expect(match).toBeDefined();
+    expect(match!.ruleId).toBe('auto_report_critical');
+    expect(match!.outcome).toBe('REPORT_AND_REMOVE');
+    expect(match!.bypassLlm).toBe(true);
+    expect(match!.matchedValue).toBe('CRITICAL');
+  });
+
+  it('returns second rule when first does not match', () => {
+    const queryResults = {
+      hash_match_history: makeResult([
+        { severity_tier: 'HIGH', total_matches: 7 },
+      ]),
+    };
+
+    const match = evaluateHardRules(rules, queryResults);
+    expect(match).toBeDefined();
+    expect(match!.ruleId).toBe('escalate_high_count');
+    expect(match!.outcome).toBe('ESCALATE_FOR_REVIEW');
+  });
+
+  it('returns undefined when no rules match', () => {
+    const queryResults = {
+      hash_match_history: makeResult([
+        { severity_tier: 'LOW', total_matches: 1 },
+      ]),
+    };
+
+    const match = evaluateHardRules(rules, queryResults);
+    expect(match).toBeUndefined();
+  });
+
+  it('handles missing query results gracefully', () => {
+    const match = evaluateHardRules(rules, {});
+    expect(match).toBeUndefined();
+  });
+
+  it('handles failed queries gracefully', () => {
+    const queryResults = {
+      hash_match_history: makeResult([], false),
+    };
+
+    const match = evaluateHardRules(rules, queryResults);
+    expect(match).toBeUndefined();
+  });
+
+  it('matches across any row in the result set', () => {
+    const queryResults = {
+      hash_match_history: makeResult([
+        { severity_tier: 'LOW', total_matches: 1 },
+        { severity_tier: 'CRITICAL', total_matches: 1 },
+      ]),
+    };
+
+    const match = evaluateHardRules(rules, queryResults);
+    expect(match).toBeDefined();
+    expect(match!.ruleId).toBe('auto_report_critical');
+  });
+
+  it('handles != operator', () => {
+    const notNullRule: HardRule[] = [
+      {
+        ruleId: 'not_null_check',
+        description: 'Check field is not null',
+        condition: "data.status != 'inactive'",
+        outcome: 'FLAG',
+        bypassLlm: false,
+      },
+    ];
+
+    const queryResults = {
+      data: makeResult([{ status: 'active' }]),
+    };
+
+    const match = evaluateHardRules(notNullRule, queryResults);
+    expect(match).toBeDefined();
+    expect(match!.ruleId).toBe('not_null_check');
+  });
+
+  it('returns empty array for empty rules', () => {
+    const match = evaluateHardRules([], { some_query: makeResult([{ a: 1 }]) });
+    expect(match).toBeUndefined();
+  });
+});

--- a/server/services/playbookAgentService/hardRuleEngine.ts
+++ b/server/services/playbookAgentService/hardRuleEngine.ts
@@ -1,0 +1,139 @@
+/**
+ * Hard Rule Engine — Deterministic rules evaluated before the LLM.
+ *
+ * Hard rules provide guardrails for critical cases that must never be left
+ * to probabilistic reasoning. When a hard rule fires, its outcome is locked
+ * and the LLM verdict cannot override it.
+ *
+ * Example: A known CSAM series hash match always results in REPORT_AND_REMOVE,
+ * regardless of what the LLM produces.
+ *
+ * @license Apache-2.0
+ */
+
+import type { HardRule, QueryResult } from './playbookTypes.js';
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export type HardRuleMatch = {
+  readonly ruleId: string;
+  readonly outcome: string;
+  readonly bypassLlm: boolean;
+  readonly matchedCondition: string;
+  readonly matchedValue: unknown;
+};
+
+// ── Expression evaluation ───────────────────────────────────────────────────
+
+/**
+ * Evaluate a hard rule condition against query results.
+ *
+ * Conditions use a simple dot-path expression format:
+ *   "catalog_id.field_name == 'VALUE'"
+ *   "catalog_id.field_name >= 3"
+ *   "catalog_id.field_name != null"
+ *
+ * The left side is a dot-path into the query results (catalog_id.column).
+ * The right side is a literal value (string, number, boolean, null).
+ */
+function evaluateCondition(
+  condition: string,
+  queryResults: Readonly<Record<string, QueryResult | undefined>>,
+): { readonly matched: boolean; readonly matchedValue: unknown } {
+  // Parse condition: "catalog_id.field == 'VALUE'"
+  const match = condition.match(
+    /^(\w+)\.(\w+)\s*(==|!=|>=|<=|>|<)\s*(.+)$/,
+  );
+  if (!match) {
+    return { matched: false, matchedValue: undefined };
+  }
+
+  const [, catalogId, fieldName, operator, rawExpected] = match;
+  const result = queryResults[catalogId];
+
+  if (!result?.success || result.data.length === 0) {
+    return { matched: false, matchedValue: undefined };
+  }
+
+  // Parse the expected value
+  const expected = parseExpectedValue(rawExpected.trim());
+
+  // Check if ANY row in the result matches
+  for (const row of result.data) {
+    const actual = row[fieldName];
+    if (compare(actual, operator, expected)) {
+      return { matched: true, matchedValue: actual };
+    }
+  }
+
+  return { matched: false, matchedValue: undefined };
+}
+
+function parseExpectedValue(raw: string): unknown {
+  // String literal: 'VALUE' or "VALUE"
+  if (
+    (raw.startsWith("'") && raw.endsWith("'")) ||
+    (raw.startsWith('"') && raw.endsWith('"'))
+  ) {
+    return raw.slice(1, -1);
+  }
+  // null
+  if (raw === 'null') return null;
+  // boolean
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  // number
+  const num = Number(raw);
+  if (!Number.isNaN(num)) return num;
+  // fallback to string
+  return raw;
+}
+
+function compare(actual: unknown, operator: string, expected: unknown): boolean {
+  switch (operator) {
+    case '==':
+      return actual === expected;
+    case '!=':
+      return actual !== expected;
+    case '>=':
+      return typeof actual === 'number' && typeof expected === 'number' && actual >= expected;
+    case '<=':
+      return typeof actual === 'number' && typeof expected === 'number' && actual <= expected;
+    case '>':
+      return typeof actual === 'number' && typeof expected === 'number' && actual > expected;
+    case '<':
+      return typeof actual === 'number' && typeof expected === 'number' && actual < expected;
+    default:
+      return false;
+  }
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Evaluate all hard rules against query results.
+ *
+ * Returns the first matching rule (rules are evaluated in order).
+ * If no rule matches, returns undefined and the LLM verdict is used.
+ */
+export function evaluateHardRules(
+  hardRules: readonly HardRule[],
+  queryResults: Readonly<Record<string, QueryResult | undefined>>,
+): HardRuleMatch | undefined {
+  for (const rule of hardRules) {
+    const { matched, matchedValue } = evaluateCondition(
+      rule.condition,
+      queryResults,
+    );
+    if (matched) {
+      return {
+        ruleId: rule.ruleId,
+        outcome: rule.outcome,
+        bypassLlm: rule.bypassLlm,
+        matchedCondition: rule.condition,
+        matchedValue,
+      };
+    }
+  }
+  return undefined;
+}

--- a/server/services/playbookAgentService/index.ts
+++ b/server/services/playbookAgentService/index.ts
@@ -1,0 +1,103 @@
+/**
+ * Playbook Agent Service — AI-powered investigation framework for Coop.
+ *
+ * Open-source components ported from Risk Goose Agent (Block):
+ *   - PlaybookRunner: orchestrates evidence → hard rules → LLM → confidence
+ *   - QueryCatalog: pre-approved SQL templates (agent never writes SQL)
+ *   - ConfidenceEngine: grounded scoring — C_final = C_ground × (1 − α × u_llm)
+ *   - HardRuleEngine: deterministic rules that bypass the LLM
+ *   - JsonExtractor: robust structured output parsing from LLM text
+ *
+ * Abstract interfaces allow any organization to bring their own LLM, database,
+ * and storage backend. The framework handles orchestration, safety constraints,
+ * and audit trail.
+ *
+ * @license Apache-2.0
+ */
+
+// Service
+export {
+  PlaybookAgentService,
+  default as makePlaybookAgentService,
+  type PlaybookAgentServiceDeps,
+  type RunForJobInput,
+} from './playbookAgentService.js';
+
+// Core runner
+export { default as PlaybookRunner } from './playbookRunner.js';
+export type { PlaybookRunnerDeps } from './playbookRunner.js';
+
+// Interfaces (implement these to integrate)
+export type {
+  EvidenceQuery,
+  IArtifactStore,
+  IEvidenceStore,
+  ILLMAdapter,
+  IPlaybookRunner,
+  LLMRequest,
+  LLMResponse,
+  PlaybookArtifact,
+  PlaybookRunInput,
+} from './interfaces.js';
+
+// Query catalog
+export {
+  default as QueryCatalog,
+  parseCatalogEntry,
+  type CatalogEntry,
+  type CatalogEntryMap,
+} from './queryCatalog.js';
+
+// Confidence engine
+export { computeConfidence } from './confidenceEngine.js';
+
+// Hard rule engine
+export {
+  evaluateHardRules,
+  type HardRuleMatch,
+} from './hardRuleEngine.js';
+
+// JSON extractor
+export {
+  extractJsonObjects,
+  extractVerdict,
+  validateAgainstContract,
+} from './jsonExtractor.js';
+
+// Playbook loader
+export { parsePlaybook, type PlaybookValidationError } from './playbookLoader.js';
+
+// Types
+export type {
+  CatalogReference,
+  CatalogType,
+  ConfidenceBreakdown,
+  ConfidenceComputation,
+  DecisionLogic,
+  DeepDiveCondition,
+  DeepDiveModule,
+  EvidenceOntology,
+  EvidenceQuality,
+  EvidenceRequestPolicy,
+  EvidenceType,
+  HardRule,
+  InputContextField,
+  InputFieldType,
+  LabelDefinition,
+  OutputContract,
+  PhaseBudget,
+  Playbook,
+  PlaybookResult,
+  PlaybookVerdict,
+  QueryResult,
+  QueryResults,
+  ScoringGuidance,
+  SemanticVersion,
+} from './playbookTypes.js';
+
+export {
+  formatCatalogReference,
+  formatSemanticVersion,
+  parseSemanticVersion,
+  validateCatalogReference,
+} from './playbookTypes.js';

--- a/server/services/playbookAgentService/interfaces.ts
+++ b/server/services/playbookAgentService/interfaces.ts
@@ -1,0 +1,92 @@
+/**
+ * Abstract interfaces for the Playbook Agent framework.
+ *
+ * Organizations bring their own infrastructure by implementing these interfaces.
+ * The framework handles orchestration, safety constraints, and audit trail.
+ *
+ * @license Apache-2.0
+ */
+
+import type { PlaybookResult, QueryResult } from './playbookTypes.js';
+
+// ── LLM Adapter ─────────────────────────────────────────────────────────────
+
+export type LLMRequest = {
+  readonly systemPrompt: string;
+  readonly userPrompt: string;
+  readonly outputSchema?: Record<string, unknown>;
+  readonly maxTokens?: number;
+  readonly temperature?: number;
+};
+
+export type LLMResponse = {
+  readonly content: string;
+  readonly usage?: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  };
+};
+
+/**
+ * Adapter for LLM providers.
+ *
+ * Implementations may use OpenAI, Anthropic, local models, etc.
+ * The framework never calls the LLM directly — all calls go through this interface.
+ */
+export interface ILLMAdapter {
+  complete(request: LLMRequest): Promise<LLMResponse>;
+}
+
+// ── Evidence Store ──────────────────────────────────────────────────────────
+
+export type EvidenceQuery = {
+  readonly catalogId: string;
+  readonly version: string;
+  readonly parameters: Record<string, unknown>;
+};
+
+/**
+ * Adapter for executing pre-approved evidence queries.
+ *
+ * Implementations execute catalog-referenced queries against the org's database.
+ * The agent never writes SQL — it requests evidence by catalog ID.
+ */
+export interface IEvidenceStore {
+  executeQuery(query: EvidenceQuery): Promise<QueryResult>;
+}
+
+// ── Artifact Store ──────────────────────────────────────────────────────────
+
+export type PlaybookArtifact = {
+  readonly sessionId: string;
+  readonly playbookId: string;
+  readonly artifactType: 'verdict' | 'evidence' | 'query_result' | 'confidence';
+  readonly data: Record<string, unknown>;
+  readonly createdAt: Date;
+};
+
+/**
+ * Adapter for storing investigation artifacts.
+ *
+ * Artifacts are insert-only for compliance — they form an immutable evidence chain
+ * for law enforcement referrals and audit purposes.
+ */
+export interface IArtifactStore {
+  store(artifact: PlaybookArtifact): Promise<void>;
+  getBySessionId(sessionId: string): Promise<readonly PlaybookArtifact[]>;
+}
+
+// ── Playbook Runner Interface ───────────────────────────────────────────────
+
+export type PlaybookRunInput = {
+  readonly playbookId: string;
+  readonly inputContext: Record<string, unknown>;
+  readonly sessionId?: string;
+};
+
+/**
+ * Core runner interface that orchestrates a playbook investigation.
+ */
+export interface IPlaybookRunner {
+  run(input: PlaybookRunInput): Promise<PlaybookResult>;
+}

--- a/server/services/playbookAgentService/jsonExtractor.test.ts
+++ b/server/services/playbookAgentService/jsonExtractor.test.ts
@@ -1,0 +1,129 @@
+import {
+  extractJsonObjects,
+  extractVerdict,
+  validateAgainstContract,
+} from './jsonExtractor.js';
+import type { OutputContract } from './playbookTypes.js';
+
+describe('extractJsonObjects', () => {
+  it('extracts a single JSON object from text', () => {
+    const text = 'Some text before {"verdict": "RISKY", "score": 5} and after';
+    const objects = extractJsonObjects(text);
+    expect(objects).toHaveLength(1);
+    expect(objects[0]).toEqual({ verdict: 'RISKY', score: 5 });
+  });
+
+  it('extracts multiple JSON objects', () => {
+    const text = '{"a": 1} blah {"b": 2}';
+    const objects = extractJsonObjects(text);
+    expect(objects).toHaveLength(2);
+  });
+
+  it('handles nested JSON objects', () => {
+    const text = '{"outer": {"inner": {"deep": true}}, "other": 1}';
+    const objects = extractJsonObjects(text);
+    expect(objects).toHaveLength(1);
+    expect(objects[0]).toEqual({
+      outer: { inner: { deep: true } },
+      other: 1,
+    });
+  });
+
+  it('handles strings containing braces', () => {
+    const text = '{"message": "use { and } in strings", "ok": true}';
+    const objects = extractJsonObjects(text);
+    expect(objects).toHaveLength(1);
+    expect(objects[0]).toEqual({ message: 'use { and } in strings', ok: true });
+  });
+
+  it('skips invalid JSON', () => {
+    const text = '{invalid json} {"valid": true}';
+    const objects = extractJsonObjects(text);
+    expect(objects).toHaveLength(1);
+    expect(objects[0]).toEqual({ valid: true });
+  });
+
+  it('returns empty array for no JSON', () => {
+    const objects = extractJsonObjects('no json here');
+    expect(objects).toHaveLength(0);
+  });
+});
+
+describe('extractVerdict', () => {
+  it('extracts verdict from FINAL_VERDICT wrapper', () => {
+    const text = `Here is my analysis: {"FINAL_VERDICT": {"verdict": "RISKY", "rationale": "Found issues", "confidence_score": 4, "u_llm": 0.1, "queries_executed": ["q1"], "supporting_evidence": ["e1"], "contradicting_evidence": [], "critical_evidence_missing": false, "has_contradictory_signals": false}}`;
+
+    const verdict = extractVerdict(text);
+    expect(verdict).toBeDefined();
+    expect(verdict!.verdict).toBe('RISKY');
+    expect(verdict!.rationale).toBe('Found issues');
+    expect(verdict!.confidenceScore).toBe(4);
+    expect(verdict!.uLlm).toBe(0.1);
+  });
+
+  it('extracts verdict from root-level fields', () => {
+    const text = `{"verdict": "SAFE", "rationale": "All clear", "confidence_score": 5, "u_llm": 0.05}`;
+
+    const verdict = extractVerdict(text);
+    expect(verdict).toBeDefined();
+    expect(verdict!.verdict).toBe('SAFE');
+    expect(verdict!.uLlm).toBe(0.05);
+  });
+
+  it('returns the last valid verdict (most recent)', () => {
+    const text = `
+      {"verdict": "SAFE", "rationale": "First", "confidence_score": 3}
+      Some more analysis...
+      {"verdict": "RISKY", "rationale": "Revised", "confidence_score": 4}
+    `;
+
+    const verdict = extractVerdict(text);
+    expect(verdict).toBeDefined();
+    expect(verdict!.verdict).toBe('RISKY');
+    expect(verdict!.rationale).toBe('Revised');
+  });
+
+  it('filters out template patterns', () => {
+    const text = `{"verdict": "<NPG | PG | further review>", "rationale": "[REQUIRED]", "confidence_score": 0}`;
+
+    const verdict = extractVerdict(text);
+    expect(verdict).toBeUndefined();
+  });
+
+  it('defaults u_llm to 0.5 when not provided', () => {
+    const text = `{"verdict": "RISKY", "rationale": "test", "confidence_score": 3}`;
+
+    const verdict = extractVerdict(text);
+    expect(verdict!.uLlm).toBe(0.5);
+  });
+
+  it('returns undefined for empty text', () => {
+    expect(extractVerdict('')).toBeUndefined();
+  });
+});
+
+describe('validateAgainstContract', () => {
+  const contract: OutputContract = {
+    version: { major: 1, minor: 0, patch: 0 },
+    requiredFields: ['verdict', 'rationale', 'confidence_score'],
+  };
+
+  it('returns no errors for valid JSON', () => {
+    const json = { verdict: 'SAFE', rationale: 'OK', confidence_score: 5 };
+    expect(validateAgainstContract(json, contract)).toHaveLength(0);
+  });
+
+  it('returns errors for missing fields', () => {
+    const json = { verdict: 'SAFE' };
+    const errors = validateAgainstContract(json, contract);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.some((e) => e.includes('rationale'))).toBe(true);
+  });
+
+  it('validates inside FINAL_VERDICT wrapper', () => {
+    const json = {
+      FINAL_VERDICT: { verdict: 'SAFE', rationale: 'OK', confidence_score: 5 },
+    };
+    expect(validateAgainstContract(json, contract)).toHaveLength(0);
+  });
+});

--- a/server/services/playbookAgentService/jsonExtractor.ts
+++ b/server/services/playbookAgentService/jsonExtractor.ts
@@ -1,0 +1,252 @@
+/**
+ * JSON Extractor — Parse and validate structured verdicts from LLM output.
+ *
+ * Extracts JSON objects from free-form LLM text using balanced brace counting,
+ * filters out template/placeholder patterns, and validates against the playbook's
+ * output contract schema.
+ *
+ * @license Apache-2.0
+ */
+
+import type { OutputContract, PlaybookVerdict } from './playbookTypes.js';
+import {
+  jsonStringify,
+  tryJsonParse,
+} from '../../utils/encoding.js';
+
+// ── Template patterns to filter out ─────────────────────────────────────────
+
+const TEMPLATE_PATTERNS: readonly RegExp[] = [
+  /<NPG\s*\|\s*PG\s*\|\s*further\s*review>/i,
+  /<≤?\d+\s*words[^>]*>/i,
+  /<integer\s+\d+-\d+>/i,
+  /\[REQUIRED[^\]]*\]/i,
+  /\[if\s+available[^\]]*\]/i,
+  /\[note\s+if[^\]]*\]/i,
+  /\[list\s+all[^\]]*\]/i,
+  /\[yes\/no[^\]]*\]/i,
+  /\[MUST\s+include[^\]]*\]/i,
+  /\[calculate\s+in[^\]]*\]/i,
+  /\[provide\s+detailed[^\]]*\]/i,
+  /\[Must\s+be\s+one\s+of[^\]]*\]/i,
+  /\[List\s+ALL[^\]]*\]/i,
+  /\[Explain\s+why[^\]]*\]/i,
+  /\[Specify\s+what[^\]]*\]/i,
+  /\[Note\s+ANY[^\]]*\]/i,
+  /\[Highlight\s+any[^\]]*\]/i,
+  /\[Flag\s+any[^\]]*\]/i,
+];
+
+// ── JSON extraction ─────────────────────────────────────────────────────────
+
+/**
+ * Extract all valid JSON objects from free-form text using balanced brace counting.
+ *
+ * More robust than regex-based extraction — handles nested objects,
+ * strings containing braces, and escaped characters.
+ */
+export function extractJsonObjects(text: string): Record<string, unknown>[] {
+  const objects: Record<string, unknown>[] = [];
+  const textLen = text.length;
+  let i = 0;
+
+  while (i < textLen) {
+    if (text[i] === '{') {
+      const startPos = i;
+      let braceCount = 0;
+      let inString = false;
+      let escapeNext = false;
+
+      while (i < textLen) {
+        const char = text[i];
+        if (escapeNext) {
+          escapeNext = false;
+        } else if (char === '\\') {
+          escapeNext = true;
+        } else if (char === '"') {
+          inString = !inString;
+        } else if (!inString) {
+          if (char === '{') {
+            braceCount++;
+          } else if (char === '}') {
+            braceCount--;
+            if (braceCount === 0) {
+              const jsonStr = text.slice(startPos, i + 1);
+              const parsed = tryJsonParse(jsonStr);
+              if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+                objects.push(parsed);
+              }
+              break;
+            }
+          }
+        }
+        i++;
+      }
+    } else {
+      i++;
+    }
+  }
+
+  return objects;
+}
+
+/**
+ * Check whether a JSON object looks like an unfilled template.
+ */
+function isTemplate(obj: Record<string, unknown>): boolean {
+  const jsonStr = jsonStringify(obj);
+  return TEMPLATE_PATTERNS.some((pattern) => pattern.test(jsonStr));
+}
+
+// ── Verdict extraction ──────────────────────────────────────────────────────
+
+type RawVerdict = {
+  verdict: string;
+  rationale: string;
+  confidence_score: number;
+  u_llm?: number;
+  ncmec_report_required?: boolean;
+  content_removal_required?: boolean;
+  queries_executed?: string[];
+  supporting_evidence?: string[];
+  contradicting_evidence?: string[];
+  critical_evidence_missing?: boolean;
+  has_contradictory_signals?: boolean;
+  is_edge_case?: boolean;
+};
+
+/**
+ * Extract a PlaybookVerdict from the raw JSON, handling both
+ * FINAL_VERDICT wrapper and direct root-level fields.
+ */
+function extractVerdictFromJson(
+  json: Record<string, unknown>,
+): RawVerdict | undefined {
+  // Prefer FINAL_VERDICT wrapper
+  const nested = json['FINAL_VERDICT'];
+  const source =
+    typeof nested === 'object' && nested !== null
+      ? (nested as Record<string, unknown>)
+      : json;
+
+  const verdict = source['verdict'];
+  const rationale = source['rationale'];
+  const confidenceScore = source['confidence_score'];
+
+  if (typeof verdict !== 'string' || typeof rationale !== 'string') {
+    return undefined;
+  }
+  if (typeof confidenceScore !== 'number') {
+    return undefined;
+  }
+
+  return {
+    verdict,
+    rationale,
+    confidence_score: confidenceScore,
+    u_llm:
+      typeof source['u_llm'] === 'number' ? source['u_llm'] : undefined,
+    ncmec_report_required:
+      typeof source['ncmec_report_required'] === 'boolean'
+        ? source['ncmec_report_required']
+        : undefined,
+    content_removal_required:
+      typeof source['content_removal_required'] === 'boolean'
+        ? source['content_removal_required']
+        : undefined,
+    queries_executed: Array.isArray(source['queries_executed'])
+      ? (source['queries_executed'] as string[])
+      : undefined,
+    supporting_evidence: Array.isArray(source['supporting_evidence'])
+      ? (source['supporting_evidence'] as string[])
+      : undefined,
+    contradicting_evidence: Array.isArray(source['contradicting_evidence'])
+      ? (source['contradicting_evidence'] as string[])
+      : undefined,
+    critical_evidence_missing:
+      typeof source['critical_evidence_missing'] === 'boolean'
+        ? source['critical_evidence_missing']
+        : undefined,
+    has_contradictory_signals:
+      typeof source['has_contradictory_signals'] === 'boolean'
+        ? source['has_contradictory_signals']
+        : undefined,
+    is_edge_case:
+      typeof source['is_edge_case'] === 'boolean'
+        ? source['is_edge_case']
+        : undefined,
+  };
+}
+
+// ── Validation ──────────────────────────────────────────────────────────────
+
+/**
+ * Validate that a verdict contains all required fields from the output contract.
+ */
+export function validateAgainstContract(
+  json: Record<string, unknown>,
+  contract: OutputContract,
+): string[] {
+  const errors: string[] = [];
+  // Check in both the root and FINAL_VERDICT wrapper
+  const nested = json['FINAL_VERDICT'];
+  const source =
+    typeof nested === 'object' && nested !== null
+      ? (nested as Record<string, unknown>)
+      : json;
+
+  for (const field of contract.requiredFields) {
+    if (!(field in source)) {
+      errors.push(`Missing required field: '${field}'`);
+    }
+  }
+  return errors;
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Extract the last valid, non-template verdict JSON from LLM output text.
+ *
+ * Returns the parsed PlaybookVerdict or undefined if no valid verdict is found.
+ */
+export function extractVerdict(
+  text: string,
+  contract?: OutputContract,
+): PlaybookVerdict | undefined {
+  const jsonObjects = extractJsonObjects(text);
+
+  // Filter out templates, validate, and prefer the last valid object
+  const candidates: PlaybookVerdict[] = [];
+
+  for (const obj of jsonObjects) {
+    if (isTemplate(obj)) continue;
+
+    // Validate against output contract if provided
+    if (contract) {
+      const contractErrors = validateAgainstContract(obj, contract);
+      if (contractErrors.length > 0) continue;
+    }
+
+    const raw = extractVerdictFromJson(obj);
+    if (!raw) continue;
+
+    candidates.push({
+      verdict: raw.verdict,
+      rationale: raw.rationale,
+      confidenceScore: raw.confidence_score,
+      uLlm: raw.u_llm ?? 0.5,
+      ncmecReportRequired: raw.ncmec_report_required,
+      contentRemovalRequired: raw.content_removal_required,
+      queriesExecuted: raw.queries_executed ?? [],
+      supportingEvidence: raw.supporting_evidence ?? [],
+      contradictingEvidence: raw.contradicting_evidence ?? [],
+      criticalEvidenceMissing: raw.critical_evidence_missing ?? false,
+      hasContradictorySignals: raw.has_contradictory_signals ?? false,
+      isEdgeCase: raw.is_edge_case,
+    });
+  }
+
+  // Return the last valid candidate (most recent in the LLM output)
+  return candidates.length > 0 ? candidates[candidates.length - 1] : undefined;
+}

--- a/server/services/playbookAgentService/jsonExtractor.ts
+++ b/server/services/playbookAgentService/jsonExtractor.ts
@@ -105,8 +105,7 @@ type RawVerdict = {
   rationale: string;
   confidence_score: number;
   u_llm?: number;
-  ncmec_report_required?: boolean;
-  content_removal_required?: boolean;
+  additional_outputs?: Record<string, unknown>;
   queries_executed?: string[];
   supporting_evidence?: string[];
   contradicting_evidence?: string[];
@@ -114,6 +113,20 @@ type RawVerdict = {
   has_contradictory_signals?: boolean;
   is_edge_case?: boolean;
 };
+
+const CORE_VERDICT_FIELDS = new Set([
+  'verdict',
+  'rationale',
+  'confidence_score',
+  'u_llm',
+  'queries_executed',
+  'supporting_evidence',
+  'contradicting_evidence',
+  'critical_evidence_missing',
+  'has_contradictory_signals',
+  'is_edge_case',
+  'FINAL_VERDICT',
+]);
 
 /**
  * Extract a PlaybookVerdict from the raw JSON, handling both
@@ -136,8 +149,15 @@ function extractVerdictFromJson(
   if (typeof verdict !== 'string' || typeof rationale !== 'string') {
     return undefined;
   }
-  if (typeof confidenceScore !== 'number') {
+  if (typeof confidenceScore !== 'number' || !Number.isFinite(confidenceScore)) {
     return undefined;
+  }
+
+  const additionalOutputs: Record<string, unknown> = {};
+  for (const key of Object.keys(source)) {
+    if (!CORE_VERDICT_FIELDS.has(key)) {
+      additionalOutputs[key] = source[key];
+    }
   }
 
   return {
@@ -145,15 +165,8 @@ function extractVerdictFromJson(
     rationale,
     confidence_score: confidenceScore,
     u_llm:
-      typeof source['u_llm'] === 'number' ? source['u_llm'] : undefined,
-    ncmec_report_required:
-      typeof source['ncmec_report_required'] === 'boolean'
-        ? source['ncmec_report_required']
-        : undefined,
-    content_removal_required:
-      typeof source['content_removal_required'] === 'boolean'
-        ? source['content_removal_required']
-        : undefined,
+      Number.isFinite(source['u_llm']) ? (source['u_llm'] as number) : undefined,
+    additional_outputs: Object.keys(additionalOutputs).length > 0 ? additionalOutputs : undefined,
     queries_executed: Array.isArray(source['queries_executed'])
       ? (source['queries_executed'] as string[])
       : undefined,
@@ -236,8 +249,7 @@ export function extractVerdict(
       rationale: raw.rationale,
       confidenceScore: raw.confidence_score,
       uLlm: raw.u_llm ?? 0.5,
-      ncmecReportRequired: raw.ncmec_report_required,
-      contentRemovalRequired: raw.content_removal_required,
+      additionalOutputs: raw.additional_outputs,
       queriesExecuted: raw.queries_executed ?? [],
       supportingEvidence: raw.supporting_evidence ?? [],
       contradictingEvidence: raw.contradicting_evidence ?? [],

--- a/server/services/playbookAgentService/playbookAgentService.test.ts
+++ b/server/services/playbookAgentService/playbookAgentService.test.ts
@@ -1,0 +1,249 @@
+import { PlaybookAgentService } from './playbookAgentService.js';
+import { jsonStringify } from '../../utils/encoding.js';
+import type {
+  IArtifactStore,
+  IEvidenceStore,
+  ILLMAdapter,
+  PlaybookArtifact,
+} from './interfaces.js';
+import type { Playbook } from './playbookTypes.js';
+
+function makePlaybook(): Playbook {
+  return {
+    useCaseId: 'dummy_csam_triage',
+    version: { major: 1, minor: 0, patch: 0 },
+    displayName: 'Dummy CSAM Triage',
+    description: 'Smoke-test playbook for local service verification.',
+    inputContext: [
+      {
+        fieldName: 'item_id',
+        fieldType: 'string',
+        required: true,
+        description: 'Submitted item id',
+      },
+    ],
+    evidenceOntology: {
+      version: { major: 1, minor: 0, patch: 0 },
+      evidenceTypes: [
+        {
+          evidenceId: 'hash_match',
+          displayName: 'Hash Match',
+          description: 'Known hash match evidence',
+          quality: {
+            minimumConfidence: 1,
+            minimumNumRequiredSources: 1,
+          },
+        },
+      ],
+    },
+    baselineCatalogRefs: [
+      {
+        catalogId: 'hash_match_history',
+        version: { major: 1, minor: 0, patch: 0 },
+        catalogType: 'query',
+      },
+    ],
+    allowedCatalogRefs: [
+      {
+        catalogId: 'hash_match_history',
+        version: { major: 1, minor: 0, patch: 0 },
+        catalogType: 'query',
+      },
+    ],
+    evidenceRequestPolicy: {
+      querySelectionMode: 'query_id',
+      maxRounds: 1,
+      targetConfidence: 0.8,
+      maxAdditionalQueries: 0,
+      stopIfNoNewEvidence: true,
+      guidance: 'Use only the supplied evidence.',
+    },
+    labels: [
+      {
+        labelId: 'NO_ACTION',
+        displayName: 'No Action',
+        description: 'No enforcement needed.',
+        severity: 'INFO',
+      },
+      {
+        labelId: 'REPORT_AND_REMOVE',
+        displayName: 'Report and Remove',
+        description: 'Known critical hash match requires reporting and removal.',
+        severity: 'CRITICAL',
+      },
+    ],
+    decisionLogic: {
+      hardRules: [
+        {
+          ruleId: 'known_critical_hash',
+          description: 'Critical hash matches are deterministic.',
+          condition: "hash_match_history.severity_tier == 'CRITICAL'",
+          outcome: 'REPORT_AND_REMOVE',
+          bypassLlm: true,
+        },
+      ],
+      scoringGuidance: [],
+      defaultLabel: 'NO_ACTION',
+    },
+    confidenceComputation: {
+      evidenceCompletenessWeight: 0.35,
+      signalStrengthWeight: 0.25,
+      signalAgreementWeight: 0.25,
+      dataQualityWeight: 0.15,
+      llmUncertaintyAlpha: 0.4,
+      baseCoverageWeight: 1,
+      additionalCoverageWeight: 0,
+      criticalEvidenceMissingPenalty: 0.3,
+      additionalQueryBonusMax: 0,
+    },
+    outputContract: {
+      version: { major: 1, minor: 0, patch: 0 },
+      requiredFields: [
+        'verdict',
+        'rationale',
+        'confidence_score',
+        'u_llm',
+        'queries_executed',
+        'supporting_evidence',
+        'contradicting_evidence',
+        'critical_evidence_missing',
+        'has_contradictory_signals',
+      ],
+    },
+  };
+}
+
+function makeArtifactsStore(): IArtifactStore {
+  const store = jest.fn(async (_artifact: PlaybookArtifact) => {});
+  return {
+    store,
+    async getBySessionId(sessionId) {
+      const artifacts = store.mock.calls.map(([artifact]) => artifact);
+      return artifacts.filter((artifact) => artifact.sessionId === sessionId);
+    },
+  };
+}
+
+function makeService(options?: {
+  llmAdapter?: ILLMAdapter;
+  evidenceStore?: IEvidenceStore;
+  artifactStore?: IArtifactStore;
+}) {
+  const playbook = makePlaybook();
+
+  return new PlaybookAgentService({
+    llmAdapter:
+      options?.llmAdapter ??
+      ({
+        async complete() {
+          return {
+            content: jsonStringify({
+              verdict: 'NO_ACTION',
+              rationale:
+                'The model chose NO_ACTION, but the hard rule should override it.',
+              confidence_score: 2,
+              u_llm: 0.2,
+              queries_executed: ['hash_match_history'],
+              supporting_evidence: [
+                'hash_match_history.severity_tier=CRITICAL',
+              ],
+              contradicting_evidence: [],
+              critical_evidence_missing: false,
+              has_contradictory_signals: false,
+            }),
+          };
+        },
+      } satisfies ILLMAdapter),
+    evidenceStore:
+      options?.evidenceStore ??
+      ({
+        async executeQuery(query) {
+          return {
+            success: true,
+            data: [
+              {
+                item_id: query.parameters['item_id'],
+                severity_tier: 'CRITICAL',
+                total_matches: 1,
+              },
+            ],
+          };
+        },
+      } satisfies IEvidenceStore),
+    artifactStore: options?.artifactStore ?? makeArtifactsStore(),
+    playbooks: new Map([[playbook.useCaseId, playbook]]),
+    queuePlaybookMapping: new Map([['dummy-queue', playbook.useCaseId]]),
+  });
+}
+
+describe('PlaybookAgentService', () => {
+  it('returns undefined when the queue has no configured playbook', async () => {
+    const service = makeService();
+
+    await expect(
+      service.runForJob({
+        orgId: 'org-1',
+        queueId: 'unmapped-queue',
+        itemId: 'item-without-playbook',
+        itemTypeId: 'content-type',
+        itemData: { text: 'no playbook here' },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('runs a mapped playbook and lets hard rules override the LLM verdict', async () => {
+    const artifactStore = makeArtifactsStore();
+    const service = makeService({ artifactStore });
+
+    const result = await service.runForJob({
+      orgId: 'org-1',
+      queueId: 'dummy-queue',
+      itemId: 'dummy-item-123',
+      itemTypeId: 'content-type',
+      itemData: { text: 'dummy test content' },
+    });
+
+    expect(result).toBeDefined();
+    expect(result!.verdict.verdict).toBe('REPORT_AND_REMOVE');
+    expect(result!.verdict.rationale).toContain('hard rule should override');
+    expect(result!.hardRuleTriggered).toBe('known_critical_hash');
+    expect(result!.queriesExecuted).toEqual(['hash_match_history']);
+    expect(result!.evidence).toEqual([
+      {
+        item_id: 'dummy-item-123',
+        severity_tier: 'CRITICAL',
+        total_matches: 1,
+        _catalogId: 'hash_match_history',
+      },
+    ]);
+    expect(result!.confidence.confidenceScore0To1).toBeGreaterThan(0);
+    expect(result!.confidence.confidenceScore1To5).toBeGreaterThanOrEqual(1);
+    const storedArtifacts = await artifactStore.getBySessionId(
+      result!.sessionId,
+    );
+    expect(storedArtifacts.map((artifact) => artifact.artifactType)).toEqual([
+      'verdict',
+      'confidence',
+    ]);
+  });
+
+  it('returns undefined instead of blocking the caller when a playbook run fails', async () => {
+    const service = makeService({
+      llmAdapter: {
+        async complete() {
+          throw new Error('llm unavailable');
+        },
+      },
+    });
+
+    await expect(
+      service.runForJob({
+        orgId: 'org-1',
+        queueId: 'dummy-queue',
+        itemId: 'dummy-item-123',
+        itemTypeId: 'content-type',
+        itemData: { text: 'dummy test content' },
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/server/services/playbookAgentService/playbookAgentService.ts
+++ b/server/services/playbookAgentService/playbookAgentService.ts
@@ -1,0 +1,104 @@
+/**
+ * Playbook Agent Service — Coop integration layer.
+ *
+ * Wraps the generic PlaybookRunner in Coop's service conventions:
+ *   - BottleJS dependency injection
+ *   - Graceful failure (never blocks the MRT enqueue path)
+ *   - Coop-specific type mappings
+ *
+ * This service is called from JobEnrichment.enrichJobPayload() to run
+ * a playbook investigation before a job is written to the MRT queue.
+ *
+ * @license Apache-2.0
+ */
+
+import type {
+  IArtifactStore,
+  IEvidenceStore,
+  ILLMAdapter,
+  PlaybookRunInput,
+} from './interfaces.js';
+import PlaybookRunner from './playbookRunner.js';
+import type { Playbook, PlaybookResult } from './playbookTypes.js';
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export type PlaybookAgentServiceDeps = {
+  readonly llmAdapter: ILLMAdapter;
+  readonly evidenceStore: IEvidenceStore;
+  readonly artifactStore: IArtifactStore;
+  readonly playbooks: ReadonlyMap<string, Playbook>;
+  readonly queuePlaybookMapping: ReadonlyMap<string, string>;
+};
+
+export type RunForJobInput = {
+  readonly orgId: string;
+  readonly queueId: string;
+  readonly itemId: string;
+  readonly itemTypeId: string;
+  readonly itemData: Record<string, unknown>;
+};
+
+// ── Service ─────────────────────────────────────────────────────────────────
+
+export class PlaybookAgentService {
+  readonly #runner: PlaybookRunner;
+  readonly #queuePlaybookMapping: ReadonlyMap<string, string>;
+
+  constructor(deps: PlaybookAgentServiceDeps) {
+    this.#runner = new PlaybookRunner(
+      {
+        llmAdapter: deps.llmAdapter,
+        evidenceStore: deps.evidenceStore,
+        artifactStore: deps.artifactStore,
+      },
+      deps.playbooks,
+    );
+    this.#queuePlaybookMapping = deps.queuePlaybookMapping;
+  }
+
+  /**
+   * Run a playbook investigation for an MRT job, if the queue has one configured.
+   *
+   * Returns the PlaybookResult, or undefined if:
+   *   - The queue has no playbook configured
+   *   - The playbook run fails (failure is caught — never blocks enqueue)
+   */
+  async runForJob(input: RunForJobInput): Promise<PlaybookResult | undefined> {
+    const playbookId = this.#queuePlaybookMapping.get(input.queueId);
+    if (!playbookId) {
+      return undefined;
+    }
+
+    const runInput: PlaybookRunInput = {
+      playbookId,
+      inputContext: {
+        org_id: input.orgId,
+        item_id: input.itemId,
+        item_type_id: input.itemTypeId,
+        ...input.itemData,
+      },
+    };
+
+    try {
+      return await this.#runner.run(runInput);
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Check whether a queue has a playbook configured.
+   */
+  hasPlaybookForQueue(queueId: string): boolean {
+    return this.#queuePlaybookMapping.has(queueId);
+  }
+}
+
+// ── Factory (BottleJS-compatible) ───────────────────────────────────────────
+
+export default function makePlaybookAgentService(
+  deps: PlaybookAgentServiceDeps,
+): PlaybookAgentService {
+  return new PlaybookAgentService(deps);
+}

--- a/server/services/playbookAgentService/playbookLoader.test.ts
+++ b/server/services/playbookAgentService/playbookLoader.test.ts
@@ -1,0 +1,157 @@
+import { parsePlaybook } from './playbookLoader.js';
+
+const MINIMAL_PLAYBOOK = {
+  use_case_id: 'test_investigation',
+  version: '1.0.0',
+  display_name: 'Test Investigation',
+  description: 'A test playbook',
+  input_context: [
+    {
+      field_name: 'account_id',
+      field_type: 'string',
+      required: true,
+      description: 'Account to investigate',
+    },
+  ],
+  evidence_ontology: {
+    version: '1.0.0',
+    evidence_types: [
+      {
+        evidence_id: 'login_patterns',
+        display_name: 'Login Patterns',
+        description: 'Login frequency analysis',
+        quality: { minimum_confidence: 0.7, minimum_num_required_sources: 1 },
+      },
+    ],
+  },
+  baseline_catalog_refs: [
+    { catalog_id: 'login_patterns', version: '1.0.0', catalog_type: 'query' },
+  ],
+  allowed_catalog_refs: [
+    { catalog_id: 'login_patterns', version: '1.0.0', catalog_type: 'query' },
+    { catalog_id: 'device_info', version: '1.0.0', catalog_type: 'query' },
+  ],
+  evidence_request_policy: {
+    query_selection_mode: 'query_id',
+    max_rounds: 3,
+    target_confidence: 0.75,
+    max_additional_queries: 5,
+    stop_if_no_new_evidence: true,
+  },
+  labels: [
+    { label_id: 'RISKY', display_name: 'Risky', description: 'Account is risky' },
+    { label_id: 'SAFE', display_name: 'Safe', description: 'Account is safe' },
+  ],
+  decision_logic: {
+    hard_rules: [],
+    default_label: 'SAFE',
+  },
+  confidence_computation: {
+    evidence_completeness_weight: 0.35,
+    signal_strength_weight: 0.25,
+    signal_agreement_weight: 0.25,
+    data_quality_weight: 0.15,
+    llm_uncertainty_alpha: 0.4,
+  },
+  output_contract: {
+    version: '1.0.0',
+    required_fields: ['verdict', 'rationale', 'confidence_score'],
+  },
+};
+
+describe('parsePlaybook', () => {
+  it('parses a valid playbook', () => {
+    const playbook = parsePlaybook(MINIMAL_PLAYBOOK);
+
+    expect(playbook.useCaseId).toBe('test_investigation');
+    expect(playbook.version).toEqual({ major: 1, minor: 0, patch: 0 });
+    expect(playbook.baselineCatalogRefs).toHaveLength(1);
+    expect(playbook.allowedCatalogRefs).toHaveLength(2);
+    expect(playbook.labels).toHaveLength(2);
+    expect(playbook.confidenceComputation.llmUncertaintyAlpha).toBe(0.4);
+  });
+
+  it('applies default values for optional confidence fields', () => {
+    const playbook = parsePlaybook(MINIMAL_PLAYBOOK);
+
+    expect(playbook.confidenceComputation.baseCoverageWeight).toBe(0.7);
+    expect(playbook.confidenceComputation.additionalCoverageWeight).toBe(0.3);
+    expect(playbook.confidenceComputation.criticalEvidenceMissingPenalty).toBe(0.3);
+    expect(playbook.confidenceComputation.additionalQueryBonusMax).toBe(0.2);
+  });
+
+  it('rejects baseline ref not in allowed set', () => {
+    const bad = {
+      ...MINIMAL_PLAYBOOK,
+      baseline_catalog_refs: [
+        { catalog_id: 'unknown_query', version: '1.0.0', catalog_type: 'query' },
+      ],
+    };
+
+    expect(() => parsePlaybook(bad)).toThrow('not found in allowed_catalog_refs');
+  });
+
+  it('rejects invalid default label', () => {
+    const bad = {
+      ...MINIMAL_PLAYBOOK,
+      decision_logic: {
+        hard_rules: [],
+        default_label: 'NONEXISTENT',
+      },
+    };
+
+    expect(() => parsePlaybook(bad)).toThrow("'NONEXISTENT' is not a valid label");
+  });
+
+  it('rejects confidence weights that do not sum to ~1.0', () => {
+    const bad = {
+      ...MINIMAL_PLAYBOOK,
+      confidence_computation: {
+        ...MINIMAL_PLAYBOOK.confidence_computation,
+        evidence_completeness_weight: 0.5,
+        signal_strength_weight: 0.5,
+        signal_agreement_weight: 0.5,
+        data_quality_weight: 0.5,
+      },
+    };
+
+    expect(() => parsePlaybook(bad)).toThrow('weights sum to');
+  });
+
+  it('rejects invalid semantic version', () => {
+    const bad = { ...MINIMAL_PLAYBOOK, version: 'not-a-version' };
+    expect(() => parsePlaybook(bad)).toThrow('Invalid semantic version');
+  });
+
+  it('rejects forbidden catalog IDs', () => {
+    const bad = {
+      ...MINIMAL_PLAYBOOK,
+      allowed_catalog_refs: [
+        ...MINIMAL_PLAYBOOK.allowed_catalog_refs,
+        { catalog_id: 'latest', version: '1.0.0', catalog_type: 'query' },
+      ],
+    };
+
+    expect(() => parsePlaybook(bad)).toThrow("cannot be 'latest'");
+  });
+
+  it('validates hard rule outcomes against labels', () => {
+    const bad = {
+      ...MINIMAL_PLAYBOOK,
+      decision_logic: {
+        hard_rules: [
+          {
+            rule_id: 'test_rule',
+            description: 'Test',
+            condition: "data.field == 'value'",
+            outcome: 'NONEXISTENT_LABEL',
+            bypass_llm: true,
+          },
+        ],
+        default_label: 'SAFE',
+      },
+    };
+
+    expect(() => parsePlaybook(bad)).toThrow("'NONEXISTENT_LABEL' is not a valid label");
+  });
+});

--- a/server/services/playbookAgentService/playbookLoader.ts
+++ b/server/services/playbookAgentService/playbookLoader.ts
@@ -136,7 +136,14 @@ type RawPlaybook = {
 
 // ── Conversion helpers ──────────────────────────────────────────────────────
 
+const VALID_CATALOG_TYPES = new Set<string>(['query', 'query_bundle']);
+
 function toCatalogReference(raw: RawCatalogRef): CatalogReference {
+  if (!VALID_CATALOG_TYPES.has(raw.catalog_type)) {
+    throw new Error(
+      `Invalid catalog_type '${raw.catalog_type}' for catalog '${raw.catalog_id}'. Must be one of: ${[...VALID_CATALOG_TYPES].join(', ')}`,
+    );
+  }
   const ref: CatalogReference = {
     catalogId: raw.catalog_id,
     version: parseSemanticVersion(raw.version),
@@ -361,6 +368,20 @@ export function parsePlaybook(raw: unknown): Playbook {
   };
 
   const cc = r.confidence_computation;
+
+  function validateRange(value: number, name: string): void {
+    if (!Number.isFinite(value) || value < 0 || value > 1) {
+      throw new Error(
+        `Invalid ${name}: ${value}. Must be a finite number in [0, 1].`,
+      );
+    }
+  }
+  validateRange(cc.llm_uncertainty_alpha, 'llm_uncertainty_alpha');
+  validateRange(cc.evidence_completeness_weight, 'evidence_completeness_weight');
+  validateRange(cc.signal_strength_weight, 'signal_strength_weight');
+  validateRange(cc.signal_agreement_weight, 'signal_agreement_weight');
+  validateRange(cc.data_quality_weight, 'data_quality_weight');
+
   const confidenceComputation: ConfidenceComputation = {
     evidenceCompletenessWeight: cc.evidence_completeness_weight,
     signalStrengthWeight: cc.signal_strength_weight,

--- a/server/services/playbookAgentService/playbookLoader.ts
+++ b/server/services/playbookAgentService/playbookLoader.ts
@@ -1,0 +1,417 @@
+/**
+ * Playbook Loader — Load and validate investigation playbooks from YAML.
+ *
+ * Handles parsing, validation, and cross-reference checking of playbook configs.
+ * Ensures baseline_catalog_refs is a subset of allowed_catalog_refs,
+ * deep-dive query refs are in allowed set, and all label references are valid.
+ *
+ * @license Apache-2.0
+ */
+
+import {
+  type CatalogReference,
+  type CatalogType,
+  type ConfidenceComputation,
+  type DecisionLogic,
+  type DeepDiveModule,
+  type EvidenceOntology,
+  type EvidenceRequestPolicy,
+  type HardRule,
+  type InputContextField,
+  type InputFieldType,
+  type LabelDefinition,
+  type OutputContract,
+  type PhaseBudget,
+  type Playbook,
+  formatCatalogReference,
+  parseSemanticVersion,
+  validateCatalogReference,
+} from './playbookTypes.js';
+
+// ── Raw YAML types (snake_case as authored) ─────────────────────────────────
+
+type RawCatalogRef = {
+  catalog_id: string;
+  version: string;
+  catalog_type: string;
+};
+
+type RawPlaybook = {
+  use_case_id: string;
+  version: string;
+  display_name: string;
+  description: string;
+  input_context: Array<{
+    field_name: string;
+    field_type: string;
+    required: boolean;
+    description: string;
+    default?: unknown;
+    validation_pattern?: string;
+    catalog_parameter_name?: string;
+  }>;
+  evidence_ontology: {
+    version: string;
+    evidence_types: Array<{
+      evidence_id: string;
+      display_name: string;
+      description: string;
+      quality?: {
+        freshness_max_age_ms?: number;
+        minimum_confidence?: number;
+        minimum_num_required_sources?: number;
+      };
+    }>;
+  };
+  baseline_catalog_refs: RawCatalogRef[];
+  allowed_catalog_refs: RawCatalogRef[];
+  evidence_request_policy: {
+    query_selection_mode: string;
+    max_rounds: number;
+    target_confidence: number;
+    max_additional_queries: number;
+    stop_if_no_new_evidence: boolean;
+    trigger_deep_dive_if?: string;
+    stop_investigation_if?: string;
+    guidance?: string;
+  };
+  deep_dive_modules?: Array<{
+    module_id: string;
+    display_name: string;
+    description: string;
+    entry_conditions: Array<{
+      condition_id: string;
+      description: string;
+      expression: string;
+    }>;
+    exit_conditions: Array<{
+      condition_id: string;
+      description: string;
+      expression: string;
+    }>;
+    query_refs: RawCatalogRef[];
+  }>;
+  labels: Array<{
+    label_id: string;
+    display_name: string;
+    description: string;
+    severity?: string;
+  }>;
+  decision_logic: {
+    hard_rules: Array<{
+      rule_id: string;
+      description: string;
+      condition: string;
+      outcome: string;
+      bypass_llm: boolean;
+    }>;
+    scoring_guidance?: Array<{
+      guidance_id: string;
+      description: string;
+    }>;
+    default_label: string;
+  };
+  confidence_computation: {
+    evidence_completeness_weight: number;
+    signal_strength_weight: number;
+    signal_agreement_weight: number;
+    data_quality_weight: number;
+    llm_uncertainty_alpha: number;
+    base_coverage_weight?: number;
+    additional_coverage_weight?: number;
+    critical_evidence_missing_penalty?: number;
+    additional_query_bonus_max?: number;
+  };
+  phase_budget?: {
+    max_queries: number;
+    max_llm_calls: number;
+    max_duration_ms: number;
+  };
+  output_contract: {
+    version: string;
+    required_fields: string[];
+    schema?: Record<string, unknown>;
+  };
+};
+
+// ── Conversion helpers ──────────────────────────────────────────────────────
+
+function toCatalogReference(raw: RawCatalogRef): CatalogReference {
+  const ref: CatalogReference = {
+    catalogId: raw.catalog_id,
+    version: parseSemanticVersion(raw.version),
+    catalogType: raw.catalog_type as CatalogType,
+  };
+  validateCatalogReference(ref);
+  return ref;
+}
+
+const VALID_INPUT_FIELD_TYPES = new Set([
+  'string',
+  'integer',
+  'float',
+  'boolean',
+  'date',
+  'datetime',
+]);
+
+const VALID_SEVERITIES = new Set([
+  'CRITICAL',
+  'HIGH',
+  'MEDIUM',
+  'LOW',
+  'INFO',
+]);
+
+// ── Validation ──────────────────────────────────────────────────────────────
+
+export type PlaybookValidationError = {
+  readonly field: string;
+  readonly message: string;
+};
+
+function validatePlaybookCrossRefs(playbook: Playbook): PlaybookValidationError[] {
+  const errors: PlaybookValidationError[] = [];
+
+  // baseline_catalog_refs must be a subset of allowed_catalog_refs
+  const allowedIds = new Set(
+    playbook.allowedCatalogRefs.map(formatCatalogReference),
+  );
+  for (const ref of playbook.baselineCatalogRefs) {
+    const refStr = formatCatalogReference(ref);
+    if (!allowedIds.has(refStr)) {
+      errors.push({
+        field: 'baselineCatalogRefs',
+        message: `Baseline ref '${refStr}' not found in allowed_catalog_refs`,
+      });
+    }
+  }
+
+  // deep-dive query refs must be in allowed set
+  if (playbook.deepDiveModules) {
+    for (const mod of playbook.deepDiveModules) {
+      for (const ref of mod.queryRefs) {
+        const refStr = formatCatalogReference(ref);
+        if (!allowedIds.has(refStr)) {
+          errors.push({
+            field: `deepDiveModules.${mod.moduleId}`,
+            message: `Deep-dive ref '${refStr}' not found in allowed_catalog_refs`,
+          });
+        }
+      }
+    }
+  }
+
+  // hard rule outcomes must reference valid labels
+  const labelIds = new Set(playbook.labels.map((l) => l.labelId));
+  for (const rule of playbook.decisionLogic.hardRules) {
+    if (!labelIds.has(rule.outcome)) {
+      errors.push({
+        field: `decisionLogic.hardRules.${rule.ruleId}`,
+        message: `Hard rule outcome '${rule.outcome}' is not a valid label`,
+      });
+    }
+  }
+
+  // default label must be valid
+  if (!labelIds.has(playbook.decisionLogic.defaultLabel)) {
+    errors.push({
+      field: 'decisionLogic.defaultLabel',
+      message: `Default label '${playbook.decisionLogic.defaultLabel}' is not a valid label`,
+    });
+  }
+
+  // confidence weights should sum to ~1.0
+  const cc = playbook.confidenceComputation;
+  const weightSum =
+    cc.evidenceCompletenessWeight +
+    cc.signalStrengthWeight +
+    cc.signalAgreementWeight +
+    cc.dataQualityWeight;
+  if (Math.abs(weightSum - 1.0) > 0.01) {
+    errors.push({
+      field: 'confidenceComputation',
+      message: `Confidence weights sum to ${weightSum}, expected ~1.0`,
+    });
+  }
+
+  return errors;
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Parse a raw YAML-deserialized object into a validated Playbook.
+ *
+ * Call this with the result of `yaml.load(...)` or `JSON.parse(...)`.
+ * Throws on invalid structure or cross-reference violations.
+ */
+export function parsePlaybook(raw: unknown): Playbook {
+  const r = raw as Partial<RawPlaybook>;
+
+  if (
+    typeof r.use_case_id !== 'string' ||
+    typeof r.version !== 'string' ||
+    typeof r.display_name !== 'string' ||
+    typeof r.description !== 'string' ||
+    r.evidence_ontology == null ||
+    !Array.isArray(r.baseline_catalog_refs) ||
+    !Array.isArray(r.allowed_catalog_refs) ||
+    r.evidence_request_policy == null ||
+    !Array.isArray(r.labels) ||
+    r.decision_logic == null ||
+    r.confidence_computation == null ||
+    r.output_contract == null
+  ) {
+    throw new Error('Playbook is missing required top-level fields');
+  }
+
+  const inputContext: InputContextField[] = (r.input_context ?? []).map(
+    (f) => {
+      if (!VALID_INPUT_FIELD_TYPES.has(f.field_type)) {
+        throw new Error(`Invalid field_type '${f.field_type}' for input '${f.field_name}'`);
+      }
+      return {
+        fieldName: f.field_name,
+        fieldType: f.field_type as InputFieldType,
+        required: f.required,
+        description: f.description,
+        default: f.default,
+        validationPattern: f.validation_pattern,
+        catalogParameterName: f.catalog_parameter_name,
+      };
+    },
+  );
+
+  const evidenceOntology: EvidenceOntology = {
+    version: parseSemanticVersion(r.evidence_ontology.version),
+    evidenceTypes: r.evidence_ontology.evidence_types.map((et) => ({
+      evidenceId: et.evidence_id,
+      displayName: et.display_name,
+      description: et.description,
+      quality: {
+        freshnessMaxAgeMs: et.quality?.freshness_max_age_ms,
+        minimumConfidence: et.quality?.minimum_confidence ?? 0.0,
+        minimumNumRequiredSources: et.quality?.minimum_num_required_sources ?? 1,
+      },
+    })),
+  };
+
+  const baselineCatalogRefs = r.baseline_catalog_refs.map(toCatalogReference);
+  const allowedCatalogRefs = r.allowed_catalog_refs.map(toCatalogReference);
+
+  const evidenceRequestPolicy: EvidenceRequestPolicy = {
+    querySelectionMode: 'query_id',
+    maxRounds: r.evidence_request_policy.max_rounds,
+    targetConfidence: r.evidence_request_policy.target_confidence,
+    maxAdditionalQueries: r.evidence_request_policy.max_additional_queries,
+    stopIfNoNewEvidence: r.evidence_request_policy.stop_if_no_new_evidence,
+    triggerDeepDiveIf: r.evidence_request_policy.trigger_deep_dive_if,
+    stopInvestigationIf: r.evidence_request_policy.stop_investigation_if,
+    guidance: r.evidence_request_policy.guidance,
+  };
+
+  const deepDiveModules: DeepDiveModule[] | undefined =
+    r.deep_dive_modules?.map((m) => ({
+      moduleId: m.module_id,
+      displayName: m.display_name,
+      description: m.description,
+      entryConditions: m.entry_conditions.map((c) => ({
+        conditionId: c.condition_id,
+        description: c.description,
+        expression: c.expression,
+      })),
+      exitConditions: m.exit_conditions.map((c) => ({
+        conditionId: c.condition_id,
+        description: c.description,
+        expression: c.expression,
+      })),
+      queryRefs: m.query_refs.map(toCatalogReference),
+    }));
+
+  const labels: LabelDefinition[] = r.labels.map((l) => {
+    if (l.severity && !VALID_SEVERITIES.has(l.severity)) {
+      throw new Error(
+        `Invalid severity '${l.severity}' for label '${l.label_id}'`,
+      );
+    }
+    return {
+      labelId: l.label_id,
+      displayName: l.display_name,
+      description: l.description,
+      severity: l.severity as LabelDefinition['severity'],
+    };
+  });
+
+  const hardRules: HardRule[] = r.decision_logic.hard_rules.map((hr) => ({
+    ruleId: hr.rule_id,
+    description: hr.description,
+    condition: hr.condition,
+    outcome: hr.outcome,
+    bypassLlm: hr.bypass_llm,
+  }));
+
+  const decisionLogic: DecisionLogic = {
+    hardRules,
+    scoringGuidance: (r.decision_logic.scoring_guidance ?? []).map((sg) => ({
+      guidanceId: sg.guidance_id,
+      description: sg.description,
+    })),
+    defaultLabel: r.decision_logic.default_label,
+  };
+
+  const cc = r.confidence_computation;
+  const confidenceComputation: ConfidenceComputation = {
+    evidenceCompletenessWeight: cc.evidence_completeness_weight,
+    signalStrengthWeight: cc.signal_strength_weight,
+    signalAgreementWeight: cc.signal_agreement_weight,
+    dataQualityWeight: cc.data_quality_weight,
+    llmUncertaintyAlpha: cc.llm_uncertainty_alpha,
+    baseCoverageWeight: cc.base_coverage_weight ?? 0.7,
+    additionalCoverageWeight: cc.additional_coverage_weight ?? 0.3,
+    criticalEvidenceMissingPenalty: cc.critical_evidence_missing_penalty ?? 0.3,
+    additionalQueryBonusMax: cc.additional_query_bonus_max ?? 0.2,
+  };
+
+  const phaseBudget: PhaseBudget | undefined = r.phase_budget
+    ? {
+        maxQueries: r.phase_budget.max_queries,
+        maxLlmCalls: r.phase_budget.max_llm_calls,
+        maxDurationMs: r.phase_budget.max_duration_ms,
+      }
+    : undefined;
+
+  const outputContract: OutputContract = {
+    version: parseSemanticVersion(r.output_contract.version),
+    requiredFields: r.output_contract.required_fields,
+    schema: r.output_contract.schema,
+  };
+
+  const playbook: Playbook = {
+    useCaseId: r.use_case_id,
+    version: parseSemanticVersion(r.version),
+    displayName: r.display_name,
+    description: r.description,
+    inputContext,
+    evidenceOntology,
+    baselineCatalogRefs,
+    allowedCatalogRefs,
+    evidenceRequestPolicy,
+    deepDiveModules,
+    labels,
+    decisionLogic,
+    confidenceComputation,
+    phaseBudget,
+    outputContract,
+  };
+
+  const errors = validatePlaybookCrossRefs(playbook);
+  if (errors.length > 0) {
+    const details = errors
+      .map((e) => `  - ${e.field}: ${e.message}`)
+      .join('\n');
+    throw new Error(`Playbook validation failed:\n${details}`);
+  }
+
+  return playbook;
+}

--- a/server/services/playbookAgentService/playbookRunner.ts
+++ b/server/services/playbookAgentService/playbookRunner.ts
@@ -1,0 +1,272 @@
+/**
+ * Playbook Runner — Core orchestrator for investigation playbooks.
+ *
+ * Executes the full investigation pipeline:
+ *   1. Load playbook config
+ *   2. Execute baseline queries (evidence gathering)
+ *   3. Evaluate hard rules (deterministic — before LLM)
+ *   4. If no hard rule fires: call LLM for verdict
+ *   5. Extract structured verdict from LLM output
+ *   6. Compute grounded confidence score
+ *   7. Store artifacts (immutable evidence chain)
+ *   8. Return PlaybookResult
+ *
+ * @license Apache-2.0
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { jsonStringify } from '../../utils/encoding.js';
+
+import { computeConfidence } from './confidenceEngine.js';
+import { evaluateHardRules, type HardRuleMatch } from './hardRuleEngine.js';
+import type {
+  IArtifactStore,
+  IEvidenceStore,
+  ILLMAdapter,
+  IPlaybookRunner,
+  PlaybookRunInput,
+} from './interfaces.js';
+import { extractVerdict } from './jsonExtractor.js';
+import {
+  type Playbook,
+  type PlaybookResult,
+  type QueryResult,
+  type QueryResults,
+  formatSemanticVersion,
+} from './playbookTypes.js';
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export type PlaybookRunnerDeps = {
+  readonly llmAdapter: ILLMAdapter;
+  readonly evidenceStore: IEvidenceStore;
+  readonly artifactStore: IArtifactStore;
+};
+
+// ── Prompt builders ─────────────────────────────────────────────────────────
+
+function buildSystemPrompt(playbook: Playbook): string {
+  const labelList = playbook.labels
+    .map((l) => `- ${l.labelId}: ${l.description}`)
+    .join('\n');
+
+  const evidenceList = playbook.evidenceOntology.evidenceTypes
+    .map((et) => `- ${et.evidenceId}: ${et.description}`)
+    .join('\n');
+
+  const outputFields = playbook.outputContract.requiredFields.join(', ');
+
+  return [
+    `You are an investigation agent for the "${playbook.displayName}" use case.`,
+    `${playbook.description}`,
+    '',
+    'EVIDENCE TYPES:',
+    evidenceList,
+    '',
+    'POSSIBLE VERDICTS:',
+    labelList,
+    '',
+    `OUTPUT: Return a JSON object with these required fields: ${outputFields}`,
+    '',
+    playbook.evidenceRequestPolicy.guidance ?? '',
+  ].join('\n');
+}
+
+function buildUserPrompt(
+  inputContext: Record<string, unknown>,
+  evidence: Record<string, QueryResult>,
+  hardRuleMatch: HardRuleMatch | undefined,
+): string {
+  const sections: string[] = ['INVESTIGATION CONTEXT:'];
+
+  // Input context
+  for (const [key, value] of Object.entries(inputContext)) {
+    sections.push(`  ${key}: ${jsonStringify(value)}`);
+  }
+
+  // Evidence from baseline queries
+  sections.push('', 'EVIDENCE GATHERED:');
+  for (const [catalogId, result] of Object.entries(evidence)) {
+    if (result.success && result.data.length > 0) {
+      sections.push(`  ${catalogId}: ${jsonStringify(result.data)}`);
+    } else if (!result.success) {
+      sections.push(`  ${catalogId}: QUERY FAILED — ${result.error ?? 'unknown error'}`);
+    } else {
+      sections.push(`  ${catalogId}: NO DATA RETURNED`);
+    }
+  }
+
+  // Hard rule context
+  if (hardRuleMatch) {
+    sections.push(
+      '',
+      'HARD RULE TRIGGERED:',
+      `  Rule: ${hardRuleMatch.ruleId}`,
+      `  Condition: ${hardRuleMatch.matchedCondition}`,
+      `  Outcome: ${hardRuleMatch.outcome} (LOCKED — you cannot override this verdict)`,
+      '',
+      'Your role: provide rationale and populate all required output fields.',
+      'The verdict is already determined by the hard rule.',
+    );
+  }
+
+  sections.push(
+    '',
+    'Analyze the evidence and return your verdict as a JSON object.',
+  );
+
+  return sections.join('\n');
+}
+
+// ── PlaybookRunner ──────────────────────────────────────────────────────────
+
+export default class PlaybookRunner implements IPlaybookRunner {
+  readonly #deps: PlaybookRunnerDeps;
+  readonly #playbooks: ReadonlyMap<string, Playbook>;
+
+  constructor(deps: PlaybookRunnerDeps, playbooks: ReadonlyMap<string, Playbook>) {
+    this.#deps = deps;
+    this.#playbooks = playbooks;
+  }
+
+  async run(input: PlaybookRunInput): Promise<PlaybookResult> {
+    const startTime = Date.now();
+    const sessionId = input.sessionId ?? uuidv4();
+
+    // 1. Load playbook
+    const playbook = this.#playbooks.get(input.playbookId);
+    if (!playbook) {
+      throw new Error(`Playbook not found: '${input.playbookId}'`);
+    }
+
+    // 2. Execute baseline queries
+    const queryResults = await this.#executeBaselineQueries(
+      playbook,
+      input.inputContext,
+    );
+
+    // 3. Evaluate hard rules
+    const hardRuleMatch = evaluateHardRules(
+      playbook.decisionLogic.hardRules,
+      queryResults.results,
+    );
+
+    // 4. Call LLM for verdict (even if hard rule fired — for rationale)
+    const llmResponse = await this.#deps.llmAdapter.complete({
+      systemPrompt: buildSystemPrompt(playbook),
+      userPrompt: buildUserPrompt(
+        input.inputContext,
+        queryResults.results,
+        hardRuleMatch,
+      ),
+    });
+
+    // 5. Extract structured verdict
+    let verdict = extractVerdict(llmResponse.content, playbook.outputContract);
+    verdict ??= {
+      verdict: playbook.decisionLogic.defaultLabel,
+      rationale: 'Unable to extract structured verdict from LLM output',
+      confidenceScore: 1,
+      uLlm: 1.0,
+      queriesExecuted: Object.keys(queryResults.results),
+      supportingEvidence: [],
+      contradictingEvidence: [],
+      criticalEvidenceMissing: true,
+      hasContradictorySignals: false,
+    };
+
+    // Override verdict if hard rule fired
+    if (hardRuleMatch) {
+      verdict = {
+        ...verdict,
+        verdict: hardRuleMatch.outcome,
+      };
+    }
+
+    // 6. Compute grounded confidence
+    const confidence = computeConfidence(verdict, queryResults, playbook);
+
+    // 7. Store artifacts
+    const result: PlaybookResult = {
+      playbookId: playbook.useCaseId,
+      playbookVersion: formatSemanticVersion(playbook.version),
+      verdict,
+      confidence,
+      hardRuleTriggered: hardRuleMatch?.ruleId,
+      evidence: this.#flattenEvidence(queryResults),
+      queriesExecuted: Object.keys(queryResults.results),
+      ranAt: new Date(),
+      durationMs: Date.now() - startTime,
+      sessionId,
+    };
+
+    await this.#storeArtifacts(result, sessionId, playbook.useCaseId);
+
+    return result;
+  }
+
+  async #executeBaselineQueries(
+    playbook: Playbook,
+    inputContext: Record<string, unknown>,
+  ): Promise<QueryResults> {
+    const results: Record<string, QueryResult> = {};
+
+    // Execute baseline queries in parallel
+    const queryPromises = playbook.baselineCatalogRefs.map(async (ref) => {
+      try {
+        const result = await this.#deps.evidenceStore.executeQuery({
+          catalogId: ref.catalogId,
+          version: formatSemanticVersion(ref.version),
+          parameters: inputContext,
+        });
+        results[ref.catalogId] = result;
+      } catch (error) {
+        results[ref.catalogId] = {
+          success: false,
+          data: [],
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    });
+
+    await Promise.all(queryPromises);
+    return { results };
+  }
+
+  #flattenEvidence(queryResults: QueryResults): Record<string, unknown>[] {
+    const evidence: Record<string, unknown>[] = [];
+    for (const [catalogId, result] of Object.entries(queryResults.results)) {
+      if (result.success) {
+        for (const row of result.data) {
+          evidence.push({ ...row, _catalogId: catalogId });
+        }
+      }
+    }
+    return evidence;
+  }
+
+  async #storeArtifacts(
+    result: PlaybookResult,
+    sessionId: string,
+    playbookId: string,
+  ): Promise<void> {
+    const now = new Date();
+
+    await Promise.all([
+      this.#deps.artifactStore.store({
+        sessionId,
+        playbookId,
+        artifactType: 'verdict',
+        data: result.verdict,
+        createdAt: now,
+      }),
+      this.#deps.artifactStore.store({
+        sessionId,
+        playbookId,
+        artifactType: 'confidence',
+        data: result.confidence,
+        createdAt: now,
+      }),
+    ]);
+  }
+}

--- a/server/services/playbookAgentService/playbookTypes.ts
+++ b/server/services/playbookAgentService/playbookTypes.ts
@@ -22,19 +22,13 @@ export type SemanticVersion = {
 };
 
 export function parseSemanticVersion(input: string): SemanticVersion {
-  const parts = input.split('.');
-  if (parts.length !== 3) {
+  const match = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.exec(input);
+  if (!match) {
     throw new Error(
-      `Invalid semantic version format: '${input}'. Expected format: 'X.Y.Z'`,
+      `Invalid semantic version format: '${input}'. Expected format: 'X.Y.Z' with no leading zeros.`,
     );
   }
-  const [major, minor, patch] = parts.map(Number);
-  if ([major, minor, patch].some((n) => !Number.isInteger(n) || n < 0)) {
-    throw new Error(
-      `Invalid semantic version format: '${input}'. All parts must be non-negative integers.`,
-    );
-  }
-  return { major, minor, patch };
+  return { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]) };
 }
 
 export function formatSemanticVersion(v: SemanticVersion): string {
@@ -68,9 +62,7 @@ export function validateCatalogReference(ref: CatalogReference): void {
     );
   }
   if (
-    FORBIDDEN_CATALOG_IDS.includes(
-      ref.catalogId.toLowerCase() as (typeof FORBIDDEN_CATALOG_IDS)[number],
-    )
+    (FORBIDDEN_CATALOG_IDS as readonly string[]).includes(ref.catalogId)
   ) {
     throw new Error(
       `Catalog ID cannot be '${ref.catalogId}' — use specific versioned IDs`,
@@ -236,9 +228,10 @@ export type PlaybookVerdict = {
   readonly verdict: string;
   readonly rationale: string;
   readonly confidenceScore: number;
+  /** LLM self-reported uncertainty (0–1). Higher = less certain. */
   readonly uLlm: number;
-  readonly ncmecReportRequired?: boolean;
-  readonly contentRemovalRequired?: boolean;
+  /** Domain-specific outputs defined by the playbook's output_contract. */
+  readonly additionalOutputs?: Record<string, unknown>;
   readonly queriesExecuted: readonly string[];
   readonly supportingEvidence: readonly string[];
   readonly contradictingEvidence: readonly string[];

--- a/server/services/playbookAgentService/playbookTypes.ts
+++ b/server/services/playbookAgentService/playbookTypes.ts
@@ -1,0 +1,285 @@
+/**
+ * Playbook Schema Types — Declarative configs for risk investigation use cases.
+ *
+ * Playbooks are versioned, declarative configurations that define investigation
+ * workflows, evidence requirements, decision logic, and output contracts.
+ *
+ * Key design principles:
+ *   - Versioned using semantic versioning for reproducibility
+ *   - Declarative: define requirements, not implementation
+ *   - Catalog-based: reference queries by ID + version, never contain SQL
+ *   - Deterministic: same input + same playbook version = same behavior
+ *
+ * @license Apache-2.0
+ */
+
+// ── Semantic Versioning ─────────────────────────────────────────────────────
+
+export type SemanticVersion = {
+  readonly major: number;
+  readonly minor: number;
+  readonly patch: number;
+};
+
+export function parseSemanticVersion(input: string): SemanticVersion {
+  const parts = input.split('.');
+  if (parts.length !== 3) {
+    throw new Error(
+      `Invalid semantic version format: '${input}'. Expected format: 'X.Y.Z'`,
+    );
+  }
+  const [major, minor, patch] = parts.map(Number);
+  if ([major, minor, patch].some((n) => !Number.isInteger(n) || n < 0)) {
+    throw new Error(
+      `Invalid semantic version format: '${input}'. All parts must be non-negative integers.`,
+    );
+  }
+  return { major, minor, patch };
+}
+
+export function formatSemanticVersion(v: SemanticVersion): string {
+  return `${v.major}.${v.minor}.${v.patch}`;
+}
+
+// ── Catalog References ──────────────────────────────────────────────────────
+
+const FORBIDDEN_CATALOG_IDS = [
+  'latest',
+  'head',
+  'main',
+  'master',
+  'current',
+] as const;
+
+const CATALOG_ID_PATTERN = /^[a-z0-9_]+$/;
+
+export type CatalogType = 'query' | 'query_bundle';
+
+export type CatalogReference = {
+  readonly catalogId: string;
+  readonly version: SemanticVersion;
+  readonly catalogType: CatalogType;
+};
+
+export function validateCatalogReference(ref: CatalogReference): void {
+  if (!CATALOG_ID_PATTERN.test(ref.catalogId)) {
+    throw new Error(
+      `Invalid catalog ID '${ref.catalogId}': must match /^[a-z0-9_]+$/`,
+    );
+  }
+  if (
+    FORBIDDEN_CATALOG_IDS.includes(
+      ref.catalogId.toLowerCase() as (typeof FORBIDDEN_CATALOG_IDS)[number],
+    )
+  ) {
+    throw new Error(
+      `Catalog ID cannot be '${ref.catalogId}' — use specific versioned IDs`,
+    );
+  }
+}
+
+export function formatCatalogReference(ref: CatalogReference): string {
+  return `${ref.catalogId}@${formatSemanticVersion(ref.version)}`;
+}
+
+// ── Input Context ───────────────────────────────────────────────────────────
+
+export type InputFieldType =
+  | 'string'
+  | 'integer'
+  | 'float'
+  | 'boolean'
+  | 'date'
+  | 'datetime';
+
+export type InputContextField = {
+  readonly fieldName: string;
+  readonly fieldType: InputFieldType;
+  readonly required: boolean;
+  readonly description: string;
+  readonly default?: unknown;
+  readonly validationPattern?: string;
+  readonly catalogParameterName?: string;
+};
+
+// ── Evidence Ontology ───────────────────────────────────────────────────────
+
+export type EvidenceQuality = {
+  readonly freshnessMaxAgeMs?: number;
+  readonly minimumConfidence: number;
+  readonly minimumNumRequiredSources: number;
+};
+
+export type EvidenceType = {
+  readonly evidenceId: string;
+  readonly displayName: string;
+  readonly description: string;
+  readonly quality: EvidenceQuality;
+};
+
+export type EvidenceOntology = {
+  readonly version: SemanticVersion;
+  readonly evidenceTypes: readonly EvidenceType[];
+};
+
+// ── Evidence Request Policy ─────────────────────────────────────────────────
+
+export type EvidenceRequestPolicy = {
+  readonly querySelectionMode: 'query_id';
+  readonly maxRounds: number;
+  readonly targetConfidence: number;
+  readonly maxAdditionalQueries: number;
+  readonly stopIfNoNewEvidence: boolean;
+  readonly triggerDeepDiveIf?: string;
+  readonly stopInvestigationIf?: string;
+  readonly guidance?: string;
+};
+
+// ── Deep-Dive Modules ───────────────────────────────────────────────────────
+
+export type DeepDiveCondition = {
+  readonly conditionId: string;
+  readonly description: string;
+  readonly expression: string;
+};
+
+export type DeepDiveModule = {
+  readonly moduleId: string;
+  readonly displayName: string;
+  readonly description: string;
+  readonly entryConditions: readonly DeepDiveCondition[];
+  readonly exitConditions: readonly DeepDiveCondition[];
+  readonly queryRefs: readonly CatalogReference[];
+};
+
+// ── Labels & Decision Logic ─────────────────────────────────────────────────
+
+export type LabelDefinition = {
+  readonly labelId: string;
+  readonly displayName: string;
+  readonly description: string;
+  readonly severity?: 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW' | 'INFO';
+};
+
+export type HardRule = {
+  readonly ruleId: string;
+  readonly description: string;
+  readonly condition: string;
+  readonly outcome: string;
+  readonly bypassLlm: boolean;
+};
+
+export type ScoringGuidance = {
+  readonly guidanceId: string;
+  readonly description: string;
+};
+
+export type DecisionLogic = {
+  readonly hardRules: readonly HardRule[];
+  readonly scoringGuidance: readonly ScoringGuidance[];
+  readonly defaultLabel: string;
+};
+
+// ── Confidence Computation ──────────────────────────────────────────────────
+
+export type ConfidenceComputation = {
+  readonly evidenceCompletenessWeight: number;
+  readonly signalStrengthWeight: number;
+  readonly signalAgreementWeight: number;
+  readonly dataQualityWeight: number;
+  readonly llmUncertaintyAlpha: number;
+  readonly baseCoverageWeight: number;
+  readonly additionalCoverageWeight: number;
+  readonly criticalEvidenceMissingPenalty: number;
+  readonly additionalQueryBonusMax: number;
+};
+
+// ── Phase Budget ────────────────────────────────────────────────────────────
+
+export type PhaseBudget = {
+  readonly maxQueries: number;
+  readonly maxLlmCalls: number;
+  readonly maxDurationMs: number;
+};
+
+// ── Output Contract ─────────────────────────────────────────────────────────
+
+export type OutputContract = {
+  readonly version: SemanticVersion;
+  readonly requiredFields: readonly string[];
+  readonly schema?: Record<string, unknown>;
+};
+
+// ── Playbook (top-level) ────────────────────────────────────────────────────
+
+export type Playbook = {
+  readonly useCaseId: string;
+  readonly version: SemanticVersion;
+  readonly displayName: string;
+  readonly description: string;
+  readonly inputContext: readonly InputContextField[];
+  readonly evidenceOntology: EvidenceOntology;
+  readonly baselineCatalogRefs: readonly CatalogReference[];
+  readonly allowedCatalogRefs: readonly CatalogReference[];
+  readonly evidenceRequestPolicy: EvidenceRequestPolicy;
+  readonly deepDiveModules?: readonly DeepDiveModule[];
+  readonly labels: readonly LabelDefinition[];
+  readonly decisionLogic: DecisionLogic;
+  readonly confidenceComputation: ConfidenceComputation;
+  readonly phaseBudget?: PhaseBudget;
+  readonly outputContract: OutputContract;
+};
+
+// ── Verdict & Results ───────────────────────────────────────────────────────
+
+export type PlaybookVerdict = {
+  readonly verdict: string;
+  readonly rationale: string;
+  readonly confidenceScore: number;
+  readonly uLlm: number;
+  readonly ncmecReportRequired?: boolean;
+  readonly contentRemovalRequired?: boolean;
+  readonly queriesExecuted: readonly string[];
+  readonly supportingEvidence: readonly string[];
+  readonly contradictingEvidence: readonly string[];
+  readonly criticalEvidenceMissing: boolean;
+  readonly hasContradictorySignals: boolean;
+  readonly isEdgeCase?: boolean;
+};
+
+export type ConfidenceBreakdown = {
+  readonly confidenceScore0To1: number;
+  readonly confidenceScore1To5: number;
+  readonly cGround: number;
+  readonly uLlm: number;
+  readonly alpha: number;
+  readonly evidenceCompleteness: number;
+  readonly signalStrength: number;
+  readonly signalAgreement: number;
+  readonly dataQuality: number;
+  readonly baseCoverage: number;
+  readonly additionalCoverage: number;
+};
+
+export type QueryResult = {
+  readonly success: boolean;
+  readonly data: readonly Record<string, unknown>[];
+  readonly error?: string;
+};
+
+export type QueryResults = {
+  readonly results: Record<string, QueryResult>;
+};
+
+export type PlaybookResult = {
+  readonly playbookId: string;
+  readonly playbookVersion: string;
+  readonly verdict: PlaybookVerdict;
+  readonly confidence: ConfidenceBreakdown;
+  readonly hardRuleTriggered?: string;
+  readonly evidence: readonly Record<string, unknown>[];
+  readonly queriesExecuted: readonly string[];
+  readonly ranAt: Date;
+  readonly durationMs: number;
+  readonly sessionId: string;
+};

--- a/server/services/playbookAgentService/queryCatalog.test.ts
+++ b/server/services/playbookAgentService/queryCatalog.test.ts
@@ -1,0 +1,107 @@
+import QueryCatalog, { parseCatalogEntry } from './queryCatalog.js';
+
+describe('parseCatalogEntry', () => {
+  it('parses a SQL template with metadata comments', () => {
+    const sql = `-- catalog_id: login_patterns
+-- version: 1.0.0
+-- description: Login frequency analysis
+-- Human-authored, versioned, pre-approved
+
+SELECT
+    DATE(login_timestamp) AS login_date,
+    COUNT(*) AS login_count
+FROM account_logins
+WHERE account_id = :account_id
+  AND login_timestamp >= DATEADD(day, -:lookback_days, :alert_timestamp)
+LIMIT 30;`;
+
+    const entry = parseCatalogEntry(sql);
+    expect(entry.catalogId).toBe('login_patterns');
+    expect(entry.version).toBe('1.0.0');
+    expect(entry.description).toBe('Login frequency analysis');
+    expect(entry.parameters).toEqual(
+      expect.arrayContaining(['account_id', 'lookback_days', 'alert_timestamp']),
+    );
+    expect(entry.sql).toContain('SELECT');
+    expect(entry.sql).toContain(':account_id');
+  });
+
+  it('throws on missing catalog_id', () => {
+    const sql = `-- version: 1.0.0
+SELECT 1;`;
+    expect(() => parseCatalogEntry(sql)).toThrow('catalog_id');
+  });
+
+  it('throws on missing version', () => {
+    const sql = `-- catalog_id: test_query
+SELECT 1;`;
+    expect(() => parseCatalogEntry(sql)).toThrow('version');
+  });
+
+  it('deduplicates parameters', () => {
+    const sql = `-- catalog_id: test
+-- version: 1.0.0
+SELECT * FROM t WHERE a = :id AND b = :id;`;
+
+    const entry = parseCatalogEntry(sql);
+    // :id appears twice but should be deduplicated
+    expect(entry.parameters.filter((p) => p === 'id')).toHaveLength(1);
+  });
+});
+
+describe('QueryCatalog', () => {
+  const entries = [
+    {
+      catalogId: 'query_a',
+      version: '1.0.0',
+      description: 'Query A',
+      sql: 'SELECT * FROM a WHERE id = :id',
+      parameters: ['id'],
+    },
+    {
+      catalogId: 'query_b',
+      version: '2.0.0',
+      description: 'Query B',
+      sql: 'SELECT * FROM b WHERE x = :x AND y = :y',
+      parameters: ['x', 'y'],
+    },
+  ];
+
+  it('resolves by CatalogReference', () => {
+    const catalog = new QueryCatalog(entries);
+    const result = catalog.resolve({
+      catalogId: 'query_a',
+      version: { major: 1, minor: 0, patch: 0 },
+      catalogType: 'query',
+    });
+    expect(result).toBeDefined();
+    expect(result!.catalogId).toBe('query_a');
+  });
+
+  it('resolves by string', () => {
+    const catalog = new QueryCatalog(entries);
+    expect(catalog.resolveByString('query_b@2.0.0')).toBeDefined();
+    expect(catalog.resolveByString('query_b@1.0.0')).toBeUndefined();
+  });
+
+  it('renders SQL with positional parameters', () => {
+    const catalog = new QueryCatalog(entries);
+    const entry = catalog.resolveByString('query_b@2.0.0')!;
+
+    const { sql, bindings } = catalog.renderSql(entry, { x: 'hello', y: 42 });
+    expect(sql).toBe('SELECT * FROM b WHERE x = $1 AND y = $2');
+    expect(bindings).toEqual(['hello', 42]);
+  });
+
+  it('throws on missing parameter', () => {
+    const catalog = new QueryCatalog(entries);
+    const entry = catalog.resolveByString('query_b@2.0.0')!;
+
+    expect(() => catalog.renderSql(entry, { x: 'hello' })).toThrow("Missing required parameter 'y'");
+  });
+
+  it('reports catalog size', () => {
+    const catalog = new QueryCatalog(entries);
+    expect(catalog.size).toBe(2);
+  });
+});

--- a/server/services/playbookAgentService/queryCatalog.test.ts
+++ b/server/services/playbookAgentService/queryCatalog.test.ts
@@ -100,8 +100,57 @@ describe('QueryCatalog', () => {
     expect(() => catalog.renderSql(entry, { x: 'hello' })).toThrow("Missing required parameter 'y'");
   });
 
-  it('reports catalog size', () => {
+  it('reports catalog size and keys', () => {
     const catalog = new QueryCatalog(entries);
     expect(catalog.size).toBe(2);
+    expect(catalog.catalogKeys).toEqual(
+      expect.arrayContaining(['query_a@1.0.0', 'query_b@2.0.0']),
+    );
+  });
+
+  it('does not match PostgreSQL casts as parameters', () => {
+    const sql = `-- catalog_id: cast_test
+-- version: 1.0.0
+SELECT created_at::date, amount::int FROM t WHERE id = :id;`;
+    const entry = parseCatalogEntry(sql);
+    expect(entry.parameters).toEqual(['id']);
+
+    const catalog = new QueryCatalog([entry]);
+    const resolved = catalog.resolveByString('cast_test@1.0.0')!;
+    const { sql: rendered, bindings } = catalog.renderSql(resolved, { id: 42 });
+    expect(rendered).toContain('::date');
+    expect(rendered).toContain('::int');
+    expect(bindings).toEqual([42]);
+  });
+
+  it('stops parsing metadata after SQL body starts', () => {
+    const sql = `-- catalog_id: meta_test
+-- version: 1.0.0
+SELECT 1;
+-- version: 2.0.0`;
+    const entry = parseCatalogEntry(sql);
+    expect(entry.version).toBe('1.0.0');
+  });
+
+  it('reuses $N placeholder for repeated parameters', () => {
+    const entry = {
+      catalogId: 'repeat_test',
+      version: '1.0.0',
+      description: '',
+      sql: 'SELECT * FROM t WHERE a = :id AND b = :id',
+      parameters: ['id'],
+    };
+    const catalog = new QueryCatalog([entry]);
+    const { sql: rendered, bindings } = catalog.renderSql(entry, { id: 99 });
+    expect(rendered).toBe('SELECT * FROM t WHERE a = $1 AND b = $1');
+    expect(bindings).toEqual([99]);
+  });
+
+  it('throws on duplicate catalog entries', () => {
+    const dupes = [
+      { catalogId: 'dup', version: '1.0.0', description: '', sql: 'SELECT 1', parameters: [] },
+      { catalogId: 'dup', version: '1.0.0', description: '', sql: 'SELECT 2', parameters: [] },
+    ];
+    expect(() => new QueryCatalog(dupes)).toThrow('Duplicate catalog entry');
   });
 });

--- a/server/services/playbookAgentService/queryCatalog.ts
+++ b/server/services/playbookAgentService/queryCatalog.ts
@@ -1,0 +1,165 @@
+/**
+ * Query Catalog — Pre-approved SQL template loader and resolver.
+ *
+ * The agent requests evidence by catalog_id@version. It never writes SQL
+ * or sees table names. The catalog resolves IDs to pre-approved, parameterized
+ * SQL templates that are executed by the evidence store.
+ *
+ * Template format:
+ *   -- catalog_id: login_patterns
+ *   -- version: 1.0.0
+ *   -- description: Login frequency analysis
+ *   SELECT ... WHERE account_id = :account_id
+ *
+ * Parameters use `:field_name` syntax for safe substitution.
+ *
+ * @license Apache-2.0
+ */
+
+import {
+  type CatalogReference,
+  type Playbook,
+  formatCatalogReference,
+} from './playbookTypes.js';
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export type CatalogEntry = {
+  readonly catalogId: string;
+  readonly version: string;
+  readonly description: string;
+  readonly sql: string;
+  readonly parameters: readonly string[];
+};
+
+export type CatalogEntryMap = ReadonlyMap<string, CatalogEntry>;
+
+// ── Parsing ─────────────────────────────────────────────────────────────────
+
+const METADATA_PATTERN =
+  /^--\s*(catalog_id|version|description):\s*(.+)$/;
+const PARAMETER_PATTERN = /:([a-z_][a-z0-9_]*)/g;
+
+/**
+ * Parse a SQL template file into a CatalogEntry.
+ *
+ * Extracts metadata from comment headers and discovers parameters
+ * from `:field_name` tokens in the SQL body.
+ */
+export function parseCatalogEntry(sql: string): CatalogEntry {
+  const lines = sql.split('\n');
+  const metadata: Record<string, string> = {};
+  const sqlLines: string[] = [];
+
+  for (const line of lines) {
+    const match = METADATA_PATTERN.exec(line.trim());
+    if (match) {
+      metadata[match[1]] = match[2].trim();
+    } else if (!line.trim().startsWith('--') || sqlLines.length > 0) {
+      // Once we hit non-comment lines, include everything (including inline comments)
+      sqlLines.push(line);
+    }
+  }
+
+  const sqlBody = sqlLines.join('\n').trim();
+
+  if (!metadata['catalog_id']) {
+    throw new Error('SQL template missing required "catalog_id" metadata comment');
+  }
+  if (!metadata['version']) {
+    throw new Error(
+      `SQL template '${metadata['catalog_id']}' missing required "version" metadata comment`,
+    );
+  }
+
+  // Extract parameter names from :field_name tokens
+  const parameterMatches = sqlBody.matchAll(PARAMETER_PATTERN);
+  const parameters = [...new Set([...parameterMatches].map((m) => m[1]))];
+
+  return {
+    catalogId: metadata['catalog_id'],
+    version: metadata['version'],
+    description: metadata['description'] ?? '',
+    sql: sqlBody,
+    parameters,
+  };
+}
+
+// ── Query Catalog ───────────────────────────────────────────────────────────
+
+export default class QueryCatalog {
+  readonly #entries: Map<string, CatalogEntry>;
+
+  constructor(entries: readonly CatalogEntry[]) {
+    this.#entries = new Map(
+      entries.map((e) => [`${e.catalogId}@${e.version}`, e]),
+    );
+  }
+
+  /**
+   * Resolve a catalog reference to a SQL template.
+   *
+   * Returns undefined if the reference is not found.
+   */
+  resolve(ref: CatalogReference): CatalogEntry | undefined {
+    const key = formatCatalogReference(ref);
+    return this.#entries.get(key);
+  }
+
+  /**
+   * Resolve a catalog_id@version string to a SQL template.
+   */
+  resolveByString(refString: string): CatalogEntry | undefined {
+    return this.#entries.get(refString);
+  }
+
+  /**
+   * Validate that a catalog reference is in the playbook's allowed set.
+   *
+   * Returns true only if the ref exists in the catalog AND is listed
+   * in the playbook's allowed_catalog_refs.
+   */
+  isAllowed(refString: string, playbook: Playbook): boolean {
+    const allowedKeys = new Set(
+      playbook.allowedCatalogRefs.map(formatCatalogReference),
+    );
+    return allowedKeys.has(refString) && this.#entries.has(refString);
+  }
+
+  /**
+   * Render a SQL template by substituting parameters.
+   *
+   * Uses parameterized substitution (not string interpolation) to prevent injection.
+   * Returns the SQL string with `:param` tokens replaced by their values.
+   *
+   * Throws if a required parameter is missing.
+   */
+  renderSql(
+    entry: CatalogEntry,
+    parameters: Record<string, unknown>,
+  ): { readonly sql: string; readonly bindings: readonly unknown[] } {
+    // Build ordered bindings array and replace :param with $N positional params
+    const bindings: unknown[] = [];
+    let paramIndex = 0;
+    const renderedSql = entry.sql.replace(PARAMETER_PATTERN, (_match, name: string) => {
+      if (!(name in parameters)) {
+        throw new Error(
+          `Missing required parameter '${name}' for query '${entry.catalogId}'`,
+        );
+      }
+      bindings.push(parameters[name]);
+      paramIndex++;
+      return `$${paramIndex}`;
+    });
+
+    return { sql: renderedSql, bindings };
+  }
+
+  get size(): number {
+    return this.#entries.size;
+  }
+
+  get catalogIds(): string[] {
+    return [...this.#entries.keys()];
+  }
+}

--- a/server/services/playbookAgentService/queryCatalog.ts
+++ b/server/services/playbookAgentService/queryCatalog.ts
@@ -38,7 +38,7 @@ export type CatalogEntryMap = ReadonlyMap<string, CatalogEntry>;
 
 const METADATA_PATTERN =
   /^--\s*(catalog_id|version|description):\s*(.+)$/;
-const PARAMETER_PATTERN = /:([a-z_][a-z0-9_]*)/g;
+const PARAMETER_PATTERN = /(?<!:):([a-z_][a-z0-9_]*)/g;
 
 /**
  * Parse a SQL template file into a CatalogEntry.
@@ -50,13 +50,20 @@ export function parseCatalogEntry(sql: string): CatalogEntry {
   const lines = sql.split('\n');
   const metadata: Record<string, string> = {};
   const sqlLines: string[] = [];
+  let headerDone = false;
 
   for (const line of lines) {
-    const match = METADATA_PATTERN.exec(line.trim());
-    if (match) {
-      metadata[match[1]] = match[2].trim();
-    } else if (!line.trim().startsWith('--') || sqlLines.length > 0) {
-      // Once we hit non-comment lines, include everything (including inline comments)
+    if (!headerDone) {
+      const match = METADATA_PATTERN.exec(line.trim());
+      if (match) {
+        metadata[match[1]] = match[2].trim();
+        continue;
+      }
+      if (!line.trim().startsWith('--')) {
+        headerDone = true;
+      }
+    }
+    if (headerDone) {
       sqlLines.push(line);
     }
   }
@@ -91,9 +98,14 @@ export default class QueryCatalog {
   readonly #entries: Map<string, CatalogEntry>;
 
   constructor(entries: readonly CatalogEntry[]) {
-    this.#entries = new Map(
-      entries.map((e) => [`${e.catalogId}@${e.version}`, e]),
-    );
+    this.#entries = new Map();
+    for (const e of entries) {
+      const key = `${e.catalogId}@${e.version}`;
+      if (this.#entries.has(key)) {
+        throw new Error(`Duplicate catalog entry: '${key}'`);
+      }
+      this.#entries.set(key, e);
+    }
   }
 
   /**
@@ -127,11 +139,10 @@ export default class QueryCatalog {
   }
 
   /**
-   * Render a SQL template by substituting parameters.
+   * Render a SQL template by substituting :param tokens with positional $N
+   * placeholders and collecting bindings.
    *
    * Uses parameterized substitution (not string interpolation) to prevent injection.
-   * Returns the SQL string with `:param` tokens replaced by their values.
-   *
    * Throws if a required parameter is missing.
    */
   renderSql(
@@ -140,16 +151,21 @@ export default class QueryCatalog {
   ): { readonly sql: string; readonly bindings: readonly unknown[] } {
     // Build ordered bindings array and replace :param with $N positional params
     const bindings: unknown[] = [];
-    let paramIndex = 0;
+    const paramIndexMap = new Map<string, number>();
     const renderedSql = entry.sql.replace(PARAMETER_PATTERN, (_match, name: string) => {
-      if (!(name in parameters)) {
+      if (!Object.hasOwn(parameters, name)) {
         throw new Error(
           `Missing required parameter '${name}' for query '${entry.catalogId}'`,
         );
       }
+      const existing = paramIndexMap.get(name);
+      if (existing !== undefined) {
+        return `$${existing}`;
+      }
       bindings.push(parameters[name]);
-      paramIndex++;
-      return `$${paramIndex}`;
+      const idx = bindings.length;
+      paramIndexMap.set(name, idx);
+      return `$${idx}`;
     });
 
     return { sql: renderedSql, bindings };
@@ -159,7 +175,8 @@ export default class QueryCatalog {
     return this.#entries.size;
   }
 
-  get catalogIds(): string[] {
+  /** Returns all catalogId@version keys in the catalog. */
+  get catalogKeys(): string[] {
     return [...this.#entries.keys()];
   }
 }


### PR DESCRIPTION
- depends on #572
- depends on #573
- depends on #574
- depends on #575
- depends on #576
- depends on #577
- depends on #578

## Summary

Concrete examples and an end-to-end walkthrough that exercises **every component** through two contrasting scenarios.

**Part 8 of 8** — final PR in the stack. Depends on #578 (runner and service).

### Examples
| File | Scenario |
|------|----------|
| `dummy_csam_triage.playbook.json` | Hard rule fires: CRITICAL hash -> REPORT_AND_REMOVE |
| `dummy_csam_triage.evidence.json` | Sample query request and result |
| `dummy_csam_triage.result.json` | Expected PlaybookResult with confidence breakdown |
| `account_takeover_triage.playbook.json` | LLM decides: 3 labels, scoring guidance, no hard rules |
| `account_takeover_triage.catalog.sql` | SQL template with `:account_id` and `:lookback_days` |
| `README.md` | Documents backend flow and target UI rendering |

### `componentWalkthrough.test.ts` — 8 tests across 2 scenarios

**Scenario 1: Account Takeover (LLM decides)**
| Test | Component exercised |
|------|-------------------|
| Parses ATO playbook with no hard rules | PlaybookLoader |
| Parses SQL template, renders with bindings | QueryCatalog |
| Confirms no rules fire | HardRuleEngine |
| Extracts verdict from messy LLM text with code fences | JsonExtractor |
| Verifies C_final = C_ground x (1 - alpha x u_llm) math | ConfidenceEngine |
| Full pipeline: LLM verdict used, contradictions penalize | PlaybookAgentService |

**Scenario 2: CSAM Triage (hard rule decides)**
| Test | Component exercised |
|------|-------------------|
| CRITICAL hash fires deterministic rule | HardRuleEngine |
| Hard rule overrides LLM NO_ACTION, rationale preserved | PlaybookAgentService |

### `examples.test.ts` — 2 tests
- Validates playbook fixture stays parseable
- Validates evidence and result fixtures stay aligned

## Test plan
- [ ] `npm test -- --testPathPattern=playbookAgentService` passes (all 59 tests across 8 suites)

> Depends on [#578 Runner and service](https://github.com/roostorg/coop/pull/578). Merge #572, #573, #574, #575, #576, #577, #578 first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a Playbook Agent framework for automated risk investigations, including playbook parsing, rule evaluation, evidence querying, LLM verdict extraction, and confidence scoring.
  * Added query catalog, deterministic hard-rule evaluation, JSON verdict extraction, and orchestration/runner service.
  * Included example playbooks and sample data for CSAM and account-takeover scenarios.

* **Tests**
  * Added extensive integration and unit tests covering parsing, rule evaluation, extraction, confidence computation, runner behavior, and end-to-end scenarios.

* **Documentation**
  * Added example README documenting the dummy CSAM triage example.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/579?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Part of #659