### PR TITLE
Add MEDIA scalar to @roostorg/coop-types (v2.3.0)

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -34,6 +34,11 @@ export const ScalarTypes = makeEnumLike([
   // schema field as an IP address so it can be surfaced as an identifier in
   // moderation flows (e.g., via schema-field role metadata).
   'IP_ADDRESS',
+  // Polymorphic media: holds a URL plus the resolved kind (AUDIO/IMAGE/VIDEO),
+  // detected from the URL extension at ingestion time. Lets an adopter declare
+  // a single field (or container of fields) that mixes media kinds without
+  // committing to one in the schema.
+  'MEDIA',
 ]);
 export type ScalarTypes = typeof ScalarTypes;
 export type ScalarType = keyof typeof ScalarTypes;
@@ -60,6 +65,13 @@ type ScalarTypeRuntimeTypeMapping = Satisfies<
     [ScalarTypes.RELATED_ITEM]: RelatedItem;
     [ScalarTypes.POLICY_ID]: string;
     [ScalarTypes.IP_ADDRESS]: string;
+    [ScalarTypes.MEDIA]: {
+      url: string;
+      // The resolved kind, derived from the URL extension. `null` when the
+      // extension was missing or unrecognized — consumers can fall back to
+      // probing Content-Type or treating the value as opaque.
+      mediaType: MediaKind | null;
+    };
   },
   { [K in ScalarType]: unknown }
 >;
@@ -178,18 +190,30 @@ export function getScalarType<T extends FieldType>(it: Field<T>) {
   ) as FieldScalarType<T>;
 }
 
+export type MediaKind =
+  | ScalarTypes['AUDIO']
+  | ScalarTypes['IMAGE']
+  | ScalarTypes['VIDEO'];
+
 export function isMediaType(it: ScalarType): boolean {
   return (
     it === ScalarTypes.AUDIO ||
     it === ScalarTypes.VIDEO ||
-    it === ScalarTypes.IMAGE
+    it === ScalarTypes.IMAGE ||
+    it === ScalarTypes.MEDIA
   );
 }
 
 export function isMediaValue<T extends ScalarType>(
   it: TaggedScalar<T>,
 ): it is TaggedScalar<
-  T & (ScalarTypes['IMAGE'] | ScalarTypes['VIDEO'] | ScalarTypes['AUDIO'])
+  T &
+    (
+      | ScalarTypes['IMAGE']
+      | ScalarTypes['VIDEO']
+      | ScalarTypes['AUDIO']
+      | ScalarTypes['MEDIA']
+    )
 > {
   return isMediaType(it.type);
 }

--- a/types/package-lock.json
+++ b/types/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@roostorg/coop-types",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@roostorg/coop-types",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "ISC",
       "dependencies": {
         "date-fns": "^2.29.3",

--- a/types/package.json
+++ b/types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@roostorg/coop-types",
   "type": "module",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Shared TypeScript types for Coop: schema primitives, signal data maps, and integration contracts.",
   "module": "transpiled/index.js",
   "typings": "./transpiled/index.d.ts",


### PR DESCRIPTION
## Summary
- Adds a polymorphic `MEDIA` entry to `ScalarTypes` in `@roostorg/coop-types`, bumped to v2.3.0.
- Runtime type is `{ url: string; mediaType: 'AUDIO' | 'IMAGE' | 'VIDEO' | null }` — the resolved kind is meant to be detected from the URL extension at coercion time, so an adopter can declare `MEDIA` / `Array<MEDIA>` / `Map<key, MEDIA>` and mix kinds without committing to one in the schema.
- Updates `isMediaType` / `isMediaValue` to include `MEDIA`; adds a `MediaKind` type alias.
- Pure additive types-package change, mirroring the IP_ADDRESS pattern from #559.

## Why
Related to #418. Adopters with "media lists" that mix audio/video/image currently have to pick one of the existing fixed-kind scalars or fall back to `URL`, which the dashboard doesn't render as media. A `MEDIA` scalar carries enough info to render correctly per item.

## Out of scope
Server-side coercion (URL → kind detection), GraphQL `ScalarType` / `FieldType` / `SignalInputType` enum updates, codegen regeneration, and client UI wiring are deferred. They depend on the in-progress migration off `@roostorg/types` (the `satisfies FieldType` guard at `server/graphql/modules/itemType.ts:1053` blocks new scalar additions on the consumer side until that lands). Follow-up issue/PR will pick those up once consumers see v2.3.0.

## Release note
Merging triggers `publish-types.yaml` to publish `@roostorg/coop-types@2.3.0` to npm.

## Test plan
- [x] `npm run build` in `types/` (passes)
- [ ] CI green
- [ ] Reviewer confirms the runtime-type shape for MEDIA is acceptable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new unified media scalar type supporting audio, image, and video content. Enhanced type guards provide improved runtime validation and type safety for comprehensive media operations.

* **Chores**
  * Updated package version to 2.3.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/605?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->