### PR TITLE
ci: support divine-v* release tags for semver image tagging

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # CODEOWNERS file for managing repository permissions
 # Format: path-pattern @username @org/team-name
 
-# Maintainers: Default owners for all files
-* @juanmrad @vinaysrao1 @pawiecz @cassidyjames @julietshen @dom-notion
+# Divine maintainers
+* @mbradley @notthatkindofdrliz
 
-# Docs contributors
-docs/ @roostorg/roosters
+# Upstream ROOST maintainers (for upstream sync PRs)
+# * @juanmrad @vinaysrao1 @pawiecz @cassidyjames @julietshen @dom-notion

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,3 +14,7 @@ Are there any special things that have to be done before this can be deployed
 to prod (e.g., other blocking PRs; manual load testing/validation that needs to
 be done on staging; etc.)? If so, please note them here.
  -->
+
+## Public Artifact Review
+
+- [ ] Titles, descriptions, branch names, screenshots, and linked artifacts avoid partner, customer, brand, campaign, or other sensitive external names unless explicitly approved

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -6,7 +6,7 @@ on:
       - main
       - 'divine/*'
     tags:
-      - 'v*'
+      - 'divine-v*'
 
 env:
   REGISTRY: ghcr.io
@@ -54,6 +54,8 @@ jobs:
           tags: |
             type=ref,event=branch
             type=sha,prefix=
+            type=match,pattern=divine-v(.*),group=1
+            type=match,pattern=divine-v(\d+\.\d+),group=1
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -33,6 +33,10 @@ jobs:
           - image: coop-client
             context: ./client
             dockerfile: client/Dockerfile
+          - image: coop-migrator
+            context: .
+            dockerfile: Dockerfile
+            target: build_migrator
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -1,0 +1,66 @@
+name: Build and Push Docker Images
+
+on:
+  push:
+    branches:
+      - main
+      - 'divine/*'
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+  ORG: divinevideo
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      matrix:
+        include:
+          - image: coop-server
+            context: .
+            dockerfile: Dockerfile
+            target: build_server
+          - image: coop-worker
+            context: .
+            dockerfile: Dockerfile
+            target: build_worker_runner
+          - image: coop-client
+            context: ./client
+            dockerfile: client/Dockerfile
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.image }}
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          target: ${{ matrix.target || '' }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/semantic_pr.yml
+++ b/.github/workflows/semantic_pr.yml
@@ -1,0 +1,12 @@
+name: Semantic PR
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  semantic-pull-request:
+    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/semantic_pull_request.yml@v1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# COOP (Content Operations & Oversight Platform)
+
+Divine's moderation review surface. Fork of [roostorg/coop](https://github.com/roostorg/coop).
+
+## Cross-Repo Coordination
+
+This repo is **Layer 4** (human review surface) in the moderation pipeline. Read the coordination doc at session start:
+`~/code/support-trust-safety/docs/moderation/auto-hide-evolution-plan.md`
+
+When you make decisions or discover constraints that affect other layers, update that doc and flag it for the user.
+
+## Architecture
+
+COOP receives flagged content from Osprey (rules engine) via REST API submission. Human moderators review items in the Manual Review Tool (MRT), then take actions (Ban User, Delete Content, Hide Content, Age Restrict) that fire webhooks to the relay-manager adapter.
+
+```
+Osprey verdict (flag_for_review) → COOP REST API → MRT queue
+Moderator decision → COOP webhook → adapter → relay-manager RPC
+```
+
+## Divine Integration Points
+
+- **Item Type:** "User Report" with fields for report metadata + media (VIDEO/IMAGE)
+- **Actions:** CUSTOM_ACTION webhooks to adapter service
+- **Adapter:** `support-trust-safety/scripts/coop-webhook-adapter.mjs` translates webhooks to relay-manager RPC
+- **Bridge import:** `support-trust-safety/scripts/coop-bridge-import.sh` pulls Kind 1984 reports from staging relay
+
+## Deployment
+
+Images build via GitHub Actions to `ghcr.io/divinevideo/coop-server`, `coop-worker`, `coop-client`.
+K8s manifests live in `divine-iac-coreconfig/k8s/applications/coop/`.
+
+## Staging Dependencies
+
+- **PostgreSQL:** shared CNPG cluster in `postgres-clusters` namespace
+- **Redis:** shared sentinel cluster in `redis-clusters` namespace
+- **ClickHouse:** ClickHouse operator available; needs a ClickHouseInstallation CR
+- **ScyllaDB:** not available on cluster; env vars stubbed with dummy values (MRT workflow does not require Scylla on the critical path)
+
+## Local Dev
+
+```bash
+docker compose up -d postgres redis clickhouse scylla
+docker compose run migrations
+# Then run server and client separately or via docker compose
+```
+
+## Upstream Sync
+
+Pull from `upstream` (roostorg/coop), push divine-specific changes to `origin` (divinevideo/coop).

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,3 +44,19 @@ CMD ["node", "bin/www.js"]
 
 FROM backend_base AS build_worker_runner
 CMD ["node", "bin/run-worker-or-job.js"]
+
+# Migrator: runs schema migrations via db:create / db:update scripts.
+# The K8s db-migrate Job provides the command at runtime (e.g.,
+#   npm run db:update -- --env staging --db api-server-pg
+# ). Falls back to --help if no command is given.
+FROM node:24.14.1-bullseye-slim AS build_migrator
+WORKDIR /app
+RUN groupadd -r migrator && useradd -r -g migrator -u 1001 migrator
+ENV NPM_CONFIG_CACHE=/tmp/.npm
+COPY --chown=migrator:migrator ["package.json", "./"]
+COPY --chown=migrator:migrator ["db/package.json", "db/package-lock.json", "db/"]
+RUN cd db && npm ci && chown -R migrator:migrator /app/db/node_modules
+COPY --chown=migrator:migrator ["db/src", "db/src/"]
+COPY --chown=migrator:migrator ["db/tsconfig.json", "db/"]
+USER 1001
+CMD ["npm", "run", "db:update", "--", "--help"]

--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -9,3 +9,4 @@
 !postcss.config.js
 !tailwind.config.js
 !tsconfig.json
+!nginx.conf

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -11,7 +11,7 @@ COPY package*.json .
 RUN --mount=type=cache,target=/root/.npm npm ci
 
 COPY . .
-FROM client_base
+FROM client_base AS client_build
 
 ARG VITE_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
 
@@ -20,3 +20,8 @@ ARG VITE_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
 # before we ever deploy. So no need to do it again here.
 ENV DISABLE_ESLINT_PLUGIN=true
 RUN NODE_OPTIONS="--max-old-space-size=5250" VITE_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=$VITE_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT npm run build
+
+FROM nginx:1.27.5-alpine AS serve
+COPY --from=client_build /app/build /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,0 +1,25 @@
+server {
+    listen 80;
+    server_name _;
+    server_tokens off;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Vite hashed assets: cache aggressively (hash guarantees uniqueness).
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+    }
+
+    # SPA client-side routing: serve static files if they exist,
+    # otherwise fall through to index.html.  No-cache so deploys
+    # take effect immediately without a hard refresh.
+    location / {
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        try_files $uri /index.html;
+    }
+}

