### PR TITLE
Copy Lua assets when starting the dev server

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc && npm run copy-assets",
     "copy-assets": "copyfiles \"lib/**/*.lua\" transpiled/",
-    "start": "tsc-watch --onSuccess \"node --trace-warnings --require dotenv/config ./transpiled/bin/www.js\"",
-    "start:trace": "tsc-watch --onSuccess \"node --trace-warnings --require dotenv/config --require ../nodejs-instrumentation/transpiled/autoinstrumentation.js ./transpiled/bin/www.js\"",
+    "start": "npm run copy-assets && tsc-watch --onSuccess \"node --trace-warnings --require dotenv/config ./transpiled/bin/www.js\"",
+    "start:trace": "npm run copy-assets && tsc-watch --onSuccess \"node --trace-warnings --require dotenv/config --require ../nodejs-instrumentation/transpiled/autoinstrumentation.js ./transpiled/bin/www.js\"",
     "test": "npm run test:local",
     "test:local": "NODE_OPTIONS=\"--no-warnings --loader ts-node/esm --require dotenv/config\" jest --watch --detectOpenHandles",
     "test:prepush": "NODE_OPTIONS=\"--no-warnings --loader ts-node/esm --require dotenv/config\" jest --detectOpenHandles --no-cache --forceExit",


### PR DESCRIPTION
## Summary

This is a small devx improvement.

On a fresh clone of the repo, if you run `npm run up && npm run server:start`, you'll get an error because the server doesn't have some required Lua files where it expects.

This fixes that!

## Testing

- `npm start` from a clean repo no longer throws ENOENT and boots normally.