### PR TITLE
[Permissions] Add role editor API and UI

### DIFF
--- a/client/src/graphql/generated.ts
+++ b/client/src/graphql/generated.ts
@@ -2449,6 +2449,7 @@ export type GQLMutation = {
   readonly removeAccessibleQueuesToUser: GQLRemoveAccessibleQueuesToUserResponse;
   readonly removeFavoriteMRTQueue: GQLRemoveFavoriteMrtQueueSuccessResponse;
   readonly removeFavoriteRule: GQLRemoveFavoriteRuleSuccessResponse;
+  readonly renameRole: GQLRole;
   readonly reorderRoutingRules: GQLReorderRoutingRulesResponse;
   readonly requestDemo?: Maybe<Scalars['Boolean']['output']>;
   readonly resetPassword: Scalars['Boolean']['output'];
@@ -2484,6 +2485,7 @@ export type GQLMutation = {
   readonly updatePolicy: GQLUpdatePolicyResponse;
   readonly updateReportingRule: GQLUpdateReportingRuleResponse;
   readonly updateRole?: Maybe<Scalars['Boolean']['output']>;
+  readonly updateRolePermissions: GQLRole;
   readonly updateRoutingRule: GQLUpdateRoutingRuleResponse;
   readonly updateSSOCredentials: Scalars['Boolean']['output'];
   readonly updateTextBank: GQLMutateBankResponse;
@@ -2677,6 +2679,10 @@ export type GQLMutationRemoveFavoriteRuleArgs = {
   ruleId: Scalars['ID']['input'];
 };
 
+export type GQLMutationRenameRoleArgs = {
+  input: GQLRenameRoleInput;
+};
+
 export type GQLMutationReorderRoutingRulesArgs = {
   input: GQLReorderRoutingRulesInput;
 };
@@ -2793,6 +2799,10 @@ export type GQLMutationUpdateReportingRuleArgs = {
 
 export type GQLMutationUpdateRoleArgs = {
   input: GQLUpdateRoleInput;
+};
+
+export type GQLMutationUpdateRolePermissionsArgs = {
+  input: GQLUpdateRolePermissionsInput;
 };
 
 export type GQLMutationUpdateRoutingRuleArgs = {
@@ -3205,6 +3215,21 @@ export type GQLPendingInvite = {
   readonly role: GQLUserRole;
 };
 
+export type GQLPermissionGroup = {
+  readonly __typename: 'PermissionGroup';
+  readonly description: Scalars['String']['output'];
+  readonly key: Scalars['String']['output'];
+  readonly label: Scalars['String']['output'];
+  readonly permissions: ReadonlyArray<GQLPermissionGroupItem>;
+};
+
+export type GQLPermissionGroupItem = {
+  readonly __typename: 'PermissionGroupItem';
+  readonly description: Scalars['String']['output'];
+  readonly label: Scalars['String']['output'];
+  readonly permission: GQLUserPermission;
+};
+
 export type GQLPlaceBounds = {
   readonly __typename: 'PlaceBounds';
   readonly northeastCorner: GQLLatLng;
@@ -3337,10 +3362,14 @@ export type GQLQuery = {
   readonly ncmecThreads: ReadonlyArray<GQLThreadWithMessagesAndIpAddress>;
   readonly org?: Maybe<GQLOrg>;
   readonly partialItems: GQLPartialItemsResponse;
+  /** Server-owned grouping + ordering for the role-editor UI. Gated on MANAGE_ROLES. */
+  readonly permissionGroups: ReadonlyArray<GQLPermissionGroup>;
   readonly policy?: Maybe<GQLPolicy>;
   readonly recentUserStrikeActions: ReadonlyArray<GQLRecentUserStrikeActions>;
   readonly reportingInsights: GQLReportingInsights;
   readonly reportingRule?: Maybe<GQLReportingRule>;
+  /** All system roles for the invoking admin's org. Gated on MANAGE_ROLES. */
+  readonly rolesForOrg: ReadonlyArray<GQLRole>;
   readonly rule?: Maybe<GQLRule>;
   readonly spotTestRule: GQLRuleExecutionResult;
   readonly textBank?: Maybe<GQLTextBank>;
@@ -3699,6 +3728,12 @@ export type GQLRemoveFavoriteRuleSuccessResponse = {
   readonly _?: Maybe<Scalars['Boolean']['output']>;
 };
 
+export type GQLRenameRoleInput = {
+  readonly description?: InputMaybe<Scalars['String']['input']>;
+  readonly displayName: Scalars['String']['input'];
+  readonly roleKey: GQLUserRole;
+};
+
 export type GQLReorderRoutingRulesInput = {
   readonly isAppealsRule?: InputMaybe<Scalars['Boolean']['input']>;
   readonly order: ReadonlyArray<Scalars['ID']['input']>;
@@ -3855,6 +3890,22 @@ export type GQLRetryNcmecSubmissionResponse = {
    */
   readonly error?: Maybe<Scalars['String']['output']>;
   readonly success: Scalars['Boolean']['output'];
+};
+
+export type GQLRole = {
+  readonly __typename: 'Role';
+  readonly description?: Maybe<Scalars['String']['output']>;
+  readonly displayName: Scalars['String']['output'];
+  /** Persisted public.roles.id, or null when the row is materialized lazily on first save. */
+  readonly id?: Maybe<Scalars['ID']['output']>;
+  /** True when permissions/metadata come from the static fallback rather than public.roles. */
+  readonly isFallback: Scalars['Boolean']['output'];
+  readonly isSystem: Scalars['Boolean']['output'];
+  /** Stable role identifier (matches UserRole). */
+  readonly key: GQLUserRole;
+  readonly permissions: ReadonlyArray<GQLUserPermission>;
+  /** Number of approved (non-rejected) users in the org assigned to this role. */
+  readonly userCount: Scalars['Int']['output'];
 };
 
 export type GQLRotateApiKeyError = GQLError & {
@@ -4667,6 +4718,11 @@ export type GQLUpdateReportingRuleResponse =
 export type GQLUpdateRoleInput = {
   readonly id: Scalars['ID']['input'];
   readonly role: GQLUserRole;
+};
+
+export type GQLUpdateRolePermissionsInput = {
+  readonly permissions: ReadonlyArray<GQLUserPermission>;
+  readonly roleKey: GQLUserRole;
 };
 
 export type GQLUpdateRoutingRuleInput = {
@@ -24218,6 +24274,23 @@ export type GQLChangePasswordMutation = {
       };
 };
 
+export type GQLRolesForOrgQueryVariables = Exact<{ [key: string]: never }>;
+
+export type GQLRolesForOrgQuery = {
+  readonly __typename: 'Query';
+  readonly rolesForOrg: ReadonlyArray<{
+    readonly __typename: 'Role';
+    readonly id?: string | null;
+    readonly key: GQLUserRole;
+    readonly displayName: string;
+    readonly description?: string | null;
+    readonly isSystem: boolean;
+    readonly isFallback: boolean;
+    readonly permissions: ReadonlyArray<GQLUserPermission>;
+    readonly userCount: number;
+  }>;
+};
+
 export type GQLManageUsersQueryVariables = Exact<{ [key: string]: never }>;
 
 export type GQLManageUsersQuery = {
@@ -24441,6 +24514,62 @@ export type GQLUpdateOrgInfoMutation = {
   readonly updateOrgInfo: {
     readonly __typename: 'UpdateOrgInfoSuccessResponse';
     readonly _?: boolean | null;
+  };
+};
+
+export type GQLPermissionGroupsQueryVariables = Exact<{ [key: string]: never }>;
+
+export type GQLPermissionGroupsQuery = {
+  readonly __typename: 'Query';
+  readonly permissionGroups: ReadonlyArray<{
+    readonly __typename: 'PermissionGroup';
+    readonly key: string;
+    readonly label: string;
+    readonly description: string;
+    readonly permissions: ReadonlyArray<{
+      readonly __typename: 'PermissionGroupItem';
+      readonly permission: GQLUserPermission;
+      readonly label: string;
+      readonly description: string;
+    }>;
+  }>;
+};
+
+export type GQLUpdateRolePermissionsMutationVariables = Exact<{
+  input: GQLUpdateRolePermissionsInput;
+}>;
+
+export type GQLUpdateRolePermissionsMutation = {
+  readonly __typename: 'Mutation';
+  readonly updateRolePermissions: {
+    readonly __typename: 'Role';
+    readonly id?: string | null;
+    readonly key: GQLUserRole;
+    readonly displayName: string;
+    readonly description?: string | null;
+    readonly isSystem: boolean;
+    readonly isFallback: boolean;
+    readonly permissions: ReadonlyArray<GQLUserPermission>;
+    readonly userCount: number;
+  };
+};
+
+export type GQLRenameRoleMutationVariables = Exact<{
+  input: GQLRenameRoleInput;
+}>;
+
+export type GQLRenameRoleMutation = {
+  readonly __typename: 'Mutation';
+  readonly renameRole: {
+    readonly __typename: 'Role';
+    readonly id?: string | null;
+    readonly key: GQLUserRole;
+    readonly displayName: string;
+    readonly description?: string | null;
+    readonly isSystem: boolean;
+    readonly isFallback: boolean;
+    readonly permissions: ReadonlyArray<GQLUserPermission>;
+    readonly userCount: number;
   };
 };
 
@@ -42207,6 +42336,111 @@ export type GQLChangePasswordMutationOptions = Apollo.BaseMutationOptions<
   GQLChangePasswordMutation,
   GQLChangePasswordMutationVariables
 >;
+export const GQLRolesForOrgDocument = gql`
+  query RolesForOrg {
+    rolesForOrg {
+      id
+      key
+      displayName
+      description
+      isSystem
+      isFallback
+      permissions
+      userCount
+    }
+  }
+`;
+
+/**
+ * __useGQLRolesForOrgQuery__
+ *
+ * To run a query within a React component, call `useGQLRolesForOrgQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGQLRolesForOrgQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGQLRolesForOrgQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGQLRolesForOrgQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    GQLRolesForOrgQuery,
+    GQLRolesForOrgQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<GQLRolesForOrgQuery, GQLRolesForOrgQueryVariables>(
+    GQLRolesForOrgDocument,
+    options,
+  );
+}
+export function useGQLRolesForOrgLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GQLRolesForOrgQuery,
+    GQLRolesForOrgQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<GQLRolesForOrgQuery, GQLRolesForOrgQueryVariables>(
+    GQLRolesForOrgDocument,
+    options,
+  );
+}
+// @ts-ignore
+export function useGQLRolesForOrgSuspenseQuery(
+  baseOptions?: Apollo.SuspenseQueryHookOptions<
+    GQLRolesForOrgQuery,
+    GQLRolesForOrgQueryVariables
+  >,
+): Apollo.UseSuspenseQueryResult<
+  GQLRolesForOrgQuery,
+  GQLRolesForOrgQueryVariables
+>;
+export function useGQLRolesForOrgSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GQLRolesForOrgQuery,
+        GQLRolesForOrgQueryVariables
+      >,
+): Apollo.UseSuspenseQueryResult<
+  GQLRolesForOrgQuery | undefined,
+  GQLRolesForOrgQueryVariables
+>;
+export function useGQLRolesForOrgSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GQLRolesForOrgQuery,
+        GQLRolesForOrgQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GQLRolesForOrgQuery,
+    GQLRolesForOrgQueryVariables
+  >(GQLRolesForOrgDocument, options);
+}
+export type GQLRolesForOrgQueryHookResult = ReturnType<
+  typeof useGQLRolesForOrgQuery
+>;
+export type GQLRolesForOrgLazyQueryHookResult = ReturnType<
+  typeof useGQLRolesForOrgLazyQuery
+>;
+export type GQLRolesForOrgSuspenseQueryHookResult = ReturnType<
+  typeof useGQLRolesForOrgSuspenseQuery
+>;
+export type GQLRolesForOrgQueryResult = Apollo.QueryResult<
+  GQLRolesForOrgQuery,
+  GQLRolesForOrgQueryVariables
+>;
 export const GQLManageUsersDocument = gql`
   query ManageUsers {
     myOrg {
@@ -43254,6 +43488,226 @@ export type GQLUpdateOrgInfoMutationOptions = Apollo.BaseMutationOptions<
   GQLUpdateOrgInfoMutation,
   GQLUpdateOrgInfoMutationVariables
 >;
+export const GQLPermissionGroupsDocument = gql`
+  query PermissionGroups {
+    permissionGroups {
+      key
+      label
+      description
+      permissions {
+        permission
+        label
+        description
+      }
+    }
+  }
+`;
+
+/**
+ * __useGQLPermissionGroupsQuery__
+ *
+ * To run a query within a React component, call `useGQLPermissionGroupsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGQLPermissionGroupsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGQLPermissionGroupsQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGQLPermissionGroupsQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    GQLPermissionGroupsQuery,
+    GQLPermissionGroupsQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GQLPermissionGroupsQuery,
+    GQLPermissionGroupsQueryVariables
+  >(GQLPermissionGroupsDocument, options);
+}
+export function useGQLPermissionGroupsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GQLPermissionGroupsQuery,
+    GQLPermissionGroupsQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GQLPermissionGroupsQuery,
+    GQLPermissionGroupsQueryVariables
+  >(GQLPermissionGroupsDocument, options);
+}
+// @ts-ignore
+export function useGQLPermissionGroupsSuspenseQuery(
+  baseOptions?: Apollo.SuspenseQueryHookOptions<
+    GQLPermissionGroupsQuery,
+    GQLPermissionGroupsQueryVariables
+  >,
+): Apollo.UseSuspenseQueryResult<
+  GQLPermissionGroupsQuery,
+  GQLPermissionGroupsQueryVariables
+>;
+export function useGQLPermissionGroupsSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GQLPermissionGroupsQuery,
+        GQLPermissionGroupsQueryVariables
+      >,
+): Apollo.UseSuspenseQueryResult<
+  GQLPermissionGroupsQuery | undefined,
+  GQLPermissionGroupsQueryVariables
+>;
+export function useGQLPermissionGroupsSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GQLPermissionGroupsQuery,
+        GQLPermissionGroupsQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GQLPermissionGroupsQuery,
+    GQLPermissionGroupsQueryVariables
+  >(GQLPermissionGroupsDocument, options);
+}
+export type GQLPermissionGroupsQueryHookResult = ReturnType<
+  typeof useGQLPermissionGroupsQuery
+>;
+export type GQLPermissionGroupsLazyQueryHookResult = ReturnType<
+  typeof useGQLPermissionGroupsLazyQuery
+>;
+export type GQLPermissionGroupsSuspenseQueryHookResult = ReturnType<
+  typeof useGQLPermissionGroupsSuspenseQuery
+>;
+export type GQLPermissionGroupsQueryResult = Apollo.QueryResult<
+  GQLPermissionGroupsQuery,
+  GQLPermissionGroupsQueryVariables
+>;
+export const GQLUpdateRolePermissionsDocument = gql`
+  mutation UpdateRolePermissions($input: UpdateRolePermissionsInput!) {
+    updateRolePermissions(input: $input) {
+      id
+      key
+      displayName
+      description
+      isSystem
+      isFallback
+      permissions
+      userCount
+    }
+  }
+`;
+export type GQLUpdateRolePermissionsMutationFn = Apollo.MutationFunction<
+  GQLUpdateRolePermissionsMutation,
+  GQLUpdateRolePermissionsMutationVariables
+>;
+
+/**
+ * __useGQLUpdateRolePermissionsMutation__
+ *
+ * To run a mutation, you first call `useGQLUpdateRolePermissionsMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useGQLUpdateRolePermissionsMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [gqlUpdateRolePermissionsMutation, { data, loading, error }] = useGQLUpdateRolePermissionsMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useGQLUpdateRolePermissionsMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    GQLUpdateRolePermissionsMutation,
+    GQLUpdateRolePermissionsMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    GQLUpdateRolePermissionsMutation,
+    GQLUpdateRolePermissionsMutationVariables
+  >(GQLUpdateRolePermissionsDocument, options);
+}
+export type GQLUpdateRolePermissionsMutationHookResult = ReturnType<
+  typeof useGQLUpdateRolePermissionsMutation
+>;
+export type GQLUpdateRolePermissionsMutationResult =
+  Apollo.MutationResult<GQLUpdateRolePermissionsMutation>;
+export type GQLUpdateRolePermissionsMutationOptions =
+  Apollo.BaseMutationOptions<
+    GQLUpdateRolePermissionsMutation,
+    GQLUpdateRolePermissionsMutationVariables
+  >;
+export const GQLRenameRoleDocument = gql`
+  mutation RenameRole($input: RenameRoleInput!) {
+    renameRole(input: $input) {
+      id
+      key
+      displayName
+      description
+      isSystem
+      isFallback
+      permissions
+      userCount
+    }
+  }
+`;
+export type GQLRenameRoleMutationFn = Apollo.MutationFunction<
+  GQLRenameRoleMutation,
+  GQLRenameRoleMutationVariables
+>;
+
+/**
+ * __useGQLRenameRoleMutation__
+ *
+ * To run a mutation, you first call `useGQLRenameRoleMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useGQLRenameRoleMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [gqlRenameRoleMutation, { data, loading, error }] = useGQLRenameRoleMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useGQLRenameRoleMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    GQLRenameRoleMutation,
+    GQLRenameRoleMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    GQLRenameRoleMutation,
+    GQLRenameRoleMutationVariables
+  >(GQLRenameRoleDocument, options);
+}
+export type GQLRenameRoleMutationHookResult = ReturnType<
+  typeof useGQLRenameRoleMutation
+>;
+export type GQLRenameRoleMutationResult =
+  Apollo.MutationResult<GQLRenameRoleMutation>;
+export type GQLRenameRoleMutationOptions = Apollo.BaseMutationOptions<
+  GQLRenameRoleMutation,
+  GQLRenameRoleMutationVariables
+>;
 export const GQLGetSsoCredentialsDocument = gql`
   query GetSSOCredentials {
     me {
@@ -43525,11 +43979,13 @@ export const namedOperations = {
     UserStrikeThresholds: 'UserStrikeThresholds',
     AccountSettings: 'AccountSettings',
     PersonalSafetySettings: 'PersonalSafetySettings',
+    RolesForOrg: 'RolesForOrg',
     ManageUsers: 'ManageUsers',
     HasNcmecReportingEnabled: 'HasNcmecReportingEnabled',
     NcmecOrgSettings: 'NcmecOrgSettings',
     OrgDefaultSafetySettings: 'OrgDefaultSafetySettings',
     OrgSettings: 'OrgSettings',
+    PermissionGroups: 'PermissionGroups',
     GetSSOCredentials: 'GetSSOCredentials',
   },
   Mutation: {
@@ -43611,6 +44067,8 @@ export const namedOperations = {
     UpdateNcmecOrgSettings: 'UpdateNcmecOrgSettings',
     SetOrgDefaultSafetySettings: 'SetOrgDefaultSafetySettings',
     UpdateOrgInfo: 'UpdateOrgInfo',
+    UpdateRolePermissions: 'UpdateRolePermissions',
+    RenameRole: 'RenameRole',
     UpdateSSOCredentials: 'UpdateSSOCredentials',
   },
   Fragment: {

--- a/client/src/webpages/dashboard/components/CoopButton.tsx
+++ b/client/src/webpages/dashboard/components/CoopButton.tsx
@@ -12,6 +12,7 @@ export type CoopButtonType =
   | 'green'
   | 'link';
 export type CoopButtonFontWeight = 'normal' | 'semibold';
+export type CoopButtonIconStyle = 'fill' | 'stroke';
 
 export default function CoopButton(
   props: {
@@ -27,6 +28,7 @@ export default function CoopButton(
     loading?: boolean;
     fontWeight?: CoopButtonFontWeight;
     iconPosition?: 'left' | 'right';
+    iconStyle?: CoopButtonIconStyle;
   } & (
     | {
         title: string;
@@ -56,6 +58,7 @@ export default function CoopButton(
     loading = false,
     fontWeight = 'semibold',
     iconPosition = 'left',
+    iconStyle = 'fill',
   } = props;
   const size = 'size' in props ? (props.size ?? 'middle') : 'middle';
 
@@ -83,6 +86,11 @@ export default function CoopButton(
         return 'w-8 h-8';
     }
   })();
+
+  const iconColorProps =
+    iconStyle === 'stroke'
+      ? '[fill:none] text-inherit'
+      : 'fill-inherit text-inherit';
 
   const colorProps = (() => {
     switch (type) {
@@ -120,11 +128,11 @@ export default function CoopButton(
       <div className="flex items-center justify-center gap-2">
         {/* See https://stackoverflow.com/a/37414418 for why this is capitalized */}
         {Icon !== undefined && iconPosition === 'left' ? (
-          <Icon className={`${iconSizeProps} fill-inherit text-inherit`} />
+          <Icon className={`${iconSizeProps} ${iconColorProps}`} />
         ) : null}
         {title}
         {Icon !== undefined && iconPosition === 'right' ? (
-          <Icon className={`${iconSizeProps} fill-inherit text-inherit`} />
+          <Icon className={`${iconSizeProps} ${iconColorProps}`} />
         ) : null}
       </div>
     </button>

--- a/client/src/webpages/settings/ManageRolesTab.tsx
+++ b/client/src/webpages/settings/ManageRolesTab.tsx
@@ -1,0 +1,170 @@
+import { Popover, PopoverContent, PopoverTrigger } from '@/coop-ui/Popover';
+import {
+  GQLUserRole,
+  namedOperations,
+  useGQLRolesForOrgQuery,
+} from '@/graphql/generated';
+import { titleCaseEnumString } from '@/utils/string';
+import { gql } from '@apollo/client';
+import { Eye, MoreHorizontal, Pencil, ShieldCheck, User } from 'lucide-react';
+import { useState } from 'react';
+
+import CoopButton from '../dashboard/components/CoopButton';
+
+import PermissionsMatrixModal from './PermissionsMatrixModal';
+import RoleEditDialog from './RoleEditDialog';
+
+gql`
+  query RolesForOrg {
+    rolesForOrg {
+      id
+      key
+      displayName
+      description
+      isSystem
+      isFallback
+      permissions
+      userCount
+    }
+  }
+`;
+
+/**
+ * Roles tab inside Manage Users. Lists every role with its permission count
+ * and an Edit affordance, gated on MANAGE_ROLES at the parent page.
+ */
+export default function ManageRolesTab() {
+  const { data, loading, error, refetch } = useGQLRolesForOrgQuery();
+  const [editingRoleKey, setEditingRoleKey] = useState<GQLUserRole | null>(
+    null,
+  );
+  const [openMenuKey, setOpenMenuKey] = useState<GQLUserRole | null>(null);
+  const [matrixOpen, setMatrixOpen] = useState(false);
+
+  if (error) {
+    throw error;
+  }
+
+  const roles = data?.rolesForOrg ?? [];
+  const editingRole =
+    editingRoleKey != null
+      ? (roles.find((r) => r.key === editingRoleKey) ?? null)
+      : null;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col">
+          <div className="text-xl font-bold">Roles Management</div>
+          <div className="text-sm text-gray-600 mt-1">
+            Configure roles and the permissions they grant. Editing a role
+            updates every user assigned to that role.
+          </div>
+        </div>
+        <div>
+          <CoopButton
+            title="View Permissions"
+            icon={Eye}
+            iconStyle="stroke"
+            type="secondary"
+            onClick={() => setMatrixOpen(true)}
+            disabled={loading || roles.length === 0}
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {roles.map((role) => {
+          const roleLabel = role.displayName || titleCaseEnumString(role.key);
+          return (
+            <div
+              key={role.key}
+              className="border border-gray-200 rounded-lg p-4 flex flex-col gap-3 min-h-[160px]"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="text-base font-semibold flex-1">
+                  {roleLabel}
+                </div>
+                <Popover
+                  open={openMenuKey === role.key}
+                  onOpenChange={(open) =>
+                    setOpenMenuKey(open ? role.key : null)
+                  }
+                >
+                  <PopoverTrigger asChild>
+                    <button
+                      type="button"
+                      className="text-gray-500 hover:text-gray-900 p-1 rounded hover:bg-gray-100"
+                      aria-label={`Open ${roleLabel} role menu`}
+                    >
+                      <MoreHorizontal className="w-4 h-4" aria-hidden />
+                    </button>
+                  </PopoverTrigger>
+                  <PopoverContent
+                    align="end"
+                    sideOffset={4}
+                    className="w-40 p-1"
+                  >
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setOpenMenuKey(null);
+                        setEditingRoleKey(role.key);
+                      }}
+                      className="w-full flex items-center gap-2 px-3 py-2 text-sm text-left rounded hover:bg-gray-100"
+                    >
+                      <Pencil className="w-3.5 h-3.5" aria-hidden />
+                      Edit Role
+                    </button>
+                  </PopoverContent>
+                </Popover>
+              </div>
+              {role.description && (
+                <div className="text-sm text-gray-600 line-clamp-4">
+                  {role.description}
+                </div>
+              )}
+              {role.isFallback && (
+                <div className="text-xs text-gray-500 italic">
+                  Using default permissions. Save changes to customize for your
+                  organization.
+                </div>
+              )}
+              <div className="flex-1" />
+              <div className="flex items-center gap-4 text-xs text-gray-500 pt-2 border-t border-gray-100">
+                <span className="inline-flex items-center gap-1.5">
+                  <User className="w-3.5 h-3.5" aria-hidden />
+                  {role.userCount} user{role.userCount === 1 ? '' : 's'}
+                </span>
+                <span className="inline-flex items-center gap-1.5">
+                  <ShieldCheck className="w-3.5 h-3.5" aria-hidden />
+                  {role.permissions.length} permission
+                  {role.permissions.length === 1 ? '' : 's'}
+                </span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {editingRole && (
+        <RoleEditDialog
+          role={editingRole}
+          onClose={() => setEditingRoleKey(null)}
+          onSaved={async () => {
+            await refetch();
+            setEditingRoleKey(null);
+          }}
+          refetchQueries={[namedOperations.Query.RolesForOrg]}
+        />
+      )}
+
+      {matrixOpen && (
+        <PermissionsMatrixModal
+          roles={roles}
+          onClose={() => setMatrixOpen(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/client/src/webpages/settings/ManageUsers.tsx
+++ b/client/src/webpages/settings/ManageUsers.tsx
@@ -3,13 +3,14 @@ import { gql } from '@apollo/client';
 import { Select } from 'antd';
 import { MouseEvent, useCallback, useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import FullScreenLoading from '../../components/common/FullScreenLoading';
 import CoopButton from '../dashboard/components/CoopButton';
 import CoopModal from '../dashboard/components/CoopModal';
 import DashboardHeader from '../dashboard/components/DashboardHeader';
 import RowMutations from '../dashboard/components/RowMutations';
+import TabBar from '../dashboard/components/TabBar';
 import {
   ColumnProps,
   DateRangeColumnFilter,
@@ -34,10 +35,12 @@ import {
   useGQLGeneratePasswordResetTokenMutation,
   useGQLManageUsersQuery,
   useGQLRejectUserMutation,
+  useGQLRolesForOrgQuery,
   useGQLUpdateRoleMutation,
 } from '../../graphql/generated';
 import { userHasPermissions } from '../../routing/permissions';
 import { titleCaseEnumString } from '../../utils/string';
+import ManageRolesTab from './ManageRolesTab';
 import { getRoleDescription } from './ManageUsersFormUtils';
 import ManageUsersInviteUserSection from './ManageUsersInviteUserSection';
 
@@ -106,9 +109,16 @@ gql`
   }
 `;
 
+type ManageUsersTab = 'users' | 'roles';
+
+const TAB_QUERY_PARAM = 'tab';
+
 export default function ManageUsers() {
-  // Lowest level permission required to manage users
-  const requiredPermissions = [GQLUserPermission.ManageOrg];
+  const [searchParams, setSearchParams] = useSearchParams();
+  const requestedTab = searchParams.get(TAB_QUERY_PARAM);
+  const initialTab: ManageUsersTab =
+    requestedTab === 'roles' ? 'roles' : 'users';
+  const [activeTab, setActiveTab] = useState<ManageUsersTab>(initialTab);
 
   const [modalState, setModalState] = useState<
     ManageUsersModalState | undefined
@@ -129,6 +139,29 @@ export default function ManageUsers() {
   const users = data?.myOrg?.users;
   const pendingInvites = data?.myOrg?.pendingInvites;
   const hasNCMECReportingEnabled = data?.myOrg?.hasNCMECReportingEnabled;
+
+  // Pull DB-backed role names so renames in the role editor flow through.
+  const { data: rolesData } = useGQLRolesForOrgQuery();
+  const rolesByKey = useMemo(() => {
+    const map = new Map<
+      GQLUserRole,
+      { displayName: string; description: string | null }
+    >();
+    for (const r of rolesData?.rolesForOrg ?? []) {
+      map.set(r.key, {
+        displayName: r.displayName,
+        description: r.description ?? null,
+      });
+    }
+    return map;
+  }, [rolesData]);
+  const labelForRole = (role: GQLUserRole): string =>
+    rolesByKey.get(role)?.displayName ?? titleCaseEnumString(role);
+  const descriptionForRole = (role: GQLUserRole): string => {
+    const fromServer = rolesByKey.get(role)?.description;
+    if (fromServer != null && fromServer.length > 0) return fromServer;
+    return getRoleDescription(role) ?? '';
+  };
 
   const hideModal = () => {
     setModalState(undefined);
@@ -357,7 +390,9 @@ export default function ManageUsers() {
         .map((user) => ({
           name: `${user.firstName} ${user.lastName}`,
           email: user.email,
-          role: titleCaseEnumString(user.role ?? ''),
+          role: user.role
+            ? labelForRole(user.role)
+            : titleCaseEnumString(user.role ?? ''),
           approvalStatus: Boolean(user.approvedByAdmin)
             ? 'Approved'
             : 'Pending',
@@ -372,7 +407,9 @@ export default function ManageUsers() {
       pendingInvites?.map((invite) => ({
         name: 'Pending Invite',
         email: invite.email,
-        role: titleCaseEnumString(invite.role ?? ''),
+        role: invite.role
+          ? labelForRole(invite.role)
+          : titleCaseEnumString(invite.role ?? ''),
         approvalStatus: 'Invited',
         id: invite.id,
         dateCreated: new Date(invite.createdAt).toISOString().split('T')[0],
@@ -380,7 +417,8 @@ export default function ManageUsers() {
       })) ?? [];
 
     return [...userData, ...inviteData];
-  }, [users, pendingInvites]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [users, pendingInvites, rolesByKey]);
 
   const tableData = useMemo(
     () =>
@@ -441,10 +479,23 @@ export default function ManageUsers() {
   }
 
   const permissions = data?.me?.permissions;
-  if (!permissions || !userHasPermissions(permissions, requiredPermissions)) {
+  const canManageUsers = userHasPermissions(permissions, [
+    GQLUserPermission.ManageUsers,
+  ]);
+  const canManageRoles = userHasPermissions(permissions, [
+    GQLUserPermission.ManageRoles,
+  ]);
+  if (!permissions || (!canManageUsers && !canManageRoles)) {
     navigate('/dashboard/settings');
     return null;
   }
+
+  // Snap to a tab the caller can use; redundant tab params get rewritten.
+  const effectiveTab: ManageUsersTab = (() => {
+    if (activeTab === 'users' && !canManageUsers) return 'roles';
+    if (activeTab === 'roles' && !canManageRoles) return 'users';
+    return activeTab;
+  })();
 
   if (error) {
     throw error;
@@ -511,9 +562,9 @@ export default function ManageUsers() {
                       <Option
                         key={roleType}
                         value={roleType}
-                        label={titleCaseEnumString(roleType)}
+                        label={labelForRole(roleType)}
                       >
-                        {titleCaseEnumString(roleType)}
+                        {labelForRole(roleType)}
                       </Option>
                     ))}
                 </Select>
@@ -578,10 +629,10 @@ export default function ManageUsers() {
                   .map((role) => (
                     <div key={role} className="flex flex-col">
                       <div className="text-base font-bold">
-                        {titleCaseEnumString(role)}
+                        {labelForRole(role)}
                       </div>
                       <div className="pt-1 pb-4">
-                        {getRoleDescription(role)}
+                        {descriptionForRole(role)}
                       </div>
                     </div>
                   ))}
@@ -622,16 +673,43 @@ export default function ManageUsers() {
     </CoopModal>
   );
 
+  const tabs: { label: string; value: ManageUsersTab }[] = [];
+  if (canManageUsers) tabs.push({ label: 'Users', value: 'users' });
+  if (canManageRoles) tabs.push({ label: 'Roles', value: 'roles' });
+
+  const onTabClick = (tab: ManageUsersTab) => {
+    setActiveTab(tab);
+    const next = new URLSearchParams(searchParams);
+    next.set(TAB_QUERY_PARAM, tab);
+    setSearchParams(next, { replace: true });
+  };
+
   return (
     <div className="flex flex-col">
       <Helmet>
         <title>Users</title>
       </Helmet>
-      <DashboardHeader title="Users" subtitle="" />
-      {/* @ts-ignore */}
-      <Table columns={columns} data={tableData} />
-      <div className="divider my-9" />
-      <ManageUsersInviteUserSection />
+      <DashboardHeader
+        title="Users"
+        subtitle="Manage your organization's users and roles."
+      />
+      {tabs.length > 1 && (
+        <TabBar<ManageUsersTab>
+          tabs={tabs}
+          initialSelectedTab={effectiveTab}
+          currentSelectedTab={effectiveTab}
+          onTabClick={onTabClick}
+        />
+      )}
+      {effectiveTab === 'users' && (
+        <>
+          {/* @ts-ignore */}
+          <Table columns={columns} data={tableData} />
+          <div className="divider my-9" />
+          <ManageUsersInviteUserSection />
+        </>
+      )}
+      {effectiveTab === 'roles' && <ManageRolesTab />}
       {modal}
     </div>
   );

--- a/client/src/webpages/settings/ManageUsersInviteUserSection.tsx
+++ b/client/src/webpages/settings/ManageUsersInviteUserSection.tsx
@@ -3,11 +3,12 @@ import {
   namedOperations,
   useGQLHasNcmecReportingEnabledQuery,
   useGQLInviteUserMutation,
+  useGQLRolesForOrgQuery,
 } from '@/graphql/generated';
 import { HOST_URL } from '@/lib/config';
 import { titleCaseEnumString } from '@/utils/string';
 import { gql } from '@apollo/client';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import CoopButton from '../dashboard/components/CoopButton';
 import CoopInput from '../dashboard/components/CoopInput';
@@ -15,7 +16,7 @@ import CoopModal from '../dashboard/components/CoopModal';
 import CoopRadioGroup from '../dashboard/components/CoopRadioGroup';
 import FormSectionHeader from '../dashboard/components/FormSectionHeader';
 
-import { getRoleDescription } from './ManageUsersFormUtils';
+import PermissionsMatrixModal from './PermissionsMatrixModal';
 
 gql`
   query HasNcmecReportingEnabled {
@@ -40,6 +41,29 @@ export default function ManageUsersInviteUserSection() {
   const { data } = useGQLHasNcmecReportingEnabledQuery();
   const hasNCMECReportingEnabled = data?.myOrg?.hasNCMECReportingEnabled;
 
+  // Pull DB-backed role names so renames in the role editor flow through.
+  const { data: rolesData } = useGQLRolesForOrgQuery();
+  const rolesByKey = useMemo(() => {
+    const map = new Map<GQLUserRole, { displayName: string }>();
+    for (const r of rolesData?.rolesForOrg ?? []) {
+      map.set(r.key, { displayName: r.displayName });
+    }
+    return map;
+  }, [rolesData]);
+
+  const visibleRoles = useMemo(
+    () =>
+      Object.values(GQLUserRole).filter((role) =>
+        !hasNCMECReportingEnabled
+          ? role !== GQLUserRole.ChildSafetyModerator
+          : true,
+      ),
+    [hasNCMECReportingEnabled],
+  );
+
+  const labelFor = (role: GQLUserRole): string =>
+    rolesByKey.get(role)?.displayName ?? titleCaseEnumString(role);
+
   const [inviteUser, { loading, error }] = useGQLInviteUserMutation({
     refetchQueries: [namedOperations.Query.ManageUsers],
     onError: () => setInviteSentModalVisible(true),
@@ -49,32 +73,15 @@ export default function ManageUsersInviteUserSection() {
     },
   });
 
-  const rolesModal = (
-    <CoopModal
-      title="User Roles"
-      visible={roleModalVisible}
-      onClose={() => setRoleModalVisible(false)}
-    >
-      <div className="max-w-[600px]">
-        {Object.values(GQLUserRole)
-          // If the org doesn't have NCMEC reporting enabled, don't show the CHILD_SAFETY_MODERATOR role
-          .filter((role) =>
-            !hasNCMECReportingEnabled
-              ? role !== GQLUserRole.ChildSafetyModerator
-              : true,
-          )
-          .map((role, i) => (
-            <div key={i}>
-              <div className="text-lg font-bold">
-                {titleCaseEnumString(role)}
-              </div>
-              <div className="h-1" />
-              {getRoleDescription(role)}
-              <div className="h-3" />
-            </div>
-          ))}
-      </div>
-    </CoopModal>
+  const matrixRoles = useMemo(
+    () =>
+      (rolesData?.rolesForOrg ?? []).map((r) => ({
+        key: r.key,
+        displayName: r.displayName,
+        permissions: r.permissions,
+        userCount: r.userCount,
+      })),
+    [rolesData],
   );
 
   const copyInviteLink = () => {
@@ -173,17 +180,10 @@ export default function ManageUsersInviteUserSection() {
       </div>
       <div className="ml-4">
         <CoopRadioGroup
-          options={Object.values(GQLUserRole)
-            // If the org doesn't have NCMEC reporting enabled, don't show the CHILD_SAFETY_MODERATOR role
-            .filter((role) =>
-              !hasNCMECReportingEnabled
-                ? role !== GQLUserRole.ChildSafetyModerator
-                : true,
-            )
-            .map((role) => ({
-              label: titleCaseEnumString(role),
-              value: role,
-            }))}
+          options={visibleRoles.map((role) => ({
+            label: labelFor(role),
+            value: role,
+          }))}
           onChange={(e) => setRole(e.target.value as GQLUserRole)}
         />
       </div>
@@ -196,7 +196,12 @@ export default function ManageUsersInviteUserSection() {
           disabled={!email?.length || !role}
         />
       </div>
-      {rolesModal}
+      {roleModalVisible && (
+        <PermissionsMatrixModal
+          roles={matrixRoles}
+          onClose={() => setRoleModalVisible(false)}
+        />
+      )}
       {inviteSentModal}
     </div>
   );

--- a/client/src/webpages/settings/PermissionsMatrixModal.tsx
+++ b/client/src/webpages/settings/PermissionsMatrixModal.tsx
@@ -1,0 +1,217 @@
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogTitle,
+} from '@/coop-ui/Dialog';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/coop-ui/Tooltip';
+import {
+  GQLUserPermission,
+  GQLUserRole,
+  useGQLPermissionGroupsQuery,
+} from '@/graphql/generated';
+import { titleCaseEnumString } from '@/utils/string';
+import { Check, X } from 'lucide-react';
+import { useMemo } from 'react';
+
+function GrantIndicator(props: { granted: boolean; label: string }) {
+  if (props.granted) {
+    return (
+      <span
+        className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-green-500"
+        role="img"
+        aria-label={props.label}
+      >
+        <Check className="w-3.5 h-3.5 text-white" strokeWidth={3} aria-hidden />
+      </span>
+    );
+  }
+  return (
+    <span
+      className="inline-flex items-center justify-center w-5 h-5 text-gray-300"
+      role="img"
+      aria-label={props.label}
+    >
+      <X className="w-4 h-4" strokeWidth={2} aria-hidden />
+    </span>
+  );
+}
+
+type RoleSummary = {
+  key: GQLUserRole;
+  displayName: string;
+  permissions: readonly GQLUserPermission[];
+  userCount: number;
+};
+
+const TOOLTIP_Z = '!z-[9999]';
+
+export default function PermissionsMatrixModal(props: {
+  roles: readonly RoleSummary[];
+  onClose: () => void;
+}) {
+  const { roles, onClose } = props;
+  const { data, loading } = useGQLPermissionGroupsQuery();
+  const groups = data?.permissionGroups ?? [];
+
+  const orderedRoles = useMemo(() => roles.slice(), [roles]);
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="!max-w-[1280px] w-[95vw] p-0">
+        <TooltipProvider delayDuration={150}>
+          <div className="flex items-start justify-between px-6 pt-6 pb-2">
+            <DialogTitle className="text-2xl">Permissions Overview</DialogTitle>
+            <DialogClose
+              aria-label="Close"
+              className="text-gray-500 hover:text-gray-900 p-1 rounded hover:bg-gray-100"
+            >
+              <X className="w-5 h-5" aria-hidden />
+            </DialogClose>
+          </div>
+          <div className="px-6 pb-6 max-h-[70vh] overflow-y-auto">
+            <div className="text-sm text-gray-600 mb-4">
+              Overview of which permissions are granted to each role. Changes to
+              role permissions affect all users with that role.
+            </div>
+
+            {loading && (
+              <div className="text-sm text-gray-500">Loading permissions…</div>
+            )}
+
+            {!loading &&
+              groups.map((group) => (
+                <div key={group.key} className="flex flex-col gap-2 mb-6">
+                  <div className="text-base font-semibold mt-2">
+                    {group.label}
+                  </div>
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-sm border-collapse table-fixed">
+                      <colgroup>
+                        <col className="w-[260px]" />
+                        {orderedRoles.map((role) => (
+                          <col key={role.key} />
+                        ))}
+                      </colgroup>
+                      <thead>
+                        <tr className="border-b border-gray-200">
+                          <th className="text-left py-2 pr-4 font-semibold align-bottom">
+                            Permission
+                          </th>
+                          {orderedRoles.map((role) => {
+                            const roleLabel =
+                              role.displayName || titleCaseEnumString(role.key);
+                            return (
+                              <th
+                                key={role.key}
+                                className="text-center py-2 px-2 font-semibold align-bottom"
+                              >
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <div className="cursor-help">
+                                      <div className="truncate">
+                                        {roleLabel}
+                                      </div>
+                                      <div className="text-xs text-gray-500 font-normal">
+                                        {role.userCount} user
+                                        {role.userCount === 1 ? '' : 's'}
+                                      </div>
+                                    </div>
+                                  </TooltipTrigger>
+                                  <TooltipContent
+                                    side="bottom"
+                                    align="center"
+                                    className={`max-w-xs ${TOOLTIP_Z}`}
+                                  >
+                                    <div className="font-semibold">
+                                      {roleLabel}
+                                    </div>
+                                    <div className="mt-1 font-normal">
+                                      {role.userCount} user
+                                      {role.userCount === 1 ? '' : 's'}
+                                      {' • '}
+                                      {role.permissions.length} permission
+                                      {role.permissions.length === 1 ? '' : 's'}
+                                    </div>
+                                  </TooltipContent>
+                                </Tooltip>
+                              </th>
+                            );
+                          })}
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {group.permissions.map((p) => (
+                          <tr
+                            key={p.permission}
+                            className="border-b border-gray-100"
+                          >
+                            <td className="py-3 pr-4 align-middle">
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <div className="cursor-help">
+                                    <div className="text-sm font-medium line-clamp-1">
+                                      {p.label}
+                                    </div>
+                                    {p.description && (
+                                      <div className="text-xs text-gray-600 mt-1 line-clamp-2">
+                                        {p.description}
+                                      </div>
+                                    )}
+                                  </div>
+                                </TooltipTrigger>
+                                <TooltipContent
+                                  side="right"
+                                  align="start"
+                                  className={`max-w-xs ${TOOLTIP_Z}`}
+                                >
+                                  <div className="font-semibold">{p.label}</div>
+                                  {p.description && (
+                                    <div className="mt-1 font-normal">
+                                      {p.description}
+                                    </div>
+                                  )}
+                                </TooltipContent>
+                              </Tooltip>
+                            </td>
+                            {orderedRoles.map((role) => {
+                              const granted = role.permissions.includes(
+                                p.permission,
+                              );
+                              const roleLabel =
+                                role.displayName ||
+                                titleCaseEnumString(role.key);
+                              return (
+                                <td
+                                  key={role.key}
+                                  className="text-center py-3 px-2 align-middle"
+                                >
+                                  <GrantIndicator
+                                    granted={granted}
+                                    label={
+                                      granted
+                                        ? `${roleLabel} has ${p.label}`
+                                        : `${roleLabel} does not have ${p.label}`
+                                    }
+                                  />
+                                </td>
+                              );
+                            })}
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              ))}
+          </div>
+        </TooltipProvider>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/webpages/settings/RoleEditDialog.tsx
+++ b/client/src/webpages/settings/RoleEditDialog.tsx
@@ -1,0 +1,365 @@
+import { Checkbox } from '@/coop-ui/Checkbox';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogTitle,
+} from '@/coop-ui/Dialog';
+import { Input } from '@/coop-ui/Input';
+import { Textarea } from '@/coop-ui/Textarea';
+import {
+  GQLUserPermission,
+  GQLUserRole,
+  useGQLPermissionGroupsQuery,
+  useGQLRenameRoleMutation,
+  useGQLUpdateRolePermissionsMutation,
+} from '@/graphql/generated';
+import { gql } from '@apollo/client';
+import { Info, X } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+
+import CoopButton from '../dashboard/components/CoopButton';
+
+gql`
+  query PermissionGroups {
+    permissionGroups {
+      key
+      label
+      description
+      permissions {
+        permission
+        label
+        description
+      }
+    }
+  }
+
+  mutation UpdateRolePermissions($input: UpdateRolePermissionsInput!) {
+    updateRolePermissions(input: $input) {
+      id
+      key
+      displayName
+      description
+      isSystem
+      isFallback
+      permissions
+      userCount
+    }
+  }
+
+  mutation RenameRole($input: RenameRoleInput!) {
+    renameRole(input: $input) {
+      id
+      key
+      displayName
+      description
+      isSystem
+      isFallback
+      permissions
+      userCount
+    }
+  }
+`;
+
+type EditableRole = {
+  key: GQLUserRole;
+  displayName: string;
+  description?: string | null;
+  permissions: readonly GQLUserPermission[];
+  isFallback: boolean;
+  userCount: number;
+};
+
+const MAX_DISPLAY_NAME_LENGTH = 255;
+const MAX_DESCRIPTION_LENGTH = 1000;
+
+/**
+ * Combined editor for a single role: displayName + description + grouped
+ * permissions. Saves rename and permissions independently and only when
+ * dirty, so a permissions failure doesn't roll back a successful rename.
+ */
+export default function RoleEditDialog(props: {
+  role: EditableRole;
+  onClose: () => void;
+  onSaved: () => void | Promise<void>;
+  refetchQueries: readonly string[];
+}) {
+  const { role, onClose, onSaved, refetchQueries } = props;
+
+  const { data: groupsData, loading: groupsLoading } =
+    useGQLPermissionGroupsQuery();
+
+  const [displayName, setDisplayName] = useState(role.displayName);
+  const [description, setDescription] = useState(role.description ?? '');
+  const [permissions, setPermissions] = useState<Set<GQLUserPermission>>(
+    () => new Set(role.permissions),
+  );
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Re-sync state if the parent swaps `role` without remounting the dialog.
+  useEffect(() => {
+    setDisplayName(role.displayName);
+    setDescription(role.description ?? '');
+    setPermissions(new Set(role.permissions));
+    setSubmitError(null);
+  }, [role.key, role.displayName, role.description, role.permissions]);
+
+  const [updatePermissions, { loading: savingPermissions }] =
+    useGQLUpdateRolePermissionsMutation({
+      refetchQueries: [...refetchQueries],
+    });
+  const [renameRole, { loading: renaming }] = useGQLRenameRoleMutation({
+    refetchQueries: [...refetchQueries],
+  });
+
+  const trimmedName = displayName.trim();
+  const trimmedDescription = description.trim();
+  const originalDescription = (role.description ?? '').trim();
+
+  const nameDirty = trimmedName !== role.displayName.trim();
+  const descriptionDirty = trimmedDescription !== originalDescription;
+  const permissionsDirty = useMemo(() => {
+    if (permissions.size !== role.permissions.length) return true;
+    for (const p of role.permissions) {
+      if (!permissions.has(p)) return true;
+    }
+    return false;
+  }, [permissions, role.permissions]);
+
+  const isDirty = nameDirty || descriptionDirty || permissionsDirty;
+  const isSaving = savingPermissions || renaming;
+
+  const nameError = (() => {
+    if (trimmedName.length === 0) return 'Name is required.';
+    if (trimmedName.length > MAX_DISPLAY_NAME_LENGTH)
+      return `Name must be ${MAX_DISPLAY_NAME_LENGTH} characters or fewer.`;
+    return null;
+  })();
+  const descriptionError = (() => {
+    if (trimmedDescription.length === 0) return 'Description is required.';
+    if (trimmedDescription.length > MAX_DESCRIPTION_LENGTH)
+      return `Description must be ${MAX_DESCRIPTION_LENGTH} characters or fewer.`;
+    return null;
+  })();
+
+  const togglePermission = (p: GQLUserPermission) => {
+    setPermissions((prev) => {
+      const next = new Set(prev);
+      if (next.has(p)) {
+        next.delete(p);
+      } else {
+        next.add(p);
+      }
+      return next;
+    });
+  };
+
+  const handleSave = async () => {
+    if (nameError != null || descriptionError != null) return;
+    setSubmitError(null);
+
+    try {
+      // Rename first so a permissions failure doesn't strand the rename.
+      if (nameDirty || descriptionDirty) {
+        await renameRole({
+          variables: {
+            input: {
+              roleKey: role.key,
+              displayName: trimmedName,
+              description:
+                trimmedDescription.length > 0 ? trimmedDescription : null,
+            },
+          },
+        });
+      }
+
+      if (permissionsDirty) {
+        await updatePermissions({
+          variables: {
+            input: {
+              roleKey: role.key,
+              permissions: Array.from(permissions),
+            },
+          },
+        });
+      }
+
+      await onSaved();
+    } catch (e: unknown) {
+      setSubmitError(
+        e instanceof Error ? e.message : 'Failed to save role changes.',
+      );
+    }
+  };
+
+  const groups = groupsData?.permissionGroups ?? [];
+  const saveDisabled =
+    !isDirty || isSaving || nameError != null || descriptionError != null;
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="!max-w-[880px] w-[92vw] p-0">
+        <div className="flex items-start justify-between px-6 pt-6 pb-2">
+          <div className="flex flex-col">
+            <DialogTitle className="text-2xl">Edit Role</DialogTitle>
+            <div className="text-sm text-gray-600 mt-1">
+              Update the role name, description, and permissions.
+            </div>
+          </div>
+          <DialogClose
+            aria-label="Close"
+            className="text-gray-500 hover:text-gray-900 p-1 rounded hover:bg-gray-100"
+          >
+            <X className="w-5 h-5" aria-hidden />
+          </DialogClose>
+        </div>
+        <div className="flex flex-col gap-5 px-6 pb-2 max-h-[60vh] overflow-y-auto">
+          <div
+            className="flex items-start gap-3 text-sm bg-blue-50 border border-blue-200 rounded p-3"
+            role="status"
+          >
+            <Info
+              className="w-4 h-4 mt-0.5 text-blue-600 shrink-0"
+              aria-hidden
+            />
+            <div className="text-blue-900">
+              {role.userCount > 0
+                ? `Any changes to this role will retroactively affect all ${role.userCount} user${role.userCount === 1 ? '' : 's'} currently assigned to this role.`
+                : 'Any changes to this role will retroactively apply to every user assigned to this role.'}
+            </div>
+          </div>
+
+          {role.isFallback && (
+            <div className="text-xs text-gray-600 bg-gray-50 border border-gray-200 rounded p-3">
+              This role is currently using default permissions for your
+              organization. Saving will create a custom configuration that
+              overrides the defaults.
+            </div>
+          )}
+
+          <div className="flex flex-col gap-2">
+            <label
+              className="text-sm font-semibold"
+              htmlFor="role-display-name"
+            >
+              Role Name <span className="text-red-600">*</span>
+            </label>
+            <Input
+              id="role-display-name"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              maxLength={MAX_DISPLAY_NAME_LENGTH}
+              disabled={isSaving}
+              className={
+                nameError != null
+                  ? '!border-red-500 focus:!border-red-500'
+                  : undefined
+              }
+            />
+            {nameError != null && (
+              <div className="text-xs text-red-600">{nameError}</div>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-semibold" htmlFor="role-description">
+              Description <span className="text-red-600">*</span>
+            </label>
+            <Textarea
+              id="role-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              maxLength={MAX_DESCRIPTION_LENGTH}
+              rows={3}
+              disabled={isSaving}
+              className={
+                descriptionError != null
+                  ? '!border-red-500 focus:!border-red-500'
+                  : undefined
+              }
+            />
+            {descriptionError != null && (
+              <div className="text-xs text-red-600">{descriptionError}</div>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-semibold">
+              Permissions <span className="text-red-600">*</span>{' '}
+              <span className="text-gray-500 font-normal">
+                ({permissions.size} selected)
+              </span>
+            </label>
+            {groupsLoading && (
+              <div className="text-sm text-gray-500">Loading permissions…</div>
+            )}
+            {!groupsLoading && (
+              <div className="border border-gray-200 rounded-md p-4 max-h-[320px] overflow-y-auto flex flex-col gap-5">
+                {groups.map((group) => (
+                  <div key={group.key} className="flex flex-col gap-2">
+                    <div className="text-sm font-semibold">{group.label}</div>
+                    {group.description && (
+                      <div className="text-xs text-gray-600">
+                        {group.description}
+                      </div>
+                    )}
+                    <div className="flex flex-col gap-2 pl-1">
+                      {group.permissions.map((p) => {
+                        const checked = permissions.has(p.permission);
+                        return (
+                          <label
+                            key={p.permission}
+                            className="flex items-start gap-3 py-1 cursor-pointer"
+                          >
+                            <Checkbox
+                              className="mt-0.5"
+                              checked={checked}
+                              onCheckedChange={() =>
+                                togglePermission(p.permission)
+                              }
+                              disabled={isSaving}
+                            />
+                            <div className="flex flex-col">
+                              <div className="text-sm font-medium">
+                                {p.label}
+                              </div>
+                              {p.description && (
+                                <div className="text-xs text-gray-600">
+                                  {p.description}
+                                </div>
+                              )}
+                            </div>
+                          </label>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {submitError != null && (
+            <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded p-3">
+              {submitError}
+            </div>
+          )}
+        </div>
+        <div className="flex justify-end gap-2 px-6 py-4 border-t border-gray-200">
+          <CoopButton
+            title="Cancel"
+            type="secondary"
+            onClick={onClose}
+            disabled={isSaving}
+          />
+          <CoopButton
+            title={isSaving ? 'Saving…' : 'Save Changes'}
+            onClick={handleSave}
+            loading={isSaving}
+            disabled={saveDisabled}
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/codegen.yaml
+++ b/codegen.yaml
@@ -149,6 +149,7 @@ generates:
         ItemTypeSchemaVariantInput: ../graphql/modules/itemType.js#ItemTypeSchemaVariantInputResolverValue
         ReportingInsights: ../graphql/modules/reporting.js#ReportingInsights
         ReportingRule: ../services/reportingService/ReportingRules.js#ReportingRuleWithoutVersion
+        Role: ../graphql/datasources/rolePersistence.js#RoleParent
         RoutingRule: ../services/manualReviewToolService/modules/JobRouting.js#RoutingRuleWithoutVersion
         ManualReviewJobComment: ../services/manualReviewToolService/modules/CommentOperations.js#ManualReviewJobComment
         UserItem: ./types.js#ItemSubmissionForGQL

--- a/server/graphql/datasources/RoleApi.ts
+++ b/server/graphql/datasources/RoleApi.ts
@@ -1,0 +1,58 @@
+import { type Kysely } from 'kysely';
+
+import { inject, type Dependencies } from '../../iocContainer/index.js';
+import { type CombinedPg } from '../../services/combinedDbTypes.js';
+import {
+  type PermissionGroup,
+  type UserPermission,
+  type UserRole,
+} from '../../services/userManagementService/index.js';
+import {
+  kyselyGetPermissionGroups,
+  kyselyListRolesForOrg,
+  kyselyRenameRole,
+  kyselyUpdateRolePermissions,
+  type RoleParent,
+} from './rolePersistence.js';
+
+/**
+ * GraphQL data source for the role-editor surface. Mirrors the existing
+ * Api/Persistence split (see {@link UserAPI}/{@link kyselyUserFindById}):
+ * the persistence module owns Kysely queries; this class is the DI-wired
+ * adapter resolvers reach for via `context.dataSources.roleAPI`.
+ */
+class RoleAPI {
+  private readonly db: Kysely<CombinedPg>;
+
+  constructor(db: Dependencies['KyselyPg']) {
+    this.db = db as Kysely<CombinedPg>;
+  }
+
+  async listRolesForOrg(orgId: string): Promise<RoleParent[]> {
+    return kyselyListRolesForOrg(this.db, orgId);
+  }
+
+  getPermissionGroups(): readonly PermissionGroup[] {
+    return kyselyGetPermissionGroups();
+  }
+
+  async updateRolePermissions(opts: {
+    orgId: string;
+    roleKey: UserRole;
+    permissions: readonly UserPermission[];
+  }): Promise<RoleParent> {
+    return kyselyUpdateRolePermissions(this.db, opts);
+  }
+
+  async renameRole(opts: {
+    orgId: string;
+    roleKey: UserRole;
+    displayName: string;
+    description?: string | null;
+  }): Promise<RoleParent> {
+    return kyselyRenameRole(this.db, opts);
+  }
+}
+
+export default inject(['KyselyPg'], RoleAPI);
+export type { RoleAPI };

--- a/server/graphql/datasources/rolePersistence.ts
+++ b/server/graphql/datasources/rolePersistence.ts
@@ -1,0 +1,299 @@
+import { type Kysely } from 'kysely';
+
+import { type CombinedPg } from '../../services/combinedDbTypes.js';
+import {
+  getPermissionGroups,
+  getPermissionsForRole,
+  SystemRoleDefaults,
+  UserPermission,
+  UserRole,
+  type PermissionGroup,
+} from '../../services/userManagementService/index.js';
+
+type RolesKysely = Kysely<CombinedPg>;
+
+/**
+ * GraphQL `Role` parent shape returned to the role-editor UI. `id` is the
+ * `public.roles.id` UUID when the org has a persisted row, otherwise `null`
+ * (the row is materialized lazily on first save). `key` matches a
+ * {@link UserRole} value and is the stable identifier the client sends back
+ * on mutations.
+ */
+export type RoleParent = {
+  id: string | null;
+  key: UserRole;
+  displayName: string;
+  description: string | null;
+  isSystem: boolean;
+  permissions: UserPermission[];
+  /** True when this role is materialized from {@link SystemRoleDefaults} */
+  /** plus {@link UserPermissionsForRole} rather than `public.roles`. */
+  isFallback: boolean;
+  /** Approved (non-rejected) users in the org assigned to this role. */
+  userCount: number;
+};
+
+type RoleRow = {
+  id: string;
+  key: string;
+  display_name: string;
+  description: string | null;
+  is_system: boolean;
+};
+
+/**
+ * Lists every system role for an org, merging persisted rows with the
+ * static defaults so freshly created orgs (which haven't been seeded by
+ * the role migration) still surface a complete role list. Permissions for
+ * persisted rows come from `public.role_permissions`; missing rows fall
+ * back to {@link UserPermissionsForRole}.
+ */
+export async function kyselyListRolesForOrg(
+  kysely: RolesKysely,
+  orgId: string,
+): Promise<RoleParent[]> {
+  const persistedRows: ReadonlyArray<RoleRow> = await kysely
+    .selectFrom('public.roles')
+    .select(['id', 'key', 'display_name', 'description', 'is_system'])
+    .where('org_id', '=', orgId)
+    .where('is_system', '=', true)
+    .execute();
+
+  const persistedIds = persistedRows
+    .filter((r): r is RoleRow & { id: string } => Boolean(r.id))
+    .map((r) => r.id);
+
+  const permissionRows: ReadonlyArray<{
+    role_id: string;
+    permission: string;
+  }> =
+    persistedIds.length === 0
+      ? []
+      : await kysely
+          .selectFrom('public.role_permissions')
+          .select(['role_id', 'permission'])
+          .where('role_id', 'in', persistedIds)
+          .execute();
+
+  const permissionsByRoleId = new Map<string, UserPermission[]>();
+  for (const row of permissionRows) {
+    if (!isUserPermission(row.permission)) {
+      continue;
+    }
+    const arr = permissionsByRoleId.get(row.role_id) ?? [];
+    arr.push(row.permission);
+    permissionsByRoleId.set(row.role_id, arr);
+  }
+
+  const persistedByKey = new Map<string, RoleRow>();
+  for (const row of persistedRows) {
+    persistedByKey.set(row.key, row);
+  }
+
+  // Count by legacy `role` string to cover users predating the role_id backfill.
+  const userCountRows = await countApprovedUsersByRole(kysely, orgId);
+  const userCountsByRole = new Map<string, number>();
+  for (const r of userCountRows) {
+    userCountsByRole.set(r.role, r.count);
+  }
+
+  return Object.values(UserRole).map((roleKey) => {
+    const row = persistedByKey.get(roleKey);
+    const defaults = SystemRoleDefaults[roleKey];
+    const userCount = userCountsByRole.get(roleKey) ?? 0;
+    if (row !== undefined) {
+      const persistedPermissions = permissionsByRoleId.get(row.id) ?? [];
+      return {
+        id: row.id,
+        key: roleKey,
+        displayName: row.display_name,
+        description: row.description,
+        isSystem: row.is_system,
+        permissions:
+          persistedPermissions.length > 0
+            ? persistedPermissions
+            : getPermissionsForRole(roleKey),
+        isFallback: persistedPermissions.length === 0,
+        userCount,
+      };
+    }
+    return {
+      id: null,
+      key: roleKey,
+      displayName: defaults.displayName,
+      description: defaults.description,
+      isSystem: true,
+      permissions: getPermissionsForRole(roleKey),
+      isFallback: true,
+      userCount,
+    };
+  });
+}
+
+async function countApprovedUsersByRole(
+  kysely: RolesKysely,
+  orgId: string,
+): Promise<ReadonlyArray<{ role: string; count: number }>> {
+  const rows = await kysely
+    .selectFrom('public.users')
+    .select((eb) => ['role', eb.fn.countAll<string>().as('count')])
+    .where('org_id', '=', orgId)
+    .where('rejected_by_admin', '=', false)
+    .where('role', 'is not', null)
+    .groupBy('role')
+    .execute();
+  return rows
+    .filter((r): r is { role: string; count: string } => r.role != null)
+    .map((r) => ({ role: r.role, count: Number(r.count) }));
+}
+
+/**
+ * Atomically replaces the permission set for `(orgId, roleKey)`. Materializes
+ * the `public.roles` row on first save and backfills `role_id` on existing
+ * users/invites so the next load picks up the persisted permissions.
+ */
+export async function kyselyUpdateRolePermissions(
+  kysely: RolesKysely,
+  opts: {
+    orgId: string;
+    roleKey: UserRole;
+    permissions: readonly UserPermission[];
+  },
+): Promise<RoleParent> {
+  const { orgId, roleKey, permissions } = opts;
+  return kysely.transaction().execute(async (tx) => {
+    const roleId = await ensureSystemRoleRow(tx, { orgId, roleKey });
+    await tx
+      .deleteFrom('public.role_permissions')
+      .where('role_id', '=', roleId)
+      .execute();
+    if (permissions.length > 0) {
+      const dedupedPermissions = Array.from(new Set(permissions));
+      await tx
+        .insertInto('public.role_permissions')
+        .values(
+          dedupedPermissions.map((permission) => ({
+            role_id: roleId,
+            permission,
+          })),
+        )
+        .execute();
+    }
+    return readRoleAfterWrite(tx, { orgId, roleKey, roleId });
+  });
+}
+
+/**
+ * Renames a role's display name and optionally its description.
+ * Materializes the `public.roles` row on first save.
+ */
+export async function kyselyRenameRole(
+  kysely: RolesKysely,
+  opts: {
+    orgId: string;
+    roleKey: UserRole;
+    displayName: string;
+    description?: string | null;
+  },
+): Promise<RoleParent> {
+  const { orgId, roleKey, displayName, description } = opts;
+  return kysely.transaction().execute(async (tx) => {
+    const roleId = await ensureSystemRoleRow(tx, { orgId, roleKey });
+    await tx
+      .updateTable('public.roles')
+      .set({
+        display_name: displayName,
+        ...(description !== undefined ? { description } : {}),
+        updated_at: new Date(),
+      })
+      .where('id', '=', roleId)
+      .execute();
+    return readRoleAfterWrite(tx, { orgId, roleKey, roleId });
+  });
+}
+
+export function kyselyGetPermissionGroups(): readonly PermissionGroup[] {
+  return getPermissionGroups();
+}
+
+async function ensureSystemRoleRow(
+  tx: RolesKysely,
+  opts: { orgId: string; roleKey: UserRole },
+): Promise<string> {
+  const existing = await tx
+    .selectFrom('public.roles')
+    .select('id')
+    .where('org_id', '=', opts.orgId)
+    .where('key', '=', opts.roleKey)
+    .where('is_system', '=', true)
+    .executeTakeFirst();
+  if (existing !== undefined) {
+    return existing.id;
+  }
+
+  const defaults = SystemRoleDefaults[opts.roleKey];
+  const inserted = await tx
+    .insertInto('public.roles')
+    .values({
+      org_id: opts.orgId,
+      key: opts.roleKey,
+      display_name: defaults.displayName,
+      description: defaults.description,
+      is_system: true,
+    })
+    .returning('id')
+    .executeTakeFirstOrThrow();
+
+  // Backfill role_id on rows where it's NULL; don't stomp existing links.
+  await tx
+    .updateTable('public.users')
+    .set({ role_id: inserted.id })
+    .where('org_id', '=', opts.orgId)
+    .where('role', '=', opts.roleKey)
+    .where('role_id', 'is', null)
+    .execute();
+  await tx
+    .updateTable('public.invite_user_tokens')
+    .set({ role_id: inserted.id })
+    .where('org_id', '=', opts.orgId)
+    .where('role', '=', opts.roleKey)
+    .where('role_id', 'is', null)
+    .execute();
+
+  return inserted.id;
+}
+
+async function readRoleAfterWrite(
+  tx: RolesKysely,
+  opts: { orgId: string; roleKey: UserRole; roleId: string },
+): Promise<RoleParent> {
+  const row = await tx
+    .selectFrom('public.roles')
+    .select(['id', 'key', 'display_name', 'description', 'is_system'])
+    .where('id', '=', opts.roleId)
+    .executeTakeFirstOrThrow();
+  const permissionRows = await tx
+    .selectFrom('public.role_permissions')
+    .select('permission')
+    .where('role_id', '=', opts.roleId)
+    .execute();
+  const permissions = permissionRows
+    .map((p) => p.permission)
+    .filter(isUserPermission);
+  const counts = await countApprovedUsersByRole(tx, opts.orgId);
+  const userCount = counts.find((c) => c.role === opts.roleKey)?.count ?? 0;
+  return {
+    id: row.id,
+    key: opts.roleKey,
+    displayName: row.display_name,
+    description: row.description,
+    isSystem: row.is_system,
+    permissions,
+    isFallback: false,
+    userCount,
+  };
+}
+
+function isUserPermission(value: string): value is UserPermission {
+  return (Object.values(UserPermission) as string[]).includes(value);
+}

--- a/server/graphql/generated.ts
+++ b/server/graphql/generated.ts
@@ -8,6 +8,7 @@ import { JsonObject, JsonValue } from 'type-fest';
 
 import type { UserHistoryForGQL } from '../graphql/datasources/InvestigationApi.js';
 import type { GraphQLOrgParent } from '../graphql/datasources/orgKyselyPersistence.js';
+import type { RoleParent } from '../graphql/datasources/rolePersistence.js';
 import type {
   GraphQLBacktestParent,
   GraphQLRuleParent,
@@ -2516,6 +2517,7 @@ export type GQLMutation = {
   readonly removeAccessibleQueuesToUser: GQLRemoveAccessibleQueuesToUserResponse;
   readonly removeFavoriteMRTQueue: GQLRemoveFavoriteMrtQueueSuccessResponse;
   readonly removeFavoriteRule: GQLRemoveFavoriteRuleSuccessResponse;
+  readonly renameRole: GQLRole;
   readonly reorderRoutingRules: GQLReorderRoutingRulesResponse;
   readonly requestDemo?: Maybe<Scalars['Boolean']['output']>;
   readonly resetPassword: Scalars['Boolean']['output'];
@@ -2551,6 +2553,7 @@ export type GQLMutation = {
   readonly updatePolicy: GQLUpdatePolicyResponse;
   readonly updateReportingRule: GQLUpdateReportingRuleResponse;
   readonly updateRole?: Maybe<Scalars['Boolean']['output']>;
+  readonly updateRolePermissions: GQLRole;
   readonly updateRoutingRule: GQLUpdateRoutingRuleResponse;
   readonly updateSSOCredentials: Scalars['Boolean']['output'];
   readonly updateTextBank: GQLMutateBankResponse;
@@ -2744,6 +2747,10 @@ export type GQLMutationRemoveFavoriteRuleArgs = {
   ruleId: Scalars['ID']['input'];
 };
 
+export type GQLMutationRenameRoleArgs = {
+  input: GQLRenameRoleInput;
+};
+
 export type GQLMutationReorderRoutingRulesArgs = {
   input: GQLReorderRoutingRulesInput;
 };
@@ -2860,6 +2867,10 @@ export type GQLMutationUpdateReportingRuleArgs = {
 
 export type GQLMutationUpdateRoleArgs = {
   input: GQLUpdateRoleInput;
+};
+
+export type GQLMutationUpdateRolePermissionsArgs = {
+  input: GQLUpdateRolePermissionsInput;
 };
 
 export type GQLMutationUpdateRoutingRuleArgs = {
@@ -3272,6 +3283,21 @@ export type GQLPendingInvite = {
   readonly role: GQLUserRole;
 };
 
+export type GQLPermissionGroup = {
+  readonly __typename?: 'PermissionGroup';
+  readonly description: Scalars['String']['output'];
+  readonly key: Scalars['String']['output'];
+  readonly label: Scalars['String']['output'];
+  readonly permissions: ReadonlyArray<GQLPermissionGroupItem>;
+};
+
+export type GQLPermissionGroupItem = {
+  readonly __typename?: 'PermissionGroupItem';
+  readonly description: Scalars['String']['output'];
+  readonly label: Scalars['String']['output'];
+  readonly permission: GQLUserPermission;
+};
+
 export type GQLPlaceBounds = {
   readonly __typename?: 'PlaceBounds';
   readonly northeastCorner: GQLLatLng;
@@ -3404,10 +3430,14 @@ export type GQLQuery = {
   readonly ncmecThreads: ReadonlyArray<GQLThreadWithMessagesAndIpAddress>;
   readonly org?: Maybe<GQLOrg>;
   readonly partialItems: GQLPartialItemsResponse;
+  /** Server-owned grouping + ordering for the role-editor UI. Gated on MANAGE_ROLES. */
+  readonly permissionGroups: ReadonlyArray<GQLPermissionGroup>;
   readonly policy?: Maybe<GQLPolicy>;
   readonly recentUserStrikeActions: ReadonlyArray<GQLRecentUserStrikeActions>;
   readonly reportingInsights: GQLReportingInsights;
   readonly reportingRule?: Maybe<GQLReportingRule>;
+  /** All system roles for the invoking admin's org. Gated on MANAGE_ROLES. */
+  readonly rolesForOrg: ReadonlyArray<GQLRole>;
   readonly rule?: Maybe<GQLRule>;
   readonly spotTestRule: GQLRuleExecutionResult;
   readonly textBank?: Maybe<GQLTextBank>;
@@ -3766,6 +3796,12 @@ export type GQLRemoveFavoriteRuleSuccessResponse = {
   readonly _?: Maybe<Scalars['Boolean']['output']>;
 };
 
+export type GQLRenameRoleInput = {
+  readonly description?: InputMaybe<Scalars['String']['input']>;
+  readonly displayName: Scalars['String']['input'];
+  readonly roleKey: GQLUserRole;
+};
+
 export type GQLReorderRoutingRulesInput = {
   readonly isAppealsRule?: InputMaybe<Scalars['Boolean']['input']>;
   readonly order: ReadonlyArray<Scalars['ID']['input']>;
@@ -3922,6 +3958,22 @@ export type GQLRetryNcmecSubmissionResponse = {
    */
   readonly error?: Maybe<Scalars['String']['output']>;
   readonly success: Scalars['Boolean']['output'];
+};
+
+export type GQLRole = {
+  readonly __typename?: 'Role';
+  readonly description?: Maybe<Scalars['String']['output']>;
+  readonly displayName: Scalars['String']['output'];
+  /** Persisted public.roles.id, or null when the row is materialized lazily on first save. */
+  readonly id?: Maybe<Scalars['ID']['output']>;
+  /** True when permissions/metadata come from the static fallback rather than public.roles. */
+  readonly isFallback: Scalars['Boolean']['output'];
+  readonly isSystem: Scalars['Boolean']['output'];
+  /** Stable role identifier (matches UserRole). */
+  readonly key: GQLUserRole;
+  readonly permissions: ReadonlyArray<GQLUserPermission>;
+  /** Number of approved (non-rejected) users in the org assigned to this role. */
+  readonly userCount: Scalars['Int']['output'];
 };
 
 export type GQLRotateApiKeyError = GQLError & {
@@ -4734,6 +4786,11 @@ export type GQLUpdateReportingRuleResponse =
 export type GQLUpdateRoleInput = {
   readonly id: Scalars['ID']['input'];
   readonly role: GQLUserRole;
+};
+
+export type GQLUpdateRolePermissionsInput = {
+  readonly permissions: ReadonlyArray<GQLUserPermission>;
+  readonly roleKey: GQLUserRole;
 };
 
 export type GQLUpdateRoutingRuleInput = {
@@ -6094,6 +6151,8 @@ export type GQLResolversTypes = {
     }
   >;
   PendingInvite: ResolverTypeWrapper<GQLPendingInvite>;
+  PermissionGroup: ResolverTypeWrapper<GQLPermissionGroup>;
+  PermissionGroupItem: ResolverTypeWrapper<GQLPermissionGroupItem>;
   PlaceBounds: ResolverTypeWrapper<GQLPlaceBounds>;
   PlaceBoundsInput: GQLPlaceBoundsInput;
   PluginIntegrationApiCredential: ResolverTypeWrapper<GQLPluginIntegrationApiCredential>;
@@ -6135,6 +6194,7 @@ export type GQLResolversTypes = {
     GQLResolversUnionTypes<GQLResolversTypes>['RemoveFavoriteRuleResponse']
   >;
   RemoveFavoriteRuleSuccessResponse: ResolverTypeWrapper<GQLRemoveFavoriteRuleSuccessResponse>;
+  RenameRoleInput: GQLRenameRoleInput;
   ReorderRoutingRulesInput: GQLReorderRoutingRulesInput;
   ReorderRoutingRulesResponse: ResolverTypeWrapper<
     GQLResolversUnionTypes<GQLResolversTypes>['ReorderRoutingRulesResponse']
@@ -6163,6 +6223,7 @@ export type GQLResolversTypes = {
   ResetPasswordInput: GQLResetPasswordInput;
   ResolvedJobCount: ResolverTypeWrapper<GQLResolvedJobCount>;
   RetryNcmecSubmissionResponse: ResolverTypeWrapper<GQLRetryNcmecSubmissionResponse>;
+  Role: ResolverTypeWrapper<RoleParent>;
   RotateApiKeyError: ResolverTypeWrapper<GQLRotateApiKeyError>;
   RotateApiKeyInput: GQLRotateApiKeyInput;
   RotateApiKeyResponse: ResolverTypeWrapper<
@@ -6332,6 +6393,7 @@ export type GQLResolversTypes = {
     GQLResolversUnionTypes<GQLResolversTypes>['UpdateReportingRuleResponse']
   >;
   UpdateRoleInput: GQLUpdateRoleInput;
+  UpdateRolePermissionsInput: GQLUpdateRolePermissionsInput;
   UpdateRoutingRuleInput: GQLUpdateRoutingRuleInput;
   UpdateRoutingRuleResponse: ResolverTypeWrapper<
     GQLResolversUnionTypes<GQLResolversTypes>['UpdateRoutingRuleResponse']
@@ -6795,6 +6857,8 @@ export type GQLResolversParentTypes = {
     items: ReadonlyArray<GQLResolversParentTypes['Item']>;
   };
   PendingInvite: GQLPendingInvite;
+  PermissionGroup: GQLPermissionGroup;
+  PermissionGroupItem: GQLPermissionGroupItem;
   PlaceBounds: GQLPlaceBounds;
   PlaceBoundsInput: GQLPlaceBoundsInput;
   PluginIntegrationApiCredential: GQLPluginIntegrationApiCredential;
@@ -6831,6 +6895,7 @@ export type GQLResolversParentTypes = {
   RemoveFavoriteMRTQueueSuccessResponse: GQLRemoveFavoriteMrtQueueSuccessResponse;
   RemoveFavoriteRuleResponse: GQLResolversUnionTypes<GQLResolversParentTypes>['RemoveFavoriteRuleResponse'];
   RemoveFavoriteRuleSuccessResponse: GQLRemoveFavoriteRuleSuccessResponse;
+  RenameRoleInput: GQLRenameRoleInput;
   ReorderRoutingRulesInput: GQLReorderRoutingRulesInput;
   ReorderRoutingRulesResponse: GQLResolversUnionTypes<GQLResolversParentTypes>['ReorderRoutingRulesResponse'];
   ReportEnqueueSourceInfo: GQLReportEnqueueSourceInfo;
@@ -6856,6 +6921,7 @@ export type GQLResolversParentTypes = {
   ResetPasswordInput: GQLResetPasswordInput;
   ResolvedJobCount: GQLResolvedJobCount;
   RetryNcmecSubmissionResponse: GQLRetryNcmecSubmissionResponse;
+  Role: RoleParent;
   RotateApiKeyError: GQLRotateApiKeyError;
   RotateApiKeyInput: GQLRotateApiKeyInput;
   RotateApiKeyResponse: GQLResolversUnionTypes<GQLResolversParentTypes>['RotateApiKeyResponse'];
@@ -6981,6 +7047,7 @@ export type GQLResolversParentTypes = {
   UpdateReportingRuleInput: GQLUpdateReportingRuleInput;
   UpdateReportingRuleResponse: GQLResolversUnionTypes<GQLResolversParentTypes>['UpdateReportingRuleResponse'];
   UpdateRoleInput: GQLUpdateRoleInput;
+  UpdateRolePermissionsInput: GQLUpdateRolePermissionsInput;
   UpdateRoutingRuleInput: GQLUpdateRoutingRuleInput;
   UpdateRoutingRuleResponse: GQLResolversUnionTypes<GQLResolversParentTypes>['UpdateRoutingRuleResponse'];
   UpdateSSOCredentialsInput: GQLUpdateSsoCredentialsInput;
@@ -10925,6 +10992,12 @@ export type GQLMutationResolvers<
     ContextType,
     RequireFields<GQLMutationRemoveFavoriteRuleArgs, 'ruleId'>
   >;
+  renameRole?: Resolver<
+    GQLResolversTypes['Role'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationRenameRoleArgs, 'input'>
+  >;
   reorderRoutingRules?: Resolver<
     GQLResolversTypes['ReorderRoutingRulesResponse'],
     ParentType,
@@ -11115,6 +11188,12 @@ export type GQLMutationResolvers<
     ParentType,
     ContextType,
     RequireFields<GQLMutationUpdateRoleArgs, 'input'>
+  >;
+  updateRolePermissions?: Resolver<
+    GQLResolversTypes['Role'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationUpdateRolePermissionsArgs, 'input'>
   >;
   updateRoutingRule?: Resolver<
     GQLResolversTypes['UpdateRoutingRuleResponse'],
@@ -11876,6 +11955,35 @@ export type GQLPendingInviteResolvers<
   role?: Resolver<GQLResolversTypes['UserRole'], ParentType, ContextType>;
 };
 
+export type GQLPermissionGroupResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['PermissionGroup'] =
+    GQLResolversParentTypes['PermissionGroup'],
+> = {
+  description?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  key?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  label?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  permissions?: Resolver<
+    ReadonlyArray<GQLResolversTypes['PermissionGroupItem']>,
+    ParentType,
+    ContextType
+  >;
+};
+
+export type GQLPermissionGroupItemResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['PermissionGroupItem'] =
+    GQLResolversParentTypes['PermissionGroupItem'],
+> = {
+  description?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  label?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  permission?: Resolver<
+    GQLResolversTypes['UserPermission'],
+    ParentType,
+    ContextType
+  >;
+};
+
 export type GQLPlaceBoundsResolvers<
   ContextType = Context,
   ParentType extends GQLResolversParentTypes['PlaceBounds'] =
@@ -12310,6 +12418,11 @@ export type GQLQueryResolvers<
     ContextType,
     RequireFields<GQLQueryPartialItemsArgs, 'input'>
   >;
+  permissionGroups?: Resolver<
+    ReadonlyArray<GQLResolversTypes['PermissionGroup']>,
+    ParentType,
+    ContextType
+  >;
   policy?: Resolver<
     Maybe<GQLResolversTypes['Policy']>,
     ParentType,
@@ -12332,6 +12445,11 @@ export type GQLQueryResolvers<
     ParentType,
     ContextType,
     RequireFields<GQLQueryReportingRuleArgs, 'id'>
+  >;
+  rolesForOrg?: Resolver<
+    ReadonlyArray<GQLResolversTypes['Role']>,
+    ParentType,
+    ContextType
   >;
   rule?: Resolver<
     Maybe<GQLResolversTypes['Rule']>,
@@ -12809,6 +12927,29 @@ export type GQLRetryNcmecSubmissionResponseResolvers<
 > = {
   error?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   success?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
+};
+
+export type GQLRoleResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Role'] =
+    GQLResolversParentTypes['Role'],
+> = {
+  description?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  displayName?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<Maybe<GQLResolversTypes['ID']>, ParentType, ContextType>;
+  isFallback?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
+  isSystem?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
+  key?: Resolver<GQLResolversTypes['UserRole'], ParentType, ContextType>;
+  permissions?: Resolver<
+    ReadonlyArray<GQLResolversTypes['UserPermission']>,
+    ParentType,
+    ContextType
+  >;
+  userCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
 };
 
 export type GQLRotateApiKeyErrorResolvers<
@@ -14789,6 +14930,8 @@ export type GQLResolvers<ContextType = Context> = {
   PartialItemsResponse?: GQLPartialItemsResponseResolvers<ContextType>;
   PartialItemsSuccessResponse?: GQLPartialItemsSuccessResponseResolvers<ContextType>;
   PendingInvite?: GQLPendingInviteResolvers<ContextType>;
+  PermissionGroup?: GQLPermissionGroupResolvers<ContextType>;
+  PermissionGroupItem?: GQLPermissionGroupItemResolvers<ContextType>;
   PlaceBounds?: GQLPlaceBoundsResolvers<ContextType>;
   PluginIntegrationApiCredential?: GQLPluginIntegrationApiCredentialResolvers<ContextType>;
   Policy?: GQLPolicyResolvers<ContextType>;
@@ -14819,6 +14962,7 @@ export type GQLResolvers<ContextType = Context> = {
   ReportingRulePassRateData?: GQLReportingRulePassRateDataResolvers<ContextType>;
   ResolvedJobCount?: GQLResolvedJobCountResolvers<ContextType>;
   RetryNcmecSubmissionResponse?: GQLRetryNcmecSubmissionResponseResolvers<ContextType>;
+  Role?: GQLRoleResolvers<ContextType>;
   RotateApiKeyError?: GQLRotateApiKeyErrorResolvers<ContextType>;
   RotateApiKeyResponse?: GQLRotateApiKeyResponseResolvers<ContextType>;
   RotateApiKeySuccessResponse?: GQLRotateApiKeySuccessResponseResolvers<ContextType>;

--- a/server/graphql/modules/roles.resolver.test.ts
+++ b/server/graphql/modules/roles.resolver.test.ts
@@ -1,0 +1,285 @@
+import {
+  UserPermission,
+  UserRole,
+} from '../../services/userManagementService/index.js';
+import { resolvers } from './roles.js';
+
+// All four role-editor resolvers gate on MANAGE_ROLES before any persistence
+// call. These tests exercise the forbidden path with a minimal mock ctx that
+// never reaches the underlying RoleAPI, plus the happy path / validation
+// branches that confirm permitted callers reach the data source with
+// sanitized input.
+
+type RoleApiMock = {
+  listRolesForOrg: jest.Mock;
+  getPermissionGroups: jest.Mock;
+  updateRolePermissions: jest.Mock;
+  renameRole: jest.Mock;
+};
+
+function makeCtx(permissions: readonly UserPermission[]) {
+  const roleAPI: RoleApiMock = {
+    listRolesForOrg: jest.fn(async () => []),
+    getPermissionGroups: jest.fn(() => []),
+    updateRolePermissions: jest.fn(async () => stubRoleParent()),
+    renameRole: jest.fn(async () => stubRoleParent()),
+  };
+  const ctx = {
+    getUser: () => ({
+      id: 'user-1',
+      orgId: 'org-1',
+      getPermissions: () => permissions,
+    }),
+    dataSources: { roleAPI },
+  };
+  return { ctx, roleAPI };
+}
+
+function stubRoleParent() {
+  return {
+    id: 'role-1',
+    key: UserRole.ADMIN,
+    displayName: 'Admin',
+    description: 'desc',
+    isSystem: true,
+    permissions: [UserPermission.MANAGE_ORG],
+    isFallback: false,
+    userCount: 1,
+  };
+}
+
+const Query = resolvers.Query as {
+  rolesForOrg: (
+    parent: unknown,
+    args: unknown,
+    ctx: unknown,
+  ) => Promise<unknown>;
+  permissionGroups: (
+    parent: unknown,
+    args: unknown,
+    ctx: unknown,
+  ) => Promise<unknown>;
+};
+const Mutation = resolvers.Mutation as {
+  updateRolePermissions: (
+    parent: unknown,
+    args: { input: { roleKey: string; permissions: readonly string[] } },
+    ctx: unknown,
+  ) => Promise<unknown>;
+  renameRole: (
+    parent: unknown,
+    args: {
+      input: { roleKey: string; displayName: string; description?: string };
+    },
+    ctx: unknown,
+  ) => Promise<unknown>;
+};
+
+describe('roles resolvers', () => {
+  describe('Query.rolesForOrg', () => {
+    it('throws forbiddenError when caller has neither MANAGE_ROLES nor MANAGE_USERS', async () => {
+      // MANAGE_ORG alone used to be sufficient here; after the role-editor
+      // permission split it is not — the invite + edit flows that need
+      // role display data are gated on MANAGE_USERS, and the editor on
+      // MANAGE_ROLES. A caller with only MANAGE_ORG should be rejected
+      // so we don't accidentally grant role visibility to legacy admins
+      // missing both new caps.
+      const { ctx, roleAPI } = makeCtx([UserPermission.MANAGE_ORG]);
+      await expect(Query.rolesForOrg({}, {}, ctx)).rejects.toThrow(
+        'User does not have permission to view roles in this organization',
+      );
+      expect(roleAPI.listRolesForOrg).not.toHaveBeenCalled();
+    });
+
+    it('throws unauthenticatedError when caller is anonymous', async () => {
+      const ctx = {
+        getUser: () => null,
+        dataSources: { roleAPI: makeCtx([]).roleAPI },
+      };
+      await expect(Query.rolesForOrg({}, {}, ctx)).rejects.toThrow(
+        'Authenticated user required',
+      );
+    });
+
+    it('delegates to roleAPI.listRolesForOrg when caller has MANAGE_ROLES', async () => {
+      const { ctx, roleAPI } = makeCtx([UserPermission.MANAGE_ROLES]);
+      await Query.rolesForOrg({}, {}, ctx);
+      expect(roleAPI.listRolesForOrg).toHaveBeenCalledWith('org-1');
+    });
+
+    it('delegates to roleAPI.listRolesForOrg when caller has only MANAGE_USERS', async () => {
+      // The invite + edit-user forms render role display names and
+      // descriptions, so MANAGE_USERS callers must be able to read the
+      // role list even when they cannot edit it. Permissions stay visible
+      // here because admins managing users routinely see what permissions
+      // their reports have via the User type already.
+      const { ctx, roleAPI } = makeCtx([UserPermission.MANAGE_USERS]);
+      await Query.rolesForOrg({}, {}, ctx);
+      expect(roleAPI.listRolesForOrg).toHaveBeenCalledWith('org-1');
+    });
+  });
+
+  describe('Query.permissionGroups', () => {
+    it('throws forbiddenError when caller lacks MANAGE_ROLES', async () => {
+      const { ctx, roleAPI } = makeCtx([UserPermission.VIEW_MRT]);
+      await expect(Query.permissionGroups({}, {}, ctx)).rejects.toThrow(
+        'User does not have permission to manage roles',
+      );
+      expect(roleAPI.getPermissionGroups).not.toHaveBeenCalled();
+    });
+
+    it('returns the server-owned groups when caller has MANAGE_ROLES', async () => {
+      const { ctx, roleAPI } = makeCtx([UserPermission.MANAGE_ROLES]);
+      await Query.permissionGroups({}, {}, ctx);
+      expect(roleAPI.getPermissionGroups).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Mutation.updateRolePermissions', () => {
+    it('throws forbiddenError when caller lacks MANAGE_ROLES', async () => {
+      const { ctx, roleAPI } = makeCtx([UserPermission.MANAGE_ORG]);
+      await expect(
+        Mutation.updateRolePermissions(
+          {},
+          { input: { roleKey: 'ADMIN', permissions: [] } },
+          ctx,
+        ),
+      ).rejects.toThrow('User does not have permission to manage roles');
+      expect(roleAPI.updateRolePermissions).not.toHaveBeenCalled();
+    });
+
+    it('rejects unknown role keys before reaching persistence', async () => {
+      const { ctx, roleAPI } = makeCtx([UserPermission.MANAGE_ROLES]);
+      await expect(
+        Mutation.updateRolePermissions(
+          {},
+          { input: { roleKey: 'NOT_A_REAL_ROLE', permissions: [] } },
+          ctx,
+        ),
+      ).rejects.toThrow('Unknown role: NOT_A_REAL_ROLE');
+      expect(roleAPI.updateRolePermissions).not.toHaveBeenCalled();
+    });
+
+    it('rejects unknown permission strings before reaching persistence', async () => {
+      const { ctx, roleAPI } = makeCtx([UserPermission.MANAGE_ROLES]);
+      await expect(
+        Mutation.updateRolePermissions(
+          {},
+          {
+            input: {
+              roleKey: 'ADMIN',
+              permissions: ['MANAGE_ORG', 'INJECTED_FAKE_PERMISSION'],
+            },
+          },
+          ctx,
+        ),
+      ).rejects.toThrow('Unknown permission: INJECTED_FAKE_PERMISSION');
+      expect(roleAPI.updateRolePermissions).not.toHaveBeenCalled();
+    });
+
+    it('passes sanitized permissions and the invokers orgId to the data source', async () => {
+      const { ctx, roleAPI } = makeCtx([UserPermission.MANAGE_ROLES]);
+      await Mutation.updateRolePermissions(
+        {},
+        {
+          input: {
+            roleKey: 'MODERATOR',
+            permissions: ['VIEW_MRT', 'VIEW_MRT_DATA'],
+          },
+        },
+        ctx,
+      );
+      expect(roleAPI.updateRolePermissions).toHaveBeenCalledWith({
+        orgId: 'org-1',
+        roleKey: 'MODERATOR',
+        permissions: [UserPermission.VIEW_MRT, UserPermission.VIEW_MRT_DATA],
+      });
+    });
+  });
+
+  describe('Mutation.renameRole', () => {
+    it('throws forbiddenError when caller lacks MANAGE_ROLES', async () => {
+      const { ctx, roleAPI } = makeCtx([UserPermission.MANAGE_ORG]);
+      await expect(
+        Mutation.renameRole(
+          {},
+          { input: { roleKey: 'ADMIN', displayName: 'New Name' } },
+          ctx,
+        ),
+      ).rejects.toThrow('User does not have permission to manage roles');
+      expect(roleAPI.renameRole).not.toHaveBeenCalled();
+    });
+
+    it('rejects empty / whitespace-only display names', async () => {
+      const { ctx, roleAPI } = makeCtx([UserPermission.MANAGE_ROLES]);
+      await expect(
+        Mutation.renameRole(
+          {},
+          { input: { roleKey: 'ADMIN', displayName: '   ' } },
+          ctx,
+        ),
+      ).rejects.toThrow('displayName must not be empty');
+      expect(roleAPI.renameRole).not.toHaveBeenCalled();
+    });
+
+    it('rejects display names longer than 255 characters', async () => {
+      const { ctx, roleAPI } = makeCtx([UserPermission.MANAGE_ROLES]);
+      await expect(
+        Mutation.renameRole(
+          {},
+          { input: { roleKey: 'ADMIN', displayName: 'A'.repeat(256) } },
+          ctx,
+        ),
+      ).rejects.toThrow('displayName must be at most 255 characters');
+      expect(roleAPI.renameRole).not.toHaveBeenCalled();
+    });
+
+    it('rejects unknown role keys before reaching persistence', async () => {
+      const { ctx, roleAPI } = makeCtx([UserPermission.MANAGE_ROLES]);
+      await expect(
+        Mutation.renameRole(
+          {},
+          { input: { roleKey: 'NOT_A_REAL_ROLE', displayName: 'OK' } },
+          ctx,
+        ),
+      ).rejects.toThrow('Unknown role: NOT_A_REAL_ROLE');
+      expect(roleAPI.renameRole).not.toHaveBeenCalled();
+    });
+
+    it('trims the display name and forwards the description as null when omitted', async () => {
+      const { ctx, roleAPI } = makeCtx([UserPermission.MANAGE_ROLES]);
+      await Mutation.renameRole(
+        {},
+        { input: { roleKey: 'ADMIN', displayName: '  Admin (renamed)  ' } },
+        ctx,
+      );
+      expect(roleAPI.renameRole).toHaveBeenCalledWith({
+        orgId: 'org-1',
+        roleKey: 'ADMIN',
+        displayName: 'Admin (renamed)',
+        description: null,
+      });
+    });
+
+    it('forwards a provided description verbatim', async () => {
+      const { ctx, roleAPI } = makeCtx([UserPermission.MANAGE_ROLES]);
+      await Mutation.renameRole(
+        {},
+        {
+          input: {
+            roleKey: 'MODERATOR',
+            displayName: 'Moderator',
+            description: 'Reviews queues',
+          },
+        },
+        ctx,
+      );
+      expect(roleAPI.renameRole).toHaveBeenCalledWith({
+        orgId: 'org-1',
+        roleKey: 'MODERATOR',
+        displayName: 'Moderator',
+        description: 'Reviews queues',
+      });
+    });
+  });
+});

--- a/server/graphql/modules/roles.ts
+++ b/server/graphql/modules/roles.ts
@@ -1,0 +1,171 @@
+import {
+  UserPermission,
+  UserRole,
+} from '../../services/userManagementService/index.js';
+import {
+  type GQLMutationResolvers,
+  type GQLQueryResolvers,
+} from '../generated.js';
+import { type Context } from '../resolvers.js';
+import {
+  forbiddenError,
+  unauthenticatedError,
+  userInputError,
+} from '../utils/errors.js';
+
+const typeDefs = /* GraphQL */ `
+  type Role {
+    "Persisted public.roles.id, or null when the row is materialized lazily on first save."
+    id: ID
+    "Stable role identifier (matches UserRole)."
+    key: UserRole!
+    displayName: String!
+    description: String
+    isSystem: Boolean!
+    permissions: [UserPermission!]!
+    "True when permissions/metadata come from the static fallback rather than public.roles."
+    isFallback: Boolean!
+    "Number of approved (non-rejected) users in the org assigned to this role."
+    userCount: Int!
+  }
+
+  type PermissionGroupItem {
+    permission: UserPermission!
+    label: String!
+    description: String!
+  }
+
+  type PermissionGroup {
+    key: String!
+    label: String!
+    description: String!
+    permissions: [PermissionGroupItem!]!
+  }
+
+  input UpdateRolePermissionsInput {
+    roleKey: UserRole!
+    permissions: [UserPermission!]!
+  }
+
+  input RenameRoleInput {
+    roleKey: UserRole!
+    displayName: String!
+    description: String
+  }
+
+  type Query {
+    "All system roles for the invoking admin's org. Gated on MANAGE_ROLES."
+    rolesForOrg: [Role!]!
+    "Server-owned grouping + ordering for the role-editor UI. Gated on MANAGE_ROLES."
+    permissionGroups: [PermissionGroup!]!
+  }
+
+  type Mutation {
+    updateRolePermissions(input: UpdateRolePermissionsInput!): Role!
+    renameRole(input: RenameRoleInput!): Role!
+  }
+`;
+
+const Query: GQLQueryResolvers = {
+  async rolesForOrg(_, __, context) {
+    const user = requireRoleVisibility(context);
+    return context.dataSources.roleAPI.listRolesForOrg(user.orgId);
+  },
+  async permissionGroups(_, __, context) {
+    requireManageRoles(context);
+    return context.dataSources.roleAPI.getPermissionGroups();
+  },
+};
+
+const Mutation: GQLMutationResolvers = {
+  async updateRolePermissions(_, params, context) {
+    const user = requireManageRoles(context);
+    const { roleKey, permissions } = params.input;
+    assertKnownRole(roleKey);
+    const sanitized = assertKnownPermissions(permissions);
+    return context.dataSources.roleAPI.updateRolePermissions({
+      orgId: user.orgId,
+      roleKey,
+      permissions: sanitized,
+    });
+  },
+  async renameRole(_, params, context) {
+    const user = requireManageRoles(context);
+    const { roleKey, displayName, description } = params.input;
+    assertKnownRole(roleKey);
+    assertNonEmptyDisplayName(displayName);
+    return context.dataSources.roleAPI.renameRole({
+      orgId: user.orgId,
+      roleKey,
+      displayName: displayName.trim(),
+      description: description ?? null,
+    });
+  },
+};
+
+function requireManageRoles(context: Context) {
+  const user = context.getUser();
+  if (user == null) {
+    throw unauthenticatedError('Authenticated user required');
+  }
+  if (!user.getPermissions().includes(UserPermission.MANAGE_ROLES)) {
+    throw forbiddenError(
+      'User does not have permission to manage roles in this organization',
+    );
+  }
+  return user;
+}
+
+function requireRoleVisibility(context: Context) {
+  const user = context.getUser();
+  if (user == null) {
+    throw unauthenticatedError('Authenticated user required');
+  }
+  const perms = user.getPermissions();
+  if (
+    !perms.includes(UserPermission.MANAGE_ROLES) &&
+    !perms.includes(UserPermission.MANAGE_USERS)
+  ) {
+    throw forbiddenError(
+      'User does not have permission to view roles in this organization',
+    );
+  }
+  return user;
+}
+
+function assertKnownRole(roleKey: string): asserts roleKey is UserRole {
+  if (!Object.values(UserRole).includes(roleKey)) {
+    throw userInputError(`Unknown role: ${roleKey}`);
+  }
+}
+
+function assertKnownPermissions(
+  permissions: readonly string[],
+): UserPermission[] {
+  const known = new Set(Object.values(UserPermission));
+  const sanitized: UserPermission[] = [];
+  for (const p of permissions) {
+    if (!known.has(p)) {
+      throw userInputError(`Unknown permission: ${p}`);
+    }
+    sanitized.push(p as UserPermission);
+  }
+  return sanitized;
+}
+
+function assertNonEmptyDisplayName(displayName: string) {
+  const trimmed = displayName.trim();
+  if (trimmed.length === 0) {
+    throw userInputError('displayName must not be empty');
+  }
+  if (trimmed.length > 255) {
+    throw userInputError('displayName must be at most 255 characters');
+  }
+}
+
+const resolvers = {
+  Query,
+  Mutation,
+};
+
+export { typeDefs, resolvers };

--- a/server/graphql/resolvers.ts
+++ b/server/graphql/resolvers.ts
@@ -31,6 +31,7 @@ import { resolvers as policyResolvers } from './modules/policy.js';
 import { resolvers as reportingResolvers } from './modules/reporting.js';
 import { resolvers as reportingRulesResolvers } from './modules/reportingRule.js';
 import { resolvers as retroactionResolvers } from './modules/retroaction.js';
+import { resolvers as rolesResolvers } from './modules/roles.js';
 import { resolvers as routingRulesResolvers } from './modules/routingRule.js';
 import { resolvers as ruleResolvers } from './modules/rule.js';
 import { resolvers as signalResolvers } from './modules/signal.js';
@@ -287,6 +288,7 @@ export default mergeResolvers([
   reportingResolvers,
   reportingRulesResolvers,
   retroactionResolvers,
+  rolesResolvers,
   routingRulesResolvers,
   ruleResolvers,
   signalResolvers,

--- a/server/graphql/schema.ts
+++ b/server/graphql/schema.ts
@@ -21,6 +21,7 @@ import { typeDefs as policyTypeDefs } from './modules/policy.js';
 import { typeDefs as reportingTypeDefs } from './modules/reporting.js';
 import { typeDefs as reportingRulesTypeDefs } from './modules/reportingRule.js';
 import { typeDefs as retroactionTypeDefs } from './modules/retroaction.js';
+import { typeDefs as rolesTypeDefs } from './modules/roles.js';
 import { typeDefs as routingRulesTypeDefs } from './modules/routingRule.js';
 import { typeDefs as ruleTypeDefs } from './modules/rule.js';
 import { typeDefs as signalTypeDefs } from './modules/signal.js';
@@ -331,7 +332,7 @@ const typeDefs = /* GraphQL */ `
   }
 
   union InviteUserTokenResponse =
-      InviteUserTokenSuccessResponse
+    | InviteUserTokenSuccessResponse
     | InviteUserTokenExpiredError
     | InviteUserTokenMissingError
 
@@ -517,6 +518,7 @@ export default mergeTypeDefs([
   reportingRulesTypeDefs,
   reportingTypeDefs,
   retroactionTypeDefs,
+  rolesTypeDefs,
   routingRulesTypeDefs,
   ruleTypeDefs,
   signalTypeDefs,

--- a/server/iocContainer/services/gqlDataSources.ts
+++ b/server/iocContainer/services/gqlDataSources.ts
@@ -13,15 +13,19 @@ import makeLocationBankAPI, {
   type LocationBankAPI,
 } from '../../graphql/datasources/LocationBankApi.js';
 import makeOrgAPI, { type OrgAPI } from '../../graphql/datasources/OrgApi.js';
+import makeRoleAPI, {
+  type RoleAPI,
+} from '../../graphql/datasources/RoleApi.js';
 import makeRuleAPI, {
   type RuleAPI,
 } from '../../graphql/datasources/RuleApi.js';
-import { type HmaService } from '../../services/hmaService/index.js';
 import makeUserAPI, {
   type UserAPI,
 } from '../../graphql/datasources/UserApi.js';
+import { type HmaService } from '../../services/hmaService/index.js';
 import { type Dependencies } from '../index.js';
 import { register } from '../utils.js';
+
 // HMA service will be registered in main IoC container to avoid circular dependencies
 
 declare module '../index.js' {
@@ -32,6 +36,7 @@ declare module '../index.js' {
     InvestigationAPIDataSource: InvestigationAPI;
     LocationBankAPIDataSource: LocationBankAPI;
     OrgAPIDataSource: OrgAPI;
+    RoleAPIDataSource: RoleAPI;
     RuleAPIDataSource: RuleAPI;
     UserAPIDataSource: UserAPI;
     DataSources: DataSources;
@@ -48,6 +53,7 @@ export function registerGqlDataSources(bottle: Bottle<Dependencies>) {
   register(bottle, 'InvestigationAPIDataSource', makeInvestigationAPI);
   register(bottle, 'LocationBankAPIDataSource', makeLocationBankAPI);
   register(bottle, 'OrgAPIDataSource', makeOrgAPI);
+  register(bottle, 'RoleAPIDataSource', makeRoleAPI);
   register(bottle, 'RuleAPIDataSource', makeRuleAPI);
   register(bottle, 'UserAPIDataSource', makeUserAPI);
 
@@ -66,6 +72,7 @@ function makeDataSources(deps: Dependencies) {
     investigationAPI: deps.InvestigationAPIDataSource,
     locationBankAPI: deps.LocationBankAPIDataSource,
     orgAPI: deps.OrgAPIDataSource,
+    roleAPI: deps.RoleAPIDataSource,
     ruleAPI: deps.RuleAPIDataSource,
     userAPI: deps.UserAPIDataSource,
     notificationsAPI: new (class {

--- a/server/services/userManagementService/index.ts
+++ b/server/services/userManagementService/index.ts
@@ -11,3 +11,9 @@ export {
   UserRole,
   getPermissionsForRole,
 } from './permissioning.js';
+export {
+  type PermissionGroup,
+  type PermissionGroupItem,
+  getPermissionGroups,
+} from './permissionGroups.js';
+export { SystemRoleDefaults } from './systemRoleDefaults.js';

--- a/server/services/userManagementService/permissionGroups.ts
+++ b/server/services/userManagementService/permissionGroups.ts
@@ -1,0 +1,185 @@
+import { UserPermission } from './permissioning.js';
+
+/**
+ * Server-owned grouping + ordering of {@link UserPermission} values for the
+ * role-editor UI. New permissions without an explicit group fall through
+ * to "Other" via {@link getPermissionGroups}.
+ */
+export type PermissionGroupItem = {
+  permission: UserPermission;
+  label: string;
+  description: string;
+};
+
+export type PermissionGroup = {
+  key: string;
+  label: string;
+  description: string;
+  permissions: readonly PermissionGroupItem[];
+};
+
+const ORG_GROUP: PermissionGroup = {
+  key: 'ORGANIZATION_MANAGEMENT',
+  label: 'Organization Management',
+  description:
+    'Highest-impact permissions. Grant only to users who should be able to ' +
+    'reconfigure the organization itself.',
+  permissions: [
+    {
+      permission: UserPermission.MANAGE_ORG,
+      label: 'Manage Organization Settings',
+      description: 'Can modify organization-level settings',
+    },
+    {
+      permission: UserPermission.MANAGE_USERS,
+      label: 'Manage Users',
+      description: 'Can add, edit, or remove users',
+    },
+    {
+      permission: UserPermission.MANAGE_ROLES,
+      label: 'Manage Roles',
+      description: 'Can modify role permissions',
+    },
+  ],
+};
+
+const RULES_GROUP: PermissionGroup = {
+  key: 'RULES_MANAGEMENT',
+  label: 'Rules Management',
+  description: 'Authoring, running, and analyzing rules.',
+  permissions: [
+    {
+      permission: UserPermission.MUTATE_NON_LIVE_RULES,
+      label: 'Create Draft Rules',
+      description: 'Can create or edit Draft and Background Rules',
+    },
+    {
+      permission: UserPermission.MUTATE_LIVE_RULES,
+      label: 'Create Live Rules',
+      description: 'Can create, edit, and deploy Live Rules',
+    },
+    {
+      permission: UserPermission.RUN_BACKTEST,
+      label: 'Run Backtests',
+      description: 'Can run Backtests on Rules',
+    },
+    {
+      permission: UserPermission.RUN_RETROACTION,
+      label: 'Run Retroaction',
+      description: 'Can run Retroaction on Live Rules',
+    },
+    {
+      permission: UserPermission.VIEW_INSIGHTS,
+      label: 'View Rules Metrics',
+      description: 'Can view metrics for all Rules',
+    },
+    {
+      permission: UserPermission.VIEW_RULES_DASHBOARD,
+      label: 'View Rules Dashboard',
+      description: 'Can access the rules dashboard surface',
+    },
+    {
+      permission: UserPermission.MANAGE_POLICIES,
+      label: 'Manage Policies',
+      description: 'Can add, update, and delete policy definitions',
+    },
+  ],
+};
+
+const MANUAL_REVIEW_GROUP: PermissionGroup = {
+  key: 'MANUAL_REVIEW',
+  label: 'Manual Review',
+  description: 'Reviewing queues and acting on jobs in the MRT.',
+  permissions: [
+    {
+      permission: UserPermission.VIEW_MRT,
+      label: 'View Manual Review Tool',
+      description:
+        'Can see that queues exist, without necessarily seeing their contents',
+    },
+    {
+      permission: UserPermission.VIEW_MRT_DATA,
+      label: 'View Manual Review Metrics',
+      description: 'Can view metrics for Manual Reviews',
+    },
+    {
+      permission: UserPermission.EDIT_MRT_QUEUES,
+      label: 'Manage Queues And Routing',
+      description: 'Can view and edit Manual Review queues and routing rules',
+    },
+    {
+      permission: UserPermission.MANAGE_ROUTING_RULES,
+      label: 'Manage Routing Rules',
+      description: 'Can manage Routing Rules for job distribution',
+    },
+    {
+      permission: UserPermission.MANUALLY_ACTION_CONTENT,
+      label: 'Manually Action Content',
+      description:
+        'Can run bulk-actioning jobs and take direct moderation action',
+    },
+    {
+      permission: UserPermission.VIEW_CHILD_SAFETY_DATA,
+      label: 'View Child Safety Content',
+      description: 'Can see Child Safety-related jobs and decisions',
+    },
+  ],
+};
+
+const INVESTIGATION_GROUP: PermissionGroup = {
+  key: 'INVESTIGATION',
+  label: 'Investigation',
+  description: 'Tooling for ad-hoc investigation across signals.',
+  permissions: [
+    {
+      permission: UserPermission.VIEW_INVESTIGATION,
+      label: 'View Investigation Tool',
+      description: 'Can use the investigation tool to query across signals',
+    },
+  ],
+};
+
+const ALL_GROUPS: readonly PermissionGroup[] = [
+  ORG_GROUP,
+  RULES_GROUP,
+  MANUAL_REVIEW_GROUP,
+  INVESTIGATION_GROUP,
+];
+
+/**
+ * Canonical permission groups plus an "Other" catch-all for ungrouped
+ * {@link UserPermission} values.
+ */
+export function getPermissionGroups(): readonly PermissionGroup[] {
+  const grouped = new Set(
+    ALL_GROUPS.flatMap((g) => g.permissions.map((p) => p.permission)),
+  );
+  const ungrouped = Object.values(UserPermission).filter(
+    (p) => !grouped.has(p),
+  );
+  if (ungrouped.length === 0) {
+    return ALL_GROUPS.map(cloneGroup);
+  }
+  return [
+    ...ALL_GROUPS.map(cloneGroup),
+    {
+      key: 'OTHER',
+      label: 'Other',
+      description:
+        'Permissions that have not yet been grouped. These remain functional; ' +
+        'add them to a group in `permissionGroups.ts` to give them copy.',
+      permissions: ungrouped.map((permission) => ({
+        permission,
+        label: permission,
+        description: '',
+      })),
+    },
+  ];
+}
+
+function cloneGroup(group: PermissionGroup): PermissionGroup {
+  return {
+    ...group,
+    permissions: group.permissions.map((p) => ({ ...p })),
+  };
+}

--- a/server/services/userManagementService/systemRoleDefaults.ts
+++ b/server/services/userManagementService/systemRoleDefaults.ts
@@ -1,0 +1,45 @@
+import { type UserRole } from './permissioning.js';
+
+/**
+ * Default `display_name` and `description` for each system role. Mirrors the
+ * seed values in `db/src/scripts/api-server-pg/<...>add_roles_and_role_permissions_tables.sql`
+ * so orgs created after the migration ship — which never went through that
+ * INSERT — surface the same copy as orgs that were seeded at deploy time.
+ *
+ * Once an admin saves edits via the role-editor UI the persisted row in
+ * `public.roles` takes precedence; this map is fallback only.
+ */
+export const SystemRoleDefaults: Readonly<
+  Record<UserRole, { displayName: string; description: string }>
+> = {
+  ADMIN: {
+    displayName: 'Admin',
+    description: 'Manages all users in the org and has every permission.',
+  },
+  RULES_MANAGER: {
+    displayName: 'Rules Manager',
+    description:
+      'Can modify and run rules and actions, but cannot manage users.',
+  },
+  MODERATOR_MANAGER: {
+    displayName: 'Moderator Manager',
+    description: 'Can view MRT, edit queues, and manage moderators.',
+  },
+  MODERATOR: {
+    displayName: 'Moderator',
+    description: 'Reviews queues they have been granted access to.',
+  },
+  CHILD_SAFETY_MODERATOR: {
+    displayName: 'Child Safety Moderator',
+    description: 'Reviews child safety jobs, including NCMEC.',
+  },
+  ANALYST: {
+    displayName: 'Analyst',
+    description:
+      'Reads rules and insights; can run backtests and edit non-live rules.',
+  },
+  EXTERNAL_MODERATOR: {
+    displayName: 'External Moderator',
+    description: 'Read-only MRT access for external moderation partners.',
+  },
+};


### PR DESCRIPTION
## Context & Requests for Reviewers

Surfaces the capabilities #560 made DB-backed to admins via a role editor:

New GraphQL API endpoints to handle permission groups and modifying permissions as well as surfacing the permission available to those roles.

Materializes the `public.roles` row on first save, atomically replaces `role_permissions` in a transaction, and backfills `role_id` on the org's `users` / `invite_user_tokens` so the JOIN-based permission lookup picks up the new permissions on next load. Falls back to `SystemRoleDefaults` + `UserPermissionsForRole` for orgs that haven't customized.
 
New UI Tab on manage users that is capability gated. Adds UI components from figma to display user editing capabilities and dialogs.

Custom roles will be on a separate PR and work to another Issue, but this completes the work. 

<img width="2542" height="1218" alt="Screenshot 2026-05-25 at 9 30 14 PM" src="https://github.com/user-attachments/assets/e55c2dba-4fef-4f4b-b01a-3bba83ca1dd0" />
<img width="2551" height="1219" alt="Screenshot 2026-05-25 at 9 30 06 PM" src="https://github.com/user-attachments/assets/9d7d8a2e-dc4a-4685-92e4-47908b19ac7e" />
<img width="2548" height="1215" alt="Screenshot 2026-05-25 at 9 29 10 PM" src="https://github.com/user-attachments/assets/ee4c4970-c75b-4565-a2e0-2521cac010cb" />
<img width="2544" height="1213" alt="Screenshot 2026-05-25 at 9 29 01 PM" src="https://github.com/user-attachments/assets/456e54b2-47c4-47d5-b20c-c307fbe1497a" />
<img width="2542" height="1092" alt="Screenshot 2026-05-25 at 9 28 52 PM" src="https://github.com/user-attachments/assets/7e978272-d83b-44a2-a04d-9d646c542aa6" />
