### PR TITLE
[Bug] Fix duplicate recent decisions on select latest

### DIFF
--- a/client/src/webpages/dashboard/mrt/ManualReviewRecentDecisions.tsx
+++ b/client/src/webpages/dashboard/mrt/ManualReviewRecentDecisions.tsx
@@ -410,10 +410,15 @@ export default function ManualReviewRecentDecisions() {
     if (!allDecisionsData || !orgLookupData?.myOrg) {
       return undefined;
     }
+    const fetchedDecision =
+      decidedJobFromJobIdData?.getDecidedJobFromJobId?.decision;
     const allDecisions = [
       ...allDecisionsData.getRecentDecisions,
-      ...(decidedJobFromJobIdData?.getDecidedJobFromJobId?.decision
-        ? [decidedJobFromJobIdData?.getDecidedJobFromJobId?.decision]
+      ...(fetchedDecision &&
+      !allDecisionsData.getRecentDecisions.some(
+        (decision) => decision.id === fetchedDecision.id,
+      )
+        ? [fetchedDecision]
         : []),
     ];
 


### PR DESCRIPTION
## Context & Requests for Reviewers

When users selects a recent decision on the recent decision pages we duplicate the last decision when selected. as we did not filter the currently selected decision. this pr fixes that

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate decisions appearing in the recent decisions table. The system now checks if a decision ID already exists before adding it to the list, preventing duplicate entries from being displayed to users. Users will now see only unique, clean decision records in the recent decisions view without any duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->