### PR TITLE
Add issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -76,17 +76,6 @@ body:
     validations:
       required: false
 
-  - type: input
-    id: contact
-    attributes:
-      label: Contact details
-      description: >
-        Outside of GitHub, how can we get in touch if we need more info? Leave
-        blank if replying here on GitHub is best.
-      placeholder: email@example.com
-    validations:
-      required: false
-
   - type: checkboxes
     id: checklist
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,100 @@
+name: Report a bug
+description: Something is broken or not working correctly
+type: bug
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for taking the time to report a bug in Coop! **Please provide as
+        much detail as you can** so we can properly confirm, triage, and
+        ultimately fix your bug.
+
+  - type: textarea
+    id: behavior
+    attributes:
+      label: What happened
+      description: >
+        …and what did you expect to happen, instead?
+      placeholder: On the Review Console page, when I click on…
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version/commit
+      description: >
+        What version of Coop are you running? If you’re not sure, leave it blank.
+        If you know the specific commit, include it here.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: Affected browser(s)
+      description: >
+        Which browser(s) are you seeing the problem in? Leave blank if it's not
+        a front-end issue. If an affected browser is not included in this list,
+        mention it below.
+      multiple: true
+      options:
+        - Chrome
+        - Firefox
+        - Microsoft Edge
+        - Safari
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs/errors
+      description: >
+        Please paste any relevant log output or error messages.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else
+      description: >
+        Share any other information that could be helpful in reproducing,
+        triaging, or fixing your bug.
+    validations:
+      required: false
+
+  - type: upload
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: >
+        If applicable, add screenshots to help explain your problem.
+        **Please redact sensitive information** such as user content or personal
+        details before uploading. Do not share content that violates GitHub’s
+        [acceptable use policies](https://docs.github.com/en/site-policy/acceptable-use-policies).
+    validations:
+      required: false
+
+  - type: input
+    id: contact
+    attributes:
+      label: Contact details
+      description: >
+        Outside of GitHub, how can we get in touch if we need more info? Leave
+        blank if replying here on GitHub is best.
+      placeholder: email@example.com
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      description: >
+        Make sure you’ve completed each step and reviewed the
+        [Code of Conduct](https://github.com/roostorg/.github/blob/main/CODE_OF_CONDUCT.md)
+        before submitting.
+      options:
+        - label: I’ve reviewed and agree to follow the code of conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+contact_links:
+  - name: Discuss Coop
+    about: See previously-asked questions and existing discussions about Coop, or start your own
+    url: https://github.com/roostorg/coop/discussions
+
+  - name: Chat with contributors
+    about: Join the #coop channel on the ROOST Discord server
+    url: https://discord.gg/2r7uUqvsut

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 contact_links:
   - name: Discuss Coop
-    about: See previously-asked questions and existing discussions about Coop, or start your own
+    about: "See previously-asked questions and existing discussions about Coop, or start your own"
     url: https://github.com/roostorg/coop/discussions
 
   - name: Chat with contributors
-    about: Join the #coop channel on the ROOST Discord server
+    about: "Join the #coop channel on the ROOST Discord server"
     url: https://discord.gg/2r7uUqvsut

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,3 +1,4 @@
+blank_issues_enabled: false # maintainers can still file blank issues for convenience
 contact_links:
   - name: Discuss Coop
     about: "See previously-asked questions and existing discussions about Coop, or start your own"

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,75 @@
+name: Request a feature
+description: An idea or new functionality
+type: feature
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for taking the time to request a feature for Coop! **Please 
+        provide as much detail as you can** so we can fully understand, triage,
+        address your request.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem being solved
+      description: >
+        What is the underlying thing you’re hoping is addressed by this feature?
+      placeholder: Our organization requires…
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: >
+        How do you imagine this feature would look or work?
+      placeholder: On the Review Console page, there should be…
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: >
+        What other possible solutions or features have you considered that would
+        address this?
+      placeholder: Admins could set this behavior, but…
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else
+      description: >
+        Share any other information that could be helpful in understanding,
+        triaging, or addressing your request.
+    validations:
+      required: false
+
+  - type: upload
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: >
+        If applicable, add screenshots or designs to help explain your request.
+        **Please redact sensitive information** such as user content or personal
+        details before uploading. Do not share content that violates GitHub’s
+        [acceptable use policies](https://docs.github.com/en/site-policy/acceptable-use-policies).
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      description: >
+        Make sure you’ve completed each step and reviewed the
+        [Code of Conduct](https://github.com/roostorg/.github/blob/main/CODE_OF_CONDUCT.md)
+        before submitting.
+      options:
+        - label: I’ve reviewed and agree to follow the code of conduct
+          required: true


### PR DESCRIPTION
Fixes #673. Test on my [forked repo](https://github.com/cassidyjames-test-org/coop/issues/new/choose). Note that contributors (anyone with write, maintain, or admin permissions) will still see a "Blank issue" option for convenience.

<img width="1408" height="703" alt="image" src="https://github.com/user-attachments/assets/51cfe57f-5ef7-4837-ac13-06573f3654db" />

Bug | Feature
--- | -------
<img width="1615" height="1847" alt="bug" src="https://github.com/user-attachments/assets/055c7281-3b73-44ee-9eda-474f43a4fb22" /> | <img width="1615" height="1968" alt="feature" src="https://github.com/user-attachments/assets/74284a4f-f3d2-4f2a-9871-b501cfe78682" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added structured GitHub issue templates for bug reports and feature requests to streamline and improve the contribution process.
  * Configured the issue creation workflow to guide contributors with required and optional fields for higher-quality issue reporting.
  * Disabled blank issue creation to reduce noise and added convenient links to community discussions and live contributor chat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->