### PR TITLE
ci: add .github AGENTS.md

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,1 @@
+Coop is an open-source project. When working on GitHub Actions, remember that PRs will be opened by external contributors who have forked the main repo. Workflows that run on PRs should also work on these forks, i.e. they should not require permissions from the main repo.


### PR DESCRIPTION
## Context & Requests for Reviewers

On a [recent PR](https://github.com/roostorg/coop/pull/721#discussion_r3377577717), @juanmrad made a helpful comment to ensure that our CI workflows continue to work on PRs from forks.

I hadn't thought about this, but it makes sense as a principle that we have to keep in mind!

So, this PR adds an `AGENTS.md` to our `.github` folder to remind LLMs of this principle. Agents will automatically read this file when working in the `.github` directory.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal documentation regarding GitHub Actions workflow configuration for external contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->