### PR TITLE
feat: add dedicated coop-migrator Docker image

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # CODEOWNERS file for managing repository permissions
 # Format: path-pattern @username @org/team-name
 
-# Maintainers: Default owners for all files
-* @juanmrad @vinaysrao1 @pawiecz @cassidyjames @julietshen @dom-notion
+# Divine maintainers
+* @mbradley @notthatkindofdrliz
 
-# Docs contributors
-docs/ @roostorg/roosters
+# Upstream ROOST maintainers (for upstream sync PRs)
+# * @juanmrad @vinaysrao1 @pawiecz @cassidyjames @julietshen @dom-notion

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,3 +14,7 @@ Are there any special things that have to be done before this can be deployed
 to prod (e.g., other blocking PRs; manual load testing/validation that needs to
 be done on staging; etc.)? If so, please note them here.
  -->
+
+## Public Artifact Review
+
+- [ ] Titles, descriptions, branch names, screenshots, and linked artifacts avoid partner, customer, brand, campaign, or other sensitive external names unless explicitly approved

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -33,6 +33,10 @@ jobs:
           - image: coop-client
             context: ./client
             dockerfile: client/Dockerfile
+          - image: coop-migrator
+            context: .
+            dockerfile: Dockerfile
+            target: build_migrator
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -1,0 +1,66 @@
+name: Build and Push Docker Images
+
+on:
+  push:
+    branches:
+      - main
+      - 'divine/*'
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+  ORG: divinevideo
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      matrix:
+        include:
+          - image: coop-server
+            context: .
+            dockerfile: Dockerfile
+            target: build_server
+          - image: coop-worker
+            context: .
+            dockerfile: Dockerfile
+            target: build_worker_runner
+          - image: coop-client
+            context: ./client
+            dockerfile: client/Dockerfile
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.image }}
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          target: ${{ matrix.target || '' }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/semantic_pr.yml
+++ b/.github/workflows/semantic_pr.yml
@@ -1,0 +1,12 @@
+name: Semantic PR
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  semantic-pull-request:
+    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/semantic_pull_request.yml@v1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# COOP (Content Operations & Oversight Platform)
+
+Divine's moderation review surface. Fork of [roostorg/coop](https://github.com/roostorg/coop).
+
+## Cross-Repo Coordination
+
+This repo is **Layer 4** (human review surface) in the moderation pipeline. Read the coordination doc at session start:
+`~/code/support-trust-safety/docs/moderation/auto-hide-evolution-plan.md`
+
+When you make decisions or discover constraints that affect other layers, update that doc and flag it for the user.
+
+## Architecture
+
+COOP receives flagged content from Osprey (rules engine) via REST API submission. Human moderators review items in the Manual Review Tool (MRT), then take actions (Ban User, Delete Content, Hide Content, Age Restrict) that fire webhooks to the relay-manager adapter.
+
+```
+Osprey verdict (flag_for_review) → COOP REST API → MRT queue
+Moderator decision → COOP webhook → adapter → relay-manager RPC
+```
+
+## Divine Integration Points
+
+- **Item Type:** "User Report" with fields for report metadata + media (VIDEO/IMAGE)
+- **Actions:** CUSTOM_ACTION webhooks to adapter service
+- **Adapter:** `support-trust-safety/scripts/coop-webhook-adapter.mjs` translates webhooks to relay-manager RPC
+- **Bridge import:** `support-trust-safety/scripts/coop-bridge-import.sh` pulls Kind 1984 reports from staging relay
+
+## Deployment
+
+Images build via GitHub Actions to `ghcr.io/divinevideo/coop-server`, `coop-worker`, `coop-client`.
+K8s manifests live in `divine-iac-coreconfig/k8s/applications/coop/`.
+
+## Staging Dependencies
+
+- **PostgreSQL:** shared CNPG cluster in `postgres-clusters` namespace
+- **Redis:** shared sentinel cluster in `redis-clusters` namespace
+- **ClickHouse:** ClickHouse operator available; needs a ClickHouseInstallation CR
+- **ScyllaDB:** not available on cluster; env vars stubbed with dummy values (MRT workflow does not require Scylla on the critical path)
+
+## Local Dev
+
+```bash
+docker compose up -d postgres redis clickhouse scylla
+docker compose run migrations
+# Then run server and client separately or via docker compose
+```
+
+## Upstream Sync
+
+Pull from `upstream` (roostorg/coop), push divine-specific changes to `origin` (divinevideo/coop).

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,3 +44,13 @@ CMD ["node", "bin/www.js"]
 
 FROM backend_base AS build_worker_runner
 CMD ["node", "bin/run-worker-or-job.js"]
+
+# Migrator: runs schema migrations via root db:create / db:update scripts.
+# The K8s db-migrate Job provides the command at runtime.
+FROM node:24.14.1-bullseye-slim AS build_migrator
+WORKDIR /app
+COPY ["package.json", "./"]
+COPY ["db/package.json", "db/package-lock.json", "db/"]
+RUN cd db && npm ci
+COPY ["db/src", "db/src/"]
+COPY ["db/tsconfig.json", "db/"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,10 @@ CMD ["node", "bin/run-worker-or-job.js"]
 # The K8s db-migrate Job provides the command at runtime.
 FROM node:24.14.1-bullseye-slim AS build_migrator
 WORKDIR /app
-COPY ["package.json", "./"]
-COPY ["db/package.json", "db/package-lock.json", "db/"]
+RUN groupadd -r migrator && useradd -r -g migrator -u 1001 migrator
+COPY --chown=migrator:migrator ["package.json", "./"]
+COPY --chown=migrator:migrator ["db/package.json", "db/package-lock.json", "db/"]
 RUN cd db && npm ci
-COPY ["db/src", "db/src/"]
-COPY ["db/tsconfig.json", "db/"]
+COPY --chown=migrator:migrator ["db/src", "db/src/"]
+COPY --chown=migrator:migrator ["db/tsconfig.json", "db/"]
+USER 1001

--- a/db/src/index.ts
+++ b/db/src/index.ts
@@ -1,12 +1,24 @@
 #!/usr/bin/env -S node --loader ts-node/esm --require dotenv/config
+import type { DatabaseConfig } from '@roostorg/db-migrator';
 import { makeCli } from '@roostorg/db-migrator';
 
 import apiServerPostgresConfig from './configs/api-server-pg.js';
-import clickhouseConfig from './configs/clickhouse.js';
-import scyllaConfig from './configs/scylla.js';
 
-makeCli({
+// Only load Scylla/ClickHouse configs when their env vars are present.
+// The K8s db-migrate Job only targets api-server-pg and doesn't set
+// SCYLLA_HOSTS or CLICKHOUSE_* vars.
+const configs: Record<string, DatabaseConfig<any, any, any>> = {
   'api-server-pg': apiServerPostgresConfig,
-  clickhouse: clickhouseConfig,
-  scylla: scyllaConfig,
-});
+};
+
+if (process.env.CLICKHOUSE_HOST || process.env.CLICKHOUSE_DATABASE) {
+  const { default: clickhouseConfig } = await import('./configs/clickhouse.js');
+  configs.clickhouse = clickhouseConfig;
+}
+
+if (process.env.SCYLLA_HOSTS) {
+  const { default: scyllaConfig } = await import('./configs/scylla.js');
+  configs.scylla = scyllaConfig;
+}
+
+makeCli(configs);


### PR DESCRIPTION
## Summary
- Adds a `build_migrator` stage to the Dockerfile for a lightweight image dedicated to running schema migrations
- CI matrix updated to build and push `ghcr.io/divinevideo/coop-migrator` alongside existing images
- Conditional config loading in `db/src/index.ts` prevents crashes when Scylla/ClickHouse env vars are absent
- Migrator runs as non-root user (UID 1001), matching `db/Dockerfile` pattern

## Context
The K8s `db-migrate` Job was using the full `coop-server` image to run migrations. This creates a dedicated, minimal image that only contains the migration tooling (`@roostorg/db-migrator`).

## Test plan
- [ ] CI builds the migrator image successfully
- [ ] Image runs migrations against a local Postgres
- [ ] K8s Job in divine-iac-coreconfig references the new image name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive platform documentation for the moderation review surface and architecture.
  * Updated pull request template with public artifact review guidelines.

* **Chores**
  * Updated codebase ownership mappings.
  * Added CI/CD pipeline for building and pushing Docker images to container registry.
  * Added semantic pull request validation workflow.
  * Enhanced database configuration handling for flexible deployment scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/633?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->