--- a/db/src/index.ts
+++ b/db/src/index.ts
@@ -1,12 +1,19 @@
 #!/usr/bin/env -S node --loader ts-node/esm --require dotenv/config
+import type { DatabaseConfig } from '@roostorg/db-migrator';
 import { makeCli } from '@roostorg/db-migrator';
 
 import apiServerPostgresConfig from './configs/api-server-pg.js';
 import clickhouseConfig from './configs/clickhouse.js';
-import scyllaConfig from './configs/scylla.js';
 
-makeCli({
+// Scylla config crashes at module load without SCYLLA_HOSTS, so gate it.
+const configs: Record<string, DatabaseConfig<any, any, any>> = {
   'api-server-pg': apiServerPostgresConfig,
   clickhouse: clickhouseConfig,
-  scylla: scyllaConfig,
-});
+};
+
+if (process.env.SCYLLA_HOSTS) {
+  const { default: scyllaConfig } = await import('./configs/scylla.js');
+  configs.scylla = scyllaConfig;
+}
+
+makeCli(configs);


### PR DESCRIPTION
## Summary
- Changes the CI tag trigger from `v*` to `divine-v*` to namespace our fork's release tags separately from upstream Roost
- Adds `type=match` rules to `docker/metadata-action` so pushing a `divine-v0.1.0` git tag produces Docker image tags `0.1.0` and `0.1`
- Existing branch/SHA/latest tagging is unchanged

## Context
Ira requested version-tagged images instead of commit SHAs for deployment pinning. The `divine-` prefix avoids tag collisions when syncing upstream.

## Test plan
- [ ] After merge, push a `divine-v0.1.0` tag and verify CI produces images tagged `0.1.0` and `0.1` in ghcr.io