### PR TITLE
Populate NCMEC reports with the `ipAddress` schema field role

### DIFF
--- a/docs/integrations/ncmec.md
+++ b/docs/integrations/ncmec.md
@@ -213,7 +213,7 @@ When a reviewer submits a CyberTip, Coop performs the following steps:
      - `screenName`: the user's username, from your Additional Info endpoint
      - `displayName`: the user's display name, if available
      - `email`: known email addresses for the user, from your Additional Info endpoint
-     - `ipCaptureEvent`: IP addresses associated with the user (e.g. login, upload events), from your Additional Info endpoint. Providing IP data significantly improves NCMEC's ability to identify and locate the suspect. If the user item's item type maps the `ipAddress` schema field role, that IP is also appended as an `Unknown` event.
+     - `ipCaptureEvent`: IP addresses associated with the user (e.g. login, upload events), from your Additional Info endpoint. Providing IP data significantly improves NCMEC's ability to identify and locate the suspect. If the user item's item type maps the `ipAddress` schema field role, that IP is also appended as an `Unknown` event at the report's incident time.
 
    - **Victim**: if a child victim is identifiable (e.g. from a messaging context), Coop includes their `espIdentifier`, `screenName`, `displayName`, and `ipCaptureEvent`. This helps NCMEC locate and provide assistance to the victim.
 

--- a/docs/integrations/ncmec.md
+++ b/docs/integrations/ncmec.md
@@ -213,7 +213,7 @@ When a reviewer submits a CyberTip, Coop performs the following steps:
      - `screenName`: the user's username, from your Additional Info endpoint
      - `displayName`: the user's display name, if available
      - `email`: known email addresses for the user, from your Additional Info endpoint
-     - `ipCaptureEvent`: IP addresses associated with the user (e.g. login, upload events), from your Additional Info endpoint. Providing IP data significantly improves NCMEC's ability to identify and locate the suspect.
+     - `ipCaptureEvent`: IP addresses associated with the user (e.g. login, upload events), from your Additional Info endpoint. Providing IP data significantly improves NCMEC's ability to identify and locate the suspect. If the user item's item type maps the `ipAddress` schema field role, that IP is also appended as an `Unknown` event.
 
    - **Victim**: if a child victim is identifiable (e.g. from a messaging context), Coop includes their `espIdentifier`, `screenName`, `displayName`, and `ipCaptureEvent`. This helps NCMEC locate and provide assistance to the victim.
 
@@ -222,7 +222,7 @@ When a reviewer submits a CyberTip, Coop performs the following steps:
 4. **Upload media**: For each media item, Coop downloads the file from its URL and uploads it to NCMEC with full file metadata:
    - Industry classification (A1/A2/B1/B2)
    - File annotations (labels selected by the reviewer)
-   - IP capture events associated with the upload
+   - IP capture events associated with the upload. If the media item's item type maps the `ipAddress` schema field role, that IP is also appended as an `Upload` event at the media's `createdAt`.
    - Whether the content was publicly available on your platform (`publiclyAvailable`)
    - Whether the ESP viewed the file and its EXIF data (`fileViewedByEsp: true`, `exifViewedByEsp: true`)
    - File hash, if provided by your Additional Info endpoint
@@ -347,7 +347,7 @@ Coop signs every request with your org's signing key. Verify the signature befor
 | `users.typeId`            | String          | Must match the `typeId` from the request.                                                                                                                 |
 | `users.screenName`        | String          | The user's screen name or username on your platform.                                                                                                      |
 | `users.email`             | Array           | Known email addresses for the user. `type` may be `Business`, `Home`, or `Work`.                                                                          |
-| `users.ipCaptureEvent`    | Array           | IP events associated with the user (e.g. logins, registrations). `eventName` may be `Login`, `Registration`, `Purchase`, `Upload`, `Other`, or `Unknown`. |
+| `users.ipCaptureEvent`    | Array           | IP events associated with the user (e.g. logins, registrations). `eventName` may be `Login`, `Registration`, `Purchase`, `Upload`, `Other`, or `Unknown`. Coop also appends the user item's `ipAddress` field role (when mapped) as an `Unknown` event at the report's incident time. |
 | `users.data`              | Object          | Raw item data for the user.                                                                                                                               |
 | `media`                   | Array           | Must include an entry for every media item in the request if present.                                                                                     |
 | `media.id`                | String          | Must match the `id` from the request.                                                                                                                     |
