### PR TITLE
[280] Publish Docker Images

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -1,0 +1,70 @@
+# Docker Compose environment for local / self-hosted evaluation.
+# All values work out of the box with docker-compose.images.yaml.
+# Review secrets before any non-local deployment.
+
+# ── Postgres ──────────────────────────────────────────────────────────
+DATABASE_HOST=postgres
+DATABASE_READ_ONLY_HOST=postgres
+DATABASE_PORT=5432
+DATABASE_NAME=postgres
+DATABASE_USER=postgres
+DATABASE_PASSWORD=postgres123
+
+API_SERVER_DATABASE_HOST=postgres
+API_SERVER_DATABASE_READ_ONLY_HOST=postgres
+API_SERVER_DATABASE_PORT=5432
+API_SERVER_DATABASE_NAME=postgres
+API_SERVER_DATABASE_USER=postgres
+API_SERVER_DATABASE_PASSWORD=postgres123
+
+# ── Session ───────────────────────────────────────────────────────────
+SESSION_SECRET=some_long_secret_string
+
+# ── ClickHouse ────────────────────────────────────────────────────────
+CLICKHOUSE_PROTOCOL=http
+CLICKHOUSE_HOST=clickhouse
+CLICKHOUSE_PORT=8123
+CLICKHOUSE_USERNAME=default
+CLICKHOUSE_PASSWORD=clickhouse
+CLICKHOUSE_DATABASE=analytics
+CLICKHOUSE_MIGRATIONS_TABLE=MIGRATIONS_METADATA
+
+# ── ScyllaDB ──────────────────────────────────────────────────────────
+SCYLLA_USERNAME=cassandra
+SCYLLA_PASSWORD=cassandra
+SCYLLA_HOSTS='scylla'
+SCYLLA_LOCAL_DATACENTER='datacenter1'
+SCYLLA_KEYSPACE='item_investigation_service'
+SCYLLA_REPLICATION_CLASS='SimpleStrategy'
+SCYLLA_REPLICATION_FACTOR='1'
+SCYLLA_COMPACTION_STRATEGY='SizeTieredCompactionStrategy'
+SCYLLA_HAS_ENTERPRISE_FEATURES='false'
+
+# ── GraphQL / Server ──────────────────────────────────────────────────
+GRAPHQL_MAX_DEPTH=10
+EXPOSE_SENSITIVE_IMPLEMENTATION_DETAILS_IN_ERRORS=false
+ALLOW_USER_INPUT_LOCALHOST_URIS=false
+DATABASE_PRINT_LOGS=false
+GRAPHQL_OPAQUE_SCALAR_SECRET=some_long_secret_string
+
+# ── Redis ─────────────────────────────────────────────────────────────
+REDIS_USE_CLUSTER=false
+REDIS_HOST=redis
+REDIS_PORT=6379
+
+# ── Observability ─────────────────────────────────────────────────────
+OTEL_SERVICE_NAME=coop
+
+# ── General ───────────────────────────────────────────────────────────
+NODE_ENV=production
+ITEM_QUEUE_TRAFFIC_PERCENTAGE='0'
+UI_URL=http://localhost:3000
+ENABLE_DEMO_REQUEST=false
+
+# ── Optional API keys (uncomment and fill in as needed) ───────────────
+# GROQ_SECRET_KEY=
+# SENDGRID_API_KEY=
+# GOOGLE_PLACES_API_KEY=
+# READ_ME_JWT_SECRET=
+# LAUNCHDARKLY_SECRET=
+# OPEN_AI_API_KEY=

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -57,6 +57,8 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
+      - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+
       - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
@@ -88,7 +90,7 @@ jobs:
             BUILD_ID=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
 
   build-client:
     needs: changes
@@ -96,6 +98,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
@@ -128,4 +132,4 @@ jobs:
             BUILD_ID=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -15,7 +15,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 env:
   REGISTRY: ghcr.io
@@ -47,6 +46,9 @@ jobs:
     needs: changes
     if: needs.changes.outputs.server != 'false'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         include:
