### PR TITLE
Fix partial item rejects of extra top level items

### DIFF
--- a/docs/api/partial-items.md
+++ b/docs/api/partial-items.md
@@ -45,30 +45,63 @@ In each object in the `items` array, Coop expects the following fields:
 | `id`     | `String` | Your unique identifier for this Item                                                                                                                                                                   |
 | `typeId` | `String` | The ID of the [Item Type](../user/concepts.md#item-type) that corresponds to the Item. This will exactly match the ID of one of the Item Types you've [defined](../user/administration.md#item-types). |
 
-## Example response
+## Response requirements
 
-Your platform returns information about the item to Coop in its response. Even if it can't fetch _all_ attributes of the item (perhaps because of some limitations in your data model or query latency), your platform can just return as many attributes as you have access to. In other words, you can return a _partial_ version of the Item, even if some attributes are missing.
+Your endpoint must respond with a `2xx` status and a JSON body containing a single top-level object with an `items` array. Extra top-level keys are accepted but ignored — only `items` is consumed.
 
-Coop expects a response in the following format:
+Each entry in `items` describes one of the items Coop asked about. You can return a _partial_ version of the Item — `data` may contain only the subset of fields you have access to — but the keys below must be present and well-typed:
+
+| Property            | Type                      | Required | Description                                                                                           |
+| :------------------ | :------------------------ | :------- | :---------------------------------------------------------------------------------------------------- |
+| `id`                | `String`                  | Yes      | The `id` Coop provided in the request body.                                                           |
+| `typeId`            | `String`                  | Yes      | The `typeId` Coop provided in the request body.                                                       |
+| `data`              | `Object`                  | Yes      | The same shape you'd send via the Items API. May be empty (`{}`), but the key itself must be present. |
+| `typeVersion`       | `String`                  | No       | Specific Item Type version to target.                                                                 |
+| `typeSchemaVariant` | `"original" \| "partial"` | No       | Defaults to `partial`.                                                                                |
+
+Example response:
 
 ```json
 {
   "items": [
     {
-      "id": "abc123", // the `id` Coop provided in the request body
-      "typeId": "def456", // the `typeId` Coop provided in the request body
-      "data": { // the same `data` JSON object you'd provide if you had sent this Item via the Items API
+      "id": "abc123", // the `id` Coop provided
+      "typeId": "def456", // the `typeId` Coop provided
+      "data": {
+        // the same shape you'd send via the Items API
         "text": "some text uploaded by a user"
         // ... all other fields in your Item Type
-      },
-    },
-    ... // other items
+      }
+    }
   ]
 }
 ```
 
-Coop expects a `2xx` HTTP status from your endpoint. If it receives any non-2xx response, it treats the request as failed and the on-demand item fetch will not succeed for the user.
+If you can't find or return a particular item, **omit it** from the `items` array rather than returning an error or a sentinel value. Coop won't treat a missing item as a failure; it simply won't have data for that item. Items whose `(id, typeId)` did not appear in the request are silently dropped.
 
-If your platform can't find or return a particular item, omit it from the `items` array in your response rather than returning an error status. Coop won't treat a missing item as a failure; it simply won't have data for that item.
+A nested form is also accepted, in which `typeId` / `typeVersion` / `typeSchemaVariant` are grouped under a `type` object. The flat form above is recommended for new integrations; this form exists for parity with the Items API submission shape.
 
-The response body must be valid JSON with a top-level `items` array. A malformed response is also treated as a failure.
+```json
+{
+  "items": [
+    {
+      "id": "abc123",
+      "data": { "text": "..." },
+      "type": {
+        "id": "def456",
+        "version": "2025-01-01",
+        "schemaVariant": "partial"
+      }
+    }
+  ]
+}
+```
+
+## Troubleshooting
+
+If a request shows up in your webhook logs but doesn't update the item in Coop, the UI will surface one of these:
+
+- **`PartialItemsEndpointResponseError`** — the endpoint returned a non-2xx status.
+- **`PartialItemsInvalidResponseError`** — the body parsed as JSON but didn't match the schema above (most often a missing `data`, a missing top-level `items` key, or non-string `id` / `typeId`), _or_ it couldn't be parsed as JSON at all. When the body fails to parse, Coop's server logs include a short prefix of the response bytes — the most common cause is writing to the response twice (e.g. a middleware emitting a sentinel before the payload, producing something like `null{"items":[...]}`).
+
+If the request looks successful but the item still doesn't appear, verify that each returned item's `(id, typeId)` exactly matches what Coop asked for — mismatches are silently dropped. If you're testing through a tunnel (`localtunnel`, `ngrok`), make sure the tunnel isn't injecting a browser-warning page in place of your response.

--- a/docs/api/partial-items.md
+++ b/docs/api/partial-items.md
@@ -49,7 +49,7 @@ In each object in the `items` array, Coop expects the following fields:
 
 Your endpoint must respond with a `2xx` status and a JSON body containing a single top-level object with an `items` array. Extra top-level keys are accepted but ignored; only `items` is consumed.
 
-Each entry in `items` describes one of the items Coop asked about. You can return a _partial_ version of the Item — `data` may contain only the subset of fields you have access to — but the keys below must be present and well-typed:
+Each entry in `items` describes one of the items Coop asked about. You can return a _partial_ version of the Item `data` may contain only the subset of fields you have access to, but the keys below must be present and well-typed:
 
 | Property            | Type                      | Required | Description                                                                                           |
 | :------------------ | :------------------------ | :------- | :---------------------------------------------------------------------------------------------------- |

--- a/docs/api/partial-items.md
+++ b/docs/api/partial-items.md
@@ -47,7 +47,7 @@ In each object in the `items` array, Coop expects the following fields:
 
 ## Response requirements
 
-Your endpoint must respond with a `2xx` status and a JSON body containing a single top-level object with an `items` array. Extra top-level keys are accepted but ignored — only `items` is consumed.
+Your endpoint must respond with a `2xx` status and a JSON body containing a single top-level object with an `items` array. Extra top-level keys are accepted but ignored; only `items` is consumed.
 
 Each entry in `items` describes one of the items Coop asked about. You can return a _partial_ version of the Item — `data` may contain only the subset of fields you have access to — but the keys below must be present and well-typed:
 
@@ -79,7 +79,7 @@ Example response:
 
 If you can't find or return a particular item, **omit it** from the `items` array rather than returning an error or a sentinel value. Coop won't treat a missing item as a failure; it simply won't have data for that item. Items whose `(id, typeId)` did not appear in the request are silently dropped.
 
-A nested form is also accepted, in which `typeId` / `typeVersion` / `typeSchemaVariant` are grouped under a `type` object. The flat form above is recommended for new integrations; this form exists for parity with the Items API submission shape.
+A nested form is also accepted in which `typeId`, `typeVersion`, and `typeSchemaVariant` are grouped under a `type` object as `id`, `version`, and `schemaVariant`. The flat form above is recommended for new integrations; this nested form only exists for parity with the Items API submission shape.
 
 ```json
 {
@@ -101,7 +101,7 @@ A nested form is also accepted, in which `typeId` / `typeVersion` / `typeSchemaV
 
 If a request shows up in your webhook logs but doesn't update the item in Coop, the UI will surface one of these:
 
-- **`PartialItemsEndpointResponseError`** — the endpoint returned a non-2xx status.
-- **`PartialItemsInvalidResponseError`** — the body parsed as JSON but didn't match the schema above (most often a missing `data`, a missing top-level `items` key, or non-string `id` / `typeId`), _or_ it couldn't be parsed as JSON at all. When the body fails to parse, Coop's server logs include a short prefix of the response bytes — the most common cause is writing to the response twice (e.g. a middleware emitting a sentinel before the payload, producing something like `null{"items":[...]}`).
+- **`PartialItemsEndpointResponseError`**: the endpoint returned a non-2xx status.
+- **`PartialItemsInvalidResponseError`**: the body parsed as JSON but didn't match the schema above (most often a missing `data`, a missing top-level `items` key, or non-string `id`/`typeId`), _or_ it couldn't be parsed as JSON at all. When the body fails to parse, Coop's server logs include a short prefix of the response bytes; the most common cause is writing to the response twice (e.g. a middleware emitting a sentinel before the payload, producing something like `null{"items":[...]}`).
 
-If the request looks successful but the item still doesn't appear, verify that each returned item's `(id, typeId)` exactly matches what Coop asked for — mismatches are silently dropped. If you're testing through a tunnel (`localtunnel`, `ngrok`), make sure the tunnel isn't injecting a browser-warning page in place of your response.
+If the request looks successful but the item still doesn't appear, verify that each returned item's `(id, typeId)` exactly matches what Coop asked for; mismatches are silently dropped. If you're testing through a tunnel (`localtunnel`, `ngrok`), make sure the tunnel isn't injecting a browser-warning page in place of your response.

--- a/server/services/networkingService/index.test.ts
+++ b/server/services/networkingService/index.test.ts
@@ -34,6 +34,11 @@ describe('fetchHTTP', () => {
             res.write('{');
             break;
 
+          case '/sends-trailing-content-after-json':
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end('null{"items":[]}');
+            break;
+
           default:
             res.writeHead(200, { 'Content-Type': 'application/json' });
             res.end('"Hello World"');
@@ -66,6 +71,25 @@ describe('fetchHTTP', () => {
         status: 200,
         ok: true,
         body: 'Hello World',
+      });
+    },
+  );
+
+  testWithFakeServer(
+    'should reject with an error whose message includes the body prefix when the response is not valid JSON',
+    async ({ baseURL, tracer }) => {
+      await expect(
+        fetchHTTP(tracer, {
+          url: new URL(
+            '/sends-trailing-content-after-json',
+            baseURL,
+          ).toString(),
+          method: 'get',
+          handleResponseBody: 'as-json',
+        }),
+      ).rejects.toMatchObject({
+        message: expect.stringContaining('null{"items":[]}'),
+        cause: expect.any(SyntaxError),
       });
     },
   );

--- a/server/services/networkingService/index.ts
+++ b/server/services/networkingService/index.ts
@@ -339,13 +339,16 @@ export async function fetchHTTP<T extends HandleResponseBody>(
               const decodedBody = utf8DecodeBytes(
                 new Uint8Array(tempArrayBuffer),
               );
-              span.setAttribute('responseBody', decodedBody);
+              const bodyPrefix = sanitizedBodyPrefix(decodedBody);
+              span.setAttribute(
+                'responseBodyByteLength',
+                tempArrayBuffer.byteLength,
+              );
+              span.setAttribute('responseBodyPrefix', bodyPrefix);
               throw new Error(
                 `Failed to parse response body as JSON (${tempArrayBuffer.byteLength} bytes): ${
                   e instanceof Error ? e.message : String(e)
-                }. Response body started with: ${sanitizedBodyPrefix(
-                  decodedBody,
-                )}`,
+                }. Response body started with: ${bodyPrefix}`,
                 { cause: e },
               );
             }

--- a/server/services/networkingService/index.ts
+++ b/server/services/networkingService/index.ts
@@ -64,8 +64,8 @@ export function makeFormDataLikeWithStreams(parts: {
 function isFormDataLikeWithStreams(it: unknown): it is FormDataLikeWithStreams {
   return Boolean(
     typeof it === 'object' &&
-      it != null &&
-      (it as { [formDataLikeWithStreams]?: unknown })[formDataLikeWithStreams],
+    it != null &&
+    (it as { [formDataLikeWithStreams]?: unknown })[formDataLikeWithStreams],
   );
 }
 
@@ -336,16 +336,18 @@ export async function fetchHTTP<T extends HandleResponseBody>(
 
               return [parsedJson, tempArrayBuffer.byteLength];
             } catch (e) {
-              // when parsing JSON fails, since in this case we explicity
-              // called this function wiht 'as-json' we expect to recieve
-              // JSON from the remote server, we should log the body of the
-              // response to inspect, then re-throw the error so we are not
-              // changing behavior for callers
-              span.setAttribute(
-                'responseBody',
-                utf8DecodeBytes(new Uint8Array(tempArrayBuffer)),
+              const decodedBody = utf8DecodeBytes(
+                new Uint8Array(tempArrayBuffer),
               );
-              throw e;
+              span.setAttribute('responseBody', decodedBody);
+              throw new Error(
+                `Failed to parse response body as JSON (${tempArrayBuffer.byteLength} bytes): ${
+                  e instanceof Error ? e.message : String(e)
+                }. Response body started with: ${sanitizedBodyPrefix(
+                  decodedBody,
+                )}`,
+                { cause: e },
+              );
             }
           }
           case 'as-json-from-xml': {
@@ -410,6 +412,17 @@ export async function fetchHTTP<T extends HandleResponseBody>(
       };
     },
   );
+}
+
+// Bounded so unbounded customer response bodies don't end up in log
+// aggregators verbatim when JSON parsing fails.
+const JSON_PARSE_ERROR_BODY_PREFIX_LENGTH = 96;
+
+function sanitizedBodyPrefix(body: string): string {
+  const prefix = body.slice(0, JSON_PARSE_ERROR_BODY_PREFIX_LENGTH);
+  const printableOnly = prefix.replace(/[^\x20-\x7E]/g, '.');
+  const ellipsis = body.length > JSON_PARSE_ERROR_BODY_PREFIX_LENGTH ? '…' : '';
+  return `"${printableOnly}${ellipsis}"`;
 }
 
 // TextDecoder reused by each utf8DecodeBytes call,

--- a/server/services/partialItemsService/isJsonParseFailure.ts
+++ b/server/services/partialItemsService/isJsonParseFailure.ts
@@ -1,0 +1,15 @@
+/**
+ * True when `e` represents a JSON parse failure thrown by `fetchHttp` —
+ * either a bare `SyntaxError` from `JSON.parse`, or the wrapper `Error`
+ * that `networkingService` throws with the original `SyntaxError` as its
+ * `cause`.
+ */
+export function isJsonParseFailure(e: unknown): boolean {
+  if (e instanceof SyntaxError) {
+    return true;
+  }
+  if (e instanceof Error && e.cause instanceof SyntaxError) {
+    return true;
+  }
+  return false;
+}

--- a/server/services/partialItemsService/partialItemsService.test.ts
+++ b/server/services/partialItemsService/partialItemsService.test.ts
@@ -1,0 +1,39 @@
+import { isJsonParseFailure } from './isJsonParseFailure.js';
+
+describe('isJsonParseFailure', () => {
+  it('returns true for a bare SyntaxError', () => {
+    expect(
+      isJsonParseFailure(
+        new SyntaxError(
+          'Unexpected non-whitespace character after JSON at position 4',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true for an Error whose cause is a SyntaxError', () => {
+    const underlying = new SyntaxError(
+      'Unexpected non-whitespace character after JSON at position 4',
+    );
+    expect(
+      isJsonParseFailure(new Error('wrapped', { cause: underlying })),
+    ).toBe(true);
+  });
+
+  it('returns false for a generic error with no SyntaxError cause', () => {
+    expect(isJsonParseFailure(new Error('ECONNREFUSED'))).toBe(false);
+  });
+
+  it('returns false for an error whose cause is something other than a SyntaxError', () => {
+    expect(
+      isJsonParseFailure(new Error('boom', { cause: new TypeError('nope') })),
+    ).toBe(false);
+  });
+
+  it('returns false for non-Error thrown values', () => {
+    expect(isJsonParseFailure('parse failed')).toBe(false);
+    expect(isJsonParseFailure(undefined)).toBe(false);
+    expect(isJsonParseFailure(null)).toBe(false);
+    expect(isJsonParseFailure({ message: 'parse failed' })).toBe(false);
+  });
+});

--- a/server/services/partialItemsService/partialItemsService.ts
+++ b/server/services/partialItemsService/partialItemsService.ts
@@ -1,7 +1,8 @@
 import { type ItemIdentifier } from '@roostorg/types';
 import _Ajv from 'ajv-draft-04';
 
-import { inject, type Dependencies } from '../../iocContainer/index.js';
+import { type Dependencies } from '../../iocContainer/index.js';
+import { inject } from '../../iocContainer/utils.js';
 import { type GetItemTypesForOrgEventuallyConsistent } from '../../rule_engine/ruleEngineQueries.js';
 import { jsonStringify } from '../../utils/encoding.js';
 import {
@@ -22,12 +23,14 @@ import {
 import { type GetItemTypeEventuallyConsistent } from '../moderationConfigService/moderationConfigServiceQueries.js';
 import { type FetchHTTP } from '../networkingService/index.js';
 import { type OrgSettingsService } from '../orgSettingsService/orgSettingsService.js';
+import { isJsonParseFailure } from './isJsonParseFailure.js';
 
 const Ajv = _Ajv as unknown as typeof _Ajv.default;
 const ajv = new Ajv();
 
 type PartialItemsResponse = { items: RawItemSubmission[] };
 
+// Extra top-level keys are accepted but ignored.
 const validatePartialItemsResponse = ajv.compile<PartialItemsResponse>({
   type: 'object',
   properties: {
@@ -37,7 +40,6 @@ const validatePartialItemsResponse = ajv.compile<PartialItemsResponse>({
     },
   },
   required: ['items'],
-  additionalProperties: false,
 } as const satisfies JSONSchemaV4<PartialItemsResponse>);
 
 function makePartialItemsService(
@@ -65,9 +67,8 @@ function makePartialItemsService(
             jsonStringify(itemsToFetch),
           );
 
-          const partialItemsInfo = await orgSettingsService.partialItemsInfo(
-            orgId,
-          );
+          const partialItemsInfo =
+            await orgSettingsService.partialItemsInfo(orgId);
 
           const partialItemsEndpoint = partialItemsInfo?.partialItemsEndpoint;
 
@@ -96,6 +97,16 @@ function makePartialItemsService(
               signingKeyPairService,
               orgId,
             ),
+          }).catch((e: unknown) => {
+            // Surface JSON parse failures as a typed GraphQL error instead of
+            // letting them bubble up as an opaque "Unknown error".
+            if (isJsonParseFailure(e)) {
+              throw makePartialItemsEndpointInvalidResponseError({
+                shouldErrorSpan: true,
+                cause: e,
+              });
+            }
+            throw e;
           });
 
           if (!response.ok) {


### PR DESCRIPTION
Fixes #585 

## Context & Requests for Reviewers

The initial user reports that partial items webhook was firing successfully but the data never reached the investigation view. The most likely culprit is that the endpoint was emitting a stray `null` ahead of the payload (producing `null{"items":[...]}`), which tripped `JSON.parse` in `networkingService`. The resulting `SyntaxError` bubbled up untouched. I added more visibility in this case to help further debug if this is an error.

This PR also addresses two other potential errors:

1. Even when we did catch a bad payload, the GraphQL response back to the client was an opaque "Unknown error" nothing that is actually actionable. Now `partialItemsService` detects parse failures from `fetchHttp` and re-throws them as `PartialItemsInvalidResponseError`to help debug further errors from partial items endpoint.
2. The top-level response schema had `additionalProperties: false`, which would reject any valid response that carried extra keys. That was inconsistent with the per-item schema and with the public Items API ingestion endpoint as both ignore extras so I dropped it them. 

Re-write part of the docs `docs/api/partial-items.md` make it more explicit on expectations of the endpoint and the contract expewcted.


## Tests

Added additional test and was able to repro bad partial items being rejected with extra data before fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified API response requirements: single top-level items array, per-item required fields, omission of not-found items, optional nested-type shape, and expanded troubleshooting including visible error types and common causes.

* **Bug Fixes**
  * Better handling and clearer messages for malformed/trailing-content JSON responses; parse failures are surfaced as explicit endpoint errors; validation now tolerates extra top-level keys.

* **Tests**
  * Added tests for JSON parse failures and responses with trailing content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/601?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->