### PR TITLE
[NCMEC] Allow to configure min images to review for NCMEC report

### DIFF
--- a/client/src/graphql/generated.ts
+++ b/client/src/graphql/generated.ts
@@ -2967,6 +2967,19 @@ export type GQLNcmecMediaInput = {
   readonly url: Scalars['String']['input'];
 };
 
+/**
+ * How much media a reviewer must classify before an NCMEC report can be sent.
+ * ALL requires every piece of media on the account to be reviewed (the original
+ * behaviour); MINIMUM only requires `minMediaToReview` items, so reviewers
+ * don't have to classify hundreds of items to submit a report.
+ */
+export const GQLNcmecMediaReviewRequirement = {
+  All: 'ALL',
+  Minimum: 'MINIMUM',
+} as const;
+
+export type GQLNcmecMediaReviewRequirement =
+  (typeof GQLNcmecMediaReviewRequirement)[keyof typeof GQLNcmecMediaReviewRequirement];
 export type GQLNcmecOrgSettings = {
   readonly __typename: 'NcmecOrgSettings';
   readonly companyTemplate?: Maybe<Scalars['String']['output']>;
@@ -2978,6 +2991,8 @@ export type GQLNcmecOrgSettings = {
   readonly defaultInternetDetailType?: Maybe<GQLNcmecInternetDetailType>;
   readonly defaultNcmecQueueId?: Maybe<Scalars['String']['output']>;
   readonly legalUrl?: Maybe<Scalars['String']['output']>;
+  readonly mediaReviewRequirement?: Maybe<GQLNcmecMediaReviewRequirement>;
+  readonly minMediaToReview?: Maybe<Scalars['Int']['output']>;
   readonly moreInfoUrl?: Maybe<Scalars['String']['output']>;
   readonly ncmecAdditionalInfoEndpoint?: Maybe<Scalars['String']['output']>;
   readonly ncmecPreservationEndpoint?: Maybe<Scalars['String']['output']>;
@@ -2996,6 +3011,8 @@ export type GQLNcmecOrgSettingsInput = {
   readonly defaultInternetDetailType?: InputMaybe<GQLNcmecInternetDetailType>;
   readonly defaultNcmecQueueId?: InputMaybe<Scalars['String']['input']>;
   readonly legalUrl?: InputMaybe<Scalars['String']['input']>;
+  readonly mediaReviewRequirement?: InputMaybe<GQLNcmecMediaReviewRequirement>;
+  readonly minMediaToReview?: InputMaybe<Scalars['Int']['input']>;
   readonly moreInfoUrl?: InputMaybe<Scalars['String']['input']>;
   readonly ncmecAdditionalInfoEndpoint?: InputMaybe<Scalars['String']['input']>;
   readonly ncmecPreservationEndpoint?: InputMaybe<Scalars['String']['input']>;
@@ -3096,6 +3113,17 @@ export type GQLOrg = {
   readonly itemTypes: ReadonlyArray<GQLItemType>;
   readonly mrtQueues: ReadonlyArray<GQLManualReviewQueue>;
   readonly name: Scalars['String']['output'];
+  /**
+   * How much media a reviewer must classify before they can send an NCMEC
+   * report for this org. Readable by any org member (not just MANAGE_ORG) so the
+   * NCMEC review UI can enforce the policy. Defaults to ALL when unset.
+   */
+  readonly ncmecMediaReviewRequirement: GQLNcmecMediaReviewRequirement;
+  /**
+   * Minimum number of media items that must be reviewed before sending an NCMEC
+   * report when ncmecMediaReviewRequirement is MINIMUM. Defaults to 1.
+   */
+  readonly ncmecMinMediaToReview: Scalars['Int']['output'];
   readonly ncmecReports: ReadonlyArray<GQLNcmecReport>;
   readonly onCallAlertEmail?: Maybe<Scalars['String']['output']>;
   readonly pendingInvites: ReadonlyArray<GQLPendingInvite>;
@@ -16725,6 +16753,19 @@ export type GQLGetLatestUserSubmittedItemsWithThreadsQuery = {
   }>;
 };
 
+export type GQLNcmecMediaReviewPolicyQueryVariables = Exact<{
+  [key: string]: never;
+}>;
+
+export type GQLNcmecMediaReviewPolicyQuery = {
+  readonly __typename: 'Query';
+  readonly myOrg?: {
+    readonly __typename: 'Org';
+    readonly ncmecMediaReviewRequirement: GQLNcmecMediaReviewRequirement;
+    readonly ncmecMinMediaToReview: number;
+  } | null;
+};
+
 export type GQLGetMoreInfoForThreadItemsQueryVariables = Exact<{
   ids: ReadonlyArray<GQLItemIdentifierInput> | GQLItemIdentifierInput;
 }>;
@@ -24532,6 +24573,8 @@ export type GQLNcmecOrgSettingsQuery = {
     readonly contactPersonFirstName?: string | null;
     readonly contactPersonLastName?: string | null;
     readonly contactPersonPhone?: string | null;
+    readonly mediaReviewRequirement?: GQLNcmecMediaReviewRequirement | null;
+    readonly minMediaToReview?: number | null;
   } | null;
   readonly myOrg?: {
     readonly __typename: 'Org';
@@ -35200,6 +35243,105 @@ export type GQLGetLatestUserSubmittedItemsWithThreadsQueryResult =
     GQLGetLatestUserSubmittedItemsWithThreadsQuery,
     GQLGetLatestUserSubmittedItemsWithThreadsQueryVariables
   >;
+export const GQLNcmecMediaReviewPolicyDocument = gql`
+  query NcmecMediaReviewPolicy {
+    myOrg {
+      ncmecMediaReviewRequirement
+      ncmecMinMediaToReview
+    }
+  }
+`;
+
+/**
+ * __useGQLNcmecMediaReviewPolicyQuery__
+ *
+ * To run a query within a React component, call `useGQLNcmecMediaReviewPolicyQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGQLNcmecMediaReviewPolicyQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGQLNcmecMediaReviewPolicyQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGQLNcmecMediaReviewPolicyQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    GQLNcmecMediaReviewPolicyQuery,
+    GQLNcmecMediaReviewPolicyQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GQLNcmecMediaReviewPolicyQuery,
+    GQLNcmecMediaReviewPolicyQueryVariables
+  >(GQLNcmecMediaReviewPolicyDocument, options);
+}
+export function useGQLNcmecMediaReviewPolicyLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GQLNcmecMediaReviewPolicyQuery,
+    GQLNcmecMediaReviewPolicyQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GQLNcmecMediaReviewPolicyQuery,
+    GQLNcmecMediaReviewPolicyQueryVariables
+  >(GQLNcmecMediaReviewPolicyDocument, options);
+}
+// @ts-ignore
+export function useGQLNcmecMediaReviewPolicySuspenseQuery(
+  baseOptions?: Apollo.SuspenseQueryHookOptions<
+    GQLNcmecMediaReviewPolicyQuery,
+    GQLNcmecMediaReviewPolicyQueryVariables
+  >,
+): Apollo.UseSuspenseQueryResult<
+  GQLNcmecMediaReviewPolicyQuery,
+  GQLNcmecMediaReviewPolicyQueryVariables
+>;
+export function useGQLNcmecMediaReviewPolicySuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GQLNcmecMediaReviewPolicyQuery,
+        GQLNcmecMediaReviewPolicyQueryVariables
+      >,
+): Apollo.UseSuspenseQueryResult<
+  GQLNcmecMediaReviewPolicyQuery | undefined,
+  GQLNcmecMediaReviewPolicyQueryVariables
+>;
+export function useGQLNcmecMediaReviewPolicySuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GQLNcmecMediaReviewPolicyQuery,
+        GQLNcmecMediaReviewPolicyQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GQLNcmecMediaReviewPolicyQuery,
+    GQLNcmecMediaReviewPolicyQueryVariables
+  >(GQLNcmecMediaReviewPolicyDocument, options);
+}
+export type GQLNcmecMediaReviewPolicyQueryHookResult = ReturnType<
+  typeof useGQLNcmecMediaReviewPolicyQuery
+>;
+export type GQLNcmecMediaReviewPolicyLazyQueryHookResult = ReturnType<
+  typeof useGQLNcmecMediaReviewPolicyLazyQuery
+>;
+export type GQLNcmecMediaReviewPolicySuspenseQueryHookResult = ReturnType<
+  typeof useGQLNcmecMediaReviewPolicySuspenseQuery
+>;
+export type GQLNcmecMediaReviewPolicyQueryResult = Apollo.QueryResult<
+  GQLNcmecMediaReviewPolicyQuery,
+  GQLNcmecMediaReviewPolicyQueryVariables
+>;
 export const GQLGetMoreInfoForThreadItemsDocument = gql`
   query getMoreInfoForThreadItems($ids: [ItemIdentifierInput!]!) {
     partialItems(input: $ids) {
@@ -43137,6 +43279,8 @@ export const GQLNcmecOrgSettingsDocument = gql`
       contactPersonFirstName
       contactPersonLastName
       contactPersonPhone
+      mediaReviewRequirement
+      minMediaToReview
     }
     myOrg {
       hasNCMECReportingEnabled
@@ -44039,6 +44183,7 @@ export const namedOperations = {
     AllManualReviewQueues: 'AllManualReviewQueues',
     getLatestUserSubmittedItemsWithThreads:
       'getLatestUserSubmittedItemsWithThreads',
+    NcmecMediaReviewPolicy: 'NcmecMediaReviewPolicy',
     getMoreInfoForThreadItems: 'getMoreInfoForThreadItems',
     getMoreInfoForPartialItems: 'getMoreInfoForPartialItems',
     getExistingJobsForItem: 'getExistingJobsForItem',

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ncmec/NCMECActions.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ncmec/NCMECActions.tsx
@@ -37,7 +37,8 @@ export default function NCMECActions(props: {
   setSendReportModalVisible: (visible: boolean) => void;
   setDeselectAndIgnoreModalVisible: (visible: boolean) => void;
   isAnyMediaSelected: boolean;
-  isAllMediaSelected: boolean;
+  canSendReport: boolean;
+  sendDisabledReason: string;
   submitDecision: (input: GQLDecisionSubmission) => void;
   moveToQueueMenuVisible: boolean;
   setMoveToQueueMenuVisible: (visible: boolean) => void;
@@ -48,7 +49,8 @@ export default function NCMECActions(props: {
     setSendReportModalVisible,
     setDeselectAndIgnoreModalVisible,
     isAnyMediaSelected,
-    isAllMediaSelected,
+    canSendReport,
+    sendDisabledReason,
     submitDecision,
     moveToQueueMenuVisible,
     setMoveToQueueMenuVisible,
@@ -78,7 +80,7 @@ export default function NCMECActions(props: {
       if (disableKeyboardShortcuts) {
         return;
       }
-      if (isAllMediaSelected && event.key === 'Enter') {
+      if (canSendReport && event.key === 'Enter') {
         setSendReportModalVisible(true);
       }
     };
@@ -91,7 +93,7 @@ export default function NCMECActions(props: {
       window.removeEventListener('keydown', handleKeyPress);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isAllMediaSelected, disableKeyboardShortcuts]);
+  }, [canSendReport, disableKeyboardShortcuts]);
 
   const onMoveToDifferentQueue = useCallback(
     (newQueueId: string) => {
@@ -170,7 +172,7 @@ export default function NCMECActions(props: {
 
   const button = useCallback(
     (decision: NCMECDecisionType | SkipDecisionType) => {
-      const isDisabled = decision === 'Send' && !isAllMediaSelected;
+      const isDisabled = decision === 'Send' && !canSendReport;
       const button = (
         <div
           className={`block relative cursor-pointer p-2 rounded-md font-medium justify-center items-center px-4 h-fit border-none ${
@@ -227,7 +229,7 @@ export default function NCMECActions(props: {
       );
       return isDisabled ? (
         <Tooltip
-          title="Please make a decision on every piece of media in this job before sending a report to NCMEC."
+          title={sendDisabledReason}
           className="relative items-center justify-center block p-2 px-4 font-medium cursor-pointer rounded-md text-slate-300 bg-slate-100 h-fit"
         >
           {button}
@@ -238,7 +240,8 @@ export default function NCMECActions(props: {
     },
     [
       data?.myOrg?.mrtQueues,
-      isAllMediaSelected,
+      canSendReport,
+      sendDisabledReason,
       loading,
       moveToQueueMenuVisible,
       onClick,

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ncmec/NCMECReviewUser.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ncmec/NCMECReviewUser.tsx
@@ -21,9 +21,11 @@ import {
   GQLNcmecFileAnnotation,
   GQLNcmecIncidentType,
   GQLNcmecIndustryClassification,
+  GQLNcmecMediaReviewRequirement,
   GQLNcmecThreadInput,
   GQLThreadItem,
   useGQLGetMoreInfoForThreadItemsQuery,
+  useGQLNcmecMediaReviewPolicyQuery,
   useGQLPersonalSafetySettingsQuery,
 } from '../../../../../../graphql/generated';
 import { filterNullOrUndefined } from '../../../../../../utils/collections';
@@ -69,6 +71,15 @@ type NCMECJobPayloadQueryResult = Extract<
 
 export type NCMECMediaQueryResult =
   NCMECJobPayloadQueryResult['allMediaItems'][0];
+
+gql`
+  query NcmecMediaReviewPolicy {
+    myOrg {
+      ncmecMediaReviewRequirement
+      ncmecMinMediaToReview
+    }
+  }
+`;
 
 gql`
   query getMoreInfoForThreadItems($ids: [ItemIdentifierInput!]!) {
@@ -378,6 +389,12 @@ export default function NCMECReviewUser(
   const navigate = useNavigate();
 
   const { loading, data } = useGQLPersonalSafetySettingsQuery();
+  const { data: mediaReviewPolicyData } = useGQLNcmecMediaReviewPolicyQuery();
+  const mediaReviewRequirement =
+    mediaReviewPolicyData?.myOrg?.ncmecMediaReviewRequirement ??
+    GQLNcmecMediaReviewRequirement.All;
+  const mediaReviewMinToReview =
+    mediaReviewPolicyData?.myOrg?.ncmecMinMediaToReview ?? 1;
   const noValidMedia = (
     <div className="flex items-start justify-center w-full h-full">
       <div className="flex flex-col items-center justify-center p-12 mt-20 shadow rounded-xl bg-slate-50 text-slate-500">
@@ -873,6 +890,33 @@ export default function NCMECReviewUser(
     mediaInDetailViewItem?.__typename === 'ContentItem'
       ? getFieldValueForRole(mediaInDetailViewItem, 'threadId')
       : undefined;
+
+  // "None" counts as reviewed but not reported.
+  const reviewedCount = selectedMedia.length;
+  const reportedCount = selectedMedia.filter(
+    (media) => media.category !== 'None',
+  ).length;
+  // Cap the minimum at the job's media count so it's always achievable.
+  const effectiveMinToReview = Math.min(
+    Math.max(mediaReviewMinToReview, 1),
+    allMediaItemsWithUrls.length,
+  );
+  const reviewThresholdMet =
+    mediaReviewRequirement === GQLNcmecMediaReviewRequirement.Minimum
+      ? reviewedCount >= effectiveMinToReview
+      : reviewedCount === allMediaItemsWithUrls.length;
+  // A report can't be empty: require at least one reported item.
+  const canSendReport = reviewThresholdMet && reportedCount > 0;
+  const sendDisabledReason = !reviewThresholdMet
+    ? mediaReviewRequirement === GQLNcmecMediaReviewRequirement.Minimum
+      ? `Please review at least ${effectiveMinToReview} ${
+          effectiveMinToReview === 1 ? 'piece' : 'pieces'
+        } of media before sending a report to NCMEC.`
+      : 'Please make a decision on every piece of media in this job before sending a report to NCMEC.'
+    : reportedCount === 0
+      ? 'Select a category for at least one piece of media to include it in the report before sending to NCMEC.'
+      : '';
+
   return (
     <div
       className="flex flex-col items-start outline-none"
@@ -953,9 +997,8 @@ export default function NCMECReviewUser(
                 setDeselectAndIgnoreModalVisible
               }
               isAnyMediaSelected={selectedMedia.length > 0}
-              isAllMediaSelected={
-                selectedMedia.length === allMediaItemsWithUrls.length
-              }
+              canSendReport={canSendReport}
+              sendDisabledReason={sendDisabledReason}
               submitDecision={props.submitDecision}
               moveToQueueMenuVisible={moveToQueueMenuVisible}
               setMoveToQueueMenuVisible={setMoveToQueueMenuVisible}

--- a/client/src/webpages/settings/NCMECSettings.tsx
+++ b/client/src/webpages/settings/NCMECSettings.tsx
@@ -203,7 +203,7 @@ export default function NCMECSettings() {
     const isMinimumPolicy =
       settings.mediaReviewRequirement ===
       GQLNcmecMediaReviewRequirement.Minimum;
-    const parsedMinMedia = Number.parseInt(settings.minMediaToReview, 10);
+    const parsedMinMedia = Number(settings.minMediaToReview);
     if (
       isMinimumPolicy &&
       (!Number.isInteger(parsedMinMedia) || parsedMinMedia < 1)
@@ -499,13 +499,18 @@ export default function NCMECSettings() {
                   type="number"
                   min={1}
                   step={1}
+                  inputMode="numeric"
                   value={settings.minMediaToReview}
-                  onChange={(e) =>
-                    setSettings({
-                      ...settings,
-                      minMediaToReview: e.target.value,
-                    })
-                  }
+                  onChange={(e) => {
+                    const value = e.target.value;
+                    // Whole numbers only — fractional thresholds are invalid.
+                    if (value === '' || /^\d+$/.test(value)) {
+                      setSettings({
+                        ...settings,
+                        minMediaToReview: value,
+                      });
+                    }
+                  }}
                   placeholder="1"
                 />
                 <Text size="XS" className="text-gray-500">

--- a/client/src/webpages/settings/NCMECSettings.tsx
+++ b/client/src/webpages/settings/NCMECSettings.tsx
@@ -11,6 +11,7 @@ import {
 import { toast } from '@/coop-ui/Toast';
 import { Heading, Text } from '@/coop-ui/Typography';
 import {
+  GQLNcmecMediaReviewRequirement,
   GQLUserPermission,
   useGQLNcmecOrgSettingsQuery,
   useGQLUpdateNcmecOrgSettingsMutation,
@@ -45,6 +46,8 @@ gql`
       contactPersonFirstName
       contactPersonLastName
       contactPersonPhone
+      mediaReviewRequirement
+      minMediaToReview
     }
     myOrg {
       hasNCMECReportingEnabled
@@ -78,6 +81,8 @@ type NcmecSettings = {
   contactPersonFirstName: string;
   contactPersonLastName: string;
   contactPersonPhone: string;
+  mediaReviewRequirement: GQLNcmecMediaReviewRequirement;
+  minMediaToReview: string;
 };
 
 export default function NCMECSettings() {
@@ -97,9 +102,13 @@ export default function NCMECSettings() {
     contactPersonFirstName: '',
     contactPersonLastName: '',
     contactPersonPhone: '',
+    mediaReviewRequirement: GQLNcmecMediaReviewRequirement.All,
+    minMediaToReview: '1',
   });
 
-  const { loading, error, data } = useGQLNcmecOrgSettingsQuery({ errorPolicy: 'all' });
+  const { loading, error, data } = useGQLNcmecOrgSettingsQuery({
+    errorPolicy: 'all',
+  });
 
   const [updateSettings, { loading: isUpdateLoading }] =
     useGQLUpdateNcmecOrgSettingsMutation({
@@ -136,6 +145,10 @@ export default function NCMECSettings() {
         contactPersonLastName:
           data.ncmecOrgSettings.contactPersonLastName ?? '',
         contactPersonPhone: data.ncmecOrgSettings.contactPersonPhone ?? '',
+        mediaReviewRequirement:
+          data.ncmecOrgSettings.mediaReviewRequirement ??
+          GQLNcmecMediaReviewRequirement.All,
+        minMediaToReview: String(data.ncmecOrgSettings.minMediaToReview ?? 1),
       });
     }
   }, [data?.ncmecOrgSettings]);
@@ -145,7 +158,10 @@ export default function NCMECSettings() {
   }
 
   const permissions = data?.me?.permissions;
-  if (!permissions || !userHasPermissions(permissions, [GQLUserPermission.ManageOrg])) {
+  if (
+    !permissions ||
+    !userHasPermissions(permissions, [GQLUserPermission.ManageOrg])
+  ) {
     return <Navigate to="/dashboard/settings" replace />;
   }
 
@@ -184,6 +200,20 @@ export default function NCMECSettings() {
       return;
     }
 
+    const isMinimumPolicy =
+      settings.mediaReviewRequirement ===
+      GQLNcmecMediaReviewRequirement.Minimum;
+    const parsedMinMedia = Number.parseInt(settings.minMediaToReview, 10);
+    if (
+      isMinimumPolicy &&
+      (!Number.isInteger(parsedMinMedia) || parsedMinMedia < 1)
+    ) {
+      toast.error(
+        'Minimum media to review must be a whole number of at least 1.',
+      );
+      return;
+    }
+
     updateSettings({
       variables: {
         input: {
@@ -205,6 +235,8 @@ export default function NCMECSettings() {
           contactPersonFirstName: settings.contactPersonFirstName || null,
           contactPersonLastName: settings.contactPersonLastName || null,
           contactPersonPhone: settings.contactPersonPhone || null,
+          mediaReviewRequirement: settings.mediaReviewRequirement,
+          minMediaToReview: isMinimumPolicy ? parsedMinMedia : null,
         },
       },
     });
@@ -414,6 +446,74 @@ export default function NCMECSettings() {
               }
               placeholder="Phone"
             />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label
+              htmlFor="mediaReviewRequirement"
+              className="text-sm font-medium"
+            >
+              Media review requirement
+            </Label>
+            <Select
+              value={settings.mediaReviewRequirement}
+              onValueChange={(value) =>
+                setSettings({
+                  ...settings,
+                  mediaReviewRequirement:
+                    value as GQLNcmecMediaReviewRequirement,
+                })
+              }
+            >
+              <SelectTrigger id="mediaReviewRequirement">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={GQLNcmecMediaReviewRequirement.All}>
+                  Review all media before reporting
+                </SelectItem>
+                <SelectItem value={GQLNcmecMediaReviewRequirement.Minimum}>
+                  Require a minimum number of reviewed media
+                </SelectItem>
+              </SelectContent>
+            </Select>
+            <Text size="XS" className="text-gray-500">
+              Controls how much media a reviewer must classify before they can
+              send an NCMEC report. &quot;Review all media&quot; requires a
+              decision on every item on the account (which can be hundreds);
+              &quot;minimum&quot; only requires the number below, so reviewers
+              can report the relevant media without classifying everything.
+            </Text>
+            {settings.mediaReviewRequirement ===
+            GQLNcmecMediaReviewRequirement.Minimum ? (
+              <div className="flex flex-col gap-2">
+                <Label
+                  htmlFor="minMediaToReview"
+                  className="text-sm font-medium"
+                >
+                  Minimum media to review{' '}
+                  <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="minMediaToReview"
+                  type="number"
+                  min={1}
+                  step={1}
+                  value={settings.minMediaToReview}
+                  onChange={(e) =>
+                    setSettings({
+                      ...settings,
+                      minMediaToReview: e.target.value,
+                    })
+                  }
+                  placeholder="1"
+                />
+                <Text size="XS" className="text-gray-500">
+                  Reviewers must classify at least this many media items (and
+                  report at least one) before they can submit the report.
+                </Text>
+              </div>
+            ) : null}
           </div>
 
           <div className="flex flex-col gap-2">

--- a/db/src/scripts/api-server-pg/2026.06.03T04.19.05.add_media_review_requirement_to_ncmec_org_settings.sql
+++ b/db/src/scripts/api-server-pg/2026.06.03T04.19.05.add_media_review_requirement_to_ncmec_org_settings.sql
@@ -1,0 +1,26 @@
+-- Lets orgs control how much media a reviewer must classify before an NCMEC
+-- report can be sent. 'ALL' (default) keeps the existing behaviour where every
+-- piece of media on the account must be reviewed; 'MINIMUM' only requires
+-- `min_media_to_review` items to be reviewed, so reviewers no longer have to
+-- classify hundreds of items to submit a report.
+ALTER TABLE ncmec_reporting.ncmec_org_settings
+  ADD COLUMN IF NOT EXISTS media_review_requirement character varying(16) NOT NULL DEFAULT 'ALL';
+
+ALTER TABLE ncmec_reporting.ncmec_org_settings
+  ADD CONSTRAINT ncmec_org_settings_media_review_requirement_check
+  CHECK (media_review_requirement IN ('ALL', 'MINIMUM'));
+
+ALTER TABLE ncmec_reporting.ncmec_org_settings
+  ADD COLUMN IF NOT EXISTS min_media_to_review integer NULL;
+
+-- Guard against non-positive thresholds; NULL is allowed (only meaningful when
+-- media_review_requirement = 'MINIMUM', where the app falls back to 1).
+ALTER TABLE ncmec_reporting.ncmec_org_settings
+  ADD CONSTRAINT ncmec_org_settings_min_media_to_review_check
+  CHECK (min_media_to_review IS NULL OR min_media_to_review >= 1);
+
+COMMENT ON COLUMN ncmec_reporting.ncmec_org_settings.media_review_requirement IS
+  'How much media must be reviewed before an NCMEC report can be sent: ALL (every item) or MINIMUM (at least min_media_to_review items).';
+
+COMMENT ON COLUMN ncmec_reporting.ncmec_org_settings.min_media_to_review IS
+  'Minimum number of media items a reviewer must classify before sending a report when media_review_requirement = MINIMUM. NULL falls back to 1.';

--- a/docs/user/child-safety.md
+++ b/docs/user/child-safety.md
@@ -89,7 +89,14 @@ Apply one or more labels to individual media items to provide NCMEC with additio
 
 ### Submitting the CyberTip
 
-Once you have classified all media and selected the incident type, select **Submit to NCMEC**. Coop builds and submits the CyberTip automatically, including fetching enriched metadata, uploading media files, and finalizing the report with NCMEC. See [CyberTip Submission Flow](../integrations/ncmec.md#cybertip-submission-flow) for the technical details.
+Once you have reviewed the required amount of media and selected the incident type, select **Submit to NCMEC**. Coop builds and submits the CyberTip automatically, including fetching enriched metadata, uploading media files, and finalizing the report with NCMEC. See [CyberTip Submission Flow](../integrations/ncmec.md#cybertip-submission-flow) for the technical details.
+
+How much media you must review before sending is controlled by the **Media review requirement** org setting (Settings → NCMEC Settings):
+
+- **Review all media** (default): you must make a decision on every piece of media on the account before sending. This is the original behavior.
+- **Require a minimum number of reviewed media**: you only need to classify the configured minimum number of items. This avoids having to review hundreds of items just to report the relevant ones.
+
+In both cases at least one piece of media must be classified with a reporting category (not `None`) for the report to be sent.
 
 ## Viewing submitted reports
 

--- a/server/graphql/generated.ts
+++ b/server/graphql/generated.ts
@@ -3035,6 +3035,19 @@ export type GQLNcmecMediaInput = {
   readonly url: Scalars['String']['input'];
 };
 
+/**
+ * How much media a reviewer must classify before an NCMEC report can be sent.
+ * ALL requires every piece of media on the account to be reviewed (the original
+ * behaviour); MINIMUM only requires `minMediaToReview` items, so reviewers
+ * don't have to classify hundreds of items to submit a report.
+ */
+export const GQLNcmecMediaReviewRequirement = {
+  All: 'ALL',
+  Minimum: 'MINIMUM',
+} as const;
+
+export type GQLNcmecMediaReviewRequirement =
+  (typeof GQLNcmecMediaReviewRequirement)[keyof typeof GQLNcmecMediaReviewRequirement];
 export type GQLNcmecOrgSettings = {
   readonly __typename?: 'NcmecOrgSettings';
   readonly companyTemplate?: Maybe<Scalars['String']['output']>;
@@ -3046,6 +3059,8 @@ export type GQLNcmecOrgSettings = {
   readonly defaultInternetDetailType?: Maybe<GQLNcmecInternetDetailType>;
   readonly defaultNcmecQueueId?: Maybe<Scalars['String']['output']>;
   readonly legalUrl?: Maybe<Scalars['String']['output']>;
+  readonly mediaReviewRequirement?: Maybe<GQLNcmecMediaReviewRequirement>;
+  readonly minMediaToReview?: Maybe<Scalars['Int']['output']>;
   readonly moreInfoUrl?: Maybe<Scalars['String']['output']>;
   readonly ncmecAdditionalInfoEndpoint?: Maybe<Scalars['String']['output']>;
   readonly ncmecPreservationEndpoint?: Maybe<Scalars['String']['output']>;
@@ -3064,6 +3079,8 @@ export type GQLNcmecOrgSettingsInput = {
   readonly defaultInternetDetailType?: InputMaybe<GQLNcmecInternetDetailType>;
   readonly defaultNcmecQueueId?: InputMaybe<Scalars['String']['input']>;
   readonly legalUrl?: InputMaybe<Scalars['String']['input']>;
+  readonly mediaReviewRequirement?: InputMaybe<GQLNcmecMediaReviewRequirement>;
+  readonly minMediaToReview?: InputMaybe<Scalars['Int']['input']>;
   readonly moreInfoUrl?: InputMaybe<Scalars['String']['input']>;
   readonly ncmecAdditionalInfoEndpoint?: InputMaybe<Scalars['String']['input']>;
   readonly ncmecPreservationEndpoint?: InputMaybe<Scalars['String']['input']>;
@@ -3164,6 +3181,17 @@ export type GQLOrg = {
   readonly itemTypes: ReadonlyArray<GQLItemType>;
   readonly mrtQueues: ReadonlyArray<GQLManualReviewQueue>;
   readonly name: Scalars['String']['output'];
+  /**
+   * How much media a reviewer must classify before they can send an NCMEC
+   * report for this org. Readable by any org member (not just MANAGE_ORG) so the
+   * NCMEC review UI can enforce the policy. Defaults to ALL when unset.
+   */
+  readonly ncmecMediaReviewRequirement: GQLNcmecMediaReviewRequirement;
+  /**
+   * Minimum number of media items that must be reviewed before sending an NCMEC
+   * report when ncmecMediaReviewRequirement is MINIMUM. Defaults to 1.
+   */
+  readonly ncmecMinMediaToReview: Scalars['Int']['output'];
   readonly ncmecReports: ReadonlyArray<GQLNcmecReport>;
   readonly onCallAlertEmail?: Maybe<Scalars['String']['output']>;
   readonly pendingInvites: ReadonlyArray<GQLPendingInvite>;
@@ -6078,6 +6106,7 @@ export type GQLResolversTypes = {
   NcmecInternetDetailType: GQLNcmecInternetDetailType;
   NcmecManualReviewJobPayload: ResolverTypeWrapper<NcmecManualReviewJobPayload>;
   NcmecMediaInput: GQLNcmecMediaInput;
+  NcmecMediaReviewRequirement: GQLNcmecMediaReviewRequirement;
   NcmecOrgSettings: ResolverTypeWrapper<GQLNcmecOrgSettings>;
   NcmecOrgSettingsInput: GQLNcmecOrgSettingsInput;
   NcmecReportedMediaDetails: ResolverTypeWrapper<GQLNcmecReportedMediaDetails>;
@@ -11373,6 +11402,16 @@ export type GQLNcmecOrgSettingsResolvers<
     ParentType,
     ContextType
   >;
+  mediaReviewRequirement?: Resolver<
+    Maybe<GQLResolversTypes['NcmecMediaReviewRequirement']>,
+    ParentType,
+    ContextType
+  >;
+  minMediaToReview?: Resolver<
+    Maybe<GQLResolversTypes['Int']>,
+    ParentType,
+    ContextType
+  >;
   moreInfoUrl?: Resolver<
     Maybe<GQLResolversTypes['String']>,
     ParentType,
@@ -11603,6 +11642,16 @@ export type GQLOrgResolvers<
     ContextType
   >;
   name?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  ncmecMediaReviewRequirement?: Resolver<
+    GQLResolversTypes['NcmecMediaReviewRequirement'],
+    ParentType,
+    ContextType
+  >;
+  ncmecMinMediaToReview?: Resolver<
+    GQLResolversTypes['Int'],
+    ParentType,
+    ContextType
+  >;
   ncmecReports?: Resolver<
     ReadonlyArray<GQLResolversTypes['NCMECReport']>,
     ParentType,

--- a/server/graphql/modules/ncmec.resolver.test.ts
+++ b/server/graphql/modules/ncmec.resolver.test.ts
@@ -1,0 +1,122 @@
+import { UserPermission } from '../../services/userManagementService/index.js';
+import { resolvers } from './ncmec.js';
+
+const Mutation = resolvers.Mutation as {
+  updateNcmecOrgSettings: (
+    parent: unknown,
+    args: { input: Record<string, unknown> },
+    ctx: unknown,
+  ) => Promise<unknown>;
+};
+
+const VALID_INPUT = {
+  username: 'cyber-user',
+  password: 'cyber-pass',
+  contactEmail: 'reporter@example.com',
+};
+
+function makeCtx(permissions: readonly UserPermission[]) {
+  const updateNcmecOrgSettings = jest.fn(async () => undefined);
+  const ctx = {
+    getUser: () => ({
+      id: 'user-1',
+      orgId: 'org-1',
+      getPermissions: () => permissions,
+    }),
+    services: { NcmecService: { updateNcmecOrgSettings } },
+  };
+  return { ctx, updateNcmecOrgSettings };
+}
+
+describe('updateNcmecOrgSettings media review policy', () => {
+  it('defaults to ALL and drops any supplied threshold', async () => {
+    const { ctx, updateNcmecOrgSettings } = makeCtx([
+      UserPermission.MANAGE_ORG,
+    ]);
+    await Mutation.updateNcmecOrgSettings(
+      {},
+      { input: { ...VALID_INPUT, minMediaToReview: 5 } },
+      ctx,
+    );
+    expect(updateNcmecOrgSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mediaReviewRequirement: 'ALL',
+        minMediaToReview: null,
+      }),
+    );
+  });
+
+  it('persists the threshold when requirement is MINIMUM', async () => {
+    const { ctx, updateNcmecOrgSettings } = makeCtx([
+      UserPermission.MANAGE_ORG,
+    ]);
+    await Mutation.updateNcmecOrgSettings(
+      {},
+      {
+        input: {
+          ...VALID_INPUT,
+          mediaReviewRequirement: 'MINIMUM',
+          minMediaToReview: 3,
+        },
+      },
+      ctx,
+    );
+    expect(updateNcmecOrgSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mediaReviewRequirement: 'MINIMUM',
+        minMediaToReview: 3,
+      }),
+    );
+  });
+
+  it('defaults MINIMUM threshold to 1 when omitted', async () => {
+    const { ctx, updateNcmecOrgSettings } = makeCtx([
+      UserPermission.MANAGE_ORG,
+    ]);
+    await Mutation.updateNcmecOrgSettings(
+      {},
+      { input: { ...VALID_INPUT, mediaReviewRequirement: 'MINIMUM' } },
+      ctx,
+    );
+    expect(updateNcmecOrgSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mediaReviewRequirement: 'MINIMUM',
+        minMediaToReview: 1,
+      }),
+    );
+  });
+
+  it('rejects a non-positive MINIMUM threshold', async () => {
+    const { ctx, updateNcmecOrgSettings } = makeCtx([
+      UserPermission.MANAGE_ORG,
+    ]);
+    await expect(
+      Mutation.updateNcmecOrgSettings(
+        {},
+        {
+          input: {
+            ...VALID_INPUT,
+            mediaReviewRequirement: 'MINIMUM',
+            minMediaToReview: 0,
+          },
+        },
+        ctx,
+      ),
+    ).rejects.toThrow('minMediaToReview');
+    expect(updateNcmecOrgSettings).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown requirement value', async () => {
+    const { ctx, updateNcmecOrgSettings } = makeCtx([
+      UserPermission.MANAGE_ORG,
+    ]);
+    await expect(
+      Mutation.updateNcmecOrgSettings(
+        {},
+        { input: { ...VALID_INPUT, mediaReviewRequirement: 'SOME' } },
+        ctx,
+      ),
+    ).rejects.toThrow('mediaReviewRequirement');
+    expect(updateNcmecOrgSettings).not.toHaveBeenCalled();
+  });
+});

--- a/server/graphql/modules/ncmec.resolver.test.ts
+++ b/server/graphql/modules/ncmec.resolver.test.ts
@@ -106,6 +106,26 @@ describe('updateNcmecOrgSettings media review policy', () => {
     expect(updateNcmecOrgSettings).not.toHaveBeenCalled();
   });
 
+  it('rejects a fractional MINIMUM threshold', async () => {
+    const { ctx, updateNcmecOrgSettings } = makeCtx([
+      UserPermission.MANAGE_ORG,
+    ]);
+    await expect(
+      Mutation.updateNcmecOrgSettings(
+        {},
+        {
+          input: {
+            ...VALID_INPUT,
+            mediaReviewRequirement: 'MINIMUM',
+            minMediaToReview: 1.5,
+          },
+        },
+        ctx,
+      ),
+    ).rejects.toThrow('minMediaToReview');
+    expect(updateNcmecOrgSettings).not.toHaveBeenCalled();
+  });
+
   it('rejects an unknown requirement value', async () => {
     const { ctx, updateNcmecOrgSettings } = makeCtx([
       UserPermission.MANAGE_ORG,

--- a/server/graphql/modules/ncmec.ts
+++ b/server/graphql/modules/ncmec.ts
@@ -10,43 +10,12 @@ import {
   unauthenticatedError,
   userInputError,
 } from '../utils/errors.js';
-
-/** Input shape for updateNcmecOrgSettings; matches NcmecOrgSettingsInput in schema (used so resolver type-checks even if generated types are stale). */
-type NcmecOrgSettingsInputShape = {
-  username: string;
-  password: string;
-  contactEmail?: string | null;
-  moreInfoUrl?: string | null;
-  companyTemplate?: string | null;
-  legalUrl?: string | null;
-  ncmecPreservationEndpoint?: string | null;
-  ncmecAdditionalInfoEndpoint?: string | null;
-  defaultNcmecQueueId?: string | null;
-  defaultInternetDetailType?: string | null;
-  termsOfService?: string | null;
-  contactPersonEmail?: string | null;
-  contactPersonFirstName?: string | null;
-  contactPersonLastName?: string | null;
-  contactPersonPhone?: string | null;
-};
-
-const VALID_NCMEC_INTERNET_DETAIL_TYPES: readonly string[] = [
-  'WEB_PAGE',
-  'EMAIL',
-  'NEWSGROUP',
-  'CHAT_IM',
-  'ONLINE_GAMING',
-  'CELL_PHONE',
-  'NON_INTERNET',
-  'PEER_TO_PEER',
-];
-
-const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-const MAX_EMAIL_LENGTH = 254;
-
-function isValidContactEmail(value: string): boolean {
-  return value.length <= MAX_EMAIL_LENGTH && EMAIL_PATTERN.test(value);
-}
+import {
+  isValidContactEmail,
+  parseInternetDetailType,
+  parseMediaReviewPolicy,
+  type NcmecOrgSettingsInputShape,
+} from './ncmecOrgSettingsValidation.js';
 
 const typeDefs = /* GraphQL */ `
   type Query {
@@ -81,6 +50,17 @@ const typeDefs = /* GraphQL */ `
     PEER_TO_PEER
   }
 
+  """
+  How much media a reviewer must classify before an NCMEC report can be sent.
+  ALL requires every piece of media on the account to be reviewed (the original
+  behaviour); MINIMUM only requires \`minMediaToReview\` items, so reviewers
+  don't have to classify hundreds of items to submit a report.
+  """
+  enum NcmecMediaReviewRequirement {
+    ALL
+    MINIMUM
+  }
+
   type NcmecOrgSettings {
     username: String!
     password: String!
@@ -97,6 +77,8 @@ const typeDefs = /* GraphQL */ `
     contactPersonFirstName: String
     contactPersonLastName: String
     contactPersonPhone: String
+    mediaReviewRequirement: NcmecMediaReviewRequirement
+    minMediaToReview: Int
   }
 
   input NcmecOrgSettingsInput {
@@ -115,6 +97,8 @@ const typeDefs = /* GraphQL */ `
     contactPersonFirstName: String
     contactPersonLastName: String
     contactPersonPhone: String
+    mediaReviewRequirement: NcmecMediaReviewRequirement
+    minMediaToReview: Int
   }
 
   type UpdateNcmecOrgSettingsResponse {
@@ -360,21 +344,11 @@ const Mutation: GQLMutationResolvers = {
       );
     }
 
-    const defaultInternetDetailType =
-      input.defaultInternetDetailType == null
-        ? null
-        : (() => {
-            const trimmed = String(input.defaultInternetDetailType).trim();
-            if (
-              trimmed !== '' &&
-              !VALID_NCMEC_INTERNET_DETAIL_TYPES.includes(trimmed)
-            ) {
-              throw userInputError(
-                `defaultInternetDetailType must be one of: ${VALID_NCMEC_INTERNET_DETAIL_TYPES.join(', ')}`,
-              );
-            }
-            return trimmed === '' ? null : trimmed;
-          })();
+    const defaultInternetDetailType = parseInternetDetailType(input);
+
+    const { mediaReviewRequirement, minMediaToReview } =
+      parseMediaReviewPolicy(input);
+
     await context.services.NcmecService.updateNcmecOrgSettings({
       orgId: user.orgId,
       username,
@@ -392,6 +366,8 @@ const Mutation: GQLMutationResolvers = {
       contactPersonFirstName: input.contactPersonFirstName ?? null,
       contactPersonLastName: input.contactPersonLastName ?? null,
       contactPersonPhone: input.contactPersonPhone ?? null,
+      mediaReviewRequirement,
+      minMediaToReview,
     });
 
     return { success: true };

--- a/server/graphql/modules/ncmecOrgSettingsValidation.ts
+++ b/server/graphql/modules/ncmecOrgSettingsValidation.ts
@@ -1,0 +1,101 @@
+import { userInputError } from '../utils/errors.js';
+
+/** Input shape for updateNcmecOrgSettings; mirrors NcmecOrgSettingsInput so the
+ * resolver type-checks even when generated types are stale. */
+export type NcmecOrgSettingsInputShape = {
+  username: string;
+  password: string;
+  contactEmail?: string | null;
+  moreInfoUrl?: string | null;
+  companyTemplate?: string | null;
+  legalUrl?: string | null;
+  ncmecPreservationEndpoint?: string | null;
+  ncmecAdditionalInfoEndpoint?: string | null;
+  defaultNcmecQueueId?: string | null;
+  defaultInternetDetailType?: string | null;
+  termsOfService?: string | null;
+  contactPersonEmail?: string | null;
+  contactPersonFirstName?: string | null;
+  contactPersonLastName?: string | null;
+  contactPersonPhone?: string | null;
+  mediaReviewRequirement?: string | null;
+  minMediaToReview?: number | null;
+};
+
+const VALID_NCMEC_MEDIA_REVIEW_REQUIREMENTS = ['ALL', 'MINIMUM'] as const;
+export type NcmecMediaReviewRequirement =
+  (typeof VALID_NCMEC_MEDIA_REVIEW_REQUIREMENTS)[number];
+
+function isNcmecMediaReviewRequirement(
+  value: string,
+): value is NcmecMediaReviewRequirement {
+  return (VALID_NCMEC_MEDIA_REVIEW_REQUIREMENTS as readonly string[]).includes(
+    value,
+  );
+}
+
+const VALID_NCMEC_INTERNET_DETAIL_TYPES: readonly string[] = [
+  'WEB_PAGE',
+  'EMAIL',
+  'NEWSGROUP',
+  'CHAT_IM',
+  'ONLINE_GAMING',
+  'CELL_PHONE',
+  'NON_INTERNET',
+  'PEER_TO_PEER',
+];
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MAX_EMAIL_LENGTH = 254;
+
+export function isValidContactEmail(value: string): boolean {
+  return value.length <= MAX_EMAIL_LENGTH && EMAIL_PATTERN.test(value);
+}
+
+/** Returns the trimmed detail type or null, throwing when a non-empty value is
+ * not in the allowlist. */
+export function parseInternetDetailType(
+  input: NcmecOrgSettingsInputShape,
+): string | null {
+  if (input.defaultInternetDetailType == null) {
+    return null;
+  }
+  const trimmed = String(input.defaultInternetDetailType).trim();
+  if (trimmed === '') {
+    return null;
+  }
+  if (!VALID_NCMEC_INTERNET_DETAIL_TYPES.includes(trimmed)) {
+    throw userInputError(
+      `defaultInternetDetailType must be one of: ${VALID_NCMEC_INTERNET_DETAIL_TYPES.join(', ')}`,
+    );
+  }
+  return trimmed;
+}
+
+/** Normalises the media-review policy for storage. ALL discards any supplied
+ * threshold so stale values don't linger; MINIMUM requires a whole number >= 1
+ * (defaulting to 1 when omitted). */
+export function parseMediaReviewPolicy(input: NcmecOrgSettingsInputShape): {
+  mediaReviewRequirement: NcmecMediaReviewRequirement;
+  minMediaToReview: number | null;
+} {
+  if (input.mediaReviewRequirement == null) {
+    return { mediaReviewRequirement: 'ALL', minMediaToReview: null };
+  }
+  const requirement = String(input.mediaReviewRequirement).trim();
+  if (!isNcmecMediaReviewRequirement(requirement)) {
+    throw userInputError(
+      `mediaReviewRequirement must be one of: ${VALID_NCMEC_MEDIA_REVIEW_REQUIREMENTS.join(', ')}`,
+    );
+  }
+  if (requirement === 'ALL') {
+    return { mediaReviewRequirement: 'ALL', minMediaToReview: null };
+  }
+  const minMediaToReview = input.minMediaToReview ?? 1;
+  if (!Number.isInteger(minMediaToReview) || minMediaToReview < 1) {
+    throw userInputError(
+      'minMediaToReview must be a whole number greater than or equal to 1.',
+    );
+  }
+  return { mediaReviewRequirement: requirement, minMediaToReview };
+}

--- a/server/graphql/modules/org.ts
+++ b/server/graphql/modules/org.ts
@@ -44,6 +44,17 @@ const typeDefs = /* GraphQL */ `
     integrationConfigs: [IntegrationConfig!]!
     hasReportingRulesEnabled: Boolean!
     hasNCMECReportingEnabled: Boolean!
+    """
+    How much media a reviewer must classify before they can send an NCMEC
+    report for this org. Readable by any org member (not just MANAGE_ORG) so the
+    NCMEC review UI can enforce the policy. Defaults to ALL when unset.
+    """
+    ncmecMediaReviewRequirement: NcmecMediaReviewRequirement!
+    """
+    Minimum number of media items that must be reviewed before sending an NCMEC
+    report when ncmecMediaReviewRequirement is MINIMUM. Defaults to 1.
+    """
+    ncmecMinMediaToReview: Int!
     hasAppealsEnabled: Boolean!
     ncmecReports: [NCMECReport!]!
     """
@@ -420,6 +431,26 @@ const Org: GQLOrgResolvers = {
       throw unauthenticatedError('User required.');
     }
     return context.services.NcmecService.hasNCMECReportingEnabled(org.id);
+  },
+  async ncmecMediaReviewRequirement(org, _, context) {
+    const user = context.getUser();
+    if (!user || user.orgId !== org.id) {
+      throw unauthenticatedError('User required.');
+    }
+    const settings = await context.services.NcmecService.getNcmecOrgSettings(
+      org.id,
+    );
+    return settings?.mediaReviewRequirement === 'MINIMUM' ? 'MINIMUM' : 'ALL';
+  },
+  async ncmecMinMediaToReview(org, _, context) {
+    const user = context.getUser();
+    if (!user || user.orgId !== org.id) {
+      throw unauthenticatedError('User required.');
+    }
+    const settings = await context.services.NcmecService.getNcmecOrgSettings(
+      org.id,
+    );
+    return settings?.minMediaToReview ?? 1;
   },
   async ncmecReports(org, _, context) {
     const user = context.getUser();

--- a/server/services/ncmecService/dbTypes.ts
+++ b/server/services/ncmecService/dbTypes.ts
@@ -25,6 +25,8 @@ export type NcmecReportingServicePg = {
     contact_person_first_name?: string | null;
     contact_person_last_name?: string | null;
     contact_person_phone?: string | null;
+    media_review_requirement?: 'ALL' | 'MINIMUM';
+    min_media_to_review?: number | null;
     created_at: GeneratedAlways<Date>;
     updated_at: GeneratedAlways<Date>;
   } & (

--- a/server/services/ncmecService/ncmecService.ts
+++ b/server/services/ncmecService/ncmecService.ts
@@ -228,6 +228,8 @@ export class NcmecService {
         'contact_person_first_name as contactPersonFirstName',
         'contact_person_last_name as contactPersonLastName',
         'contact_person_phone as contactPersonPhone',
+        'media_review_requirement as mediaReviewRequirement',
+        'min_media_to_review as minMediaToReview',
       ])
       .where('org_id', '=', orgId)
       .executeTakeFirst();
@@ -252,6 +254,8 @@ export class NcmecService {
     contactPersonFirstName: string | null;
     contactPersonLastName: string | null;
     contactPersonPhone: string | null;
+    mediaReviewRequirement: 'ALL' | 'MINIMUM';
+    minMediaToReview: number | null;
   }) {
     await this.pgQuery
       .insertInto('ncmec_reporting.ncmec_org_settings')
@@ -274,6 +278,8 @@ export class NcmecService {
         contact_person_first_name: params.contactPersonFirstName ?? null,
         contact_person_last_name: params.contactPersonLastName ?? null,
         contact_person_phone: params.contactPersonPhone ?? null,
+        media_review_requirement: params.mediaReviewRequirement,
+        min_media_to_review: params.minMediaToReview ?? null,
         actions_to_run_upon_report_creation: null,
         policies_applied_to_actions_run_on_report_creation: null,
       })
@@ -297,6 +303,8 @@ export class NcmecService {
           contact_person_first_name: params.contactPersonFirstName ?? null,
           contact_person_last_name: params.contactPersonLastName ?? null,
           contact_person_phone: params.contactPersonPhone ?? null,
+          media_review_requirement: params.mediaReviewRequirement,
+          min_media_to_review: params.minMediaToReview ?? null,
         }),
       )
       .execute();


### PR DESCRIPTION
Fixes #517

## Context & Requests for Reviewers

Adds an org-level policy for how much media a reviewer must classify before they can send an NCMEC CyberTip.

- **Review all media** (default): existing behavior — every piece of media on the account must get a decision before Send is enabled.
- **Require a minimum number of reviewed media**: Send is enabled after the configured minimum is reviewed, so reviewers aren’t blocked by hundreds of unrelated items on the same account.
In both modes, at least one piece of media must be classified with a reporting category (not `None`) before a report can be sent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can configure NCMEC "Media review requirement" (All vs Minimum) and a minimum count; reviewer UI now enables/disables the Send action based on that policy and shows a contextual tooltip. Keyboard shortcut behavior updated to respect the policy.

* **Documentation**
  * User guide updated to explain the two media-review modes and report eligibility.

* **Tests**
  * Added tests covering media-review policy validation and defaults.

* **Chores**
  * Database migration to store the new org settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->