@@ -96,6 +98,9 @@ jobs:
     needs: changes
     if: needs.changes.outputs.client != 'false'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -1,0 +1,131 @@
+name: Publish Docker Images
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'server/**'
+      - 'client/**'
+      - 'Dockerfile'
+      - 'client/Dockerfile'
+      - '.github/workflows/publish-docker.yaml'
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      server: ${{ steps.filter.outputs.server }}
+      client: ${{ steps.filter.outputs.client }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        if: github.event_name == 'push'
+        with:
+          filters: |
+            server:
+              - 'server/**'
+              - 'Dockerfile'
+            client:
+              - 'client/**'
+
+      # On release/dispatch, paths-filter is skipped so outputs are empty.
+      # The downstream jobs use != 'false', so empty triggers a build.
+
+  build-server:
+    needs: changes
+    if: needs.changes.outputs.server != 'false'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - target: build_server
+            image: coop-server
+          - target: build_worker_runner
+            image: coop-worker
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
+          tags: |
+            type=sha,prefix=
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@263435318d21b8e681c14492fe198e19c816078e # v6.18.0
+        with:
+          context: .
+          file: Dockerfile
+          target: ${{ matrix.target }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_ID=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+
+  build-client:
+    needs: changes
+    if: needs.changes.outputs.client != 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/coop-client
+          tags: |
+            type=sha,prefix=
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@263435318d21b8e681c14492fe198e19c816078e # v6.18.0
+        with:
+          context: client
+          file: client/Dockerfile
+          target: serve
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_ID=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ We want to hear from you! Whether you're testing it out, running into issues, or
 
 Your feedback directly shapes our [roadmap](https://roostorg.github.io/community/roadmap).
 
+## Docker
+
+Run Coop with a single command using Docker Compose. See the [Docker guide](docs/development/docker.md) for setup instructions and published image details.
+
 ## Learn more
 
 We maintain [documentation](docs/) directly in this repo covering functionality, development, integrations, and more. Versioned documentation is also [available online](https://roostorg.github.io/coop) for easier browsing.

--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -9,3 +9,4 @@
 !postcss.config.js
 !tailwind.config.js
 !tsconfig.json
+!nginx.conf

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -11,8 +11,7 @@ COPY package*.json .
 RUN --mount=type=cache,target=/root/.npm npm ci
 
 COPY . .
-FROM client_base
-
+FROM client_base AS build
 ARG VITE_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
 
 # Don't run eslint over the frontend code when building the image, b/c we should
@@ -20,3 +19,9 @@ ARG VITE_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
 # before we ever deploy. So no need to do it again here.
 ENV DISABLE_ESLINT_PLUGIN=true
 RUN NODE_OPTIONS="--max-old-space-size=5250" VITE_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=$VITE_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT npm run build
+
+FROM nginx:1.27-bookworm AS serve
+COPY --from=build /app/build /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,0 +1,25 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    resolver 127.0.0.11 valid=30s;
+    set $backend "http://server:8080";
+
+    location /api/ {
+        proxy_pass $backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+}

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -6,12 +6,13 @@ server {
     resolver 127.0.0.11 valid=30s;
     set $backend "http://server:8080";
 
-    location /api/ {
+    location ^~ /api/ {
         proxy_pass $backend;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        client_max_body_size 50m;
     }
 
     location / {

--- a/docker-compose.images.yaml
+++ b/docker-compose.images.yaml
@@ -1,0 +1,131 @@
+services:
+  postgres:
+    image: ankane/pgvector:v0.5.1
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD', 'pg_isready', '-U', 'postgres', '-d', 'postgres']
+      interval: 2s
+      start_period: 2s
+    environment:
+      POSTGRES_PASSWORD: postgres123
+      POSTGRES_USER: postgres
+      POSTGRES_DB: postgres
+
+  redis:
+    image: redis:8.6.1-trixie
+    command:
+      - redis-server
+      - --appendonly
+      - 'yes'
+      - --maxmemory
+      - '256mb'
+      - --maxmemory-policy
+      - noeviction
+
+  scylla:
+    image: scylladb/scylla:5.2
+    command: --smp 1 --memory 4G --overprovisioned 1 --developer-mode 1
+    volumes:
+      - scylla_data:/var/lib/scylla
+    healthcheck:
+      test: ['CMD-SHELL', 'nodetool status || exit 1']
+      interval: 5s
+      timeout: 5s
+      retries: 28
+      start_period: 35s
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:24.3
+    volumes:
+      - clickhouse_data:/var/lib/clickhouse
+    environment:
+      CLICKHOUSE_DB: analytics
+      CLICKHOUSE_USER: default
+      CLICKHOUSE_PASSWORD: clickhouse
+    healthcheck:
+      test:
+        ['CMD-SHELL', 'clickhouse-client --host localhost --query "SELECT 1"']
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  migrations:
+    image: node:24.14.1-bullseye-slim
+    command: bash -c 'set -e
+      && npm i
+      && for db in api-server-pg scylla clickhouse; do npm run db:create -- --db "$$db" --env staging; npm run db:update -- --db "$$db" --env staging; done'
+    working_dir: /src
+    env_file: ./.env.githubci
+    volumes:
+      - .:/src
+    depends_on:
+      postgres:
+        condition: service_healthy
+      scylla:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+
+  seed:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: build_server
+    entrypoint: ['sh', '-c']
+    command:
+      - |
+        PASSWORD=$$(node -e "process.stdout.write(require('crypto').randomBytes(18).toString('base64url'))")
+        node bin/create-org-and-user.js \
+          --name "Coop" \
+          --email "admin@coop.local" \
+          --website "https://coop.local" \
+          --firstName "Admin" \
+          --lastName "User" \
+          --password "$$PASSWORD" \
+        && echo "" \
+        && echo "============================================" \
+        && echo "  Login:    admin@coop.local" \
+        && echo "  Password: $$PASSWORD" \
+        && echo "============================================" \
+        || echo "Seed user already exists — skipping."
+    env_file: ./.env.githubci
+    environment:
+      NODE_ENV: development
+    depends_on:
+      migrations:
+        condition: service_completed_successfully
+      redis:
+        condition: service_started
+
+  server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: build_server
+    ports:
+      - '8080:8080'
+    env_file: ./.env.githubci
+    environment:
+      NODE_ENV: development
+      PORT: '8080'
+    depends_on:
+      seed:
+        condition: service_completed_successfully
+      redis:
+        condition: service_started
+
+  client:
+    build:
+      context: client
+      dockerfile: Dockerfile
+      target: serve
+    ports:
+      - '3000:80'
+    depends_on:
+      - server
+
+volumes:
+  pg_data:
+  scylla_data:
+  clickhouse_data:

--- a/docker-compose.images.yaml
+++ b/docker-compose.images.yaml
@@ -56,7 +56,7 @@ services:
       && npm i
       && for db in api-server-pg scylla clickhouse; do npm run db:create -- --db "$$db" --env staging; npm run db:update -- --db "$$db" --env staging; done'
     working_dir: /src
-    env_file: ./.env.githubci
+    env_file: ./.env.docker
     volumes:
       - .:/src
     depends_on:
@@ -68,10 +68,7 @@ services:
         condition: service_healthy
 
   seed:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: build_server
+    image: ghcr.io/roostorg/coop-server:latest
     entrypoint: ['sh', '-c']
     command:
       - |
@@ -90,7 +87,7 @@ services:
         && echo "  Password: $$PASSWORD" \
         && echo "============================================" \
         || { echo "$$OUTPUT"; echo "$$OUTPUT" | grep -q "duplicate key" && echo "Seed user already exists — skipping." || exit 1; }
-    env_file: ./.env.githubci
+    env_file: ./.env.docker
     environment:
       NODE_ENV: development
     depends_on:
@@ -100,13 +97,10 @@ services:
         condition: service_started
 
   server:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: build_server
+    image: ghcr.io/roostorg/coop-server:latest
     ports:
       - '8080:8080'
-    env_file: ./.env.githubci
+    env_file: ./.env.docker
     environment:
       NODE_ENV: development
       PORT: '8080'
@@ -117,14 +111,9 @@ services:
         condition: service_started
 
   client:
-    build:
-      context: client
-      dockerfile: Dockerfile
-      target: serve
+    image: ghcr.io/roostorg/coop-client:latest
     ports:
       - '3000:80'
-    depends_on:
-      - server
 
 volumes:
   pg_data:

--- a/docker-compose.images.yaml
+++ b/docker-compose.images.yaml
@@ -76,19 +76,20 @@ services:
     command:
       - |
         PASSWORD=$$(node -e "process.stdout.write(require('crypto').randomBytes(18).toString('base64url'))")
-        node bin/create-org-and-user.js \
+        OUTPUT=$$(node bin/create-org-and-user.js \
           --name "Coop" \
           --email "admin@coop.local" \
           --website "https://coop.local" \
           --firstName "Admin" \
           --lastName "User" \
-          --password "$$PASSWORD" \
+          --password "$$PASSWORD" 2>&1) \
+        && echo "$$OUTPUT" \
         && echo "" \
         && echo "============================================" \
         && echo "  Login:    admin@coop.local" \
         && echo "  Password: $$PASSWORD" \
         && echo "============================================" \
-        || echo "Seed user already exists — skipping."
+        || { echo "$$OUTPUT"; echo "$$OUTPUT" | grep -q "duplicate key" && echo "Seed user already exists — skipping." || exit 1; }
     env_file: ./.env.githubci
     environment:
       NODE_ENV: development

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -24,6 +24,7 @@
   - [Architecture](development/architecture.md)
   - [API Authentication](development/api-auth.md)
   - [Data Warehouse Abstraction](development/data-warehouse.md)
+  - [Docker](development/docker.md)
   - [Deployment](development/deployment.md)
 
 ---

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -80,4 +80,4 @@ docker compose -f docker-compose.images.yaml down -v
 | `coop-worker` | `Dockerfile`        | `build_worker_runner` | node:24-bullseye-slim + dumb-init |
 | `coop-client` | `client/Dockerfile` | `serve`               | nginx:1.27-bookworm               |
 
-The client image serves the Vite-built SPA via nginx and proxies `/api/` and `/graphql` requests to a backend service named `server` on port 8080.
+The client image serves the Vite-built SPA via nginx and proxies `/api/` requests (including `/api/v1/graphql`) to a backend service named `server` on port 8080.

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -1,0 +1,83 @@
+# Docker
+
+## Published images
+
+Pre-built images are published to GitHub Container Registry on every push to `main`:
+
+```
+ghcr.io/roostorg/coop-server   # API server
+ghcr.io/roostorg/coop-worker   # Background worker
+ghcr.io/roostorg/coop-client   # Frontend (nginx)
+```
+
+Images are tagged with `latest`, the git SHA, and semver tags on release.
+
+## Quick start
+
+Build and run the full stack locally with a single command:
+
+```bash
+docker compose -f docker-compose.images.yaml up --build -d
+```
+
+This starts:
+
+- **Coop server** on port 8080
+- **Coop client** (nginx) on port 3000
+- **Postgres** (pgvector), **Redis**, **ScyllaDB**, **ClickHouse**
+- Database migrations (run automatically)
+- A seed service that creates an admin user with a randomly generated password
+
+### Get your login credentials
+
+The seed service prints the generated credentials to its logs:
+
+```bash
+docker compose -f docker-compose.images.yaml logs seed
+```
+
+Look for the output at the bottom:
+
+```
+============================================
+  Login:    admin@coop.local
+  Password: <randomly-generated>
+============================================
+```
+
+Then open [http://localhost:3000](http://localhost:3000) and log in.
+
+On subsequent startups (with the same volumes), the seed service detects the existing user and skips — your credentials remain the same. If you lose the password, tear down with `-v` to reset.
+
+## Create additional users
+
+```bash
+docker compose -f docker-compose.images.yaml exec server \
+  node bin/create-org-and-user.js \
+  --name "My Org" \
+  --email "you@example.com" \
+  --website "https://example.com" \
+  --firstName "Jane" \
+  --lastName "Doe" \
+  --password "your-password"
+```
+
+## Tear down
+
+```bash
+# Stop containers, keep data volumes
+docker compose -f docker-compose.images.yaml down
+
+# Stop containers and wipe all data
+docker compose -f docker-compose.images.yaml down -v
+```
+
+## Image details
+
+| Image         | Dockerfile          | Build target          | Base                              |
+| ------------- | ------------------- | --------------------- | --------------------------------- |
+| `coop-server` | `Dockerfile`        | `build_server`        | node:24-bullseye-slim + dumb-init |
+| `coop-worker` | `Dockerfile`        | `build_worker_runner` | node:24-bullseye-slim + dumb-init |
+| `coop-client` | `client/Dockerfile` | `serve`               | nginx:1.27-bookworm               |
+
+The client image serves the Vite-built SPA via nginx and proxies `/api/` and `/graphql` requests to a backend service named `server` on port 8080.

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -14,11 +14,13 @@ Images are tagged with `latest`, the git SHA, and semver tags on release.
 
 ## Quick start
 
-Build and run the full stack locally with a single command:
+Pull the published images and run the full stack locally with a single command:
 
 ```bash
-docker compose -f docker-compose.images.yaml up --build -d
+docker compose -f docker-compose.images.yaml up -d
 ```
+
+> **Warning:** `docker-compose.images.yaml` uses `.env.docker`, which ships working defaults for local evaluation but includes placeholder secrets. Review and replace secrets before any non-local deployment.
 
 This starts:
 


### PR DESCRIPTION
Closes #280

Adds Docker image publishing to GHCR and improves the first-start experience for self-hosted deployments.

## Context & Requests for Reviewers

**What's included:**
- GitHub Actions workflow(`.github/workflows/publish-docker.yaml`) that builds and pushes `coop-server`, `coop-worker`, and `coop-client` images to `ghcr.io/roostorg/` on push to main, release, or manual dispatch
- nginx serving stage added to `client/Dockerfile` so the client image is runnable (serves the Vite SPA, proxies `/api/` to the server)
- `docker-compose.images.yaml` for local full-stack testing — builds both images, runs all infra (Postgres, Redis, ScyllaDB, ClickHouse), runs migrations, and seeds an admin user with a randomly generated password
- Docker documentation added to `docs/development/docker.md`

**Reviewers:** 
The workflow uses SHA-pinned actions consistent with existing workflows. The nginx config uses lazy DNS resolution so the client container can start independently of the server.

## Tests

- Built server, worker, and client images locally with `docker build`
- Ran full stack from scratch via `docker compose -f docker-compose.images.yaml up --build -d`
- Verified all services come up healthy (`docker compose ps`)
- Confirmed seed service creates admin user and prints credentials to logs
- Verified client serves SPA at `localhost:3000`
- Verified server responds at `localhost:8080`
- Verified nginx proxy: `POST localhost:3000/api/v1/graphql` proxies to server and returns 200
- Logged in successfully with seeded credentials
- Verified idempotency: seed skips on subsequent startups when user already exists

## (Optional) Rollout Plan

Decide on where to host the Docker images. Common locations are [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) and [Docker Hub](https://docs.docker.com/docker-hub/repos/).

GHCR is currently setup. Both should be free for this repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Official multi-architecture Docker images published for server, worker, and client; full-stack Docker Compose launch with automatic migrations and initial seed user provisioning
  * Client served as a static SPA (Nginx) with SPA routing, long-lived asset caching, and API proxying

* **Documentation**
  * Added Docker guide, quick-start, image details, credential retrieval, and README “Docker” section
  * Added a .env.docker for Docker-specific configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->