### PR TITLE
Show related item's name instead of its raw ID and fix duplicate relatedItems

### DIFF
--- a/client/src/graphql/generated.ts
+++ b/client/src/graphql/generated.ts
@@ -16558,6 +16558,10 @@ export type GQLGetRelatedItemsQuery = {
               readonly valueScalarType: GQLScalarType;
             } | null;
           }>;
+          readonly schemaFieldRoles: {
+            readonly __typename: 'ContentSchemaFieldRoles';
+            readonly displayName?: string | null;
+          };
         };
       }
     | {
@@ -16582,6 +16586,10 @@ export type GQLGetRelatedItemsQuery = {
               readonly valueScalarType: GQLScalarType;
             } | null;
           }>;
+          readonly schemaFieldRoles: {
+            readonly __typename: 'ThreadSchemaFieldRoles';
+            readonly displayName?: string | null;
+          };
         };
       }
     | {
@@ -34529,6 +34537,9 @@ export const GQLGetRelatedItemsDocument = gql`
               valueScalarType
             }
           }
+          schemaFieldRoles {
+            displayName
+          }
         }
       }
       ... on ThreadItem {
@@ -34548,6 +34559,9 @@ export const GQLGetRelatedItemsDocument = gql`
               keyScalarType
               valueScalarType
             }
+          }
+          schemaFieldRoles {
+            displayName
           }
         }
       }

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ContentRelatedItemComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ContentRelatedItemComponent.tsx
@@ -52,6 +52,9 @@ gql`
               valueScalarType
             }
           }
+          schemaFieldRoles {
+            displayName
+          }
         }
       }
       ... on ThreadItem {
@@ -71,6 +74,9 @@ gql`
               keyScalarType
               valueScalarType
             }
+          }
+          schemaFieldRoles {
+            displayName
           }
         }
       }

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobFieldsComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobFieldsComponent.tsx
@@ -170,7 +170,7 @@ function TableRowComponent(props: {
         },
       ],
     },
