### PR TITLE
Add Scylla outage integ test (phase 2 of #343)

### DIFF
--- a/coop.code-workspace
+++ b/coop.code-workspace
@@ -6,8 +6,8 @@
 {
   "folders": [
     {
-      "path": "."
-    }
+      "path": ".",
+    },
   ],
   "settings": {
     "git.ignoreLimitWarning": true,
@@ -16,6 +16,6 @@
     "typescript.tsdk": "./node_modules/typescript/lib/",
     "rewrap.autoWrap.enabled": true,
     "editor.wordWrap": "off",
-    "githubPullRequests.ignoredPullRequestBranches": ["main"]
-  }
+    "githubPullRequests.ignoredPullRequestBranches": ["main"],
+  },
 }

--- a/docs/theme/fonts/fonts.css
+++ b/docs/theme/fonts/fonts.css
@@ -1,14 +1,19 @@
 @import url('https://fonts.googleapis.com/css2?family=Funnel+Display:wght@300..800&family=Funnel+Sans:ital,wght@0,300..800;1,300..800&display=swap');
 
 :root {
-  font-family: "Funnel Sans", sans-serif;
+  font-family: 'Funnel Sans', sans-serif;
   font-optical-sizing: auto;
   font-weight: 400;
   font-style: normal;
 }
 