@@ -356,7 +356,7 @@ Coop signs every request with your org's signing key. Verify the signature befor
 | `media.publiclyAvailable` | Boolean         | Whether the media was publicly accessible on your platform at the time of reporting.                                                                      |
 | `media.fileName`          | String          | Original filename of the media.                                                                                                                           |
 | `media.additionalInfo`    | Array\<String\> | Additional context about the media to include in the NCMEC file details.                                                                                  |
-| `media.ipCaptureEvent`    | Array           | IP events associated with this media item (e.g. the upload event).                                                                                        |
+| `media.ipCaptureEvent`    | Array           | IP events associated with this media item. Coop also appends the media item's `ipAddress` field role (when mapped) as an `Upload` event at the media's `createdAt`. |
 | `media.fileDetails`       | Object          | Hash information for the file: `{ hash, hashType }`.                                                                                                      |
 | `additionalFiles`         | Array           | Extra files to upload to NCMEC as supplemental evidence (e.g. screenshots).                                                                               |
 | `messages`                | Array           | Message-level IP address data for conversation thread context.                                                                                            |

--- a/server/services/ncmecService/buildSubmitReportParamsFromDecision.test.ts
+++ b/server/services/ncmecService/buildSubmitReportParamsFromDecision.test.ts
@@ -249,6 +249,44 @@ describe('buildSubmitReportParamsFromDecision', () => {
       expect(result.media[0]).not.toHaveProperty('ipAddress');
     });
 
