### PR TITLE
Community links and information on server startup

### DIFF
--- a/server/bin/www.ts
+++ b/server/bin/www.ts
@@ -11,6 +11,7 @@ import {
 } from '../services/integrationRegistry/index.js';
 import { logErrorJson, logJson } from '../utils/logging.js';
 import { sleep } from '../utils/misc.js';
+import { printStartupBanner } from '../utils/startupBanner.js';
 
 const { app, shutdown } = await getBottle().then(async (bottle) =>
   makeServer(bottle.container),
@@ -40,6 +41,7 @@ app.set('port', port);
 const server = http
   .createServer(app)
   .listen(port, () => {
+    printStartupBanner();
     // eslint-disable-next-line no-restricted-syntax
     logJson(`Server is running at http://localhost:${port}`);
   })

--- a/server/utils/startupBanner.ts
+++ b/server/utils/startupBanner.ts
@@ -1,0 +1,55 @@
+/* eslint-disable no-console */
+
+// A small, one-time ASCII banner printed at server startup. It is intentionally
+// only emitted to an interactive terminal (TTY) so it never clutters
+// structured/JSON logs in production or CI environments.
+
+const LOGO = [
+  '            +########++ ',
+  '              +#+    +# ',
+  '                +#+  +# ',
+  ' +#######+      +#+  +# ',
+  '   +#+   +#+   +#+   +# ',
+  '     +#+   +#+ +#    +# ',
+  '       +#+  +#+#+    +# ',
+  '         +#####+   +#+ ',
+  '          +#+ +###++   ',
+  '           +#+    +#+  ',
+  '       +++++#+++++++#+ ',
+  '       +#+   +#+   +#+ ',
+  '       +#+   +#+  +#+  ',
+  '         ++#++#++#++   ',
+  '           +###+       ',
+];
+
+const LINKS = [
+  ['ROOST', 'https://roost.tools'],
+  ['GitHub', 'https://github.com/roostorg/coop'],
+  ['Docs', 'https://roostorg.github.io/coop/latest'],
+  ['Discord', 'https://discord.gg/5Csqnw2FSQ'],
+] as const;
+
+/**
+ * Prints a compact Coop banner with project links. No-op unless stdout is an
+ * interactive terminal, so it stays out of aggregated logs.
+ */
+export function printStartupBanner(): void {
+  if (!process.stdout.isTTY) {
+    return;
+  }
+
+  const labelWidth = Math.max(...LINKS.map(([label]) => label.length));
+  const linkLines = [
+    'ROOST · Open Source Trust & Safety',
+    'Coop · Review and moderation tool',
+    '',
+    ...LINKS.map(([label, url]) => `  ${label.padEnd(labelWidth)}  ${url}`),
+  ];
+
+  const lines = LOGO.map((logoLine, i) => {
+    const text = linkLines[i] ?? '';
+    return `  ${logoLine}   ${text}`;
+  });
+
+  console.log(`\n${lines.join('\n')}\n`);
+}

--- a/server/utils/startupBanner.ts
+++ b/server/utils/startupBanner.ts
@@ -41,7 +41,7 @@ export function printStartupBanner(): void {
   const labelWidth = Math.max(...LINKS.map(([label]) => label.length));
   const linkLines = [
     'ROOST · Open Source Trust & Safety',
-    'Coop · Review and moderation tool',
+    'Coop · Review and enforcement tool',
     '',
     ...LINKS.map(([label, url]) => `  ${label.padEnd(labelWidth)}  ${url}`),
   ];


### PR DESCRIPTION
## Context & Requests for Reviewers

Add simple community links and logo on server startup to help everyone to quickly find community links as they spin up server. 

<img width="561" height="233" alt="Screenshot 2026-06-08 at 1 53 16 PM" src="https://github.com/user-attachments/assets/ff3e406b-071d-42d5-980d-125d3231b516" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a startup banner that displays server initialization information and project links in interactive terminal environments, providing visual feedback when the service launches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->