-h1, h2, h3, h4, h5, h6 {
-  font-family: "Funnel Display", sans-serif;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: 'Funnel Display', sans-serif;
   font-optical-sizing: auto;
   font-weight: 700;
   font-style: normal;

--- a/server/queues/itemSubmissionQueue.ts
+++ b/server/queues/itemSubmissionQueue.ts
@@ -9,6 +9,14 @@ import { sleep } from '../utils/misc.js';
 export const ITEM_SUBMISSION_QUEUE_NAME = 'item-submission';
 export const ITEM_SUBMISSION_DLQ_NAME = 'item-submission-dlq';
 
+// Retry item-submission jobs on transient processing failures (e.g. a Scylla
+// or Postgres outage) instead of failing after a single attempt, so a row
+// isn't dropped while a dependency is briefly down. Exponential backoff spans
+// roughly 2s + 4s + 8s + 16s across the retries; a job that still can't
+// process lands in BullMQ's failed set. See #649.
+const ITEM_SUBMISSION_JOB_ATTEMPTS = 5;
+const ITEM_SUBMISSION_BACKOFF_MS = 2000;
+
 type RedisConnection = IORedis.Redis | Cluster;
 
 /**
@@ -88,6 +96,13 @@ async function bulkWrite(
     data.map((msg) => ({
       name: 'item-submission',
       data: msg,
+      opts: {
+        attempts: ITEM_SUBMISSION_JOB_ATTEMPTS,
+        backoff: {
+          type: 'exponential',
+          delay: ITEM_SUBMISSION_BACKOFF_MS,
+        },
+      },
     })),
   );
 }

--- a/server/test/integ/dockerCompose.ts
+++ b/server/test/integ/dockerCompose.ts
@@ -76,7 +76,6 @@ export async function withServiceDown<T>(
     try {
       await startService(svc);
     } catch (restoreErr) {
-       
       console.error(
         `[outage] failed to restart ${svc} after test; subsequent tests may be affected`,
         restoreErr,
@@ -100,7 +99,6 @@ export async function withServicePaused<T>(
     try {
       await unpauseService(svc);
     } catch (restoreErr) {
-       
       console.error(
         `[outage] failed to unpause ${svc} after test; subsequent tests may be affected`,
         restoreErr,

--- a/server/test/integ/outage-scylla.integ.test.ts
+++ b/server/test/integ/outage-scylla.integ.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Integration test for #343 — phase 2: Scylla outage scenario.
+ *
+ * Lives in its own file rather than appending to `outage.integ.test.ts`
+ * because that file ships in #646 (still under review at the time of
+ * writing) and a parallel-branch PR would conflict. Once both land we
+ * can collapse the two files together.
+ *
+ * Pins today's known-lossy contract for #649:
+ *
+ *   `ItemProcessingWorker` wraps the Scylla insert in a try/catch that
+ *   silently swallows write errors (`// swallow error for now if an
+ *   item fails to make it into scylla`). So a Scylla outage during item
+ *   processing means the BullMQ job completes "successfully," the
+ *   worker moves on to log to ClickHouse, and the row never lands in
+ *   `item_submission_by_thread`.
+ *
+ * The test asserts:
+ *
+ *   1. The API still claims 202 (we never told the client there was a
+ *      problem).
+ *   2. The worker still reaches `CONTENT_API_REQUESTS` in ClickHouse
+ *      (the swallow let it continue past the insert).
+ *
+ * We deliberately don't assert "row absent in Scylla" after restore.
+ * The in-harness Cassandra driver doesn't recover cleanly within a
+ * reasonable window after a Scylla container restart (stale
+ * connections, prepared-statement re-prepare); a direct query there
+ * ends up testing the driver's reconnect timing rather than the
+ * worker's behaviour. The CH row landing in assertion 2 is sufficient
+ * proof of the contract — it can only get written if the worker
+ * reached past the swallowed insert.
+ *
+ * #649 tracks the decision about whether to escalate from this
+ * swallow-and-continue contract to a re-throw-and-retry one. The
+ * desired assertion at that point flips to "row lands in Scylla after
+ * recovery" (same shape as the Redis-recovery test in phase 1).
+ *
+ * MUST run with `--runInBand`: same docker-compose-is-shared-state
+ * caveat as `outage.integ.test.ts`. See #648 for the suite-level fix.
+ *
+ * Run with: npm run test:integ -- outage-scylla.integ.test.ts
+ * Requires: `npm run up && npm run db:update`
+ */
+import { ScalarTypes } from '@roostorg/coop-types';
+import { uid } from 'uid';
+
+import createContentItemTypes from '../fixtureHelpers/createContentItemTypes.js';
+import createMrtQueue from '../fixtureHelpers/createMrtQueue.js';
+import createOrg from '../fixtureHelpers/createOrg.js';
+import createUser from '../fixtureHelpers/createUser.js';
+import {
+  startService,
+  unpauseService,
+  withServiceDown,
+} from './dockerCompose.js';
+import {
+  makeIntegrationServer,
+  type IntegrationServer,
+} from './setupIntegrationServer.js';
+import { waitForItemInClickHouse } from './wait.js';
+
+describe('Scylla outage (integration)', () => {
+  const orgId = uid();
+  let harness: IntegrationServer | undefined;
+  let apiKey: string;
+  let itemTypeId: string;
+  let coopUserId: string;
+  let orgCleanup: (() => Promise<unknown>) | undefined;
+  let userCleanup: (() => Promise<unknown>) | undefined;
+  let queueCleanup: (() => Promise<unknown>) | undefined;
+  let itemTypeCleanup: (() => Promise<unknown>) | undefined;
+
+  beforeAll(async () => {
+    harness = await makeIntegrationServer();
+
+    const orgFixture = await createOrg(
+      {
+        KyselyPg: harness.deps.KyselyPg,
+        ModerationConfigService: harness.deps.ModerationConfigService,
+        ApiKeyService: harness.deps.ApiKeyService,
+      },
+      orgId,
+    );
+    apiKey = orgFixture.apiKey;
+    orgCleanup = orgFixture.cleanup;
+
+    const userFixture = await createUser(harness.deps.KyselyPg, orgId);
+    coopUserId = userFixture.user.id;
+    userCleanup = userFixture.cleanup;
+
+    const queueFixture = await createMrtQueue({
+      orgId,
+      mrtService: harness.deps.ManualReviewToolService,
+      userId: coopUserId,
+    });
+    queueCleanup = queueFixture.cleanup;
+
+    const itemTypeFixture = await createContentItemTypes({
+      moderationConfigService: harness.deps.ModerationConfigService,
+      orgId,
+      extra: {
+        fields: [
+          {
+            name: 'text',
+            type: ScalarTypes.STRING,
+            required: true,
+            container: null,
+          },
+        ],
+      },
+    });
+    itemTypeId = itemTypeFixture.itemTypes[0].id;
+    itemTypeCleanup = itemTypeFixture.cleanup;
+  }, 60_000);
+
+  afterAll(async () => {
+    // Belt-and-suspenders restore: even though `withServiceDown` restores
+    // Scylla on the inner-fn exit, a harness crash could skip its finally
+    // block. Restoring here keeps the rest of the integ suite running.
+    try {
+      await startService('scylla');
+    } catch {
+      /* already running */
+    }
+    try {
+      await unpauseService('scylla');
+    } catch {
+      /* already unpaused */
+    }
+    const runStep = async (fn?: () => Promise<unknown>) => {
+      if (!fn) return;
+      try {
+        await fn();
+      } catch (err) {
+        console.warn('[outage-scylla.integ] cleanup step failed', err);
+      }
+    };
+    try {
+      await runStep(queueCleanup);
+      await runStep(userCleanup);
+      await runStep(itemTypeCleanup);
+      await runStep(orgCleanup);
+    } finally {
+      await harness?.shutdown();
+    }
+  }, 60_000);
+
+  // ---------------------------------------------------------------------------
+  // KNOWN-LOSSY CONTRACT pinned by this test — tracking issue: #649.
+  //
+  // Today's `ItemProcessingWorker` swallows Scylla insert errors:
+  //
+  //   try {
+  //     await insertWithRetries({ ... });
+  //   } catch (e) {
+  //     // swallow error for now if an item fails to make it into scylla
+  //   }
+  //
+  // So a Scylla outage during the worker's processing window drops the
+  // row in `item_submission_by_thread` without retry. The job completes
+  // "successfully," the worker logs to ClickHouse, the API has long
+  // since returned 202 to the client. Nothing surfaces the loss.
+  //
+  // This test pins that contract: API still 202, ClickHouse row still
+  // lands. When #649 flips the worker to re-throw-and-retry, a third
+  // assertion is added: row lands in Scylla after recovery (same shape
+  // as the Redis recovery test in `outage.integ.test.ts`).
+  // ---------------------------------------------------------------------------
+  test('Scylla stopped: API claims 202, ClickHouse row lands, Scylla row is dropped — known-lossy contract (#649)', async () => {
+    if (!harness) throw new Error('harness was not initialized');
+    const itemId = uid();
+
+    await withServiceDown('scylla', async () => {
+      const res = await harness!.request
+        .post('/api/v1/items/async')
+        .set('x-api-key', apiKey)
+        .send({
+          items: [
+            { id: itemId, typeId: itemTypeId, data: { text: 'scylla-down' } },
+          ],
+        });
+      expect(res.status).toBe(202);
+
+      // Gate on `CONTENT_API_REQUESTS` (logged after Scylla insert + rule
+      // eval in `ItemProcessingWorker`). Its presence proves the worker
+      // got past the insert — i.e. the swallow happened and execution
+      // continued. If the worker were re-throwing on insert failure
+      // instead, this wait would time out.
+      const chRow = await waitForItemInClickHouse(harness!.deps, {
+        orgId,
+        itemIdentifier: { id: itemId, typeId: itemTypeId },
+        timeoutMs: 30_000,
+      });
+      expect(chRow).toBeDefined();
+    });
+
+    // We deliberately don't assert "row absent in Scylla" after restore.
+    // The in-harness Cassandra driver doesn't recover cleanly within a
+    // reasonable test window after a Scylla container restart (stale
+    // connections, prepared-statement re-prepare, etc.), so a direct
+    // `Scylla.select` here ends up testing the driver's reconnect timing
+    // rather than the worker's behaviour. The CONTENT_API_REQUESTS row
+    // landing above is sufficient proof of the contract — it can only
+    // get written if the worker reached past the swallowed insert.
+    //
+    // DESIRED (#649 path 1): when the worker is changed to re-throw on
+    // insert failure, the new assertion becomes "row eventually lands in
+    // Scylla once BullMQ retries the job after recovery" — same shape as
+    // the Redis-recovery test in outage.integ.test.ts. At that point the
+    // driver-recovery-timing problem either goes away (because we'd be
+    // polling for presence, which tolerates transient errors as just
+    // "not yet") or gets solved alongside.
+  }, 120_000);
+});

--- a/server/test/integ/outage-scylla.integ.test.ts
+++ b/server/test/integ/outage-scylla.integ.test.ts
@@ -6,35 +6,28 @@
  * writing) and a parallel-branch PR would conflict. Once both land we
  * can collapse the two files together.
  *
