### PR TITLE
Rename published package to @roostorg/coop-types

### DIFF
--- a/.github/workflows/publish-types.yaml
+++ b/.github/workflows/publish-types.yaml
@@ -28,13 +28,14 @@ jobs:
       - name: Check and publish types
         run: |
           cd types
+          PKG_NAME=$(node -p "require('./package.json').name")
           VERSION=$(node -p "require('./package.json').version")
-          echo "Checking @roostorg/types@$VERSION..."
-          
-          if npm view "@roostorg/types@$VERSION" version >/dev/null 2>&1; then
-            echo "⚠️  Version $VERSION of @roostorg/types already exists on npm - skipping"
+          echo "Checking $PKG_NAME@$VERSION..."
+
+          if npm view "$PKG_NAME@$VERSION" version >/dev/null 2>&1; then
+            echo "⚠️  Version $VERSION of $PKG_NAME already exists on npm - skipping"
           else
-            echo "✅ Publishing @roostorg/types@$VERSION..."
+            echo "✅ Publishing $PKG_NAME@$VERSION..."
             npm ci --ignore-scripts
             npm run build
             npm publish

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -68,7 +68,7 @@ publish_if_needed() {
 }
 
 # Publish packages
-publish_if_needed "types" "@roostorg/types"
+publish_if_needed "types" "@roostorg/coop-types"
 publish_if_needed "migrator" "@roostorg/db-migrator"
 
 echo "✅ All packages published successfully!"

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -51,8 +51,12 @@ publish_if_needed() {
     # Derive name and version from package.json so the script stays in sync
     # with whatever npm publish will actually publish (avoids drift if the
     # package is renamed without updating this script).
-    local package_name=$(node -p "require('./package.json').name")
-    local version=$(node -p "require('./package.json').version")
+    # Declare and assign separately so `set -e` catches node -p failures
+    # (shellcheck SC2155: `local foo=$(...)` masks the subshell's exit status).
+    local package_name
+    package_name=$(node -p "require('./package.json').name")
+    local version
+    version=$(node -p "require('./package.json').version")
 
     echo "📦 Checking $package_name@$version..."
 

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -45,21 +45,23 @@ check_version_exists() {
 # Function to publish package if version doesn't exist
 publish_if_needed() {
     local package_dir=$1
-    local package_name=$2
-    
+
     cd "$package_dir"
-    
-    # Get current version from package.json
+
+    # Derive name and version from package.json so the script stays in sync
+    # with whatever npm publish will actually publish (avoids drift if the
+    # package is renamed without updating this script).
+    local package_name=$(node -p "require('./package.json').name")
     local version=$(node -p "require('./package.json').version")
-    
+
     echo "📦 Checking $package_name@$version..."
-    
+
     if check_version_exists "$package_name" "$version"; then
         echo "⏭️  Skipping $package_name@$version (already published)"
         cd ..
         return
     fi
-    
+
     echo "📦 Publishing $package_name@$version..."
     npm install
     npm run build
@@ -68,8 +70,8 @@ publish_if_needed() {
 }
 
 # Publish packages
-publish_if_needed "types" "@roostorg/coop-types"
-publish_if_needed "migrator" "@roostorg/db-migrator"
+publish_if_needed "types"
+publish_if_needed "migrator"
 
 echo "✅ All packages published successfully!"
 echo ""

--- a/types/package-lock.json
+++ b/types/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@roostorg/types",
-  "version": "2.1.0",
+  "name": "@roostorg/coop-types",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@roostorg/types",
-      "version": "2.1.0",
+      "name": "@roostorg/coop-types",
+      "version": "2.2.0",
       "license": "ISC",
       "dependencies": {
         "date-fns": "^2.29.3",

--- a/types/package.json
+++ b/types/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@roostorg/types",
+  "name": "@roostorg/coop-types",
   "type": "module",
-  "version": "2.1.0",
-  "description": "Shared types across Coop services",
+  "version": "2.2.0",
+  "description": "Shared TypeScript types for Coop: schema primitives, signal data maps, and integration contracts.",
   "module": "transpiled/index.js",
   "typings": "./transpiled/index.d.ts",
   "scripts": {


### PR DESCRIPTION
Fixes #598 

## Context & Requests for Reviewers

Renames the types package in coop to a more appropriate `coop-types` already published a 2.1.0 so here we are bumping to 2.2.0 to confirm work of the release via CI. 

There will be a follow up pr after this to move to use 2.2.0 on codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * TypeScript types package renamed from `@roostorg/types` to `@roostorg/coop-types`.
  * Package version bumped to 2.2.0.
  * Publish process updated to derive the package name dynamically and skip publishing when the specific package@version already exists.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/602?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->