### PR TITLE
Fix MEDIA fields rendering as links instead of images in manual review

### DIFF
--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobFieldsComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobFieldsComponent.tsx
@@ -30,6 +30,52 @@ import ManualReviewJobContentBlurableImage from '../ManualReviewJobContentBlurab
 import ManualReviewJobContentBlurableVideo from '../ManualReviewJobContentBlurableVideo';
 import { BlurStrength } from './ncmec/NCMECMediaViewer';
 
+// Best-effort media-kind inference from a URL's file extension. Mirrors the
+// server's `detectMediaKindFromUrl` so the review tool can still render a
+// preview when a MEDIA value's `mediaType` is absent — e.g. items submitted
+// before the field became MEDIA, or legacy data missing the resolved kind.
+const MEDIA_EXTENSION_TO_KIND: Readonly<Record<string, ScalarType>> = {
+  jpg: 'IMAGE',
+  jpeg: 'IMAGE',
+  png: 'IMAGE',
+  gif: 'IMAGE',
+  webp: 'IMAGE',
+  bmp: 'IMAGE',
+  svg: 'IMAGE',
+  avif: 'IMAGE',
+  heic: 'IMAGE',
+  heif: 'IMAGE',
+  tif: 'IMAGE',
+  tiff: 'IMAGE',
+  mp4: 'VIDEO',
+  m4v: 'VIDEO',
+  mov: 'VIDEO',
+  webm: 'VIDEO',
+  mkv: 'VIDEO',
+  avi: 'VIDEO',
+  flv: 'VIDEO',
+  mp3: 'AUDIO',
+  m4a: 'AUDIO',
+  wav: 'AUDIO',
+  aac: 'AUDIO',
+  flac: 'AUDIO',
+  opus: 'AUDIO',
+  wma: 'AUDIO',
+};
+
+function inferMediaKindFromUrl(url: string): ScalarType | null {
+  let pathname: string;
+  try {
+    pathname = new URL(url).pathname;
+  } catch {
+    return null;
+  }
+  const dot = pathname.lastIndexOf('.');
+  if (dot < 0 || dot === pathname.length - 1) return null;
+  const ext = pathname.slice(dot + 1).toLowerCase();
+  return MEDIA_EXTENSION_TO_KIND[ext] ?? null;
+}
+
 type FieldsComponentOptions = {
   hideLabels?: boolean;
   maxWidthImage?: number;
@@ -245,13 +291,16 @@ function TableRowComponent(props: {
       );
     }
     case 'MEDIA': {
-      // Polymorphic field — render with the kind detected at coercion time,
-      // falling back to a plain link when detection didn't resolve.
+      // Polymorphic field — render with the kind detected at coercion time.
+      // When that's missing (legacy data, or items submitted before the field
+      // became MEDIA), fall back to inferring the kind from the URL extension,
+      // and only render a plain link if even that doesn't resolve.
       const url = value?.url;
       if (url == null) {
         return <NotProvidedComponent />;
       }
-      if (value.mediaType === 'IMAGE') {
+      const resolvedMediaType = value.mediaType ?? inferMediaKindFromUrl(url);
+      if (resolvedMediaType === 'IMAGE') {
         return (
           <div className="flex flex-col px-2 align-top text-start">
             <ManualReviewJobContentBlurableImage
@@ -275,7 +324,7 @@ function TableRowComponent(props: {
           </div>
         );
       }
-      if (value.mediaType === 'VIDEO') {
+      if (resolvedMediaType === 'VIDEO') {
         return (
           <div className="p-2 align-top text-start">
             <ManualReviewJobContentBlurableVideo
@@ -299,7 +348,7 @@ function TableRowComponent(props: {
           </div>
         );
       }
-      if (value.mediaType === 'AUDIO') {
+      if (resolvedMediaType === 'AUDIO') {
         return (
           <div className="flex flex-col px-2 align-top text-start">
             {label ? <div className="pr-3 font-bold">{label}</div> : null}

--- a/server/routes/items/submitItems.ts
+++ b/server/routes/items/submitItems.ts
@@ -110,7 +110,7 @@ Dependencies): RequestHandlerWithBodies<SubmitItemsInput, undefined> {
           try {
             const images = itemSubmission.itemSubmission.data.images as (
               | string
-              | { url: string }
+              | { url: string; [key: string]: unknown }
             )[];
 
             // Get all hash banks for this org once
@@ -120,6 +120,12 @@ Dependencies): RequestHandlerWithBodies<SubmitItemsInput, undefined> {
             const imageHashes = await Promise.all(
               images.map(async (image) => {
                 const url = typeof image === 'string' ? image : image.url;
+                // Preserve any fields the coercion step already populated on
+                // the media object (e.g. MEDIA's `mediaType`, which the manual
+                // review tool relies on to decide whether to render an image,
+                // video, or audio player). Rebuilding a fresh object below
+                // would otherwise silently drop them.
+                const coercedFields = typeof image === 'string' ? {} : image;
                 if (typeof url === 'string' && url) {
                   try {
                     const hmaHashWithRetries = await withRetries(
@@ -173,6 +179,7 @@ Dependencies): RequestHandlerWithBodies<SubmitItemsInput, undefined> {
                     }
 
                     return {
+                      ...coercedFields,
                       url,
                       hashes,
                       matchedBanks:
@@ -182,6 +189,7 @@ Dependencies): RequestHandlerWithBodies<SubmitItemsInput, undefined> {
                     };
                   } catch (e) {
                     return {
+                      ...coercedFields,
                       url,
                       hashes: {},
                     };


### PR DESCRIPTION
## Context & Requests for Reviewers

The `images` HMA-hashing step in submitItems rebuilt each media object from scratch, which dropped the `mediaType` populated during coercion. With no `mediaType`, the manual review tool's MEDIA renderer fell through to a plain link instead of an image/video/audio preview.

- Preserve the already-coerced fields (including `mediaType`) when attaching hash/matched-bank data to submitted images.
- In the MRT MEDIA renderer, fall back to inferring the kind from the URL extension when `mediaType` is absent, so legacy data and items submitted before the field became MEDIA still preview correctly.

Before:
<img width="1483" height="731" alt="Screenshot 2026-06-03 at 12 54 45 PM" src="https://github.com/user-attachments/assets/d1c3c8ac-5b82-43ac-8595-cb6019dec724" />

After:
<img width="1510" height="946" alt="Screenshot 2026-06-03 at 12 54 37 PM" src="https://github.com/user-attachments/assets/931be432-6903-4067-b7b2-ad4d158d8102" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media file identification for images, videos, and audio when explicit type information is missing, leveraging file extension inference
  * Enhanced image processing to preserve additional metadata fields during enrichment operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->