### PR TITLE
fix: gate job view iframe on content URL pattern

### DIFF
--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobContentView.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobContentView.tsx
@@ -11,12 +11,13 @@ import {
   GQLThreadAppealManualReviewJobPayload,
   GQLThreadManualReviewJobPayload,
 } from '../../../../../graphql/generated';
+import { shouldDisplayInIframe } from '../../../../../utils/contentUrlUtils';
 import { getFieldValueForRole } from '../../../../../utils/itemUtils';
+import IframeContentDisplayComponent from '../IframeContentDisplayComponent';
 import {
   ManualReviewJobAction,
   ManualReviewJobEnqueuedActionData,
 } from '../ManualReviewJobReview';
-import IframeContentDisplayComponent from '../IframeContentDisplayComponent';
 import ManualReviewJobContentThreadHistory from './ManualReviewJobContentThreadHistory';
 import FieldsComponent from './ManualReviewJobFieldsComponent';
 import ManualReviewJobRelatedUserComponent from './user/ManualReviewJobRelatedUserComponent';
@@ -95,8 +96,8 @@ export default function ManualReviewJobContentView(props: {
     payload.__typename === 'ContentManualReviewJobPayload'
       ? getFieldValueForRole(payload.item, 'threadId')
       : payload.__typename === 'ThreadManualReviewJobPayload'
-      ? { id: payload.item.id, typeId: payload.item.type.id }
-      : undefined;
+        ? { id: payload.item.id, typeId: payload.item.type.id }
+        : undefined;
 
   const inspectUserModal = (
     <CoopModal
@@ -145,8 +146,11 @@ export default function ManualReviewJobContentView(props: {
           />
         </div>
       </div>
-      {'url' in payload.item.data ? (
-        <IframeContentDisplayComponent contentUrl={String(payload.item.data.url)} />
+      {'url' in payload.item.data &&
+      shouldDisplayInIframe(String(payload.item.data.url)) ? (
+        <IframeContentDisplayComponent
+          contentUrl={String(payload.item.data.url)}
+        />
       ) : null}
       {!contentThread ? null : (
         <div className="my-6">


### PR DESCRIPTION
## Context & Requests for Reviewers

ManualReviewJobContentView was rendering the iframe for any item with a url field, ignoring VITE_CONTENT_URL_PATTERN. Now uses shouldDisplayInIframe(), consistent with the investigation views.

Fixes #375

## Tests

Tested locally with my atproto branch; when `VITE_CONTENT_URL_PATTERN` is set to `bsky.app`, I get iframes trying to render the posts in the job view; when it's empty, they don't try to render.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined iframe content rendering with improved validation checks to ensure proper display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->