### PR TITLE
client: Disable Point of Interest when Google Maps API Key not enabled

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -25,6 +25,14 @@ VITE_UI_URL=
 # or mirror's docs.
 VITE_DOCS_URL=https://roostorg.github.io/coop/latest
 
+# Google Maps Places API key used for the "Points of Interest" location search
+# experience (Location Banks, rule location conditions, etc.). Leave unset to
+# disable that tab in the UI; the rest of the location features (geohashes,
+# location banks) keep working without it. The key is sent in client-side
+# requests, so restrict it via HTTP referrer + API allowlists in the Google
+# Cloud Console rather than relying on it being secret.
+VITE_GOOGLE_PLACES_API_KEY=
+
 # URL of the content proxy service to use for content display in iframes.
 # This is used to proxy the content URL to the content proxy service.
 VITE_CONTENT_PROXY_URL=http://localhost:4000

--- a/client/src/lib/config.ts
+++ b/client/src/lib/config.ts
@@ -29,3 +29,28 @@ export const HOST_URL: string =
  */
 export const DOCS_URL: string =
   import.meta.env.VITE_DOCS_URL ?? 'https://roostorg.github.io/coop/latest';
+
+/**
+ * Google Maps Places API key used for the "Points of Interest" location
+ * search experience (Location Banks, rule location conditions, etc.).
+ *
+ * Configure with `VITE_GOOGLE_PLACES_API_KEY` at build time. The key is
+ * sent in client-side requests to Google's Places API; lock it down via
+ * HTTP referrer + API allowlists in the Google Cloud Console rather than
+ * relying on it being secret. Adopters who don't want to integrate
+ * Google Maps can leave this unset — the Points of Interest tab will be
+ * disabled in the UI and the rest of Location Banks (geohashes, banks)
+ * keeps working.
+ */
+export const GOOGLE_PLACES_API_KEY: string =
+  import.meta.env.VITE_GOOGLE_PLACES_API_KEY ?? '';
+
+/**
+ * Whether this Coop build has a Google Maps Places API key configured.
+ *
+ * UI surfaces that depend on Google Places (e.g. the Points of Interest
+ * tab in `LocationInputModal`) should disable themselves when this is
+ * false rather than silently failing at request time.
+ */
+export const IS_GOOGLE_PLACES_API_CONFIGURED: boolean =
+  GOOGLE_PLACES_API_KEY.length > 0;

--- a/client/src/utils/useMapsApis.ts
+++ b/client/src/utils/useMapsApis.ts
@@ -1,9 +1,7 @@
 import { Loader } from '@googlemaps/js-api-loader';
 import { useEffect, useState } from 'react';
 
-// The key should be available at build time in VITE_GOOGLE_PLACES_API_KEY env.
-// It's not a secret key, though, so hardcoding it is fine.
-const placesApiKey = import.meta.env.VITE_GOOGLE_PLACES_API_KEY ?? '';
+import { GOOGLE_PLACES_API_KEY } from '../lib/config';
 
 // Use this variable to not load the Google APIs twice.
 let placesApiLoaded = false;
@@ -27,19 +25,24 @@ export function useMapsApi() {
         geocoderService: new google.maps.Geocoder(),
       });
     } else {
-      new Loader({ apiKey: placesApiKey, libraries: ['places'] }).load().then(
-        () => {
-          placesApiLoaded = true;
-          setMapsApi({
-            type: 'LOADED',
-            autocompleteService: new google.maps.places.AutocompleteService(),
-            geocoderService: new google.maps.Geocoder(),
-          });
-        },
-        (e: Error) => {
-          setMapsApi({ type: 'ERROR', error: e });
-        },
-      );
+      new Loader({
+        apiKey: GOOGLE_PLACES_API_KEY,
+        libraries: ['places'],
+      })
+        .load()
+        .then(
+          () => {
+            placesApiLoaded = true;
+            setMapsApi({
+              type: 'LOADED',
+              autocompleteService: new google.maps.places.AutocompleteService(),
+              geocoderService: new google.maps.Geocoder(),
+            });
+          },
+          (e: Error) => {
+            setMapsApi({ type: 'ERROR', error: e });
+          },
+        );
     }
   }, []);
 

--- a/client/src/webpages/dashboard/components/location/LocationInputModal.tsx
+++ b/client/src/webpages/dashboard/components/location/LocationInputModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { IS_GOOGLE_PLACES_API_CONFIGURED } from '../../../../lib/config';
 import { LocationFormLocation } from '../../../../models/locationBank';
 import CoopModal from '../CoopModal';
 import TabBar from '../TabBar';
@@ -12,6 +13,9 @@ enum LocationInputModalTab {
   GOOGLE_PLACE = 'GOOGLE_PLACE',
   LOCATION_BANK = 'LOCATION_BANK',
 }
+
+const POI_DISABLED_TOOLTIP =
+  "Points of Interest search is unavailable because this Coop instance doesn't have a Google Maps Places API key configured.";
 
 export function locationSectionHeader(header: string) {
   return <div className="my-3 text-sm">{header}</div>;
@@ -40,7 +44,9 @@ export default function LocationInputModal(props: {
   } = props;
 
   const [activeTab, setActiveTab] = useState<LocationInputModalTab>(
-    LocationInputModalTab.GOOGLE_PLACE,
+    IS_GOOGLE_PLACES_API_CONFIGURED
+      ? LocationInputModalTab.GOOGLE_PLACE
+      : LocationInputModalTab.GEOHASH,
   );
 
   return (
@@ -53,6 +59,10 @@ export default function LocationInputModal(props: {
           {
             label: 'Points of Interest',
             value: LocationInputModalTab.GOOGLE_PLACE,
+            disabled: !IS_GOOGLE_PLACES_API_CONFIGURED,
+            tooltip: !IS_GOOGLE_PLACES_API_CONFIGURED
+              ? POI_DISABLED_TOOLTIP
+              : undefined,
           },
           {
             label: 'Geohashes',


### PR DESCRIPTION
Fixes #143 

## Context & Requests for Reviewers

When a Coop instance doesn't have a Google Maps Places API key configured, the "Points of Interest" tab in the location picker still rendered and then failed at click time. This PR keeps the tab visible (so the capability is discoverable), disables it with a tooltip explaining what's missing, and defaults the modal to the "Geohashes" tab so users land on a working surface.

<img width="2498" height="950" alt="Screenshot 2026-05-25 at 11 21 16 PM" src="https://github.com/user-attachments/assets/5b72b0b8-c9b6-47a4-a073-482b88e5d311" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Places API integration for Points of Interest search functionality.
  * Points of Interest tab is conditionally available based on API configuration status.

* **Chores**
  * Added environment configuration for Google Places API key with security notes.
  * Centralized API key management through configuration module.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/584?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->