### PR TITLE
feat: add nginx serve stage to client Dockerfile

### DIFF
--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -9,3 +9,4 @@
 !postcss.config.js
 !tailwind.config.js
 !tsconfig.json
+!nginx.conf

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -21,7 +21,7 @@ ARG VITE_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
 ENV DISABLE_ESLINT_PLUGIN=true
 RUN NODE_OPTIONS="--max-old-space-size=5250" VITE_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=$VITE_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT npm run build
 
-FROM nginx:1.27-alpine AS serve
+FROM nginx:1.27.5-alpine AS serve
 COPY --from=client_build /app/build /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -11,7 +11,7 @@ COPY package*.json .
 RUN --mount=type=cache,target=/root/.npm npm ci
 
 COPY . .
-FROM client_base
+FROM client_base AS client_build
 
 ARG VITE_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
 
@@ -20,3 +20,8 @@ ARG VITE_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
 # before we ever deploy. So no need to do it again here.
 ENV DISABLE_ESLINT_PLUGIN=true
 RUN NODE_OPTIONS="--max-old-space-size=5250" VITE_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=$VITE_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT npm run build
+
+FROM nginx:1.27-alpine AS serve
+COPY --from=client_build /app/build /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,8 +1,12 @@
 server {
     listen 80;
     server_name _;
+    server_tokens off;
     root /usr/share/nginx/html;
     index index.html;
+
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
 
     # Don't cache index.html so deployments take effect immediately.
     location ~* \.html$ {
@@ -12,6 +16,6 @@ server {
     # SPA client-side routing: serve static files if they exist,
     # otherwise fall through to index.html.
     location / {
-        try_files $uri /index.html;
+        try_files $uri $uri/ /index.html;
     }
 }

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,0 +1,17 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Don't cache index.html so deployments take effect immediately.
+    location ~* \.html$ {
+        expires -1;
+    }
+
+    # SPA client-side routing: serve static files if they exist,
+    # otherwise fall through to index.html.
+    location / {
+        try_files $uri /index.html;
+    }
+}

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -5,17 +5,21 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-Frame-Options "DENY" always;
-
-    # Don't cache index.html so deployments take effect immediately.
-    location ~* \.html$ {
-        expires -1;
+    # Vite hashed assets: cache aggressively (hash guarantees uniqueness).
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
     }
 
     # SPA client-side routing: serve static files if they exist,
-    # otherwise fall through to index.html.
+    # otherwise fall through to index.html.  No-cache so deploys
+    # take effect immediately without a hard refresh.
     location / {
-        try_files $uri $uri/ /index.html;
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        try_files $uri /index.html;
     }
 }


### PR DESCRIPTION
## Summary
- Adds `nginx:1.27.5-alpine` serve stage to the client Dockerfile for production SPA serving
- `nginx.conf` with SPA routing (`try_files`), security headers, and correct caching strategy
- Vite hashed assets (`/assets/`) get aggressive 1-year cache; everything else gets no-cache so deploys take effect immediately
- `.dockerignore` updated to allow `nginx.conf` through

## Context
The client Dockerfile only had a build stage with no production serving. The K8s `coop-client` deployment serves the built React SPA via nginx on port 80, with liveness/readiness probes on `GET /`.

## Test plan
- [ ] CI builds the client image successfully
- [ ] nginx serves the SPA on port 80
- [ ] `GET /` returns 200 (K8s probes will pass)
- [ ] Client-side routing works (deep links serve index.html)
- [ ] Static assets are cached, HTML is not