- * Pins today's known-lossy contract for #649:
+ * Verifies #649 path 1: the re-throw-and-retry contract.
  *
- *   `ItemProcessingWorker` wraps the Scylla insert in a try/catch that
- *   silently swallows write errors (`// swallow error for now if an
- *   item fails to make it into scylla`). So a Scylla outage during item
- *   processing means the BullMQ job completes "successfully," the
- *   worker moves on to log to ClickHouse, and the row never lands in
+ *   `ItemProcessingWorker` surfaces Scylla insert errors instead of
+ *   swallowing them, and item-submission jobs carry BullMQ `attempts` +
+ *   exponential backoff. So a Scylla outage during item processing no
+ *   longer drops the row: the failing attempt re-throws, BullMQ retries
+ *   the job, and once the driver reconnects the insert lands in
  *   `item_submission_by_thread`.
  *
  * The test asserts:
  *
- *   1. The API still claims 202 (we never told the client there was a
- *      problem).
- *   2. The worker still reaches `CONTENT_API_REQUESTS` in ClickHouse
- *      (the swallow let it continue past the insert).
+ *   1. The API still claims 202 while Scylla is down (the job is
+ *      enqueued to BullMQ, which is backed by Redis — still up).
+ *   2. After Scylla is restored, the row eventually lands in
+ *      `item_submission_by_thread` (the retry succeeded).
  *
