### PR TITLE
Label the OpenAI integration as "OpenAI Moderation API" and surface the model card link

### DIFF
--- a/client/src/webpages/dashboard/integrations/integrationConfigs.ts
+++ b/client/src/webpages/dashboard/integrations/integrationConfigs.ts
@@ -30,7 +30,7 @@ export const INTEGRATION_CONFIGS: IntegrationConfig[] = [
   },
   {
     name: 'OPEN_AI' as GQLIntegration,
-    title: 'OpenAI',
+    title: 'OpenAI Moderation API',
     logo: OpenAILogo,
     logoWithBackground: OpenAILogoWithBackground,
     url: 'https://openai.com/',

--- a/server/services/integrationRegistry/integrationManifests.ts
+++ b/server/services/integrationRegistry/integrationManifests.ts
@@ -104,7 +104,7 @@ const GOOGLE_CONTENT_SAFETY: IntegrationManifestEntry = {
 
 const OPENAI: IntegrationManifestEntry = {
   modelCard: {
-    modelName: 'OpenAI',
+    modelName: 'OpenAI Moderation API',
     version: 'Omni-moderation-2024-09-26',
     releaseDate: 'September 2024',
     sections: [
@@ -186,13 +186,18 @@ const OPENAI: IntegrationManifestEntry = {
             label: 'Documentation',
             value: 'https://platform.openai.com/docs/guides/moderation',
           },
+          {
+            label: 'Model Card',
+            value:
+              'https://cdn.openai.com/API/docs/omni_moderation_information_for_developers.pdf',
+          },
         ],
       },
     ],
   },
   modelCardLearnMoreUrl:
     'https://cdn.openai.com/API/docs/omni_moderation_information_for_developers.pdf',
-  title: 'OpenAI',
+  title: 'OpenAI Moderation API',
   docsUrl: 'https://platform.openai.com/docs',
   requiresConfig: true,
 };


### PR DESCRIPTION
## Summary

Three user-facing strings called this integration just "OpenAI". The actual scope is narrower: it is OpenAI's Moderation API specifically, not a generic OpenAI integration. Rename to match the docs (which already say "OpenAI Moderation API") and the integration's actual function.

Also adds the model card PDF as a second row inside the Relevant Links section of the integration card. The `modelCardLearnMoreUrl` was set on the manifest but wasn't visible to reviewers from the integration view, so they had no in-product path to the source document the model card was built from.

## Files

- `server/services/integrationRegistry/integrationManifests.ts`: `modelCard.modelName` and `title` updated; new `Model Card` field added to the `relevantLinks` section.
- `client/src/webpages/dashboard/integrations/integrationConfigs.ts`: client-side integration list `title` updated.

## Test plan

- [x] `tsc --noEmit` clean for server and client.
- [ ] Smoke check the integration card UI in the dashboard: title reads "OpenAI Moderation API"; Relevant Links shows both Documentation and Model Card rows; both links open.
- [ ] Integrations list page shows "OpenAI Moderation API".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Updates
* Clarified the display name of the OpenAI integration to "OpenAI Moderation API" for improved clarity across the platform.
* Added a dedicated "Model Card" link to the OpenAI Moderation API documentation, providing users with direct access to additional resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->