+    it('falls back to "now" when the role-derived `createdAt` is unparseable', async () => {
+      const userItemType = makeUserItemType({});
+      const contentItemType = makeContentItemType({});
+      const before = Date.now();
+      const result = await buildSubmitReportParamsFromDecision(
+        makeInput({
+          reportedUserItemType: userItemType,
+          reportedUserData: asNormalizedData({ display_name: 'Alice' }),
+          contentItemType,
+          contentData: asNormalizedData({
+            created_at: 'not-a-real-date',
+          }),
+        }),
+      );
+      const after = Date.now();
+
+      expect(result.media).toHaveLength(1);
+      const fallbackMs = Date.parse(result.media[0].createdAt);
+      expect(Number.isNaN(fallbackMs)).toBe(false);
+      expect(fallbackMs).toBeGreaterThanOrEqual(before);
+      expect(fallbackMs).toBeLessThanOrEqual(after);
+    });
+
+    it('preserves a valid role-derived `createdAt` unchanged', async () => {
+      const userItemType = makeUserItemType({});
+      const contentItemType = makeContentItemType({});
+      const result = await buildSubmitReportParamsFromDecision(
+        makeInput({
+          reportedUserItemType: userItemType,
+          reportedUserData: asNormalizedData({ display_name: 'Alice' }),
+          contentItemType,
+          contentData: asNormalizedData({ created_at: FIXED_NOW }),
+        }),
+      );
+
+      expect(result.media[0].createdAt).toBe(FIXED_NOW);
+    });
+
     it('propagates IPv6 addresses unchanged', async () => {
       const userItemType = makeUserItemType({
         ipAddressField: 'client_ip',

--- a/server/services/ncmecService/buildSubmitReportParamsFromDecision.test.ts
+++ b/server/services/ncmecService/buildSubmitReportParamsFromDecision.test.ts
@@ -1,0 +1,271 @@
+import { ScalarTypes, type DateString, type Field } from '@roostorg/coop-types';
+
+import { type NormalizedItemData } from '../itemProcessingService/index.js';
+import {
+  type ContentItemType,
+  type UserItemType,
+} from '../moderationConfigService/types/itemTypes.js';
+import {
+  buildSubmitReportParamsFromDecision,
+  type BuildSubmitReportParamsInput,
+} from './buildSubmitReportParamsFromDecision.js';
+
+const FIXED_NOW_ISO = '2026-05-27T18:00:00.000Z';
+// `makeDateString` returns `DateString | undefined`; we know our literal is a
+// well-formed ISO string, so this skips the runtime branch in tests.
+const FIXED_NOW = FIXED_NOW_ISO as DateString;
+// `NormalizedItemData` is an Opaque<RawItemData> type produced by the items
+// pipeline; tests need to bypass the brand to construct fixtures.
+const asNormalizedData = (data: Record<string, unknown>): NormalizedItemData =>
+  data as unknown as NormalizedItemData;
+
+// Minimal Field factories for the test fixtures below; these match the shape
+// that the items API would store after normalising an `IP_ADDRESS`-typed
+// field, so we don't need to plug in fieldTypeHandlers here.
+const stringField = (name: string): Field => ({
+  name,
+  type: ScalarTypes.STRING,
+  required: false,
+  container: null,
+});
+
+const ipAddressField = (name: string): Field => ({
+  name,
+  type: ScalarTypes.IP_ADDRESS,
+  required: false,
+  container: null,
+});
+
+const datetimeField = (name: string): Field => ({
+  name,
+  type: ScalarTypes.DATETIME,
+  required: false,
+  container: null,
+});
+
+function makeUserItemType(overrides: {
+  ipAddressField?: string;
+  ipAddressFieldName?: string;
+  data?: NormalizedItemData;
+}): UserItemType {
+  const ipFieldName = overrides.ipAddressFieldName ?? 'client_ip';
+  // The schema is built immutably (no .push) to satisfy
+  // functional/immutable-data; we then cast to the non-empty `ItemSchema`
+  // brand because the constructor is internal.
+  const fields: readonly Field[] =
+    overrides.ipAddressField !== undefined
+      ? [stringField('display_name'), ipAddressField(ipFieldName)]
+      : [stringField('display_name')];
+  return {
+    id: 'user-type-1',
+    kind: 'USER',
+    name: 'User',
+    description: null,
+    schema: fields as unknown as UserItemType['schema'],
+    version: 'v1',
+    schemaVariant: 'original',
+    orgId: 'org-1',
+    isDefaultUserType: true,
+    schemaFieldRoles: {
+      displayName: 'display_name',
+      ...(overrides.ipAddressField !== undefined
+        ? { ipAddress: overrides.ipAddressField }
+        : {}),
+    },
+  };
+}
+
+function makeContentItemType(overrides: {
+  ipAddressField?: string;
+}): ContentItemType {
+  const fields: readonly Field[] =
+    overrides.ipAddressField !== undefined
+      ? [
+          datetimeField('created_at'),
+          stringField('caption'),
+          ipAddressField(overrides.ipAddressField),
+        ]
+      : [datetimeField('created_at'), stringField('caption')];
+  // `ContentSchemaFieldRoles` is a discriminated union; setting `createdAt`
+  // narrows it to the variant that also requires `threadId`. The fixture
+  // doesn't model threads, so we widen via `unknown` to keep the rest of the
+  // schema-role plumbing exercised without dragging thread fields in.
+  const schemaFieldRoles = {
+    createdAt: 'created_at',
+    ...(overrides.ipAddressField !== undefined
+      ? { ipAddress: overrides.ipAddressField }
+      : {}),
+  } as unknown as ContentItemType['schemaFieldRoles'];
+  return {
+    id: 'content-type-1',
+    kind: 'CONTENT',
+    name: 'Photo',
+    description: null,
+    schema: fields as unknown as ContentItemType['schema'],
+    version: 'v1',
+    schemaVariant: 'original',
+    orgId: 'org-1',
+    schemaFieldRoles,
+  };
+}
+
+/** Build a `BuildSubmitReportParamsInput` with sensible defaults; tests
+ * override only the bits relevant to what they exercise. */
+function makeInput(opts: {
+  reportedUserItemType: UserItemType;
+  reportedUserData: NormalizedItemData;
+  contentItemType: ContentItemType;
+  contentData: NormalizedItemData;
+}): BuildSubmitReportParamsInput {
+  const mediaItem = {
+    contentItem: {
+      itemId: 'media-1',
+      itemTypeIdentifier: { id: 'content-type-1' },
+      data: opts.contentData,
+    },
+  };
+
+  return {
+    orgId: 'org-1',
+    reviewerId: 'reviewer-1',
+    reportedItemId: 'user-1',
+    reportedItemTypeId: 'user-type-1',
+    reportedUserItemType: opts.reportedUserItemType,
+    reportedUserData: opts.reportedUserData,
+    allMediaItems: [mediaItem],
+    decisionComponent: {
+      reportedMedia: [
+        {
+          id: 'media-1',
+          typeId: 'content-type-1',
+          url: 'https://example.com/m1.png',
+          industryClassification: 'A1',
+          fileAnnotations: [],
+        },
+      ],
+      reportedMessages: [],
+      incidentType:
+        'Child Pornography (possession, manufacture, and distribution)',
+    },
+    getItemTypeEventuallyConsistent: async () => opts.contentItemType,
+  };
+}
+
+describe('buildSubmitReportParamsFromDecision', () => {
+  describe('ipAddress field-role propagation', () => {
+    it('reads the user IP from the schema field role and surfaces it on `reportedUser.ipAddress`', async () => {
+      const userItemType = makeUserItemType({
+        ipAddressField: 'client_ip',
+      });
+      const result = await buildSubmitReportParamsFromDecision(
+        makeInput({
+          reportedUserItemType: userItemType,
+          reportedUserData: asNormalizedData({
+            display_name: 'Alice',
+            client_ip: '192.0.2.10',
+          }),
+          contentItemType: makeContentItemType({}),
+          contentData: asNormalizedData({ created_at: FIXED_NOW }),
+        }),
+      );
+
+      expect(result.reportedUser).toMatchObject({
+        id: 'user-1',
+        typeId: 'user-type-1',
+        displayName: 'Alice',
+        ipAddress: '192.0.2.10',
+      });
+    });
+
+    it('omits `reportedUser.ipAddress` when the role is not mapped (legacy item types)', async () => {
+      const userItemType = makeUserItemType({});
+      const result = await buildSubmitReportParamsFromDecision(
+        makeInput({
+          reportedUserItemType: userItemType,
+          reportedUserData: asNormalizedData({ display_name: 'Alice' }),
+          contentItemType: makeContentItemType({}),
+          contentData: asNormalizedData({ created_at: FIXED_NOW }),
+        }),
+      );
+
+      // SECURITY-ish: missing role must produce a missing key, not an empty
+      // string. NCMEC's ipAddress validator requires a non-empty string, so an
+      // empty string would silently produce an invalid CyberTip payload.
+      expect(result.reportedUser).not.toHaveProperty('ipAddress');
+    });
+
+    it('omits `reportedUser.ipAddress` when the field is mapped but absent in the data', async () => {
+      const userItemType = makeUserItemType({
+        ipAddressField: 'client_ip',
+      });
+      const result = await buildSubmitReportParamsFromDecision(
+        makeInput({
+          reportedUserItemType: userItemType,
+          reportedUserData: asNormalizedData({ display_name: 'Alice' }),
+          contentItemType: makeContentItemType({}),
+          contentData: asNormalizedData({ created_at: FIXED_NOW }),
+        }),
+      );
+
+      expect(result.reportedUser).not.toHaveProperty('ipAddress');
+    });
+
+    it('reads the per-media IP from the content item type role', async () => {
+      const userItemType = makeUserItemType({});
+      const contentItemType = makeContentItemType({
+        ipAddressField: 'upload_ip',
+      });
+
+      const result = await buildSubmitReportParamsFromDecision(
+        makeInput({
+          reportedUserItemType: userItemType,
+          reportedUserData: asNormalizedData({ display_name: 'Alice' }),
+          contentItemType,
+          contentData: asNormalizedData({
+            created_at: FIXED_NOW,
+            upload_ip: '203.0.113.42',
+          }),
+        }),
+      );
+
+      expect(result.media).toHaveLength(1);
+      expect(result.media[0]).toMatchObject({
+        id: 'media-1',
+        typeId: 'content-type-1',
+        ipAddress: '203.0.113.42',
+      });
+    });
+
+    it('omits per-media `ipAddress` when role is not mapped', async () => {
+      const result = await buildSubmitReportParamsFromDecision(
+        makeInput({
+          reportedUserItemType: makeUserItemType({}),
+          reportedUserData: asNormalizedData({ display_name: 'Alice' }),
+          contentItemType: makeContentItemType({}),
+          contentData: asNormalizedData({ created_at: FIXED_NOW }),
+        }),
+      );
+
+      expect(result.media[0]).not.toHaveProperty('ipAddress');
+    });
+
+    it('propagates IPv6 addresses unchanged', async () => {
+      const userItemType = makeUserItemType({
+        ipAddressField: 'client_ip',
+      });
+      const result = await buildSubmitReportParamsFromDecision(
+        makeInput({
+          reportedUserItemType: userItemType,
+          reportedUserData: asNormalizedData({
+            display_name: 'Alice',
+            client_ip: '2001:db8::1',
+          }),
+          contentItemType: makeContentItemType({}),
+          contentData: asNormalizedData({ created_at: FIXED_NOW }),
+        }),
+      );
+
+      expect(result.reportedUser.ipAddress).toBe('2001:db8::1');
+    });
+  });
+});

--- a/server/services/ncmecService/buildSubmitReportParamsFromDecision.ts
+++ b/server/services/ncmecService/buildSubmitReportParamsFromDecision.ts
@@ -104,6 +104,12 @@ export async function buildSubmitReportParamsFromDecision(
     'profileIcon',
     reportedUserData,
   );
+  const reportedUserIp = getFieldValueForRole(
+    reportedUserItemType.schema,
+    reportedUserItemType.schemaFieldRoles,
+    'ipAddress',
+    reportedUserData,
+  );
 
   // Pre-index allMediaItems by (itemId, typeId) so the per-decisionComponent
   // lookup below is O(1) instead of O(n) for every reportedMedia entry. The
@@ -147,6 +153,12 @@ export async function buildSubmitReportParamsFromDecision(
       if (createdAt === undefined) {
         throw new Error('No created at for reported media');
       }
+      const mediaIp = getFieldValueForRole(
+        mediaItemType.schema,
+        mediaItemType.schemaFieldRoles,
+        'ipAddress',
+        reportedItem.contentItem.data,
+      );
       return {
         id: it.id,
         typeId: it.typeId,
@@ -154,6 +166,7 @@ export async function buildSubmitReportParamsFromDecision(
         createdAt,
         industryClassification: it.industryClassification,
         fileAnnotations: it.fileAnnotations,
+        ...(mediaIp ? { ipAddress: mediaIp } : {}),
       };
     }),
   );
@@ -170,6 +183,7 @@ export async function buildSubmitReportParamsFromDecision(
       typeId: reportedItemTypeId,
       ...(displayName ? { displayName } : {}),
       ...(profilePicUrl ? { profilePicture: profilePicUrl.url } : {}),
+      ...(reportedUserIp ? { ipAddress: reportedUserIp } : {}),
     },
     orgId,
     media,

--- a/server/services/ncmecService/buildSubmitReportParamsFromDecision.ts
+++ b/server/services/ncmecService/buildSubmitReportParamsFromDecision.ts
@@ -139,17 +139,21 @@ export async function buildSubmitReportParamsFromDecision(
       if (mediaItemType === undefined) {
         throw new Error('Unable to find item type for reported media');
       }
-      // Fall back to "now" when the source row is missing `createdAt`.
-      // This keeps retries submittable for legacy data (predates the field)
-      // better to send the retry timestamp than to permanently block the
-      // report from being submitted to NCMEC at all.
+      const roleCreatedAt = getFieldValueForRole(
+        mediaItemType.schema,
+        mediaItemType.schemaFieldRoles,
+        'createdAt',
+        reportedItem.contentItem.data,
+      );
+      // Fall back to "now" when `createdAt` is missing or unparseable (e.g.
+      // legacy rows that predate the field, or a `createdAt` schema field
+      // role mapped to a non-date column). Better to send the retry
+      // timestamp than to permanently block the report.
       const createdAt =
-        getFieldValueForRole(
-          mediaItemType.schema,
-          mediaItemType.schemaFieldRoles,
-          'createdAt',
-          reportedItem.contentItem.data,
-        ) ?? makeDateString(new Date().toISOString());
+        roleCreatedAt !== undefined &&
+        !Number.isNaN(Date.parse(roleCreatedAt))
+          ? roleCreatedAt
+          : makeDateString(new Date().toISOString());
       if (createdAt === undefined) {
         throw new Error('No created at for reported media');
       }

--- a/server/services/ncmecService/ncmecReporting.test.ts
+++ b/server/services/ncmecService/ncmecReporting.test.ts
@@ -1,6 +1,8 @@
 import {
   buildInternetDetailsFromOrgSetting,
   clampIncidentDateTimeToPast,
+  mergeFieldRoleIpIntoEvents,
+  NCMECEvent,
   summarizeCyberTipFailure,
 } from './ncmecReporting.js';
 
@@ -142,6 +144,166 @@ describe('NCMEC reporting', () => {
       expect(() => clampIncidentDateTimeToPast('not-a-date', NOW_MS)).toThrow(
         /Invalid media createdAt timestamp/,
       );
+    });
+  });
+
+  describe('mergeFieldRoleIpIntoEvents', () => {
+    const synth = {
+      eventName: NCMECEvent.Upload,
+      dateTime: '2026-05-27T12:00:00.000Z',
+    };
+
+    const webhookEvent = {
+      ipAddress: '192.0.2.1',
+      eventName: NCMECEvent.Login,
+      dateTime: '2026-01-01T00:00:00.000Z',
+      port: 443,
+    };
+    const paramEvent = {
+      ipAddress: '198.51.100.5',
+      eventName: NCMECEvent.Registration,
+      dateTime: '2026-02-02T00:00:00.000Z',
+    };
+    const otherParamEvent = {
+      ipAddress: '198.51.100.6',
+      eventName: NCMECEvent.Other,
+      dateTime: '2026-02-03T00:00:00.000Z',
+    };
+
+    it('passes webhook events through when nothing else is set', () => {
+      expect(
+        mergeFieldRoleIpIntoEvents([webhookEvent], undefined, undefined, synth),
+      ).toEqual([webhookEvent]);
+    });
+
+    it('accepts a single param event (not wrapped in an array)', () => {
+      // Partial-items-derived data may produce a single event or many; we
+      // accept either shape so callers don't need to wrap.
+      expect(
+        mergeFieldRoleIpIntoEvents(undefined, paramEvent, undefined, synth),
+      ).toEqual([paramEvent]);
+    });
+
+    it('accepts an array of param events', () => {
+      expect(
+        mergeFieldRoleIpIntoEvents(
+          undefined,
+          [paramEvent, otherParamEvent],
+          undefined,
+          synth,
+        ),
+      ).toEqual([paramEvent, otherParamEvent]);
+    });
+
+    it('concatenates webhook + param + role-synth events in that order', () => {
+      expect(
+        mergeFieldRoleIpIntoEvents(
+          [webhookEvent],
+          [paramEvent, otherParamEvent],
+          '203.0.113.5',
+          synth,
+        ),
+      ).toEqual([
+        webhookEvent,
+        paramEvent,
+        otherParamEvent,
+        {
+          ipAddress: '203.0.113.5',
+          eventName: NCMECEvent.Upload,
+          dateTime: '2026-05-27T12:00:00.000Z',
+        },
+      ]);
+    });
+
+    it('appends the role IP as a synthesised event after webhook events', () => {
+      // The role IP is always included alongside webhook events — adopters
+      // who tag the item with the IP get coverage even when the webhook
+      // already returns a richer event from a different system of record.
+      expect(
+        mergeFieldRoleIpIntoEvents(
+          [webhookEvent],
+          undefined,
+          '203.0.113.5',
+          synth,
+        ),
+      ).toEqual([
+        webhookEvent,
+        {
+          ipAddress: '203.0.113.5',
+          eventName: NCMECEvent.Upload,
+          dateTime: '2026-05-27T12:00:00.000Z',
+        },
+      ]);
+    });
+
+    it('returns a single synthesised event when only the role IP is available', () => {
+      expect(
+        mergeFieldRoleIpIntoEvents([], undefined, '192.0.2.10', synth),
+      ).toEqual([
+        {
+          ipAddress: '192.0.2.10',
+          eventName: NCMECEvent.Upload,
+          dateTime: '2026-05-27T12:00:00.000Z',
+        },
+      ]);
+    });
+
+    it('returns undefined when no source has data', () => {
+      expect(
+        mergeFieldRoleIpIntoEvents(undefined, undefined, undefined, synth),
+      ).toBeUndefined();
+      expect(
+        mergeFieldRoleIpIntoEvents(undefined, undefined, null, synth),
+      ).toBeUndefined();
+      expect(
+        mergeFieldRoleIpIntoEvents([], [], undefined, synth),
+      ).toBeUndefined();
+    });
+
+    it('treats blank/whitespace role IP as absent', () => {
+      // Don't synthesise from blank/whitespace; ingestion validates real IPs
+      // upstream, but we trim defensively here.
+      expect(
+        mergeFieldRoleIpIntoEvents(undefined, undefined, '', synth),
+      ).toBeUndefined();
+      expect(
+        mergeFieldRoleIpIntoEvents(undefined, undefined, '   ', synth),
+      ).toBeUndefined();
+      // With a webhook event, the blank role IP is dropped silently.
+      expect(
+        mergeFieldRoleIpIntoEvents([webhookEvent], undefined, '   ', synth),
+      ).toEqual([webhookEvent]);
+    });
+
+    it('trims surrounding whitespace from the role IP before emitting', () => {
+      const result = mergeFieldRoleIpIntoEvents(
+        undefined,
+        undefined,
+        '  198.51.100.7  ',
+        synth,
+      );
+      expect(result).toEqual([
+        {
+          ipAddress: '198.51.100.7',
+          eventName: NCMECEvent.Upload,
+          dateTime: '2026-05-27T12:00:00.000Z',
+        },
+      ]);
+    });
+
+    it('does not mutate the input webhook or param event arrays', () => {
+      const webhook = [webhookEvent];
+      const params = [paramEvent];
+      const result = mergeFieldRoleIpIntoEvents(
+        webhook,
+        params,
+        '203.0.113.5',
+        synth,
+      );
+      expect(result).not.toBe(webhook);
+      expect(result).not.toBe(params);
+      expect(webhook).toHaveLength(1);
+      expect(params).toHaveLength(1);
     });
   });
 

--- a/server/services/ncmecService/ncmecReporting.ts
+++ b/server/services/ncmecService/ncmecReporting.ts
@@ -168,7 +168,11 @@ type Media = {
   createdAt: string;
   industryClassification: NCMECIndustryClassificationType;
   fileAnnotations?: readonly NCMECFileAnnotationType[];
-  ipCaptureEvent?: IPNCMECEvent;
+  /** Pre-built IP event(s); accepts a single event or an array. */
+  ipCaptureEvent?: IPNCMECEvent | readonly IPNCMECEvent[];
+  /** Bare IP from the `ipAddress` field role; appended as a synthesised
+   * `Upload` event. */
+  ipAddress?: string;
   deviceId?: DeviceNCMECEvent[];
 };
 
@@ -177,6 +181,11 @@ type NCMECUserParams = {
   typeId: string;
   profilePicture?: string;
   displayName?: string;
+  /** Pre-built IP event(s); accepts a single event or an array. */
+  ipCaptureEvent?: IPNCMECEvent | readonly IPNCMECEvent[];
+  /** Bare IP from the `ipAddress` field role; appended as a synthesised
+   * `Unknown` event. */
+  ipAddress?: string;
 };
 
 export type NCMECReportParams = {
@@ -496,6 +505,40 @@ export function clampIncidentDateTimeToPast(
     value: new Date(finalMs).toISOString(),
     wasClamped,
   };
+}
+
+/** Build the `ipCaptureEvent` array for an NCMEC person or media block:
+ * webhook events + caller-supplied events + role-IP-synthesised event, in
+ * that order. Returns `undefined` when all sources are empty. */
+export function mergeFieldRoleIpIntoEvents(
+  webhookEvents: readonly IPNCMECEvent[] | undefined,
+  paramEvents: IPNCMECEvent | readonly IPNCMECEvent[] | undefined,
+  roleIpAddress: string | undefined | null,
+  synthesisedEvent: { eventName: NCMECEventType; dateTime: string },
+): IPNCMECEvent[] | undefined {
+  const isEventArray = (
+    v: IPNCMECEvent | readonly IPNCMECEvent[],
+  ): v is readonly IPNCMECEvent[] => Array.isArray(v);
+  const paramEventsArray: readonly IPNCMECEvent[] =
+    paramEvents == null
+      ? []
+      : isEventArray(paramEvents)
+        ? paramEvents
+        : [paramEvents];
+  const trimmedRoleIp =
+    typeof roleIpAddress === 'string' ? roleIpAddress.trim() : '';
+  const events: IPNCMECEvent[] = [
+    ...(webhookEvents ?? []),
+    ...paramEventsArray,
+  ];
+  if (trimmedRoleIp !== '') {
+    events.push({
+      ipAddress: trimmedRoleIp,
+      eventName: synthesisedEvent.eventName,
+      dateTime: synthesisedEvent.dateTime,
+    });
+  }
+  return events.length > 0 ? events : undefined;
 }
 
 export function buildInternetDetailsFromOrgSetting(
@@ -1539,6 +1582,18 @@ export default class NcmecReporting {
             ? { email: reportedPersonEmail }
             : undefined;
 
+          // The role IP is a bare string, not a login/upload signal, so
+          // `Unknown` is the safest event-name claim.
+          const reportedUserIpCaptureEvents = mergeFieldRoleIpIntoEvents(
+            userAdditionalInfo.ipCaptureEvent,
+            reportParams.reportedUser.ipCaptureEvent,
+            reportParams.reportedUser.ipAddress,
+            {
+              eventName: NCMECEvent.Unknown,
+              dateTime: clampedIncidentDateTime,
+            },
+          );
+
           const report: Report = {
             report: {
               incidentSummary: {
@@ -1568,9 +1623,9 @@ export default class NcmecReporting {
                       displayName: [reportParams.reportedUser.displayName],
                     }
                   : {}),
-                ...(userAdditionalInfo.ipCaptureEvent &&
-                userAdditionalInfo.ipCaptureEvent.length > 0
-                  ? { ipCaptureEvent: userAdditionalInfo.ipCaptureEvent }
+                ...(reportedUserIpCaptureEvents &&
+                reportedUserIpCaptureEvents.length > 0
+                  ? { ipCaptureEvent: reportedUserIpCaptureEvents }
                   : {}),
               },
               ...(reportAdditionalInfo !== undefined
@@ -1608,11 +1663,23 @@ export default class NcmecReporting {
                 additionalInfo: [],
                 ipCaptureEvent: [],
               };
+              const mergedMediaInfo = {
+                ...mediaAdditionalInfo,
+                ipCaptureEvent: mergeFieldRoleIpIntoEvents(
+                  mediaAdditionalInfo.ipCaptureEvent,
+                  media.ipCaptureEvent,
+                  media.ipAddress,
+                  {
+                    eventName: NCMECEvent.Upload,
+                    dateTime: media.createdAt,
+                  },
+                ),
+              };
               return this.#upload(
                 reportId,
                 media,
                 cybertipAuthenticationCredentials,
-                mediaAdditionalInfo,
+                mergedMediaInfo,
                 isTest,
               );
             }),

--- a/server/services/ncmecService/ncmecReporting.ts
+++ b/server/services/ncmecService/ncmecReporting.ts
@@ -530,14 +530,16 @@ export function mergeFieldRoleIpIntoEvents(
   const events: IPNCMECEvent[] = [
     ...(webhookEvents ?? []),
     ...paramEventsArray,
+    ...(trimmedRoleIp !== ''
+      ? [
+          {
+            ipAddress: trimmedRoleIp,
+            eventName: synthesisedEvent.eventName,
+            dateTime: synthesisedEvent.dateTime,
+          },
+        ]
+      : []),
   ];
-  if (trimmedRoleIp !== '') {
-    events.push({
-      ipAddress: trimmedRoleIp,
-      eventName: synthesisedEvent.eventName,
-      dateTime: synthesisedEvent.dateTime,
-    });
-  }
   return events.length > 0 ? events : undefined;
 }
 


### PR DESCRIPTION
Fixes #468 
Fixes #592 

## Context & Requests for Reviewers

Adopters can already tag User and Content items with the new `ipAddress` schema field role from previous prs. This PR closes the loop by sending those IPs to NCMEC.

When `buildSubmitReportParamsFromDecision` assembles a CyberTip payload it now reads the `ipAddress` role off the reported user and each reported media item. `submitReport` appends those IPs to `<ipCaptureEvent>` on the user (`Unknown` event at the report's incident time) and on each file (`Upload` at the media's `createdAt`). 

The additional-info webhook stays the authoritative source. Its events come first, and the role IP is appended alongside, so adopters who haven't yet wired the webhook still get the reported IP into the submission. 

If neither source has data, the element is omitted entirely as usual.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IP address field mapping and synthesized IP-capture events are now included in NCMEC incident reports for reported users and media uploads.

* **Bug Fixes**
  * Media item timestamps now reliably fall back to the report time when an invalid media date is encountered, improving report accuracy.

* **Documentation**
  * NCMEC docs clarified to explain how mapped IP roles become specific IP-capture events (Unknown for users, Upload for media).

* **Tests**
  * Added tests validating IP propagation, event merging, and createdAt fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->