### PR TITLE
docs: add intention statement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,17 @@ Coop is the open source review and moderation tool from [ROOST](https://roost.to
 - **Rules Engine**: Automated content evaluation against customizable policies
 - **API Integration**: Simple REST and GraphQL APIs for seamless platform integration
 
-It's designed for trust and safety teams for online platforms of all sizes from small indie projects to large enterprise-scale deployments.
+## Who Coop is for
+
+Coop is for anyone who needs to make online safety decisions: platforms of all sizes, solo developers, and community teams without dedicated trust and safety staff.
+
+Most moderation tooling is proprietary and priced for platforms that can already afford it. Coop is free and open source so your data stays within your infrastructure, and you can customize it for your community's needs.
+
+A few things that shape how we build it:
+
+- **The platform owns its policy.** Coop is the plumbing to implement and enforce your own rules.
+- **Child safety is a prioritized workflow.** As the first free end-to-end online child safety system, it is one of the reasons Coop exists.
+- **The codebase is auditable**, with no hidden logic and no vendor lock-in.
 
 ## Built in the open
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ Coop is the open source review and moderation tool from [ROOST](https://roost.to
 - **Rules Engine**: Automated content evaluation against customizable policies
 - **API Integration**: Simple REST and GraphQL APIs for seamless platform integration
 
-It's designed for trust and safety teams for online platforms of all sizes from small indie projects to large enterprise-scale deployments.
-
 ## Who Coop is for
 
 Coop is for anyone who needs to make online safety decisions: platforms of all sizes, solo developers, and community teams without dedicated trust and safety staff.
@@ -34,10 +32,12 @@ We want to hear from you! Whether you're testing it out, running into issues, or
 
 Your feedback directly shapes our [roadmap](https://roostorg.github.io/community/roadmap).
 
-## Docker
+## Quick start
 
 Run Coop with a single command using Docker Compose. See the [Docker guide](docs/development/docker.md) for setup instructions and published image details.
 
 ## Learn more
 
-We maintain [documentation](docs/) directly in this repo covering functionality, development, integrations, and more. Versioned documentation is also [available online](https://roostorg.github.io/coop) for easier browsing.
+See our comprehensive [documentation](https://roostorg.github.io/coop/latest) covering both functional and technical information including a user guide, development guide, API reference, and integration details.
+
+The docs are also available [directly in this repo](docs/) for your convenience.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Coop is the open source review and moderation tool from [ROOST](https://roost.to
 - **Rules Engine**: Automated content evaluation against customizable policies
 - **API Integration**: Simple REST and GraphQL APIs for seamless platform integration
 
+It's designed for trust and safety teams for online platforms of all sizes from small indie projects to large enterprise-scale deployments.
+
 ## Who Coop is for
 
 Coop is for anyone who needs to make online safety decisions: platforms of all sizes, solo developers, and community teams without dedicated trust and safety staff.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,20 @@
 
 Welcome to the Coop documentation! For the Coop source code and basic information, [check out Coop on GitHub](https://github.com/roostorg/coop).
 
+## Who Coop is for
+
+Coop is for anyone who needs to make online safety decisions: platforms of all sizes, solo developers, and community teams without dedicated trust and safety staff.
+
+Most moderation tooling is proprietary and priced for platforms that can already afford it. Coop is free and open source so your data stays within your infrastructure, and you can customize it for your community's needs.
+
+A few things that shape how we build it:
+
+- **The platform owns its policy.** Coop is the plumbing to implement and enforce your own rules.
+- **Child safety is a prioritized workflow.** As the first free end-to-end online child safety system, it is one of the reasons Coop exists.
+- **The codebase is auditable**, with no hidden logic and no vendor lock-in.
+
+## Finding your way around
+
 These docs are split into a few guides, depending on who you are and what you're looking for:
 
 - [User Guide](user/): learn about Coop, its functionality, and the user interface

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,20 +1,6 @@
 # Welcome
 
-Welcome to the Coop documentation! For the Coop source code and basic information, [check out Coop on GitHub](https://github.com/roostorg/coop).
-
-## Who Coop is for
-
-Coop is for anyone who needs to make online safety decisions: platforms of all sizes, solo developers, and community teams without dedicated trust and safety staff.
-
-Most moderation tooling is proprietary and priced for platforms that can already afford it. Coop is free and open source so your data stays within your infrastructure, and you can customize it for your community's needs.
-
-A few things that shape how we build it:
-
-- **The platform owns its policy.** Coop is the plumbing to implement and enforce your own rules.
-- **Child safety is a prioritized workflow.** As the first free end-to-end online child safety system, it is one of the reasons Coop exists.
-- **The codebase is auditable**, with no hidden logic and no vendor lock-in.
-
-## Finding your way around
+Welcome to the Coop documentation! Visit [Coop on GitHub](https://github.com/roostorg/coop#readme) for source code and project information.
 
 These docs are split into a few guides, depending on who you are and what you're looking for:
 

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -7,6 +7,7 @@ Coop enables you to protect your users from harm with remarkable ease.
 Coop is a trust and safety platform built around two functional areas that can be used independently or together:
 
 - **Automated Enforcement**: rules that evaluate every submitted item and automatically take action or route it to a review queue
+
 - **Review Console**: a human review queue where moderators examine flagged content and make enforcement decisions
 
 This simplified diagram can help you better understand how data flows between a platform and Coop:
@@ -17,12 +18,16 @@ This simplified diagram can help you better understand how data flows between a 
 
 We recommend beginning by familiarizing yourself with Coop's [basic concepts](concepts.md). Once you're up to speed:
 
-1. Ensure you have an account and API key for your Coop instance (find or generate one under **Settings** → **API Keys**)
+1. Ensure you have an account and API key for your Coop instance
 
-2. Define your [Item Types](administration.md#item-types); the kinds of content or users on your platform (posts, comments, profiles, etc.)
+2. Define your [Item Types](administration.md#item-types); the kinds of content and actors on your platform
 
-3. Define your [Actions](administration.md#actions) and expose callback endpoints so Coop can trigger enforcement on your platform; see [Handling Actions](../api/actions.md) for the webhook format
+3. Input your detailed platform [Policies](administration.html#policies)
 
-4. Begin submitting items to Coop via the [Items API](../api/items.md) so they run through your proactive rules
+4. Define your [Actions](administration.md#actions) and expose [callback endpoints](../api/actions.md) so Coop can trigger enforcement on your platform
 
-5. Submit user reports via the [Report API](../api/report.md) to route them into review queues for your moderators
+Once Coop is configured, your platform can:
+
+1. Begin submitting items to Coop via the [Items API](../api/items.md) so they run through your proactive rules
+
+2. Submit user reports via the [Report API](../api/report.md) to route them into review queues for your moderators


### PR DESCRIPTION
## Summary

Closes #287: adds the intention statement requested in the issue to both the top-level `README.md` and the docs landing page (`docs/README.md`) as part of SDLC requirements.

- Adds a "Who Coop is for" section that explicitly broadens the audience to solo developers and community teams without dedicated T&S staff, matching the framing in ROOST's [software development practices](https://roostorg.github.io/community/software-development-practices) ("ethos for what kind of software we're building and for who").
- Mirrors the same section in `docs/README.md` so readers landing on the docs site (versioned at https://roostorg.github.io/coop) get the same context before navigating into the guides.
- Three principles (platform-owns-its-policy, child-safety-is-prioritized, auditable-codebase) come straight from the text in #287.

## Test plan

- [x] Render `README.md` on the PR page — confirm headings, list
      formatting, and the bold-then-period pattern for principles
      render correctly on GitHub.
- [ ] Spot-check the mdBook build for `docs/README.md` (no SUMMARY.md
      change needed since `docs/README.md` is already linked as the
      Welcome page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Who Coop is for" section outlining target audiences, pricing/value, and three guiding product principles (platform-owned policy, child-safety‑first workflow, auditable/no‑vendor-lock‑in).
  * Introduced a "Quick start" entry point and clarified "Learn more" wording to cover both online and repo-hosted docs.
  * Rewrote admin "Getting started" into two phases: an ordered configuration checklist and subsequent platform capabilities (Items/Reports APIs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->