### PR TITLE
[Fix] Potential injection and safety consistency

### DIFF
--- a/client/src/utils/contentUrlUtils.test.ts
+++ b/client/src/utils/contentUrlUtils.test.ts
@@ -2,8 +2,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { shouldDisplayInIframe } from './contentUrlUtils';
 
-function setPattern(value: string | undefined) {
-  vi.stubEnv('VITE_CONTENT_URL_PATTERN', value as string);
+function setPattern(value: string) {
+  vi.stubEnv('VITE_CONTENT_URL_PATTERN', value);
 }
 
 describe('shouldDisplayInIframe', () => {
@@ -12,38 +12,40 @@ describe('shouldDisplayInIframe', () => {
   });
 
   it('returns false for non-URL strings', () => {
-    setPattern('notion');
+    setPattern('example.com');
     expect(shouldDisplayInIframe('not a url')).toBe(false);
     expect(shouldDisplayInIframe('')).toBe(false);
   });
 
   it('does not match patterns smuggled via path or query', () => {
-    setPattern('bsky.app');
-    expect(shouldDisplayInIframe('https://evil.example/?ref=bsky.app')).toBe(
+    setPattern('example.com');
+    expect(shouldDisplayInIframe('https://evil.test/?ref=example.com')).toBe(
       false,
     );
-    expect(shouldDisplayInIframe('https://evil.example/bsky.app')).toBe(false);
+    expect(shouldDisplayInIframe('https://evil.test/example.com')).toBe(false);
   });
 
   describe('domain-like patterns (containing a dot)', () => {
     it('matches the exact host', () => {
-      setPattern('bsky.app');
-      expect(shouldDisplayInIframe('https://bsky.app/profile/foo')).toBe(true);
+      setPattern('example.com');
+      expect(shouldDisplayInIframe('https://example.com/profile/foo')).toBe(
+        true,
+      );
     });
 
     it('matches subdomains of the pattern', () => {
-      setPattern('bsky.app');
-      expect(shouldDisplayInIframe('https://www.bsky.app/foo')).toBe(true);
+      setPattern('example.com');
+      expect(shouldDisplayInIframe('https://www.example.com/foo')).toBe(true);
     });
 
     it('does not match lookalike hosts', () => {
-      setPattern('bsky.app');
-      expect(shouldDisplayInIframe('https://evilbsky.app/foo')).toBe(false);
+      setPattern('example.com');
+      expect(shouldDisplayInIframe('https://notexample.com/foo')).toBe(false);
     });
 
     it('does not match hosts that merely contain the pattern as a subdomain prefix', () => {
-      setPattern('bsky.app');
-      expect(shouldDisplayInIframe('https://bsky.app.evil.example/foo')).toBe(
+      setPattern('example.com');
+      expect(shouldDisplayInIframe('https://example.com.evil.test/foo')).toBe(
         false,
       );
     });
@@ -51,18 +53,37 @@ describe('shouldDisplayInIframe', () => {
 
   describe('legacy patterns (no dot)', () => {
     it('keeps substring matching for backward compatibility', () => {
-      setPattern('notion');
-      expect(shouldDisplayInIframe('https://www.notion.so/page')).toBe(true);
-      expect(shouldDisplayInIframe('https://mycompany.notion.site/x')).toBe(
+      setPattern('wiki');
+      expect(shouldDisplayInIframe('https://wiki.example.com/page')).toBe(true);
+      expect(shouldDisplayInIframe('https://team.wiki.example.org/x')).toBe(
         true,
       );
     });
   });
 
+  describe('URL-like patterns (scheme / port / path)', () => {
+    it('normalizes a pattern with a scheme to its hostname', () => {
+      setPattern('https://example.com');
+      expect(shouldDisplayInIframe('https://example.com/foo')).toBe(true);
+      expect(shouldDisplayInIframe('https://notexample.com/foo')).toBe(false);
+    });
+
+    it('normalizes a pattern with a path to its hostname', () => {
+      setPattern('example.org/page');
+      expect(shouldDisplayInIframe('https://example.org/anything')).toBe(true);
+      expect(shouldDisplayInIframe('https://www.example.org/x')).toBe(true);
+    });
+
+    it('normalizes a pattern with a port to its hostname', () => {
+      setPattern('localhost:3000');
+      expect(shouldDisplayInIframe('http://localhost/foo')).toBe(true);
+    });
+  });
+
   it('supports comma-separated patterns', () => {
-    setPattern('notion, bsky.app');
-    expect(shouldDisplayInIframe('https://www.notion.so/page')).toBe(true);
-    expect(shouldDisplayInIframe('https://bsky.app/foo')).toBe(true);
-    expect(shouldDisplayInIframe('https://evilbsky.app/foo')).toBe(false);
+    setPattern('wiki, example.com');
+    expect(shouldDisplayInIframe('https://wiki.example.org/page')).toBe(true);
+    expect(shouldDisplayInIframe('https://example.com/foo')).toBe(true);
+    expect(shouldDisplayInIframe('https://notexample.com/foo')).toBe(false);
   });
 });

--- a/client/src/utils/contentUrlUtils.test.ts
+++ b/client/src/utils/contentUrlUtils.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { shouldDisplayInIframe } from './contentUrlUtils';
+
+function setPattern(value: string | undefined) {
+  vi.stubEnv('VITE_CONTENT_URL_PATTERN', value as string);
+}
+
+describe('shouldDisplayInIframe', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns false for non-URL strings', () => {
+    setPattern('notion');
+    expect(shouldDisplayInIframe('not a url')).toBe(false);
+    expect(shouldDisplayInIframe('')).toBe(false);
+  });
+
+  it('does not match patterns smuggled via path or query', () => {
+    setPattern('bsky.app');
+    expect(shouldDisplayInIframe('https://evil.example/?ref=bsky.app')).toBe(
+      false,
+    );
+    expect(shouldDisplayInIframe('https://evil.example/bsky.app')).toBe(false);
+  });
+
+  describe('domain-like patterns (containing a dot)', () => {
+    it('matches the exact host', () => {
+      setPattern('bsky.app');
+      expect(shouldDisplayInIframe('https://bsky.app/profile/foo')).toBe(true);
+    });
+
+    it('matches subdomains of the pattern', () => {
+      setPattern('bsky.app');
+      expect(shouldDisplayInIframe('https://www.bsky.app/foo')).toBe(true);
+    });
+
+    it('does not match lookalike hosts', () => {
+      setPattern('bsky.app');
+      expect(shouldDisplayInIframe('https://evilbsky.app/foo')).toBe(false);
+    });
+
+    it('does not match hosts that merely contain the pattern as a subdomain prefix', () => {
+      setPattern('bsky.app');
+      expect(shouldDisplayInIframe('https://bsky.app.evil.example/foo')).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('legacy patterns (no dot)', () => {
+    it('keeps substring matching for backward compatibility', () => {
+      setPattern('notion');
+      expect(shouldDisplayInIframe('https://www.notion.so/page')).toBe(true);
+      expect(shouldDisplayInIframe('https://mycompany.notion.site/x')).toBe(
+        true,
+      );
+    });
+  });
+
+  it('supports comma-separated patterns', () => {
+    setPattern('notion, bsky.app');
+    expect(shouldDisplayInIframe('https://www.notion.so/page')).toBe(true);
+    expect(shouldDisplayInIframe('https://bsky.app/foo')).toBe(true);
+    expect(shouldDisplayInIframe('https://evilbsky.app/foo')).toBe(false);
+  });
+});

--- a/client/src/utils/contentUrlUtils.ts
+++ b/client/src/utils/contentUrlUtils.ts
@@ -63,16 +63,36 @@ export function getContentUrlPatterns(): string[] {
 }
 
 /**
+ * Normalize a configured pattern to a bare host fragment, stripping any scheme,
+ * port, or path so legacy full-URL configs keep working. Dotless fragments are
+ * returned as-is for substring matching.
+ */
+function normalizePatternHost(pattern: string): string {
+  const trimmed = pattern.trim().toLowerCase();
+  if (trimmed.length === 0) return '';
+  let host = trimmed;
+  if (/[:/]/.test(trimmed)) {
+    try {
+      host = new URL(trimmed.includes('://') ? trimmed : `http://${trimmed}`)
+        .hostname;
+    } catch {
+      // Not parseable as a URL; fall back to the raw fragment.
+    }
+  }
+  return host.replace(/^\.+|\.+$/g, '');
+}
+
+/**
  * Check whether a single pattern matches a hostname.
  *
- * Domain-like patterns (those containing a dot, e.g. `bsky.app`) are matched on
- * host boundaries so a pattern can't be smuggled via a lookalike or subdomain
- * (`evilbsky.app` and `bsky.app.evil.example` do NOT match `bsky.app`). Legacy
- * patterns without a dot (e.g. the default `notion`) keep substring matching for
- * backward compatibility with existing `VITE_CONTENT_URL_PATTERN` configs.
+ * Domain-like patterns (those containing a dot, e.g. `example.com`) are matched
+ * on host boundaries so a pattern can't be smuggled via a lookalike or subdomain
+ * (`notexample.com` and `example.com.evil.test` do NOT match `example.com`).
+ * Legacy patterns without a dot keep substring matching for backward
+ * compatibility with existing `VITE_CONTENT_URL_PATTERN` configs.
  */
 function hostnameMatchesPattern(hostname: string, pattern: string): boolean {
-  const normalized = pattern.toLowerCase().replace(/^\.+|\.+$/g, '');
+  const normalized = normalizePatternHost(pattern);
   if (normalized.length === 0) return false;
   if (normalized.includes('.')) {
     return hostname === normalized || hostname.endsWith(`.${normalized}`);
@@ -85,7 +105,7 @@ function hostnameMatchesPattern(hostname: string, pattern: string): boolean {
  *
  * Patterns are matched against the URL's hostname only (not the full URL), so a
  * pattern can't be smuggled in via the path or query string (e.g.
- * `https://evil.example/?ref=bsky.app` does not match the `bsky.app` pattern).
+ * `https://evil.test/?ref=example.com` does not match the `example.com` pattern).
  * Domain-like patterns are further matched on host boundaries; see
  * {@link hostnameMatchesPattern}.
  * @param url The URL to check

--- a/client/src/utils/contentUrlUtils.ts
+++ b/client/src/utils/contentUrlUtils.ts
@@ -63,11 +63,31 @@ export function getContentUrlPatterns(): string[] {
 }
 
 /**
+ * Check whether a single pattern matches a hostname.
+ *
+ * Domain-like patterns (those containing a dot, e.g. `bsky.app`) are matched on
+ * host boundaries so a pattern can't be smuggled via a lookalike or subdomain
+ * (`evilbsky.app` and `bsky.app.evil.example` do NOT match `bsky.app`). Legacy
+ * patterns without a dot (e.g. the default `notion`) keep substring matching for
+ * backward compatibility with existing `VITE_CONTENT_URL_PATTERN` configs.
+ */
+function hostnameMatchesPattern(hostname: string, pattern: string): boolean {
+  const normalized = pattern.toLowerCase().replace(/^\.+|\.+$/g, '');
+  if (normalized.length === 0) return false;
+  if (normalized.includes('.')) {
+    return hostname === normalized || hostname.endsWith(`.${normalized}`);
+  }
+  return hostname.includes(normalized);
+}
+
+/**
  * Check if a URL should be displayed in an iframe
  *
  * Patterns are matched against the URL's hostname only (not the full URL), so a
  * pattern can't be smuggled in via the path or query string (e.g.
  * `https://evil.example/?ref=bsky.app` does not match the `bsky.app` pattern).
+ * Domain-like patterns are further matched on host boundaries; see
+ * {@link hostnameMatchesPattern}.
  * @param url The URL to check
  * @returns True if the URL should be displayed in an iframe
  */
@@ -79,7 +99,7 @@ export function shouldDisplayInIframe(url: string): boolean {
     return false;
   }
   const patterns = getContentUrlPatterns();
-  return patterns.some((pattern) => hostname.includes(pattern.toLowerCase()));
+  return patterns.some((pattern) => hostnameMatchesPattern(hostname, pattern));
 }
 
 /**

--- a/client/src/utils/contentUrlUtils.ts
+++ b/client/src/utils/contentUrlUtils.ts
@@ -64,13 +64,22 @@ export function getContentUrlPatterns(): string[] {
 
 /**
  * Check if a URL should be displayed in an iframe
+ *
+ * Patterns are matched against the URL's hostname only (not the full URL), so a
+ * pattern can't be smuggled in via the path or query string (e.g.
+ * `https://evil.example/?ref=bsky.app` does not match the `bsky.app` pattern).
  * @param url The URL to check
  * @returns True if the URL should be displayed in an iframe
  */
 export function shouldDisplayInIframe(url: string): boolean {
+  let hostname: string;
+  try {
+    hostname = new URL(url).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
   const patterns = getContentUrlPatterns();
-  const urlLower = url.toLowerCase();
-  return patterns.some((pattern) => urlLower.includes(pattern.toLowerCase()));
+  return patterns.some((pattern) => hostname.includes(pattern.toLowerCase()));
 }
 
 /**

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobContentView.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobContentView.tsx
@@ -147,10 +147,9 @@ export default function ManualReviewJobContentView(props: {
         </div>
       </div>
       {'url' in payload.item.data &&
-      shouldDisplayInIframe(String(payload.item.data.url)) ? (
-        <IframeContentDisplayComponent
-          contentUrl={String(payload.item.data.url)}
-        />
+      typeof payload.item.data.url === 'string' &&
+      shouldDisplayInIframe(payload.item.data.url) ? (
+        <IframeContentDisplayComponent contentUrl={payload.item.data.url} />
       ) : null}
       {!contentThread ? null : (
         <div className="my-6">


### PR DESCRIPTION
## Context & Requests for Reviewers

Follow-up to #771. While reviewing it, I noticed `shouldDisplayInIframe` matched the configured `VITE_CONTENT_URL_PATTERN` against the entire URL as a lowercased substring. That means a pattern could match content in the path or query string rather than the actual host e.g. with `bsky.app` configured, `https://evil.example/?ref=bsky.app` would pass and get loaded into the content iframe. The iframe is sandboxed and proxied, so impact is
limited, but the match should be host-based.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced URL validation for iframe display to match patterns against hostname only instead of full URL strings.
  * Improved type checking to ensure URL strings are properly validated before iframe rendering.
  * Added error handling for failed URL parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->