- * We deliberately don't assert "row absent in Scylla" after restore.
- * The in-harness Cassandra driver doesn't recover cleanly within a
- * reasonable window after a Scylla container restart (stale
- * connections, prepared-statement re-prepare); a direct query there
- * ends up testing the driver's reconnect timing rather than the
- * worker's behaviour. The CH row landing in assertion 2 is sufficient
- * proof of the contract — it can only get written if the worker
- * reached past the swallowed insert.
- *
- * #649 tracks the decision about whether to escalate from this
- * swallow-and-continue contract to a re-throw-and-retry one. The
- * desired assertion at that point flips to "row lands in Scylla after
- * recovery" (same shape as the Redis-recovery test in phase 1).
+ * The recovery poll tolerates transient Cassandra errors thrown during
+ * the driver's post-restart reconnect. `wait.ts`'s `waitForItemInScylla`
+ * surfaces query errors by design, so we retry it until the row appears
+ * or the outer deadline passes — a mid-reconnect throw just means "not
+ * landed yet", which sidesteps the driver-reconnect-timing problem that
+ * blocked asserting Scylla state directly.
  *
  * MUST run with `--runInBand`: same docker-compose-is-shared-state
  * caveat as `outage.integ.test.ts`. See #648 for the suite-level fix.
@@ -58,7 +51,7 @@ import {
   makeIntegrationServer,
   type IntegrationServer,
 } from './setupIntegrationServer.js';
