### PR TITLE
ci: Add License Check workflow

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -49,4 +49,4 @@ jobs:
 
       - name: Check licenses
         working-directory: ${{ matrix.directory }}
-        run: npx --yes license-checker --production --excludePrivatePackages --onlyAllow "$ALLOWED_LICENSES"
+        run: npx --yes license-checker@25.0.1 --production --excludePrivatePackages --onlyAllow "$ALLOWED_LICENSES"

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -18,6 +18,7 @@ jobs:
         CC0-1.0
         ISC
         MIT
+        Python-2.0
     strategy:
       matrix:
         directory:

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -32,6 +32,8 @@ jobs:
           - types
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ matrix.directory }}
-        run: npm ci --omit=dev
+        run: npm ci --omit=dev --ignore-scripts
 
       - name: Check licenses
         working-directory: ${{ matrix.directory }}

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -19,6 +19,7 @@ jobs:
         ISC
         MIT
         Python-2.0
+        Unlicense
     strategy:
       matrix:
         directory:

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -45,4 +45,4 @@ jobs:
 
       - name: Check licenses
         working-directory: ${{ matrix.directory }}
-        run: npx --yes license-checker --production --onlyAllow "$ALLOWED_LICENSES"
+        run: npx --yes license-checker --production --excludePrivatePackages --onlyAllow "$ALLOWED_LICENSES"

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,0 +1,48 @@
+name: License Check
+on:
+  pull_request:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    env:
+      ALLOWED_LICENSES: |
+        0BSD
+        Apache-2.0
+        BSD-2-Clause
+        BSD-3-Clause
+        BlueOak-1.0.0
+        BSL-1.0
+        CC0-1.0
+        ISC
+        MIT
+    strategy:
+      matrix:
+        directory:
+          - .
+          - client
+          - db
+          - migrator
+          - nodejs-instrumentation
+          - server
+          - types
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: Format license list
+        run: echo "ALLOWED_LICENSES=$(echo "$ALLOWED_LICENSES" | tr '\n' ';' | sed 's/;$//')" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        working-directory: ${{ matrix.directory }}
+        run: npm ci --omit=dev
+
+      - name: Check licenses
+        working-directory: ${{ matrix.directory }}
+        run: npx --yes license-checker --production --onlyAllow "$ALLOWED_LICENSES"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "coop",
       "version": "0.0.0",
+      "license": "Apache-2.0",
       "devDependencies": {
         "@graphiql/create-fetcher": "^0.1.0",
         "@graphql-codegen/add": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "coop",
   "version": "0.0.0",
   "private": true,
+  "license": "Apache-2.0",
   "scripts": {
     "start": "concurrently \"npm run server:start\" \"npm run client:start\" \"npm run generate:watch\" --kill-others",
     "compile": "concurrently \"npm run server:start\" \"BROWSER=none npm run client:start\" \"npm run generate:watch\" --kill-others",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,12 @@
   },
   "devDependencies": {
     "@graphiql/create-fetcher": "^0.1.0",
+    "concurrently": "^9.2.1"
+  },
+  "engines": {
+    "node": "^24.0.0"
+  },
+  "devDependencies": {
     "@graphql-codegen/add": "^6.0.0",
     "@graphql-codegen/cli": "^6.3.1",
     "@graphql-codegen/named-operations-object": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -28,12 +28,6 @@
   },
   "devDependencies": {
     "@graphiql/create-fetcher": "^0.1.0",
-    "concurrently": "^9.2.1"
-  },
-  "engines": {
-    "node": "^24.0.0"
-  },
-  "devDependencies": {
     "@graphql-codegen/add": "^6.0.0",
     "@graphql-codegen/cli": "^6.3.1",
     "@graphql-codegen/named-operations-object": "^4.0.1",


### PR DESCRIPTION
Uses [license-checker] in each package directory to check production dependencies against the list of allowed licenses (set in the ALLOWED_LICENSES env variable). The current list of licenses is based on my initial research, but I am not a lawyer.

The workflow should pass if there are no issues, and fail (exit code 1) outputting any packages with licenses that aren't explicitly allowed.

- Fixes #611
- Depends on/includes/supersedes #691

[license-checker]: https://www.npmjs.com/package/license-checker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Declared Apache-2.0 open source license for the project
  * Added automated license compliance verification to validate third-party dependencies
  * Updated dependency configuration to ensure proper package installation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->