### PR TITLE
docker: set NODE_ENV to development for migrations

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -56,7 +56,6 @@ REDIS_PORT=6379
 OTEL_SERVICE_NAME=coop
 
 # ── General ───────────────────────────────────────────────────────────
-NODE_ENV=production
 ITEM_QUEUE_TRAFFIC_PERCENTAGE='0'
 UI_URL=http://localhost:3000
 

--- a/docker-compose.images.yaml
+++ b/docker-compose.images.yaml
@@ -58,7 +58,7 @@ services:
     working_dir: /src
     env_file: ./.env.docker
     environment:
-      HUSKY: '0'
+      NODE_ENV: development
     volumes:
       - .:/src
     depends_on:

--- a/docker-compose.images.yaml
+++ b/docker-compose.images.yaml
@@ -57,6 +57,8 @@ services:
       && for db in api-server-pg scylla clickhouse; do npm run db:create -- --db "$$db" --env staging; npm run db:update -- --db "$$db" --env staging; done'
     working_dir: /src
     env_file: ./.env.docker
+    environment:
+      HUSKY: '0'
     volumes:
       - .:/src
     depends_on:


### PR DESCRIPTION
husky wasn't available for migrations since it's using the `production` node environment as set in the `.env.docker` file (and thus not installing devDependencies). Disabling husky itself just causes the same problem with other devDependencies that are required for migrations.

We're doing this same `NODE_ENV` override for the `server` and `seed` services, which maybe begs the question: why have the environment variable settable in the `.env.docker` file at all if it always needs to be set to `development`?

Disclaimer, I'm not a docker nor node expert and might be completely missing something. :)

- Fixes #698

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker Compose configuration for the migrations service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->