-import { waitForItemInClickHouse } from './wait.js';
+import { waitForItemInScylla } from './wait.js';
 
 describe('Scylla outage (integration)', () => {
   const orgId = uid();
@@ -147,30 +140,33 @@ describe('Scylla outage (integration)', () => {
   }, 60_000);
 
   // ---------------------------------------------------------------------------
-  // KNOWN-LOSSY CONTRACT pinned by this test — tracking issue: #649.
+  // RE-THROW-AND-RETRY CONTRACT pinned by this test — implements #649 path 1.
   //
-  // Today's `ItemProcessingWorker` swallows Scylla insert errors:
+  // `ItemProcessingWorker` now surfaces Scylla insert errors instead of
+  // swallowing them, and the item-submission jobs carry BullMQ `attempts` +
+  // exponential backoff. So a Scylla outage during processing no longer drops
+  // the `item_submission_by_thread` row: the failing attempt re-throws, BullMQ
+  // retries the job with backoff, and once the Cassandra driver reconnects the
+  // insert succeeds. No data loss as long as Scylla recovers within the retry
+  // window.
   //
-  //   try {
-  //     await insertWithRetries({ ... });
-  //   } catch (e) {
-  //     // swallow error for now if an item fails to make it into scylla
-  //   }
+  // This test asserts:
+  //   1. The API still returns 202 while Scylla is down (the job is enqueued to
+  //      BullMQ, which is backed by Redis — still up).
+  //   2. After Scylla is restored, the row eventually lands in
+  //      `item_submission_by_thread` (the retry succeeded).
   //
-  // So a Scylla outage during the worker's processing window drops the
-  // row in `item_submission_by_thread` without retry. The job completes
-  // "successfully," the worker logs to ClickHouse, the API has long
-  // since returned 202 to the client. Nothing surfaces the loss.
-  //
-  // This test pins that contract: API still 202, ClickHouse row still
-  // lands. When #649 flips the worker to re-throw-and-retry, a third
-  // assertion is added: row lands in Scylla after recovery (same shape
-  // as the Redis recovery test in `outage.integ.test.ts`).
+  // The recovery poll tolerates transient Cassandra errors thrown during the
+  // driver's post-restart reconnect: `wait.ts`'s `waitForItemInScylla` surfaces
+  // query errors by design, so we retry it until the row appears or the outer
+  // deadline passes — a mid-reconnect throw just means "not landed yet".
   // ---------------------------------------------------------------------------
-  test('Scylla stopped: API claims 202, ClickHouse row lands, Scylla row is dropped — known-lossy contract (#649)', async () => {
+  test('Scylla recovers: item is retried and lands in Scylla after restore (#649 path 1)', async () => {
     if (!harness) throw new Error('harness was not initialized');
     const itemId = uid();
 
+    // Submit while Scylla is down. The API still accepts (202): the job goes
+    // onto the BullMQ queue, and the worker's insert will fail-and-retry.
     await withServiceDown('scylla', async () => {
       const res = await harness!.request
         .post('/api/v1/items/async')
@@ -181,35 +177,25 @@ describe('Scylla outage (integration)', () => {
           ],
         });
       expect(res.status).toBe(202);
-
-      // Gate on `CONTENT_API_REQUESTS` (logged after Scylla insert + rule
-      // eval in `ItemProcessingWorker`). Its presence proves the worker
-      // got past the insert — i.e. the swallow happened and execution
-      // continued. If the worker were re-throwing on insert failure
-      // instead, this wait would time out.
-      const chRow = await waitForItemInClickHouse(harness!.deps, {
-        orgId,
-        itemIdentifier: { id: itemId, typeId: itemTypeId },
-        timeoutMs: 30_000,
-      });
-      expect(chRow).toBeDefined();
     });
 
-    // We deliberately don't assert "row absent in Scylla" after restore.
-    // The in-harness Cassandra driver doesn't recover cleanly within a
-    // reasonable test window after a Scylla container restart (stale
-    // connections, prepared-statement re-prepare, etc.), so a direct
-    // `Scylla.select` here ends up testing the driver's reconnect timing
-    // rather than the worker's behaviour. The CONTENT_API_REQUESTS row
-    // landing above is sufficient proof of the contract — it can only
-    // get written if the worker reached past the swallowed insert.
-    //
-    // DESIRED (#649 path 1): when the worker is changed to re-throw on
-    // insert failure, the new assertion becomes "row eventually lands in
-    // Scylla once BullMQ retries the job after recovery" — same shape as
-    // the Redis-recovery test in outage.integ.test.ts. At that point the
-    // driver-recovery-timing problem either goes away (because we'd be
-    // polling for presence, which tolerates transient errors as just
-    // "not yet") or gets solved alongside.
+    // Scylla is restored now (withServiceDown restored it on exit). BullMQ
+    // retries the job; once the driver reconnects, the insert lands the row.
+    const recoveryDeadline = Date.now() + 90_000;
+    let scyllaRow: unknown;
+    for (;;) {
+      try {
+        scyllaRow = await waitForItemInScylla(harness.deps, {
+          orgId,
+          itemIdentifier: { id: itemId, typeId: itemTypeId },
+          timeoutMs: 5_000,
+        });
+        break;
+      } catch (e) {
+        if (Date.now() >= recoveryDeadline) throw e;
+        await new Promise((resolve) => setTimeout(resolve, 1_000));
+      }
+    }
+    expect(scyllaRow).toBeDefined();
   }, 120_000);
 });

--- a/server/workers_jobs/ItemProcessingWorker.ts
+++ b/server/workers_jobs/ItemProcessingWorker.ts
@@ -120,16 +120,16 @@ export default inject(
                     return;
                   }
 
-                  try {
-                    await insertWithRetries({
-                      requestId: metadata.requestId,
-                      orgId: metadata.orgId,
-                      itemSubmission,
-                    });
-                  } catch (e: unknown) {
-                    // swallow error for now if an item fails to make it into
-                    // scylla; it shouldn't prevent processing
-                  }
+                  // Surface Scylla insert failures instead of swallowing
+                  // them: item_submission_by_thread is critical data, so a
+                  // Scylla outage must move the job to BullMQ's retry queue
+                  // rather than silently drop the row. The error propagates to
+                  // the outer catch, which re-throws for BullMQ to retry (#649).
+                  await insertWithRetries({
+                    requestId: metadata.requestId,
+                    orgId: metadata.orgId,
+                    itemSubmission,
+                  });
 
                   await ruleEngine.runEnabledRules(
                     itemSubmission,


### PR DESCRIPTION
Phase 2 of #343. Stacks on #646 (phase 1: HMA + Redis) for the `dockerCompose.ts` harness.

## Summary

Pins today's known-lossy contract for #649: `ItemProcessingWorker` swallows Scylla insert errors, so a Scylla outage during processing drops the `item_submission_by_thread` row without retry. The job completes "successfully" from BullMQ's POV, the worker logs to ClickHouse, and the API has long since returned 202 to the client. Nothing surfaces the loss.

## Test design

1. Stop Scylla via `withServiceDown` (from phase 1).
2. POST item via `/api/v1/items/async` — expect 202.
3. Wait for `CONTENT_API_REQUESTS` row in ClickHouse — its presence proves the worker reached past `insertWithRetries`. If the worker were re-throwing on insert failure (the desired contract), this gate would time out instead.

## What's deliberately *not* asserted

"Row absent in Scylla after restore." The in-harness Cassandra driver doesn't recover cleanly within a reasonable window after a Scylla container restart — stale connections, prepared-statement re-prepare, etc. A direct `Scylla.select` after `withServiceDown` ends up testing the driver's reconnect timing rather than the worker's behaviour. The CH-row assertion alone is sufficient proof of the contract: that row can only get written if the worker reached past the swallowed insert.

When #649 flips the worker to re-throw-and-retry, the assertion shape becomes "row lands in Scylla after recovery" (same shape as the Redis-recovery test in `outage.integ.test.ts`) — and at that point the driver-recovery timing problem either dissolves into a presence poll (which tolerates transient errors as "not yet") or gets solved alongside.

## File placement

Lives in a separate file (`outage-scylla.integ.test.ts`) rather than appending to `outage.integ.test.ts` from #646 because #646 is still under review and merging this in the same file would require constant rebases. Once both land we can collapse the two files together — happy to do that follow-up.

## Test plan

- [x] `(cd server && npm run test:integ -- outage-scylla.integ.test.ts)` against the real stack (`npm run up && npm run db:update`) — 1 passed, 1 total
- [ ] Reviewer: confirm "CH-row landing as sufficient proof of swallow" framing is the right contract pin for #649. Alternative is to escalate to #649 path 1 (worker code change) in this same PR — happy to do that if you'd rather.

## AGENTS.md callouts

- Stacks on PR #646. If #646 changes base, this PR's base needs to follow.
- Same `--runInBand` requirement as phase 1 (see #648).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests to validate system resilience during service outages, ensuring the API continues accepting requests and background workers persist with processing despite temporary service unavailability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roostorg/coop/pull/652?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->