### PR TITLE
Fix release of docker image for tagged release and allow manual release

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Optional version tag to apply (e.g. 1.0.0). Also updates :latest. Leave blank for an SHA-only build.'
+        description: 'Optional semver version tag to publish (e.g. 1.0.0), for backfilling a release. Leave blank for an SHA-only build; does not move :latest.'
         required: false
         type: string
 
@@ -30,15 +30,16 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  # Shared tagging policy for every image. `latest` tracks the latest build on main
+  # Shared tag policy: release -> version tags + auto `latest` (newest
+  # non-prerelease); main -> `edge` + sha; manual dispatch -> sha (+ optional
+  # `version`). Use `github.event.inputs` since `inputs` is unset on push/release.
   TAGS: |
     type=sha,prefix=
-    type=ref,event=branch
+    type=edge,branch=main,enable=${{ github.event_name != 'workflow_dispatch' }}
     type=ref,event=tag
     type=semver,pattern={{version}}
     type=semver,pattern={{major}}.{{minor}}
-    type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
-    type=raw,value=latest,enable={{is_default_branch}}
+    type=raw,value=${{ github.event.inputs.version }},enable=${{ github.event.inputs.version != '' }}
 
 jobs:
   changes:
@@ -51,9 +52,9 @@ jobs:
       # Reject arbitrary dispatch input so it can't become an image tag like
       # `coop-server:squirtle`. Passed via env to avoid shell injection.
       - name: Validate version input
-        if: inputs.version != ''
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.version != ''
         env:
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ github.event.inputs.version }}
         run: |
           if ! printf '%s' "$VERSION" | grep -Eq '^v?[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "::error::Invalid version '$VERSION'. Expected semver like 1.2.3 or v1.2.3."

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -13,12 +13,32 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Optional version tag to apply (e.g. 1.0.0). Also updates :latest. Leave blank for an SHA-only build.'
+        required: false
+        type: string
 
 permissions:
   contents: read
 
+# Avoid redundant concurrent builds for the same ref (expensive multi-arch).
+# Keyed per-ref so releases (tag refs) never cancel main builds.
+concurrency:
+  group: publish-docker-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
+  # Shared tagging policy for every image. `latest` tracks the latest build on main
+  TAGS: |
+    type=sha,prefix=
+    type=ref,event=branch
+    type=ref,event=tag
+    type=semver,pattern={{version}}
+    type=semver,pattern={{major}}.{{minor}}
+    type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
+    type=raw,value=latest,enable={{is_default_branch}}
 
 jobs:
   changes:
@@ -28,6 +48,18 @@ jobs:
       client: ${{ steps.filter.outputs.client }}
       db: ${{ steps.filter.outputs.db }}
     steps:
+      # Reject arbitrary dispatch input so it can't become an image tag like
+      # `coop-server:squirtle`. Passed via env to avoid shell injection.
+      - name: Validate version input
+        if: inputs.version != ''
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! printf '%s' "$VERSION" | grep -Eq '^v?[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid version '$VERSION'. Expected semver like 1.2.3 or v1.2.3."
+            exit 1
+          fi
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -77,12 +109,7 @@ jobs:
         id: meta
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
-          tags: |
-            type=sha,prefix=
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
+          tags: ${{ env.TAGS }}
 
       - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
@@ -94,8 +121,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             BUILD_ID=${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,scope=${{ matrix.image }},mode=max
           platforms: linux/amd64,linux/arm64
 
   build-client:
@@ -122,12 +149,7 @@ jobs:
         id: meta
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/coop-client
-          tags: |
-            type=sha,prefix=
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
+          tags: ${{ env.TAGS }}
 
       - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
@@ -139,8 +161,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             BUILD_ID=${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=coop-client
+          cache-to: type=gha,scope=coop-client,mode=max
           platforms: linux/amd64,linux/arm64
 
   # Bundles the db/ migration files + configs into an image meant to be run as a
@@ -171,12 +193,7 @@ jobs:
         id: meta
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/coop-migrations
-          tags: |
-            type=sha,prefix=
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
+          tags: ${{ env.TAGS }}
 
       - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
@@ -185,6 +202,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=coop-migrations
+          cache-to: type=gha,scope=coop-migrations,mode=max
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -57,7 +57,7 @@ jobs:
           VERSION: ${{ github.event.inputs.version }}
         run: |
           if ! printf '%s' "$VERSION" | grep -Eq '^v?[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "::error::Invalid version '$VERSION'. Expected semver like 1.2.3 or v1.2.3."
+            echo "::error::Invalid version input. Expected semver like 1.2.3 or v1.2.3."
             exit 1
           fi
 
@@ -122,7 +122,11 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             BUILD_ID=${{ github.sha }}
-          cache-from: type=gha,scope=${{ matrix.image }}
+          # server + worker share a Dockerfile/intermediate stages: read both
+          # scopes for reuse, write only our own to avoid concurrent-write races.
+          cache-from: |
+            type=gha,scope=coop-server
+            type=gha,scope=coop-worker
           cache-to: type=gha,scope=${{ matrix.image }},mode=max
           platforms: linux/amd64,linux/arm64
 


### PR DESCRIPTION
## Context & Requests for Reviewers

Fix release of tagged versions and allow manual run of workflow to backfill the v1 version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an optional version input with validation to the Docker publish workflow for more predictable releases.
  * Enabled per-ref concurrency to avoid redundant simultaneous builds while allowing independent refs to proceed.
  * Unified Docker tag generation at workflow level so all image jobs produce consistent tags.
  * Refined build cache usage to improve cache reuse across server, client, and migration image builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->