### PR TITLE
Fix MRT crash when partialItems returns empty items array

### DIFF
--- a/client/src/utils/manualReviewTool.test.ts
+++ b/client/src/utils/manualReviewTool.test.ts
@@ -1,5 +1,8 @@
 import { GQLUserPenaltySeverity } from '../graphql/generated';
-import { recomputeSelectedRelatedActions } from './manualReviewTool';
+import {
+  recomputeSelectedRelatedActions,
+  selectPreferredUserItem,
+} from './manualReviewTool';
 
 describe('recomputeSelectedRelatedActions', () => {
   afterEach(() => {
@@ -205,5 +208,47 @@ describe('recomputeSelectedRelatedActions', () => {
         policies: [{ id: 'z', name: 'w' }],
       },
     ]);
+  });
+});
+
+describe('selectPreferredUserItem', () => {
+  const userItem = { __typename: 'UserItem' as const, id: 'u1' };
+  const contentItem = { __typename: 'ContentItem' as const, id: 'c1' };
+  const fallbackUserItem = { __typename: 'UserItem' as const, id: 'u2' };
+
+  // Regression: a `PartialItemsSuccessResponse` is partial by design and can
+  // carry an empty `items` array. Indexing `items[0].__typename` without a
+  // guard crashed the review page with "Cannot read properties of undefined
+  // (reading '__typename')" and looped the MRT subtree.
+  test('returns undefined (does not throw) when both lists are empty', () => {
+    expect(selectPreferredUserItem([], [])).toBeUndefined();
+  });
+
+  test('returns undefined when both lists are undefined', () => {
+    expect(selectPreferredUserItem(undefined, undefined)).toBeUndefined();
+  });
+
+  test('prefers the primary list when its first item is a UserItem', () => {
+    expect(selectPreferredUserItem([userItem], [fallbackUserItem])).toBe(
+      userItem,
+    );
+  });
+
+  test('falls back when the primary list is empty but the fallback has a UserItem', () => {
+    expect(selectPreferredUserItem([], [fallbackUserItem])).toBe(
+      fallbackUserItem,
+    );
+  });
+
+  test('falls back when the primary first item is not a UserItem', () => {
+    expect(selectPreferredUserItem([contentItem], [fallbackUserItem])).toBe(
+      fallbackUserItem,
+    );
+  });
+
+  test('returns undefined when neither first item is a UserItem', () => {
+    expect(
+      selectPreferredUserItem([contentItem], [contentItem]),
+    ).toBeUndefined();
   });
 });

--- a/client/src/utils/manualReviewTool.ts
+++ b/client/src/utils/manualReviewTool.ts
@@ -1,5 +1,35 @@
 import { ManualReviewJobEnqueuedActionData } from '../webpages/dashboard/mrt/manual_review_job/ManualReviewJobReview';
 
