### PR TITLE
chore: remove deprecated @graphiql/create-fetcher dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@graphiql/create-fetcher": "^0.1.0",
         "@graphql-codegen/add": "^6.0.0",
         "@graphql-codegen/cli": "^6.3.1",
         "@graphql-codegen/named-operations-object": "^4.0.1",
@@ -395,73 +394,6 @@
       "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@graphiql/create-fetcher": {
-      "version": "0.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphiql/toolkit": "^0.1.0",
-        "@n1ru4l/push-pull-async-iterable-iterator": "^2.0.1",
-        "graphql-ws": "^4.1.0",
-        "meros": "^1.1.0-beta.2",
-        "subscriptions-transport-ws": "^0.9.18"
-      }
-    },
-    "node_modules/@graphiql/create-fetcher/node_modules/graphql": {
-      "version": "15.10.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.10.1.tgz",
-      "integrity": "sha512-BL/Xd/T9baO6NFzoMpiMD7YUZ62R6viR5tp/MULVEnbYJXZA//kRNW7J0j1w/wXArgL0sCxhDfK5dczSKn3+cg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 10.x"
-      }
-    },
-    "node_modules/@graphiql/create-fetcher/node_modules/graphql-ws": {
-      "version": "4.9.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "graphql": ">=0.11 <=15"
-      }
-    },
-    "node_modules/@graphiql/toolkit": {
-      "version": "0.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@n1ru4l/push-pull-async-iterable-iterator": "^2.0.1",
-        "graphql-ws": "^4.1.0",
-        "meros": "^1.1.2",
-        "subscriptions-transport-ws": "^0.9.18"
-      }
-    },
-    "node_modules/@graphiql/toolkit/node_modules/graphql": {
-      "version": "15.10.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.10.1.tgz",
-      "integrity": "sha512-BL/Xd/T9baO6NFzoMpiMD7YUZ62R6viR5tp/MULVEnbYJXZA//kRNW7J0j1w/wXArgL0sCxhDfK5dczSKn3+cg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 10.x"
-      }
-    },
-    "node_modules/@graphiql/toolkit/node_modules/graphql-ws": {
-      "version": "4.9.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "graphql": ">=0.11 <=15"
-      }
     },
     "node_modules/@graphql-codegen/add": {
       "version": "6.0.1",
@@ -1892,14 +1824,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@n1ru4l/push-pull-async-iterable-iterator": {
-      "version": "2.1.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -2277,11 +2201,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/backo2": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
@@ -2817,11 +2736,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "3.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/expect": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
@@ -3342,11 +3256,6 @@
       "peerDependencies": {
         "ws": "*"
       }
-    },
-    "node_modules/iterall": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/jest-diff": {
       "version": "30.3.0",
@@ -4584,42 +4493,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/subscriptions-transport-ws": {
-      "version": "0.9.19",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "backo2": "^1.0.2",
-        "eventemitter3": "^3.1.0",
-        "iterall": "^1.2.1",
-        "symbol-observable": "^1.0.4",
-        "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
-      },
-      "peerDependencies": {
-        "graphql": ">=0.10.0"
-      }
-    },
-    "node_modules/subscriptions-transport-ws/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "dev": true,
@@ -4642,14 +4515,6 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/symbol-observable": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/sync-fetch": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "node": "^24.0.0"
   },
   "devDependencies": {
-    "@graphiql/create-fetcher": "^0.1.0",
     "@graphql-codegen/add": "^6.0.0",
     "@graphql-codegen/cli": "^6.3.1",
     "@graphql-codegen/named-operations-object": "^4.0.1",


### PR DESCRIPTION
## What

Removes the deprecated `@graphiql/create-fetcher` dev dependency from the root `package.json` (and prunes it from `package-lock.json`).

Closes #696.

## Why

`@graphiql/create-fetcher` is deprecated upstream (the deprecation message points to the `createFetcher` helper in `@graphiql/toolkit`). It was listed as a root `devDependency` but:

- it is **not imported anywhere** in the codebase, and
- there is no GraphiQL playground / UI wired up that would need a fetcher.

Rather than swap it for `@graphiql/toolkit` (which would just add an equally-unused dependency), the cleaner fix is to drop it. Its transitive `@graphiql/toolkit` is removed from the lockfile too, since nothing else depends on it.

This follows on from #691, where the deprecation was first noticed while moving root deps to devDependencies.

## Changes

- `package.json`: removed `@graphiql/create-fetcher` from `devDependencies` (1 line).
- `package-lock.json`: regenerated via `npm install --package-lock-only`; only deletions, no additions (135 lines).

## Notes / testing

- The diff is deletions-only — verified `package-lock.json` has no spurious additions and the content of `package.json` is unchanged apart from the removed line.
- I did not run the full build/typecheck, since the package is not referenced by any source file, so removal cannot affect compilation. Happy to run anything specific if you'd like.
- I noticed the open npm-to-pnpm migration (#669); this change targets the current npm + `package-lock.json` setup. If the pnpm migration lands first, this can be rebased trivially (it's a single dependency removal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused development dependency to streamline the project setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->