-    skip: type !== 'RELATED_ITEM',
+    skip: type !== 'RELATED_ITEM' || value == null,
   });
 
   if (value == null) {

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobFieldsComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobFieldsComponent.tsx
@@ -16,10 +16,14 @@ import { Link } from 'react-router-dom';
 import ComponentLoading from '../../../../../components/common/ComponentLoading';
 
 import {
+  GQLContentItem,
+  GQLContentSchemaFieldRoles,
   GQLItemType,
+  GQLThreadItem,
+  GQLThreadSchemaFieldRoles,
   GQLUserItem,
   GQLUserSchemaFieldRoles,
-  useGQLGetUserItemsQuery,
+  useGQLGetRelatedItemsQuery,
   useGQLItemTypeHiddenFieldsQuery,
   useGQLPersonalSafetySettingsQuery,
 } from '../../../../../graphql/generated';
@@ -156,7 +160,7 @@ function TableRowComponent(props: {
     type === 'RELATED_ITEM' && value
       ? itemTypes.find((itemType) => itemType.id === value.typeId)?.__typename
       : undefined;
-  const { data: userItem } = useGQLGetUserItemsQuery({
+  const { data: relatedItemData } = useGQLGetRelatedItemsQuery({
     variables: {
       itemIdentifiers: [
         {
@@ -166,7 +170,7 @@ function TableRowComponent(props: {
         },
       ],
     },
-    skip: type !== 'RELATED_ITEM' && relatedItemKind !== 'UserItemType',
+    skip: type !== 'RELATED_ITEM',
   });
 
   if (value == null) {
@@ -389,28 +393,43 @@ function TableRowComponent(props: {
         __throw(new Error(`Could not find item type for ID ${value.typeId}`));
       }
 
+      // Resolve a human-readable title for every related-item kind via its
+      // `displayName` schema role (not just users). The profile icon role only
+      // exists on user types, so it stays user-only.
       let displayName: string | undefined;
       let profilePhoto: { url: string } | undefined;
-      const user = userItem?.latestItemSubmissions[0] as GQLUserItem;
-      if (relatedItemKind === 'UserItemType' && user !== undefined) {
-        displayName = userItem
-          ? getFieldValueForRole<GQLUserSchemaFieldRoles, 'displayName'>(
-              {
-                data: user.data,
-                type: user.type,
-              },
-              'displayName',
-            )
-          : undefined;
-        profilePhoto = userItem
-          ? getFieldValueForRole<GQLUserSchemaFieldRoles, 'profileIcon'>(
-              {
-                data: user.data,
-                type: user.type,
-              },
-              'profileIcon',
-            )
-          : undefined;
+      const relatedItem = relatedItemData?.latestItemSubmissions[0];
+      switch (relatedItem?.__typename) {
+        case 'UserItem': {
+          const user = relatedItem as GQLUserItem;
+          displayName = getFieldValueForRole<
+            GQLUserSchemaFieldRoles,
+            'displayName'
+          >({ data: user.data, type: user.type }, 'displayName');
+          profilePhoto = getFieldValueForRole<
+            GQLUserSchemaFieldRoles,
+            'profileIcon'
+          >({ data: user.data, type: user.type }, 'profileIcon');
+          break;
+        }
+        case 'ContentItem': {
+          const content = relatedItem as GQLContentItem;
+          displayName = getFieldValueForRole<
+            GQLContentSchemaFieldRoles,
+            'displayName'
+          >({ data: content.data, type: content.type }, 'displayName');
+          break;
+        }
+        case 'ThreadItem': {
+          const thread = relatedItem as GQLThreadItem;
+          displayName = getFieldValueForRole<
+            GQLThreadSchemaFieldRoles,
+            'displayName'
+          >({ data: thread.data, type: thread.type }, 'displayName');
+          break;
+        }
+        default:
+          break;
       }
       return (
         <div className="flex flex-row align-top text-start">

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobPrimaryUserComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobPrimaryUserComponent.tsx
@@ -178,11 +178,14 @@ export default function ManualReviewJobPrimaryUserComponent(props: {
         </div>
         <FieldsComponent
           fields={[
-            ...convertRelatedItemToFieldData({
-              id: user.id,
-              typeId: user.type.id,
-              name: user.type.name,
-            }),
+            ...convertRelatedItemToFieldData(
+              {
+                id: user.id,
+                typeId: user.type.id,
+                name: user.type.name,
+              },
+              fieldData.map((it) => it.name),
+            ),
             ...fieldData,
           ]}
           itemTypeId={user.type.id}

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobRelatedUserComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobRelatedUserComponent.tsx
@@ -328,7 +328,10 @@ export default function ManualReviewJobRelatedUserComponent(props: {
           <div className="flex justify-start w-full">
             <FieldsComponent
               fields={[
-                ...convertRelatedItemToFieldData(user),
+                ...convertRelatedItemToFieldData(
+                  user,
+                  (userSubmissionItems ?? []).map((it) => it.name),
+                ),
                 ...(userSubmissionItems ?? []),
               ]}
               itemTypeId={user.typeId}

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobUserUtils.test.ts
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobUserUtils.test.ts
@@ -1,0 +1,47 @@
+import { RelatedItem } from '@roostorg/coop-types';
+
+import { convertRelatedItemToFieldData } from './ManualReviewJobUserUtils';
+
+describe('convertRelatedItemToFieldData', () => {
+  test('renders only the related item id as a field', () => {
+    const relatedItem: RelatedItem = {
+      id: 'user-123',
+      typeId: 'type-456',
+      name: 'vinny',
+    };
+
+    expect(convertRelatedItemToFieldData(relatedItem)).toEqual([
+      {
+        name: 'id',
+        type: 'STRING',
+        required: false,
+        container: null,
+        value: 'user-123',
+      },
+    ]);
+  });
+
+  // Regression for roostorg/coop#716: a RELATED_ITEM value (e.g. a content
+  // item's creator reference) can carry denormalized fields beyond the
+  // `{ id, typeId, name }` contract. Those fields are also rendered from the
+  // associated item's typed schema, so surfacing them here duplicated every
+  // shared field (Nickname/Email/IP Address/Birthday/Created Time) — once as an
+  // untyped string and once with its real type.
+  test('drops denormalized keys that leak into a related item reference', () => {
+    const relatedItemWithExtras = {
+      id: 'user-123',
+      typeId: 'type-456',
+      name: 'vinny',
+      nickname: 'vinny',
+      email: 'test_user@example.com',
+      ipAddress: '203.0.113.7',
+      birthday: '1997-08-18T00:00:00.000Z',
+      createdTime: '2026-03-13T23:18:10.000Z',
+    } as unknown as RelatedItem;
+
+    const fields = convertRelatedItemToFieldData(relatedItemWithExtras);
+
+    expect(fields).toHaveLength(1);
+    expect(fields.map((field) => field.name)).toEqual(['id']);
+  });
+});

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobUserUtils.test.ts
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobUserUtils.test.ts
@@ -3,7 +3,7 @@ import { RelatedItem } from '@roostorg/coop-types';
 import { convertRelatedItemToFieldData } from './ManualReviewJobUserUtils';
 
 describe('convertRelatedItemToFieldData', () => {
-  test('renders only the related item id as a field', () => {
+  test('renders the related item id and drops name/typeId', () => {
     const relatedItem: RelatedItem = {
       id: 'user-123',
       typeId: 'type-456',
@@ -23,25 +23,55 @@ describe('convertRelatedItemToFieldData', () => {
 
   // Regression for roostorg/coop#716: a RELATED_ITEM value (e.g. a content
   // item's creator reference) can carry denormalized fields beyond the
-  // `{ id, typeId, name }` contract. Those fields are also rendered from the
-  // associated item's typed schema, so surfacing them here duplicated every
-  // shared field (Nickname/Email/IP Address/Birthday/Created Time) — once as an
-  // untyped string and once with its real type.
-  test('drops denormalized keys that leak into a related item reference', () => {
-    const relatedItemWithExtras = {
-      id: 'user-123',
-      typeId: 'type-456',
-      name: 'vinny',
-      nickname: 'vinny',
-      email: 'test_user@example.com',
-      ipAddress: '203.0.113.7',
-      birthday: '1997-08-18T00:00:00.000Z',
-      createdTime: '2026-03-13T23:18:10.000Z',
-    } as unknown as RelatedItem;
+  // `{ id, typeId, name }` contract. Those same fields are also rendered from
+  // the associated item's typed schema, so without deduping every shared field
+  // (Nickname/Email/IP Address/Birthday/Created Time) appeared twice — once as
+  // an untyped string here and once with its real type from the schema.
+  const relatedItemWithExtras = {
+    id: 'user-123',
+    typeId: 'type-456',
+    name: 'vinny',
+    nickname: 'vinny',
+    email: 'test_user@example.com',
+    ipAddress: '203.0.113.7',
+    birthday: '1997-08-18T00:00:00.000Z',
+    createdTime: '2026-03-13T23:18:10.000Z',
+  } as unknown as RelatedItem;
 
-    const fields = convertRelatedItemToFieldData(relatedItemWithExtras);
+  test('drops inlined keys already rendered from the typed schema', () => {
+    const fields = convertRelatedItemToFieldData(relatedItemWithExtras, [
+      'nickname',
+      'email',
+      'ipAddress',
+      'birthday',
+      'createdTime',
+    ]);
 
-    expect(fields).toHaveLength(1);
     expect(fields.map((field) => field.name)).toEqual(['id']);
+  });
+
+  test('matches schema field names case/whitespace-insensitively', () => {
+    const fields = convertRelatedItemToFieldData(relatedItemWithExtras, [
+      ' Nickname ',
+      'EMAIL',
+      'IPAddress',
+      'Birthday',
+      'CreatedTime',
+    ]);
+
+    expect(fields.map((field) => field.name)).toEqual(['id']);
+  });
+
+  test('keeps inlined keys that have no typed-schema counterpart', () => {
+    const fields = convertRelatedItemToFieldData(relatedItemWithExtras, []);
+
+    expect(fields.map((field) => field.name)).toEqual([
+      'id',
+      'nickname',
+      'email',
+      'ipAddress',
+      'birthday',
+      'createdTime',
+    ]);
   });
 });

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobUserUtils.ts
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobUserUtils.ts
@@ -1,12 +1,16 @@
 import type { ItemTypeFieldFieldData } from '@/webpages/dashboard/item_types/itemTypeUtils';
 import { Field, RelatedItem, ScalarType } from '@roostorg/coop-types';
-import omit from 'lodash/omit';
 
 const createFieldType = (name: string, type: ScalarType) =>
   ({ name, type, required: false, container: null }) satisfies Field;
 
+// Only surface the `id`: the related item's other fields are rendered from its
+// typed schema elsewhere, so spreading any denormalized keys the reference may
+// carry would duplicate those fields (as untyped strings).
 export const convertRelatedItemToFieldData = (relatedItem: RelatedItem) =>
-  Object.entries(omit(relatedItem, ['name', 'typeId'])).map(([key, value]) => ({
-    ...createFieldType(key, 'STRING'),
-    value,
-  })) as ItemTypeFieldFieldData[];
+  [
+    {
+      ...createFieldType('id', 'STRING'),
+      value: relatedItem.id,
+    },
+  ] as ItemTypeFieldFieldData[];

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobUserUtils.ts
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobUserUtils.ts
@@ -1,16 +1,26 @@
 import type { ItemTypeFieldFieldData } from '@/webpages/dashboard/item_types/itemTypeUtils';
 import { Field, RelatedItem, ScalarType } from '@roostorg/coop-types';
+import omit from 'lodash/omit';
 
 const createFieldType = (name: string, type: ScalarType) =>
   ({ name, type, required: false, container: null }) satisfies Field;
 
-// Only surface the `id`: the related item's other fields are rendered from its
-// typed schema elsewhere, so spreading any denormalized keys the reference may
-// carry would duplicate those fields (as untyped strings).
-export const convertRelatedItemToFieldData = (relatedItem: RelatedItem) =>
-  [
-    {
-      ...createFieldType('id', 'STRING'),
-      value: relatedItem.id,
-    },
-  ] as ItemTypeFieldFieldData[];
+const normalizeFieldName = (name: string) => name.trim().toLowerCase();
+
+// `schemaRenderedFieldNames` are fields the caller already renders from the
+// typed schema; inlined keys matching one are skipped to avoid showing the same
+// field twice (roostorg/coop#716). Match is case/whitespace-insensitive.
+export const convertRelatedItemToFieldData = (
+  relatedItem: RelatedItem,
+  schemaRenderedFieldNames: readonly string[] = [],
+) => {
+  const renderedNames = new Set(
+    schemaRenderedFieldNames.map(normalizeFieldName),
+  );
+  return Object.entries(omit(relatedItem, ['name', 'typeId']))
+    .filter(([key]) => !renderedNames.has(normalizeFieldName(key)))
+    .map(([key, value]) => ({
+      ...createFieldType(key, 'STRING'),
+      value,
+    })) as ItemTypeFieldFieldData[];
+};


### PR DESCRIPTION
Fixes #716

## Context & Requests for Reviewers

Two small fixes for how related items show up in MRT.

1. Related items rendered inline only resolved a title when the item was a User. Meaning every other type (Content, Thread) fell through to showing the raw ID. The data was available if the Item Type is setup with the property roles, we just weren't reading the `displayName` role for non-user types. Now we resolve it for all item kinds, so e.g. a related "Item" shows its name instead of raw ids. `clwuq0a62...`.

2. The reference-to-fields helper rendered denormalized keys carried on the related item reference, which could duplicate fields already shown from the item's typed schema. It now dedupes those inlined keys against the schema-rendered field names (case/whitespace-insensitive), so the same field isn't shown twice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Manual review job submissions now support displaying and submitting related items of multiple types (users, content, threads).
  * Related items display human-readable names and profile images appropriate to their type.

* **Improvements**
  * Enhanced field deduplication for related items to prevent duplicate information display.

* **Tests**
  * Added comprehensive test coverage for related item field data conversion and name deduplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->