### PR TITLE
Fix createOrg FK ordering and seed built-in actions

### DIFF
--- a/server/graphql/datasources/OrgApi.test.ts
+++ b/server/graphql/datasources/OrgApi.test.ts
@@ -7,6 +7,7 @@ import createOrg from '../../test/fixtureHelpers/createOrg.js';
 import { makeMockedServer } from '../../test/setupMockedServer.js';
 import { makeTestWithFixture } from '../../test/utils.js';
 import { CoopError } from '../../utils/errors.js';
+import { kyselyOrgDeleteById } from './orgKyselyPersistence.js';
 import {
   kyselyUserDeleteById,
   kyselyUserInsert,
@@ -330,6 +331,34 @@ describe('OrgAPI', () => {
           name: 'BadRequestError',
           pointer: '/input/email',
         });
+      },
+    );
+
+    testWithFixture(
+      'seeds the built-in actions for the new org',
+      async ({ deps }) => {
+        const created = await deps.OrgAPIDataSource.createOrg({
+          input: {
+            name: `NewOrg_${uid()}`,
+            email: `new_${uid()}@example.com`,
+            website: 'https://example.com',
+          },
+        });
+        try {
+          const actions = await deps.ModerationConfigService.getActions({
+            orgId: created.id,
+          });
+          const actionTypes = actions.map((a) => a.actionType).sort();
+          expect(actionTypes).toEqual(
+            [
+              'ENQUEUE_AUTHOR_TO_MRT',
+              'ENQUEUE_TO_MRT',
+              'ENQUEUE_TO_NCMEC',
+            ].sort(),
+          );
+        } finally {
+          await kyselyOrgDeleteById(deps.KyselyPg, created.id);
+        }
       },
     );
   });

