### PR TITLE
manual review: fix iframe rendering when no content proxy is set

### DIFF
--- a/client/src/webpages/dashboard/mrt/manual_review_job/IframeContentDisplayComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/IframeContentDisplayComponent.tsx
@@ -14,9 +14,11 @@ export default function IframeContentDisplayComponent(props: {
 }) {
   const { contentUrl } = props;
 
+  // An empty or unset proxy URL means the content URL is rendered directly in
+  // the iframe rather than routed through a content proxy.
+  const trimmedProxyUrl = import.meta.env.VITE_CONTENT_PROXY_URL?.trim();
   const contentProxyUrl =
-    import.meta.env.VITE_CONTENT_PROXY_URL?.trim() ??
-    (import.meta.env.DEV ? 'http://localhost:4000' : window.location.origin);
+    trimmedProxyUrl && trimmedProxyUrl.length > 0 ? trimmedProxyUrl : undefined;
 
   const [isIframeLoading, setIsIframeLoading] = useState(true);
   const [isTranslating, setIsTranslating] = useState(false);
@@ -49,6 +51,10 @@ export default function IframeContentDisplayComponent(props: {
   }, [moderatorSafetyBlurLevel, moderatorSafetyGrayscale]);
 
   useEffect(() => {
+    // Translation status messages come from the content proxy. With no proxy
+    // configured there is nothing to listen for.
+    if (!contentProxyUrl) return;
+
     const handleMessage = (event: MessageEvent) => {
       if (event.origin !== contentProxyUrl) return;
 
@@ -64,7 +70,10 @@ export default function IframeContentDisplayComponent(props: {
   const handleIframeLoad = useCallback(
     function (elm: HTMLIFrameElement | null) {
       const sendMessage = () => {
-        if (!elm?.contentWindow) return;
+        // The custom controls (blur/grayscale/translate) are implemented by the
+        // content proxy. Without a proxy there is no window to message.
+        if (!elm?.contentWindow || !contentProxyUrl) return;
+        const proxyUrl = contentProxyUrl;
 
         try {
           elm.contentWindow.postMessage(
@@ -74,7 +83,7 @@ export default function IframeContentDisplayComponent(props: {
               grayscale,
               shouldTranslate,
             },
-            contentProxyUrl,
+            proxyUrl,
           );
 
           if (shouldTranslate) {
@@ -90,7 +99,7 @@ export default function IframeContentDisplayComponent(props: {
                   grayscale,
                   shouldTranslate,
                 },
-                contentProxyUrl,
+                proxyUrl,
               );
             } catch (retryError) {
               setIsTranslating(false);
@@ -119,30 +128,38 @@ export default function IframeContentDisplayComponent(props: {
     return <FullScreenLoading />;
   }
 
-  const url = `${contentProxyUrl}/?contentUrl=${encodeURIComponent(contentUrl)}`;
+  // With a proxy configured, hand it the content URL to fetch/transform.
+  // Otherwise, load the content URL directly in the iframe.
+  const url = contentProxyUrl
+    ? `${contentProxyUrl}/?contentUrl=${encodeURIComponent(contentUrl)}`
+    : contentUrl;
 
   return (
     <div className="flex flex-col w-full p-2 isolation-auto">
-      <div className="flex flex-row items-center self-end gap-4 mb-2">
-        <div className="flex items-center space-x-2">
-          {isTranslating && (
-            <LoaderCircle className="h-4 w-4 animate-spin text-indigo-500" />
-          )}
-          <Switch
-            disabled={isIframeLoading}
-            id="translate-to-english"
-            defaultChecked={shouldTranslate}
-            onCheckedChange={(value) => {
-              setState({ ...state, shouldTranslate: value });
-              if (!value) {
-                setIsTranslating(false);
-              }
-            }}
-            checked={shouldTranslate}
-          />
-          <Label htmlFor="translate-to-english">Translate to English</Label>
+      {/* Translation is performed by the content proxy, so only offer it when
+          a proxy is configured. */}
+      {contentProxyUrl && (
+        <div className="flex flex-row items-center self-end gap-4 mb-2">
+          <div className="flex items-center space-x-2">
+            {isTranslating && (
+              <LoaderCircle className="h-4 w-4 animate-spin text-indigo-500" />
+            )}
+            <Switch
+              disabled={isIframeLoading}
+              id="translate-to-english"
+              defaultChecked={shouldTranslate}
+              onCheckedChange={(value) => {
+                setState({ ...state, shouldTranslate: value });
+                if (!value) {
+                  setIsTranslating(false);
+                }
+              }}
+              checked={shouldTranslate}
+            />
+            <Label htmlFor="translate-to-english">Translate to English</Label>
+          </div>
         </div>
-      </div>
+      )}
       <div className="relative w-full min-h-[800px] h-[800px] border border-solid rounded-md overflow-hidden">
         {isIframeLoading && (
           <div className="absolute inset-0 flex items-center justify-center z-10 bg-white bg-opacity-75">


### PR DESCRIPTION
## What

There was a bug in iframe rendering. When `VITE_CONTENT_PROXY_URL` was unset or empty, then if we showed an iframe, it would render Coop itself and not the actual URL it was intended to render! This is because the code fell back to rendering `localhost:4000` in dev or `window.location.origin` in prod, instead of the correct URL.

This PR fixes that.

## Notes

Note that blur/grayscale/translation only work when a content proxy is configured (see also https://github.com/roostorg/coop/issues/768).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of content proxy configuration to correctly disable translation features when proxy is not configured.
  * Fixed iframe content display logic to properly route content through the proxy when configured and directly when disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->