### PR TITLE
docs: Correct API key scoping in architecture doc

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -341,7 +341,7 @@ API keys authenticate programmatic requests to REST endpoints. All API requests 
 4. Returns 401 Unauthorized if invalid or missing
 
 - Keys are 32-byte random values, SHA-256 hashed before storage
-- Each key is scoped to a single team (ie. if you have different teams in the same organization whose data should not mix)
+- Each key is scoped to an organization
 - Last-used timestamp tracked for auditing
 - Keys can be rotated (creates new key, deactivates old)
 


### PR DESCRIPTION
It's org-based. Fixes #586.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation to clarify that API keys are scoped to an organization level.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/594?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->