### PR TITLE
test: migrate rule-change integ test to makeKyselyTransactionWithRetry

### DIFF
--- a/server/test/integ/rule-change.integ.test.ts
+++ b/server/test/integ/rule-change.integ.test.ts
@@ -37,6 +37,7 @@ import {
 } from '../../services/moderationConfigService/index.js';
 import { SignalType } from '../../services/signalsService/index.js';
 import { jsonStringify } from '../../utils/encoding.js';
+import { makeKyselyTransactionWithRetry } from '../../utils/kyselyTransactionWithRetry.js';
 import createActions from '../fixtureHelpers/createActions.js';
 import createContentItemTypes from '../fixtureHelpers/createContentItemTypes.js';
 import createOrg from '../fixtureHelpers/createOrg.js';
@@ -250,10 +251,10 @@ describe('Rule changes take effect (integration)', () => {
       // is now stale; reads within `freshUntilAge` will still see the original
       // condition. There is no explicit invalidation on the rule-update path.
       const kysely = harness.deps.KyselyPg as Kysely<CombinedPg>;
-      await kysely
-        .transaction()
-        .setIsolationLevel('repeatable read')
-        .execute(async (trx) => {
+      const transactionWithRetry = makeKyselyTransactionWithRetry(kysely);
+      await transactionWithRetry(
+        { isolationLevel: 'repeatable read' },
+        async (trx) => {
           await kyselyUpdateRule(trx, {
             id: rule!.id,
             orgId,
@@ -272,7 +273,8 @@ describe('Rule changes take effect (integration)', () => {
             policyIds: undefined,
             contentTypeIds: undefined,
           });
-        });
+        },
+      );
 
       // Wait past the cache TTL so the next read refetches and sees the update.
       await new Promise((r) => setTimeout(r, RULES_CACHE_REFRESH_BUFFER_MS));


### PR DESCRIPTION
## Summary

`server/test/integ/rule-change.integ.test.ts:253-275` calls `kysely.transaction().setIsolationLevel('repeatable read').execute(...)` directly. The lint rule added in #436 (`no-restricted-syntax`) mandates `makeKyselyTransactionWithRetry`. The rule-change test was authored in #637 before the wrapper grew `setIsolationLevel` support, so the original direct call couldn't have used the wrapper — but the wrapper has supported it since #436, and the test never migrated.

Result: every PR branching from main currently fails `check_api_server` on this single line. #636 and #710 are both blocked on it right now.

## Change

Replace the direct `kysely.transaction()` chain with `makeKyselyTransactionWithRetry(kysely)({ isolationLevel: 'repeatable read' }, callback)`. Same semantics (repeatable-read isolation, single call site, single transaction), plus the retry-on-40001 behaviour the rule was designed to enforce.

## Test plan

- [x] `eslint test/integ/rule-change.integ.test.ts` clean.
- [x] `tsc --noEmit` clean.
- [ ] Existing rule-change integ test still passes against the local stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)