--- a/server/graphql/datasources/OrgApi.ts
+++ b/server/graphql/datasources/OrgApi.ts
@@ -9,9 +9,9 @@ import { b64EncodeArrayBuffer } from '../../utils/encoding.js';
 import {
   CoopError,
   ErrorType,
+  isCoopErrorOfType,
   makeBadRequestError,
   type ErrorInstanceData,
-  isCoopErrorOfType,
 } from '../../utils/errors.js';
 import { WEEK_MS } from '../../utils/time.js';
 import {
@@ -20,6 +20,7 @@ import {
   type GQLRequestDemoInput,
 } from '../generated.js';
 import {
+  kyselyOrgDeleteById,
   kyselyOrgFindAll,
   kyselyOrgFindByEmail,
   kyselyOrgFindById,
@@ -34,8 +35,8 @@ import {
   type OrgValidationFailure,
 } from './orgValidation.js';
 import {
-  type GraphQLUserParent,
   kyselyUserListByOrg,
+  type GraphQLUserParent,
 } from './userKyselyPersistence.js';
 
 class OrgAPI {
@@ -80,33 +81,39 @@ class OrgAPI {
 
     const id = uid();
 
-    // Create api key before inserting the org, so we don't have to worry about
-    // the possibility of orgs existing without an api key.
-    // TODO: if org fails to save later, delete orphaned api key.
-    const { record } = await this.apiKeyService.createApiKey(
+    // Insert the org first so FK-dependent inserts (api_keys, signing_keys,
+    // and everything in the Promise.all below) have a parent row to reference.
+    // Past versions of this resolver created the api_key first, which fails
+    // against the non-deferred `api_keys.org_id` FK to `public.orgs(id)`.
+    const org = await kyselyOrgInsert({
+      db: this.kysely,
       id,
-      'Main API Key',
-      'Primary API key for organization',
-      null
-    );
-
-    // TODO: if org fails to save later, delete orphaned signing key pair
-    await this.signingKeyPairService.createAndStoreSigningKeys(id);
+      email,
+      name,
+      websiteUrl: website,
+    });
 
     try {
-      const org = await kyselyOrgInsert({
-        db: this.kysely,
+      const { record } = await this.apiKeyService.createApiKey(
         id,
-        email,
-        name,
-        websiteUrl: website,
-        apiKeyId: record.id,
-      });
+        'Main API Key',
+        'Primary API key for organization',
+        null,
+      );
+      await this.signingKeyPairService.createAndStoreSigningKeys(id);
+
+      // Backfill api_key_id on the org now that the key exists.
+      await this.kysely
+        .updateTable('public.orgs')
+        .set({ api_key_id: record.id, updated_at: new Date() })
+        .where('id', '=', id)
+        .execute();
 
       await Promise.all([
         // This should ideally be done in one transaction, but we can update
         // this after we move off of sequelize
         this.moderationConfigService.createDefaultUserType(id),
+        this.moderationConfigService.upsertBuiltInActions(id),
         this.orgCreationLogger.logOrgCreated(id, name, email, website),
         this.userManagementService.upsertOrgDefaultUserInterfaceSettings({
           orgId: id,
@@ -117,6 +124,14 @@ class OrgAPI {
 
       return org;
     } catch (e) {
+      // Roll back the org insert so we don't leave a half-provisioned row.
+      // `ON DELETE CASCADE` on org_id FKs cleans up any child rows that did
+      // make it (api_keys, signing_keys, item_types, etc.).
+      await kyselyOrgDeleteById(this.kysely, id).catch(() => {
+        // Swallow cleanup failures: the original error is more useful to the
+        // caller, and the next createOrg attempt will hit the unique-name
+        // / unique-email guards above and surface a clear conflict.
+      });
       const activeSpan = this.tracer.getActiveSpan();
       if (activeSpan?.isRecording()) {
         activeSpan.recordException(e as Exception);
@@ -156,7 +171,10 @@ class OrgAPI {
     } catch (error: unknown) {
       // Even if email fails, return the token so it can be copied
       // eslint-disable-next-line no-console
-      console.warn('Failed to send invite email, but token was created:', error);
+      console.warn(
+        'Failed to send invite email, but token was created:',
+        error,
+      );
     }
     return token;
   }
@@ -276,9 +294,8 @@ class OrgAPI {
   async getPublicSigningKeyPem(orgId: string) {
     let key: CryptoKey;
     try {
-      key = await this.signingKeyPairService.getSignatureVerificationInfo(
-        orgId,
-      );
+      key =
+        await this.signingKeyPairService.getSignatureVerificationInfo(orgId);
     } catch (error) {
       if (isCoopErrorOfType(error, 'SigningKeyPairNotFound')) {
         key = await this.signingKeyPairService.createAndStoreSigningKeys(orgId);


### PR DESCRIPTION
## Summary
- Insert the org row first in `OrgAPIDataSource.createOrg` so FK-dependent inserts (`api_keys`, `signing_keys`, …) have a parent to reference. Previous ordering made every call to the resolver fail with `api_keys_org_id_fkey`.
- Add `moderationConfigService.upsertBuiltInActions(id)` to the post-insert Promise.all so the GraphQL surface matches the CLI and test fixture — fresh orgs now get `ENQUEUE_TO_MRT` / `ENQUEUE_AUTHOR_TO_MRT` / `ENQUEUE_TO_NCMEC`.
- Add a success-path test on `OrgApi.createOrg` that asserts the built-in actions exist after the call. The previous tests covered only validation rejections, which is how both bugs slipped through.
- Roll back the org row on any failure after the initial insert via `kyselyOrgDeleteById`; `ON DELETE CASCADE` cleans up child rows.

Closes #603.

## Test plan
- [x] `npx jest graphql/datasources/OrgApi.test.ts` — 17 passed
- [x] `npx jest graphql/datasources/orgKyselyPersistence.test.ts` — 10 passed
- [ ] Smoke test the mutation end-to-end against a local DB once CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced organization creation reliability with improved error handling and automatic rollback of partially-created organizations during provisioning failures.

* **Tests**
  * Added test coverage verifying that moderation configurations are properly initialized when new organizations are created.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/604?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->