### PR TITLE
Only run License Check when we should check licenses

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -2,6 +2,8 @@ name: License Check
 on:
   pull_request:
     branches: [main]
+    paths:
+      - '**/package-lock.json'
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
## Context & Requests for Reviewers

We are running CI to check licenses on each commit on all PRs, but we should really only run this when there is a new dependency change. as such we should filter by the package-lock.json changes instead. Once we move to pnpm we can update to the appropriate lock file. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized license check workflow to run only when dependency files are modified, reducing unnecessary CI/CD executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->