### PR TITLE
chore: switch postgres to official postgres:15.18 image

### DIFF
--- a/docker-compose.images.yaml
+++ b/docker-compose.images.yaml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: ankane/pgvector:v0.5.1
+    image: postgres:15.18
     volumes:
       - pg_data:/var/lib/postgresql/data
     healthcheck:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -58,7 +58,7 @@ services:
     volumes:
       - pg_data:/var/lib/postgresql/data
     ports:
-      - '5432:5432'
+      - '127.0.0.1:5432:5432'
     healthcheck:
       test: ['CMD', 'pg_isready', '-U', 'postgres', '-d', 'postgres']
       interval: 2s

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -54,8 +54,7 @@ services:
       - postgres
 
   postgres:
-    image: ankane/pgvector:v0.5.1
-    # image: postgres:15.3
+    image: postgres:15.18
     volumes:
       - pg_data:/var/lib/postgresql/data
     ports:

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -25,7 +25,7 @@ This starts:
 
 - **Coop server** on port 8080
 - **Coop client** (nginx) on port 3000
-- **Postgres** (pgvector), **Redis**, **ScyllaDB**, **ClickHouse**
+- **Postgres**, **Redis**, **ScyllaDB**, **ClickHouse**
 - Database migrations (run automatically)
 - A seed service that creates an admin user with a randomly generated password
 


### PR DESCRIPTION
Fixes #548 

## Context & Requests for Reviewers
Replace the unmaintained third-party `ankane/pgvector:v0.5.1` image with the official `postgres:15.18` image. Same PostgreSQL 15 version, no data migration needed — existing `pg_data` volumes are compatible.

<!-- Briefly describe the changes introduced in this pull request. Link GitHub Issue if available for context on your change. -->

## Tests

<!-- Describe how you tested your changes, including any manual steps or automated tests performed. -->
<!-- Provide screenshots if available -->

## (Optional) Rollout Plan

<!--
Are there any special things that have to be done before this can be deployed
to prod (e.g., other blocking PRs; manual load testing/validation that needs to
be done on staging; etc.)? If so, please note them here.
 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the PostgreSQL service image to a newer Postgres 15 release.
  * tightened Postgres port exposure so the database is bound to localhost by default.

* **Documentation**
  * Simplified development quick-start to reference Postgres more generally (removed explicit pgvector mention).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->