### PR TITLE
User Strikes: Add to Review Console jobs and item investigation view

### DIFF
--- a/client/src/graphql/generated.ts
+++ b/client/src/graphql/generated.ts
@@ -5054,6 +5054,7 @@ export type GQLUserItem = GQLItemBase & {
   readonly submissionTime?: Maybe<Scalars['DateTime']['output']>;
   readonly type: GQLUserItemType;
   readonly userScore: Scalars['Int']['output'];
+  readonly userStrikeCount: Scalars['Int']['output'];
 };
 
 export type GQLUserItemType = GQLItemTypeBase & {
@@ -7157,6 +7158,7 @@ export type GQLGetItemsWithIdQuery = {
           readonly data: JsonObject;
           readonly submissionId: string;
           readonly submissionTime?: Date | string | null;
+          readonly userStrikeCount: number;
           readonly type: {
             readonly __typename: 'UserItemType';
             readonly id: string;
@@ -9249,6 +9251,7 @@ export type GQLGetDecidedJobFromJobIdQuery = {
             readonly actionsTaken: ReadonlyArray<string>;
             readonly item: {
               readonly __typename: 'UserItem';
+              readonly userStrikeCount: number;
               readonly id: string;
               readonly submissionId: string;
               readonly submissionTime?: Date | string | null;
@@ -9406,6 +9409,7 @@ export type GQLGetDecidedJobFromJobIdQuery = {
             }>;
             readonly item: {
               readonly __typename: 'UserItem';
+              readonly userStrikeCount: number;
               readonly id: string;
               readonly submissionId: string;
               readonly submissionTime?: Date | string | null;
@@ -11835,6 +11839,7 @@ export type GQLGetDecidedJobQuery = {
           readonly actionsTaken: ReadonlyArray<string>;
           readonly item: {
             readonly __typename: 'UserItem';
+            readonly userStrikeCount: number;
             readonly id: string;
             readonly submissionId: string;
             readonly submissionTime?: Date | string | null;
@@ -11992,6 +11997,7 @@ export type GQLGetDecidedJobQuery = {
           }>;
           readonly item: {
             readonly __typename: 'UserItem';
+            readonly userStrikeCount: number;
             readonly id: string;
             readonly submissionId: string;
             readonly submissionTime?: Date | string | null;
@@ -13541,6 +13547,7 @@ export type GQLManualReviewJobInfoQuery = {
               readonly actionsTaken: ReadonlyArray<string>;
               readonly item: {
                 readonly __typename: 'UserItem';
+                readonly userStrikeCount: number;
                 readonly id: string;
                 readonly submissionId: string;
                 readonly submissionTime?: Date | string | null;
@@ -13698,6 +13705,7 @@ export type GQLManualReviewJobInfoQuery = {
               }>;
               readonly item: {
                 readonly __typename: 'UserItem';
+                readonly userStrikeCount: number;
                 readonly id: string;
                 readonly submissionId: string;
                 readonly submissionTime?: Date | string | null;
@@ -14880,6 +14888,7 @@ export type GQLDequeueManualReviewJobMutation = {
             readonly actionsTaken: ReadonlyArray<string>;
             readonly item: {
               readonly __typename: 'UserItem';
+              readonly userStrikeCount: number;
               readonly id: string;
               readonly submissionId: string;
               readonly submissionTime?: Date | string | null;
@@ -15037,6 +15046,7 @@ export type GQLDequeueManualReviewJobMutation = {
             }>;
             readonly item: {
               readonly __typename: 'UserItem';
+              readonly userStrikeCount: number;
               readonly id: string;
               readonly submissionId: string;
               readonly submissionTime?: Date | string | null;
@@ -16276,6 +16286,7 @@ export type GQLJobFieldsFragment = {
         readonly actionsTaken: ReadonlyArray<string>;
         readonly item: {
           readonly __typename: 'UserItem';
+          readonly userStrikeCount: number;
           readonly id: string;
           readonly submissionId: string;
           readonly submissionTime?: Date | string | null;
@@ -16433,6 +16444,7 @@ export type GQLJobFieldsFragment = {
         }>;
         readonly item: {
           readonly __typename: 'UserItem';
+          readonly userStrikeCount: number;
           readonly id: string;
           readonly submissionId: string;
           readonly submissionTime?: Date | string | null;
@@ -17481,6 +17493,7 @@ export type GQLGetUserItemsQuery = {
         readonly submissionId: string;
         readonly submissionTime?: Date | string | null;
         readonly data: JsonObject;
+        readonly userStrikeCount: number;
         readonly type: {
           readonly __typename: 'UserItemType';
           readonly id: string;
@@ -25516,6 +25529,9 @@ export const GQLJobFieldsFragmentDoc = gql`
           ... on ItemBase {
             ...ItemFields
           }
+          ... on UserItem {
+            userStrikeCount
+          }
         }
         itemThreadContentItems {
           ... on ContentItem {
@@ -25643,6 +25659,9 @@ export const GQLJobFieldsFragmentDoc = gql`
         item {
           ... on ItemBase {
             ...ItemFields
+          }
+          ... on UserItem {
+            userStrikeCount
           }
         }
         additionalContentItems {
@@ -30767,6 +30786,9 @@ export const GQLGetItemsWithIdDocument = gql`
               }
             }
           }
+        }
+        ... on UserItem {
+          userStrikeCount
         }
       }
     }
@@ -36724,6 +36746,7 @@ export const GQLGetUserItemsDocument = gql`
         submissionId
         submissionTime
         data
+        userStrikeCount
         type {
           id
           name

--- a/client/src/webpages/dashboard/investigation/ItemInvestigation.tsx
+++ b/client/src/webpages/dashboard/investigation/ItemInvestigation.tsx
@@ -121,6 +121,9 @@ gql`
             }
           }
         }
+        ... on UserItem {
+          userStrikeCount
+        }
       }
     }
   }

--- a/client/src/webpages/dashboard/mrt/manual_review_job/jobFragment.ts
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/jobFragment.ts
@@ -85,6 +85,9 @@ export const JOB_FRAGMENT = gql`
           ... on ItemBase {
             ...ItemFields
           }
+          ... on UserItem {
+            userStrikeCount
+          }
         }
         itemThreadContentItems {
           ... on ContentItem {
@@ -212,6 +215,9 @@ export const JOB_FRAGMENT = gql`
         item {
           ... on ItemBase {
             ...ItemFields
+          }
+          ... on UserItem {
+            userStrikeCount
           }
         }
         additionalContentItems {

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobPrimaryUserComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobPrimaryUserComponent.tsx
@@ -22,7 +22,10 @@ import ManualReviewJobMagnifyImageComponent from '../ManualReviewJobMagnifyImage
 import ManualReviewJobCurrentJobsComponent from './ManualReviewJobCurrentJobsComponent';
 import ManualReviewJobLatestSubmissionsWithThreadComponent from './ManualReviewJobLatestSubmissionsWithThreadComponent';
 import ManualReviewJobRelatedUserComponent from './ManualReviewJobRelatedUserComponent';
-import { convertRelatedItemToFieldData } from './ManualReviewJobUserUtils';
+import {
+  convertRelatedItemToFieldData,
+  userStrikeCountField,
+} from './ManualReviewJobUserUtils';
 
 export default function ManualReviewJobPrimaryUserComponent(props: {
   user: GQLUserItem | ItemIdentifier;
@@ -186,6 +189,7 @@ export default function ManualReviewJobPrimaryUserComponent(props: {
               },
               fieldData.map((it) => it.name),
             ),
+            userStrikeCountField(user.userStrikeCount),
             ...fieldData,
           ]}
           itemTypeId={user.type.id}

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobRelatedUserComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobRelatedUserComponent.tsx
@@ -23,7 +23,10 @@ import FieldsComponent from '../ManualReviewJobFieldsComponent';
 import ManualReviewJobMagnifyImageComponent from '../ManualReviewJobMagnifyImageComponent';
 import ManualReviewJobEnqueueRelatedActionWithPoliciesButton from '../related_actions/ManualReviewJobEnqueueRelatedActionWithPoliciesButton';
 import ManualReviewJobLatestSubmissionsWithThreadComponent from './ManualReviewJobLatestSubmissionsWithThreadComponent';
-import { convertRelatedItemToFieldData } from './ManualReviewJobUserUtils';
+import {
+  convertRelatedItemToFieldData,
+  userStrikeCountField,
+} from './ManualReviewJobUserUtils';
 
 gql`
   query OrgData {
@@ -87,6 +90,7 @@ gql`
         submissionId
         submissionTime
         data
+        userStrikeCount
         type {
           id
           name
@@ -332,6 +336,9 @@ export default function ManualReviewJobRelatedUserComponent(props: {
                   user,
                   (userSubmissionItems ?? []).map((it) => it.name),
                 ),
+                ...(userItem
+                  ? [userStrikeCountField(userItem.userStrikeCount)]
+                  : []),
                 ...(userSubmissionItems ?? []),
               ]}
               itemTypeId={user.typeId}

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobRelatedUserComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobRelatedUserComponent.tsx
@@ -2,6 +2,10 @@ import UserAlt4 from '@/icons/lni/User/user-alt-4.svg?react';
 import { arrayFromArrayOrSingleItem } from '@/utils/collections';
 import type { ItemTypeFieldFieldData } from '@/webpages/dashboard/item_types/itemTypeUtils';
 import ItemActionHistory from '@/webpages/dashboard/items/ItemActionHistory';
+import {
+  convertRelatedItemToFieldData,
+  userStrikeCountField,
+} from '@/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobUserUtils';
 import { LoadingOutlined } from '@ant-design/icons';
 import { gql } from '@apollo/client';
 import { ItemIdentifier, RelatedItem } from '@roostorg/coop-types';
@@ -23,10 +27,6 @@ import FieldsComponent from '../ManualReviewJobFieldsComponent';
 import ManualReviewJobMagnifyImageComponent from '../ManualReviewJobMagnifyImageComponent';
 import ManualReviewJobEnqueueRelatedActionWithPoliciesButton from '../related_actions/ManualReviewJobEnqueueRelatedActionWithPoliciesButton';
 import ManualReviewJobLatestSubmissionsWithThreadComponent from './ManualReviewJobLatestSubmissionsWithThreadComponent';
-import {
-  convertRelatedItemToFieldData,
-  userStrikeCountField,
-} from './ManualReviewJobUserUtils';
 
 gql`
   query OrgData {

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobUserUtils.ts
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobUserUtils.ts
@@ -7,6 +7,13 @@ const createFieldType = (name: string, type: ScalarType) =>
 
 const normalizeFieldName = (name: string) => name.trim().toLowerCase();
 
+export const userStrikeCountField = (
+  count: number,
+): ItemTypeFieldFieldData => ({
+  ...createFieldType('Strikes', 'NUMBER'),
+  value: count,
+});
+
 // `schemaRenderedFieldNames` are fields the caller already renders from the
 // typed schema; inlined keys matching one are skipped to avoid showing the same
 // field twice (roostorg/coop#716). Match is case/whitespace-insensitive.

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobUserUtils.ts
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobUserUtils.ts
@@ -10,7 +10,10 @@ const normalizeFieldName = (name: string) => name.trim().toLowerCase();
 export const userStrikeCountField = (
   count: number,
 ): ItemTypeFieldFieldData => ({
-  ...createFieldType('Strikes', 'NUMBER'),
+  name: 'Strikes',
+  type: 'NUMBER',
+  required: false,
+  container: null,
   value: count,
 });
 

--- a/server/graphql/generated.ts
+++ b/server/graphql/generated.ts
@@ -5122,6 +5122,7 @@ export type GQLUserItem = GQLItemBase & {
   readonly submissionTime?: Maybe<Scalars['DateTime']['output']>;
   readonly type: GQLUserItemType;
   readonly userScore: Scalars['Int']['output'];
+  readonly userStrikeCount: Scalars['Int']['output'];
 };
 
 export type GQLUserItemType = GQLItemTypeBase & {
@@ -14733,6 +14734,7 @@ export type GQLUserItemResolvers<
   >;
   type?: Resolver<GQLResolversTypes['UserItemType'], ParentType, ContextType>;
   userScore?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
+  userStrikeCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/server/graphql/modules/itemType.ts
+++ b/server/graphql/modules/itemType.ts
@@ -203,6 +203,7 @@ const typeDefs = /* GraphQL */ `
     submissionId: ID!
     submissionTime: DateTime
     userScore: Int!
+    userStrikeCount: Int!
   }
 
   type ThreadItem implements ItemBase {
@@ -544,6 +545,19 @@ const UserItem: GQLUserItemResolvers = {
 
     const { id, type } = userItem;
     return context.services.UserStatisticsService.getUserScore(user.orgId, {
+      id,
+      typeId: type.id,
+    });
+  },
+
+  async userStrikeCount(userItem, __, context) {
+    const user = context.getUser();
+    if (!user) {
+      throw unauthenticatedError('User required.');
+    }
+
+    const { id, type } = userItem;
+    return context.services.UserStrikeService.getUserStrikeValue(user.orgId, {
       id,
       typeId: type.id,
     });


### PR DESCRIPTION
## Context & Requests for Reviewers

We removed user scores from the front-end, but weren't exposing user strikes in the same places. This PR exposes `userStrikeCount` via GraphQL, then uses that to display the strike count in the job and investigation views.

- Fixes #752 

## Tests

<!-- Describe how you tested your changes, including any manual steps or automated tests performed. -->
<!-- Provide screenshots if available -->

- [x] Tested locally

Job:
<img width="4266" height="2204" alt="Screenshot From 2026-06-12 14-59-27" src="https://github.com/user-attachments/assets/9fd2b042-91c5-41b7-b9e0-d4b0765165c4" />

Investigation:
<img width="4266" height="2204" alt="Screenshot From 2026-06-12 14-49-08" src="https://github.com/user-attachments/assets/190d73c9-4cb1-4693-9f0b-cced42524847" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User strike count now appears in the investigation dashboard view.
  * Strike count shown in manual review job interfaces for both primary and related user profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->