### PR TITLE
client: stop rendering User Score in MRT and Investigation (part 1 of #596)

### DIFF
--- a/client/src/graphql/generated.ts
+++ b/client/src/graphql/generated.ts
@@ -7030,7 +7030,6 @@ export type GQLGetItemsWithIdQuery = {
           readonly data: JsonObject;
           readonly submissionId: string;
           readonly submissionTime?: Date | string | null;
-          readonly userScore: number;
           readonly type: {
             readonly __typename: 'UserItemType';
             readonly id: string;
@@ -8160,7 +8159,6 @@ export type GQLGetDecidedJobFromJobIdQuery = {
       readonly payload:
         | {
             readonly __typename: 'ContentAppealManualReviewJobPayload';
-            readonly userScore?: number | null;
             readonly appealReason?: string | null;
             readonly appealId: string;
             readonly actionsTaken: ReadonlyArray<string>;
@@ -8310,7 +8308,6 @@ export type GQLGetDecidedJobFromJobIdQuery = {
           }
         | {
             readonly __typename: 'ContentManualReviewJobPayload';
-            readonly userScore?: number | null;
             readonly reportHistory: ReadonlyArray<{
               readonly __typename: 'ReportHistoryEntry';
               readonly policyId?: string | null;
@@ -9071,7 +9068,6 @@ export type GQLGetDecidedJobFromJobIdQuery = {
           }
         | {
             readonly __typename: 'UserAppealManualReviewJobPayload';
-            readonly userScore?: number | null;
             readonly appealReason?: string | null;
             readonly appealId: string;
             readonly actionsTaken: ReadonlyArray<string>;
@@ -9220,7 +9216,6 @@ export type GQLGetDecidedJobFromJobIdQuery = {
           }
         | {
             readonly __typename: 'UserManualReviewJobPayload';
-            readonly userScore?: number | null;
             readonly reportHistory: ReadonlyArray<{
               readonly __typename: 'ReportHistoryEntry';
               readonly reportId: string;
@@ -10747,7 +10742,6 @@ export type GQLGetDecidedJobQuery = {
     readonly payload:
       | {
           readonly __typename: 'ContentAppealManualReviewJobPayload';
-          readonly userScore?: number | null;
           readonly appealReason?: string | null;
           readonly appealId: string;
           readonly actionsTaken: ReadonlyArray<string>;
@@ -10897,7 +10891,6 @@ export type GQLGetDecidedJobQuery = {
         }
       | {
           readonly __typename: 'ContentManualReviewJobPayload';
-          readonly userScore?: number | null;
           readonly reportHistory: ReadonlyArray<{
             readonly __typename: 'ReportHistoryEntry';
             readonly policyId?: string | null;
@@ -11658,7 +11651,6 @@ export type GQLGetDecidedJobQuery = {
         }
       | {
           readonly __typename: 'UserAppealManualReviewJobPayload';
-          readonly userScore?: number | null;
           readonly appealReason?: string | null;
           readonly appealId: string;
           readonly actionsTaken: ReadonlyArray<string>;
@@ -11807,7 +11799,6 @@ export type GQLGetDecidedJobQuery = {
         }
       | {
           readonly __typename: 'UserManualReviewJobPayload';
-          readonly userScore?: number | null;
           readonly reportHistory: ReadonlyArray<{
             readonly __typename: 'ReportHistoryEntry';
             readonly reportId: string;
@@ -12456,7 +12447,6 @@ export type GQLManualReviewJobInfoQuery = {
         readonly payload:
           | {
               readonly __typename: 'ContentAppealManualReviewJobPayload';
-              readonly userScore?: number | null;
               readonly appealReason?: string | null;
               readonly appealId: string;
               readonly actionsTaken: ReadonlyArray<string>;
@@ -12606,7 +12596,6 @@ export type GQLManualReviewJobInfoQuery = {
             }
           | {
               readonly __typename: 'ContentManualReviewJobPayload';
-              readonly userScore?: number | null;
               readonly reportHistory: ReadonlyArray<{
                 readonly __typename: 'ReportHistoryEntry';
                 readonly policyId?: string | null;
@@ -13367,7 +13356,6 @@ export type GQLManualReviewJobInfoQuery = {
             }
           | {
               readonly __typename: 'UserAppealManualReviewJobPayload';
-              readonly userScore?: number | null;
               readonly appealReason?: string | null;
               readonly appealId: string;
               readonly actionsTaken: ReadonlyArray<string>;
@@ -13516,7 +13504,6 @@ export type GQLManualReviewJobInfoQuery = {
             }
           | {
               readonly __typename: 'UserManualReviewJobPayload';
-              readonly userScore?: number | null;
               readonly reportHistory: ReadonlyArray<{
                 readonly __typename: 'ReportHistoryEntry';
                 readonly reportId: string;
@@ -13799,7 +13786,6 @@ export type GQLDequeueManualReviewJobMutation = {
       readonly payload:
         | {
             readonly __typename: 'ContentAppealManualReviewJobPayload';
-            readonly userScore?: number | null;
             readonly appealReason?: string | null;
             readonly appealId: string;
             readonly actionsTaken: ReadonlyArray<string>;
@@ -13949,7 +13935,6 @@ export type GQLDequeueManualReviewJobMutation = {
           }
         | {
             readonly __typename: 'ContentManualReviewJobPayload';
-            readonly userScore?: number | null;
             readonly reportHistory: ReadonlyArray<{
               readonly __typename: 'ReportHistoryEntry';
               readonly policyId?: string | null;
@@ -14710,7 +14695,6 @@ export type GQLDequeueManualReviewJobMutation = {
           }
         | {
             readonly __typename: 'UserAppealManualReviewJobPayload';
-            readonly userScore?: number | null;
             readonly appealReason?: string | null;
             readonly appealId: string;
             readonly actionsTaken: ReadonlyArray<string>;
@@ -14859,7 +14843,6 @@ export type GQLDequeueManualReviewJobMutation = {
           }
         | {
             readonly __typename: 'UserManualReviewJobPayload';
-            readonly userScore?: number | null;
             readonly reportHistory: ReadonlyArray<{
               readonly __typename: 'ReportHistoryEntry';
               readonly reportId: string;
@@ -15199,7 +15182,6 @@ export type GQLJobFieldsFragment = {
   readonly payload:
     | {
         readonly __typename: 'ContentAppealManualReviewJobPayload';
-        readonly userScore?: number | null;
         readonly appealReason?: string | null;
         readonly appealId: string;
         readonly actionsTaken: ReadonlyArray<string>;
@@ -15349,7 +15331,6 @@ export type GQLJobFieldsFragment = {
       }
     | {
         readonly __typename: 'ContentManualReviewJobPayload';
-        readonly userScore?: number | null;
         readonly reportHistory: ReadonlyArray<{
           readonly __typename: 'ReportHistoryEntry';
           readonly policyId?: string | null;
@@ -16110,7 +16091,6 @@ export type GQLJobFieldsFragment = {
       }
     | {
         readonly __typename: 'UserAppealManualReviewJobPayload';
-        readonly userScore?: number | null;
         readonly appealReason?: string | null;
         readonly appealId: string;
         readonly actionsTaken: ReadonlyArray<string>;
@@ -16259,7 +16239,6 @@ export type GQLJobFieldsFragment = {
       }
     | {
         readonly __typename: 'UserManualReviewJobPayload';
-        readonly userScore?: number | null;
         readonly reportHistory: ReadonlyArray<{
           readonly __typename: 'ReportHistoryEntry';
           readonly reportId: string;
@@ -17256,7 +17235,6 @@ export type GQLGetMoreInfoForItemsQuery = {
               readonly id: string;
               readonly submissionId: string;
               readonly data: JsonObject;
-              readonly userScore: number;
               readonly type: {
                 readonly __typename: 'UserItemType';
                 readonly id: string;
@@ -25115,7 +25093,6 @@ export const GQLJobFieldsFragmentDoc = gql`
     numTimesReported
     payload {
       ... on ContentManualReviewJobPayload {
-        userScore
         reportHistory {
           reporterId {
             id
@@ -25176,7 +25153,6 @@ export const GQLJobFieldsFragmentDoc = gql`
         }
       }
       ... on UserManualReviewJobPayload {
-        userScore
         reportHistory {
           reportId
           reporterId {
@@ -25291,7 +25267,6 @@ export const GQLJobFieldsFragmentDoc = gql`
         }
       }
       ... on ContentAppealManualReviewJobPayload {
-        userScore
         item {
           ... on ItemBase {
             ...ItemFields
@@ -25316,7 +25291,6 @@ export const GQLJobFieldsFragmentDoc = gql`
         }
       }
       ... on UserAppealManualReviewJobPayload {
-        userScore
         item {
           ... on ItemBase {
             ...ItemFields
@@ -30393,9 +30367,6 @@ export const GQLGetItemsWithIdDocument = gql`
               }
             }
           }
-        }
-        ... on UserItem {
-          userScore
         }
       }
     }
@@ -36002,7 +35973,6 @@ export const GQLGetMoreInfoForItemsDocument = gql`
               id
             }
             data
-            userScore
           }
         }
       }

--- a/client/src/webpages/dashboard/investigation/ItemInvestigation.tsx
+++ b/client/src/webpages/dashboard/investigation/ItemInvestigation.tsx
@@ -119,9 +119,6 @@ gql`
             }
           }
         }
-        ... on UserItem {
-          userScore
-        }
       }
     }
   }
@@ -422,7 +419,6 @@ export default function ItemInvestigation(props: {
                   ? (item as GQLUserItem)
                   : __throw(`User not found for item with ID ${itemId}`)
               }
-              userScore={item.userScore ?? undefined}
               unblurAllMedia={false}
               allItemTypes={(allItemTypes as GQLItemType[] | undefined) ?? []}
               allActions={allActions ?? []}

--- a/client/src/webpages/dashboard/mrt/manual_review_job/ManualReviewJobReview.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/ManualReviewJobReview.tsx
@@ -1556,7 +1556,6 @@ function ManualReviewJobReviewImpl(props: {
         return (
           <ManualReviewJobPrimaryUserComponent
             user={payload.item as GQLUserItem}
-            userScore={payload.userScore ?? undefined}
             unblurAllMedia={unblurAllMedia}
             allItemTypes={org.itemTypes as GQLItemType[]}
             allActions={filteredActions}

--- a/client/src/webpages/dashboard/mrt/manual_review_job/jobFragment.ts
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/jobFragment.ts
@@ -11,7 +11,6 @@ export const JOB_FRAGMENT = gql`
     numTimesReported
     payload {
       ... on ContentManualReviewJobPayload {
-        userScore
         reportHistory {
           reporterId {
             id
@@ -72,7 +71,6 @@ export const JOB_FRAGMENT = gql`
         }
       }
       ... on UserManualReviewJobPayload {
-        userScore
         reportHistory {
           reportId
           reporterId {
@@ -187,7 +185,6 @@ export const JOB_FRAGMENT = gql`
         }
       }
       ... on ContentAppealManualReviewJobPayload {
-        userScore
         item {
           ... on ItemBase {
             ...ItemFields
@@ -212,7 +209,6 @@ export const JOB_FRAGMENT = gql`
         }
       }
       ... on UserAppealManualReviewJobPayload {
-        userScore
         item {
           ... on ItemBase {
             ...ItemFields

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobPrimaryUserComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobPrimaryUserComponent.tsx
@@ -27,7 +27,6 @@ import { convertRelatedItemToFieldData } from './ManualReviewJobUserUtils';
 export default function ManualReviewJobPrimaryUserComponent(props: {
   user: GQLUserItem | ItemIdentifier;
   unblurAllMedia: boolean;
-  userScore: number | undefined;
   allItemTypes: readonly GQLItemType[];
   allActions: readonly Pick<
     ManualReviewJobAction,
@@ -46,7 +45,6 @@ export default function ManualReviewJobPrimaryUserComponent(props: {
   const {
     user,
     unblurAllMedia,
-    userScore,
     allItemTypes,
     allActions,
     allPolicies,
@@ -180,10 +178,11 @@ export default function ManualReviewJobPrimaryUserComponent(props: {
         </div>
         <FieldsComponent
           fields={[
-            ...convertRelatedItemToFieldData(
-              { id: user.id, typeId: user.type.id, name: 'User Score' },
-              userScore,
-            ),
+            ...convertRelatedItemToFieldData({
+              id: user.id,
+              typeId: user.type.id,
+              name: user.type.name,
+            }),
             ...fieldData,
           ]}
           itemTypeId={user.type.id}

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobRelatedUserComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobRelatedUserComponent.tsx
@@ -60,7 +60,6 @@ gql`
               id
             }
             data
-            userScore
           }
         }
       }
@@ -329,7 +328,7 @@ export default function ManualReviewJobRelatedUserComponent(props: {
           <div className="flex justify-start w-full">
             <FieldsComponent
               fields={[
-                ...convertRelatedItemToFieldData(user, userItem?.userScore),
+                ...convertRelatedItemToFieldData(user),
                 ...(userSubmissionItems ?? []),
               ]}
               itemTypeId={user.typeId}

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobUserUtils.ts
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobUserUtils.ts
@@ -5,18 +5,8 @@ import omit from 'lodash/omit';
 const createFieldType = (name: string, type: ScalarType) =>
   ({ name, type, required: false, container: null }) satisfies Field;
 
-export const convertRelatedItemToFieldData = (
-  relatedItem: RelatedItem,
-  userScore?: number,
-) =>
-  [
-    ...Object.entries(omit(relatedItem, ['name', 'typeId'])).map(
-      ([key, value]) => ({
-        ...createFieldType(key, 'STRING'),
-        value,
-      }),
-    ),
-    userScore
-      ? { ...createFieldType('User Score', 'NUMBER'), value: userScore }
-      : {},
-  ] as ItemTypeFieldFieldData[];
+export const convertRelatedItemToFieldData = (relatedItem: RelatedItem) =>
+  Object.entries(omit(relatedItem, ['name', 'typeId'])).map(([key, value]) => ({
+    ...createFieldType(key, 'STRING'),
+    value,
+  })) as ItemTypeFieldFieldData[];


### PR DESCRIPTION
## Summary

User Strikes covers the workflow User Score was built for, with explainable per-policy scoring. Stop rendering User Score in the Review Console user panel and the Investigation page.

## Scope (UI only)

This is part 1 of two PRs that close #596. Backend stays in place since removing it would break adopter API consumers and any existing rules that reference the `USER_SCORE` signal.

Removed:
- `userScore` selection on `NcmecManualReviewJobPayload`, `ContentManualReviewJobPayload`, `UserManualReviewJobPayload`, `ContentAppealManualReviewJobPayload` in `jobFragment.ts`.
- `userScore` prop on `ManualReviewJobPrimaryUserComponent` and the corresponding `userScore` argument to `convertRelatedItemToFieldData`.
- `userScore` selection on the `UserItem` GraphQL inline fragment in `ItemInvestigation.tsx` plus the prop pass-through.
- Regenerated `client/src/graphql/generated.ts`.

Kept (follow-up):
- `GET/POST /api/v1/user-scores` route and `docs/api/user-scores.md`.
- `USER_SCORE` signal type in `signalsService` plus the rule-form switch cases / TODOs that reference it.
- `userScore: Int` on the GraphQL `UserItem` type and the MRT payload types.
- `user_statistics_service.user_scores` table and adjacent service code.

## Test plan

- [x] `tsc --noEmit` clean (server + client).
- [ ] Manual smoke against Platform A:
  - User panel in MRT Review Console no longer shows the "User Score" field.
  - Investigation page user item no longer shows a User Score row.
  - Existing rules that reference the `USER_SCORE` signal still load in the rule form (deferred to follow-up; current behaviour preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)