### PR TITLE
Fix NCMEC MRT gallery for MEDIA scalar fields

### DIFF
--- a/client/src/utils/contentUrlUtils.ts
+++ b/client/src/utils/contentUrlUtils.ts
@@ -2,15 +2,65 @@
  * Utility functions for detecting and handling content URLs that should be displayed in iframes
  */
 
-  /**
-   * Get the content URL patterns from environment variables
-   * Defaults to 'notion' for backward compatibility
-   * Supports comma-separated patterns
-   */
-  export function getContentUrlPatterns(): string[] {
-    const pattern: string = import.meta.env.VITE_CONTENT_URL_PATTERN ?? 'notion';
-    return pattern.split(',').map(p => p.trim()).filter(p => p.length > 0);
+import type { MediaKind } from '@roostorg/coop-types';
+
+const MEDIA_EXTENSION_TO_KIND: Readonly<Record<string, MediaKind>> = {
+  jpg: 'IMAGE',
+  jpeg: 'IMAGE',
+  png: 'IMAGE',
+  gif: 'IMAGE',
+  webp: 'IMAGE',
+  bmp: 'IMAGE',
+  svg: 'IMAGE',
+  avif: 'IMAGE',
+  heic: 'IMAGE',
+  heif: 'IMAGE',
+  tif: 'IMAGE',
+  tiff: 'IMAGE',
+  mp4: 'VIDEO',
+  m4v: 'VIDEO',
+  mov: 'VIDEO',
+  webm: 'VIDEO',
+  mkv: 'VIDEO',
+  avi: 'VIDEO',
+  flv: 'VIDEO',
+  mp3: 'AUDIO',
+  m4a: 'AUDIO',
+  wav: 'AUDIO',
+  aac: 'AUDIO',
+  flac: 'AUDIO',
+  opus: 'AUDIO',
+  wma: 'AUDIO',
+};
+
+// Best-effort fallback for resolving a media kind from a URL extension, used
+// when a MEDIA value's `mediaType` is absent. Mirrors the server's
+// `detectMediaKindFromUrl`. Returns `null` when it can't be resolved.
+export function inferMediaKindFromUrl(url: string): MediaKind | null {
+  let pathname: string;
+  try {
+    pathname = new URL(url).pathname;
+  } catch {
+    return null;
   }
+  const dot = pathname.lastIndexOf('.');
+  if (dot < 0 || dot === pathname.length - 1) return null;
+  const ext = pathname.slice(dot + 1).toLowerCase();
+  return MEDIA_EXTENSION_TO_KIND[ext] ?? null;
+}
+
+/**
+ * Get the content URL patterns from environment variables
+ * Defaults to 'notion' for backward compatibility
+ * Supports comma-separated patterns
+ */
+export function getContentUrlPatterns(): string[] {
+  const pattern: string = import.meta.env.VITE_CONTENT_URL_PATTERN ?? 'notion';
+  return pattern
+    .split(',')
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+}
 
 /**
  * Check if a URL should be displayed in an iframe
@@ -20,7 +70,7 @@
 export function shouldDisplayInIframe(url: string): boolean {
   const patterns = getContentUrlPatterns();
   const urlLower = url.toLowerCase();
-  return patterns.some(pattern => urlLower.includes(pattern.toLowerCase()));
+  return patterns.some((pattern) => urlLower.includes(pattern.toLowerCase()));
 }
 
 /**
@@ -32,11 +82,11 @@ export function shouldDisplayUrlFieldInIframe(urlField: any): boolean {
   if (!urlField || typeof urlField !== 'object' || !('type' in urlField)) {
     return false;
   }
-  
+
   if (urlField.type !== 'URL' || typeof urlField.value !== 'string') {
     return false;
   }
-  
+
   return shouldDisplayInIframe(urlField.value);
 }
 

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ncmec/NCMECReviewUser.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ncmec/NCMECReviewUser.tsx
@@ -1,7 +1,7 @@
 import { isTypingInEditableElement } from '@/utils/misc';
 import { BulbOutlined, ExclamationCircleOutlined } from '@ant-design/icons';
 import { gql } from '@apollo/client';
-import { ItemIdentifier, TaggedScalar } from '@roostorg/coop-types';
+import { ItemIdentifier, MediaKind, TaggedScalar } from '@roostorg/coop-types';
 import { Button } from 'antd';
 import pick from 'lodash/pick';
 import uniqBy from 'lodash/uniqBy';
@@ -27,6 +27,7 @@ import {
   useGQLPersonalSafetySettingsQuery,
 } from '../../../../../../graphql/generated';
 import { filterNullOrUndefined } from '../../../../../../utils/collections';
+import { inferMediaKindFromUrl } from '../../../../../../utils/contentUrlUtils';
 import {
   getFieldValueForRole,
   getFieldValueOrValues,
@@ -114,6 +115,25 @@ gql`
   }
 `;
 
+// NCMEC covers images and videos only. For the MEDIA scalar the kind isn't
+// implied by the field type, so use the resolved `mediaType` (or infer from URL).
+function toNcmecUrlInfo(tagged: {
+  type: string;
+  value: { url?: string; mediaType?: MediaKind | null };
+}): NCMECUrlInfo | undefined {
+  const url = tagged.value?.url;
+  if (!url) {
+    return undefined;
+  }
+  const kind =
+    tagged.type === 'IMAGE' || tagged.type === 'VIDEO'
+      ? tagged.type
+      : (tagged.value?.mediaType ?? inferMediaKindFromUrl(url));
+  return kind === 'IMAGE' || kind === 'VIDEO'
+    ? { url, mediaType: kind }
+    : undefined;
+}
+
 function getUrlsFromItem(
   item: NCMECMediaQueryResult['contentItem'],
 ): NCMECUrlInfo[] {
@@ -121,24 +141,23 @@ function getUrlsFromItem(
     (it) =>
       it.type === 'IMAGE' ||
       it.type === 'VIDEO' ||
+      it.type === 'MEDIA' ||
       it.container?.valueScalarType === 'IMAGE' ||
-      it.container?.valueScalarType === 'VIDEO',
+      it.container?.valueScalarType === 'VIDEO' ||
+      it.container?.valueScalarType === 'MEDIA',
   );
   return filterNullOrUndefined(
     mediaFields
       .map((field) => {
         const valueOrValues = getFieldValueOrValues(item.data, field) as
-          | TaggedScalar<'IMAGE' | 'VIDEO'>
-          | TaggedScalar<'IMAGE' | 'VIDEO'>[];
+          | TaggedScalar<'IMAGE' | 'VIDEO' | 'MEDIA'>
+          | TaggedScalar<'IMAGE' | 'VIDEO' | 'MEDIA'>[];
         if (valueOrValues === undefined) {
           return undefined;
         }
-        return Array.isArray(valueOrValues)
-          ? valueOrValues.map((it) => ({
-              url: it.value.url,
-              mediaType: it.type,
-            }))
-          : { url: valueOrValues.value.url, mediaType: valueOrValues.type };
+        return (
+          Array.isArray(valueOrValues) ? valueOrValues : [valueOrValues]
+        ).map(toNcmecUrlInfo);
       })
       .flat(),
   );
@@ -153,8 +172,10 @@ export function getMatchedBanksForMediaUrl(
     (it) =>
       it.type === 'IMAGE' ||
       it.type === 'VIDEO' ||
+      it.type === 'MEDIA' ||
       it.container?.valueScalarType === 'IMAGE' ||
-      it.container?.valueScalarType === 'VIDEO',
+      it.container?.valueScalarType === 'VIDEO' ||
+      it.container?.valueScalarType === 'MEDIA',
   );
   for (const field of mediaFields) {
     const valueOrValues = getFieldValueOrValues(item.data, field) as


### PR DESCRIPTION
## Context & Requests for Reviewers

Fixes NCMEC jobs whose items only expose media via the `MEDIA` scalar (no separate IMAGE/VIDEO fields), which previously showed an empty gallery / “0 videos or images failed to load”.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic media type detection from URLs for more accurate media classification.
  * Extended NCMEC review capabilities to handle additional media formats and scalar types.

* **Refactor**
  * Optimized media handling utilities for improved code organization and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->