### PR TITLE
Allow ignoring a job when "require decision reason" is enabled

### DIFF
--- a/client/src/webpages/dashboard/mrt/manual_review_job/ManualReviewJobReview.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/ManualReviewJobReview.tsx
@@ -679,10 +679,6 @@ function ManualReviewJobReviewImpl(props: {
       }
     }
 
-    // If the org requires a decision reason and none has been provided, block
-    // submission — unless the only decision is Ignore. Ignoring a job is a
-    // dismissal, not a reasoned moderation action, so it's exempt from the
-    // requirement (mirrors the server gate in JobDecisioning.ts). See #757.
     const isIgnoreOnlyDecision = selectedPrimaryActions.every(
       (it) => 'type' in it.action && it.action.type === 'IGNORE',
     );

--- a/client/src/webpages/dashboard/mrt/manual_review_job/ManualReviewJobReview.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/ManualReviewJobReview.tsx
@@ -679,11 +679,17 @@ function ManualReviewJobReviewImpl(props: {
       }
     }
 
-    // If the org requires a decision reason, and no decision reason has been
-    // provided, return false
+    // If the org requires a decision reason and none has been provided, block
+    // submission — unless the only decision is Ignore. Ignoring a job is a
+    // dismissal, not a reasoned moderation action, so it's exempt from the
+    // requirement (mirrors the server gate in JobDecisioning.ts). See #757.
+    const isIgnoreOnlyDecision = selectedPrimaryActions.every(
+      (it) => 'type' in it.action && it.action.type === 'IGNORE',
+    );
     if (
       data?.myOrg?.requiresDecisionReasonInMrt &&
-      !isNonEmptyString(decisionReason)
+      !isNonEmptyString(decisionReason) &&
+      !isIgnoreOnlyDecision
     ) {
       return false;
     }

--- a/server/services/manualReviewToolService/manualReviewToolService.test.ts
+++ b/server/services/manualReviewToolService/manualReviewToolService.test.ts
@@ -502,6 +502,48 @@ describe('Manual Review Tool Service', () => {
         // decisionReason intentionally omitted
       });
     });
+
+    // Issue #757: a plain Ignore on a standard MRT job is a dismissal, not a
+    // reasoned moderation action, so the require-reason flag should not block
+    // it — mirroring the NCMEC Ignore case above. A CUSTOM_ACTION mixed in
+    // still requires a reason (covered by the rejection test above).
+    it('allows an IGNORE decision on a standard job with no reason when the flag is on', async () => {
+      await setRequiresDecisionReason(true);
+
+      const reviewerId = uuidv1();
+      const reviewerEmail = 'test@test.com';
+      const jobPayload = makeDummyJob();
+
+      await mrtService['queueOps']['addJob']({
+        jobPayload,
+        orgId,
+        queueId,
+        enqueueSourceInfo: { kind: 'REPORT' },
+      });
+
+      const dequeuedJob = await mrtService.dequeueNextJob({
+        orgId,
+        queueId,
+        userId: reviewerId,
+      });
+
+      if (!dequeuedJob) {
+        throw new Error("should've returned a job");
+      }
+
+      await mrtService.submitDecision({
+        queueId,
+        reportHistory: [],
+        jobId: dequeuedJob.job.id,
+        lockToken: dequeuedJob.lockToken,
+        decisionComponents: [{ type: 'IGNORE' }],
+        relatedActions: [],
+        reviewerId,
+        reviewerEmail,
+        orgId,
+        // decisionReason intentionally omitted
+      });
+    });
   });
 
   // Issue #389: when an org sets `requires_policy_for_decisions`, submitDecision

--- a/server/services/manualReviewToolService/modules/JobDecisioning.ts
+++ b/server/services/manualReviewToolService/modules/JobDecisioning.ts
@@ -231,16 +231,23 @@ export default class JobDecisioning {
     // against, so the common path does no extra DB work. Matches the client
     // gate at ManualReviewJobReview.tsx, which uses isNonEmptyString.
     //
-    // Bypass the check when the decision is NCMEC-native (Submit NCMEC Report
-    // or Ignore on an NCMEC job, no CUSTOM_ACTION mixed in): those decisions
-    // don't carry a written reason and the flag is irrelevant for them. A
-    // CUSTOM_ACTION on an NCMEC job still requires a reason. See #736.
+    // Bypass the check for decisions that don't carry a written reason by
+    // nature: NCMEC-native decisions (Submit NCMEC Report or Ignore on an
+    // NCMEC job) and a plain Ignore on any job. Ignoring a job is a dismissal,
+    // not a reasoned moderation action, so the flag is irrelevant for it.
+    // Neither bypass applies when a CUSTOM_ACTION is mixed in — that still
+    // requires a reason. See #736 (NCMEC) and #757 (standard Ignore).
     const isNcmecNativeDecision =
       job.payload.kind === 'NCMEC' && customActionDecisions.length === 0;
+    const isIgnoreOnlyDecision =
+      customActionDecisions.length === 0 &&
+      decisions.length > 0 &&
+      decisions.every((decision) => decision.type === 'IGNORE');
     if (
       decisionComponents != null &&
       !isNonEmptyString(decisionReason) &&
-      !isNcmecNativeDecision
+      !isNcmecNativeDecision &&
+      !isIgnoreOnlyDecision
     ) {
       const requiresReason =
         await this.manualReviewToolSettings.getRequiresDecisionReason(orgId);

--- a/server/services/manualReviewToolService/modules/JobDecisioning.ts
+++ b/server/services/manualReviewToolService/modules/JobDecisioning.ts
@@ -233,8 +233,7 @@ export default class JobDecisioning {
     //
     // Bypass the check for decisions that don't carry a written reason by
     // nature: NCMEC-native decisions (Submit NCMEC Report or Ignore on an
-    // NCMEC job) and a plain Ignore on any job. Ignoring a job is a dismissal,
-    // not a reasoned moderation action, so the flag is irrelevant for it.
+    // NCMEC job) and a plain Ignore on any job.
     // Neither bypass applies when a CUSTOM_ACTION is mixed in — that still
     // requires a reason. See #736 (NCMEC) and #757 (standard Ignore).
     const isNcmecNativeDecision =


### PR DESCRIPTION
## Summary

Fixes #757. Before, when an org had **require decision reason** enabled, reviewers could not Ignore a job without giving a reason. As of this PR, the Ignore action is excluded from that requirement.

There is a risk here: there may be users who *want* to require a reason even for Ignores. So this change may break that hypothetical workflow.

## Testing

I wrote a test for this and also tested it manually on my machine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Decision reason requirements are now correctly waived for ignore-only submissions in manual review jobs, allowing users to submit without providing a reason when only ignoring items.

* **Tests**
  * Added test coverage to validate decision reason enforcement behavior for ignore-only decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->