### PR TITLE
fix: update Docker GH Action version

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -80,7 +80,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - uses: docker/build-push-action@263435318d21b8e681c14492fe198e19c816078e # v6.18.0
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: Dockerfile
@@ -125,7 +125,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - uses: docker/build-push-action@263435318d21b8e681c14492fe198e19c816078e # v6.18.0
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: client
           file: client/Dockerfile


### PR DESCRIPTION
## Context & Requests for Reviewers

The docker build GH action had the wrong version SHA and needed bumped.

Local dryrun: 
<img width="1134" height="571" alt="Screenshot 2026-06-03 at 11 42 04 AM" src="https://github.com/user-attachments/assets/ba0ac07d-6f64-451c-a1a9-bcbf1b6da1e5" />


## Tests

N/A