+type ItemWithTypename = { __typename: string };
+
+/**
+ * Picks the first `UserItem`, preferring `partialItems` over `fallbackItems`.
+ * `partialItems` is partial by design and may be empty, so the index is
+ * guarded — `items[0].__typename` on an empty list crashed the review page.
+ */
+export function selectPreferredUserItem<
+  TPrimary extends ItemWithTypename,
+  TFallback extends ItemWithTypename,
+>(
+  primaryItems: readonly TPrimary[] | undefined,
+  fallbackItems: readonly TFallback[] | undefined,
+):
+  | Extract<TPrimary, { __typename: 'UserItem' }>
+  | Extract<TFallback, { __typename: 'UserItem' }>
+  | undefined {
+  const primaryFirst = primaryItems?.[0];
+  if (primaryFirst?.__typename === 'UserItem') {
+    return primaryFirst as Extract<TPrimary, { __typename: 'UserItem' }>;
+  }
+
+  const fallbackFirst = fallbackItems?.[0];
+  if (fallbackFirst?.__typename === 'UserItem') {
+    return fallbackFirst as Extract<TFallback, { __typename: 'UserItem' }>;
+  }
+
+  return undefined;
+}
+
 const areRelatedActionsEqual = (
   a: ManualReviewJobEnqueuedActionData,
   b: ManualReviewJobEnqueuedActionData,

--- a/client/src/webpages/dashboard/mrt/manual_review_job/ReportInfoComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/ReportInfoComponent.tsx
@@ -10,8 +10,8 @@ import {
 } from '@/graphql/generated';
 import { filterNullOrUndefined } from '@/utils/collections';
 import { getFieldValueForRole } from '@/utils/itemUtils';
-import { ExternalLink } from 'lucide-react';
 import { format } from 'date-fns';
+import { ExternalLink } from 'lucide-react';
 import { useCallback } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -62,7 +62,7 @@ export default function ReportInfoComponent(props: {
     payload.__typename === 'UserManualReviewJobPayload' ||
     payload.__typename === 'ContentManualReviewJobPayload' ||
     payload.__typename === 'ThreadManualReviewJobPayload'
-      ? payload.reportedForReasons ?? []
+      ? (payload.reportedForReasons ?? [])
       : [];
   // TODO: we really should add reportDate into this payload instead
   // of relying on the implicit ordering
@@ -107,17 +107,17 @@ export default function ReportInfoComponent(props: {
 
   const reporterInfo =
     reporterData?.partialItems.__typename === 'PartialItemsSuccessResponse' &&
-    reporterData.partialItems.items[0].__typename === 'UserItem'
+    reporterData.partialItems.items[0]?.__typename === 'UserItem'
       ? reporterData.partialItems.items[0]
       : reporterItemInvestigationData?.latestItemSubmissions[0]?.__typename ===
-        'UserItem'
-      ? reporterItemInvestigationData.latestItemSubmissions[0]
-      : undefined;
+          'UserItem'
+        ? reporterItemInvestigationData.latestItemSubmissions[0]
+        : undefined;
   const reporterDisplayName = reporterInfo
-    ? getFieldValueForRole<GQLSchemaFieldRoles, keyof GQLSchemaFieldRoles>(
+    ? (getFieldValueForRole<GQLSchemaFieldRoles, keyof GQLSchemaFieldRoles>(
         reporterInfo,
         'displayName',
-      ) ?? reporterInfo.id
+      ) ?? reporterInfo.id)
     : latestReporterIdentifier?.id;
 
   return (

--- a/client/src/webpages/dashboard/mrt/manual_review_job/ReportInfoComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/ReportInfoComponent.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/graphql/generated';
 import { filterNullOrUndefined } from '@/utils/collections';
 import { getFieldValueForRole } from '@/utils/itemUtils';
+import { selectPreferredUserItem } from '@/utils/manualReviewTool';
 import { format } from 'date-fns';
 import { ExternalLink } from 'lucide-react';
 import { useCallback } from 'react';
@@ -105,14 +106,12 @@ export default function ReportInfoComponent(props: {
     },
   });
 
-  const reporterInfo =
-    reporterData?.partialItems.__typename === 'PartialItemsSuccessResponse' &&
-    reporterData.partialItems.items[0]?.__typename === 'UserItem'
-      ? reporterData.partialItems.items[0]
-      : reporterItemInvestigationData?.latestItemSubmissions[0]?.__typename ===
-          'UserItem'
-        ? reporterItemInvestigationData.latestItemSubmissions[0]
-        : undefined;
+  const reporterInfo = selectPreferredUserItem(
+    reporterData?.partialItems.__typename === 'PartialItemsSuccessResponse'
+      ? reporterData.partialItems.items
+      : undefined,
+    reporterItemInvestigationData?.latestItemSubmissions,
+  );
   const reporterDisplayName = reporterInfo
     ? (getFieldValueForRole<GQLSchemaFieldRoles, keyof GQLSchemaFieldRoles>(
         reporterInfo,

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobRelatedUserComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobRelatedUserComponent.tsx
@@ -14,6 +14,7 @@ import {
   useGQLGetUserItemsQuery,
 } from '../../../../../../graphql/generated';
 import { getFieldValueForRole } from '../../../../../../utils/itemUtils';
+import { selectPreferredUserItem } from '../../../../../../utils/manualReviewTool';
 import {
   ManualReviewJobAction,
   ManualReviewJobEnqueuedActionData,
@@ -181,13 +182,12 @@ export default function ManualReviewJobRelatedUserComponent(props: {
       },
     });
 
-  const moreInfo =
-    moreInfoData?.partialItems.__typename === 'PartialItemsSuccessResponse' &&
-    moreInfoData.partialItems.items[0]?.__typename === 'UserItem'
-      ? moreInfoData.partialItems.items[0]
-      : userItemData?.latestItemSubmissions[0]?.__typename === 'UserItem'
-        ? userItemData.latestItemSubmissions[0]
-        : undefined;
+  const moreInfo = selectPreferredUserItem(
+    moreInfoData?.partialItems.__typename === 'PartialItemsSuccessResponse'
+      ? moreInfoData.partialItems.items
+      : undefined,
+    userItemData?.latestItemSubmissions,
+  );
 
   const userItem = userItemData?.latestItemSubmissions?.find(
     (it) => it.__typename === 'UserItem',

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobRelatedUserComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobRelatedUserComponent.tsx
@@ -183,7 +183,7 @@ export default function ManualReviewJobRelatedUserComponent(props: {
 
   const moreInfo =
     moreInfoData?.partialItems.__typename === 'PartialItemsSuccessResponse' &&
-    moreInfoData.partialItems.items[0].__typename === 'UserItem'
+    moreInfoData.partialItems.items[0]?.__typename === 'UserItem'
       ? moreInfoData.partialItems.items[0]
       : userItemData?.latestItemSubmissions[0]?.__typename === 'UserItem'
         ? userItemData.latestItemSubmissions[0]


### PR DESCRIPTION



## Context & Requests for Reviewers

The Manual Review review page white-screened with `Cannot read properties of undefined (reading '__typename')` and then spun the MRT subtree into a remount/refetch loop (a flood of canceled `getRelatedItems` requests).

This surfaced after item fields were retyped from IMAGE to MEDIA, which caused the more-info/partialItems endpoint to return success-but-empty for the affected items.

Guard the index access with `items[0]?.__typename` in both ReportInfoComponent and ManualReviewJobRelatedUserComponent; both already fall back gracefully when no user submission is found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated utility logic for safer data selection across manual review dashboard components, improving code maintainability and reducing duplication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/645?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->