### PR TITLE
Set redis user and pw in no-cluster mode

### DIFF
--- a/server/iocContainer/index.ts
+++ b/server/iocContainer/index.ts
@@ -611,6 +611,20 @@ export default async function getBottle() {
           maxRetriesPerRequest: null,
           port: parseInt(process.env.REDIS_PORT ?? '6379'),
           host: safeGetEnvVar('REDIS_HOST'),
+          // AUTH-enabled Redis (e.g. ElastiCache with an auth token) rejects
+          // every command with NOAUTH unless credentials are sent, which
+          // leaves ioredis stuck before "ready" and parks commands in the
+          // offline queue forever. Local dev Redis has no password, so only
+          // pass credentials when REDIS_PASSWORD is set; REDIS_USER may be
+          // set-but-empty, which means the default user.
+          ...(process.env.REDIS_PASSWORD
+            ? {
+                ...(process.env.REDIS_USER
+                  ? { username: process.env.REDIS_USER }
+                  : {}),
+                password: process.env.REDIS_PASSWORD,
+              }
+            : {}),
           ...(isEnvTrue('REDIS_TLS')
             ? { tls: { servername: safeGetEnvVar('REDIS_HOST') } }
             : {}),

--- a/server/iocContainer/index.ts
+++ b/server/iocContainer/index.ts
@@ -579,6 +579,22 @@ export default async function getBottle() {
       }),
   );
 
+  // AUTH-enabled Redis (e.g. ElastiCache with an auth token) rejects every
+  // command with NOAUTH unless credentials are sent, which leaves ioredis stuck
+  // before "ready" and parks commands in the offline queue forever. Local dev
+  // Redis has no password, so only pass credentials when REDIS_PASSWORD is set;
+  // REDIS_USER may be set-but-empty, which means the default user. Shared by the
+  // cluster and single-node paths so both authenticate identically.
+  const redisAuthOptions = (): { username?: string; password?: string } =>
+    process.env.REDIS_PASSWORD
+      ? {
+          ...(process.env.REDIS_USER
+            ? { username: process.env.REDIS_USER }
+            : {}),
+          password: process.env.REDIS_PASSWORD,
+        }
+      : {};
+
   const makeRedis = (
     extraOptions: { enableOfflineQueue?: boolean } = {},
   ): IORedis.Redis | Cluster =>
@@ -599,8 +615,7 @@ export default async function getBottle() {
               // Required by BullMQ: its workers use blocking Redis commands
               // that would otherwise be misinterpreted as timed-out requests.
               maxRetriesPerRequest: null,
-              username: safeGetEnvVar('REDIS_USER'),
-              password: safeGetEnvVar('REDIS_PASSWORD'),
+              ...redisAuthOptions(),
               ...extraOptions,
             },
           },
@@ -611,20 +626,7 @@ export default async function getBottle() {
           maxRetriesPerRequest: null,
           port: parseInt(process.env.REDIS_PORT ?? '6379'),
           host: safeGetEnvVar('REDIS_HOST'),
-          // AUTH-enabled Redis (e.g. ElastiCache with an auth token) rejects
-          // every command with NOAUTH unless credentials are sent, which
-          // leaves ioredis stuck before "ready" and parks commands in the
-          // offline queue forever. Local dev Redis has no password, so only
-          // pass credentials when REDIS_PASSWORD is set; REDIS_USER may be
-          // set-but-empty, which means the default user.
-          ...(process.env.REDIS_PASSWORD
-            ? {
-                ...(process.env.REDIS_USER
-                  ? { username: process.env.REDIS_USER }
-                  : {}),
-                password: process.env.REDIS_PASSWORD,
-              }
-            : {}),
+          ...redisAuthOptions(),
           ...(isEnvTrue('REDIS_TLS')
             ? { tls: { servername: safeGetEnvVar('REDIS_HOST') } }
             : {}),


### PR DESCRIPTION
## Context & Requests for Reviewers
The redis username/pw wasn't being passed when in a single-node configuration, which is ok for local dev but doesn't work if using a single node Elasticache for example. This passes the username/pw if present in the env vars.

## Tests
Existing automated tests. Also deployed this to our instance and it works.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Redis connection initialization to properly handle authenticated Redis instances. The application now correctly passes authentication credentials only when configured, preventing connection failures and ensuring reliable command execution with auth-enabled Redis deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->