### PR TITLE
(auth) Invalidate sessions on password change

### DIFF
--- a/server/graphql/datasources/UserApi.test.ts
+++ b/server/graphql/datasources/UserApi.test.ts
@@ -88,8 +88,7 @@ describe('UserAPI', () => {
           currentSid,
         );
 
-        // The caller's own session is preserved; all others are invalidated
-        // (GHSA-g5xq-67g7-36r2).
+        // The caller's own session is preserved; all others are invalidated.
         expect(deleteFrom).toHaveBeenCalledWith('public.session');
         expect(deleteWhere).toHaveBeenCalledWith('sid', '!=', currentSid);
       },

--- a/server/graphql/datasources/UserApi.test.ts
+++ b/server/graphql/datasources/UserApi.test.ts
@@ -24,8 +24,19 @@ function makeMockKyselyPg() {
   const updateTable = jest.fn().mockReturnValue(updateBuilder);
   const deleteFrom = jest.fn().mockReturnValue(deleteBuilder);
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const kyselyPg = { updateTable, deleteFrom } as unknown as Kysely<any>;
+  // changePassword runs inside makeKyselyTransactionWithRetry, which calls
+  // `kysely.transaction().execute(cb)`. Run the callback against this same mock.
+  const transaction = jest.fn().mockReturnValue({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test trx stub
+    execute: (cb: (trx: any) => unknown) => cb(kyselyPg),
+  });
+
+   
+  const kyselyPg = {
+    updateTable,
+    deleteFrom,
+    transaction,
+  } as unknown as Kysely<any>;
   return { kyselyPg, updateExecuteTakeFirst, deleteFrom, deleteWhere };
 }
 
@@ -66,15 +77,17 @@ describe('UserAPI', () => {
         });
 
         // Remaining constructor deps are unused by changePassword.
-        /* eslint-disable @typescript-eslint/no-explicit-any */
         const sut = new UserAPI(
           kyselyPg,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- unused mock dep
           {} as any,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- unused mock dep
           {} as any,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- unused mock dep
           {} as any,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- unused mock dep
           {} as any,
         );
-        /* eslint-enable @typescript-eslint/no-explicit-any */
 
         const user = {
           id: userId,

--- a/server/graphql/datasources/UserApi.test.ts
+++ b/server/graphql/datasources/UserApi.test.ts
@@ -1,0 +1,98 @@
+import { type Kysely } from 'kysely';
+
+import { hashPassword } from '../../services/userManagementService/index.js';
+import { makeTestWithFixture } from '../../test/utils.js';
+import UserAPI from './UserApi.js';
+import { type GraphQLUserParent } from './userKyselyPersistence.js';
+
+// changePassword only touches the injected Kysely instance (for the user
+// update + session deletion); the other constructor deps are unused here.
+function makeMockKyselyPg() {
+  const updateExecuteTakeFirst = jest.fn();
+  const updateBuilder = {
+    set: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    returning: jest.fn().mockReturnThis(),
+    executeTakeFirst: updateExecuteTakeFirst,
+  };
+
+  const deleteWhere = jest.fn();
+  const deleteBuilder = { where: deleteWhere, execute: jest.fn() };
+  deleteWhere.mockReturnValue(deleteBuilder);
+  deleteBuilder.execute.mockResolvedValue([]);
+
+  const updateTable = jest.fn().mockReturnValue(updateBuilder);
+  const deleteFrom = jest.fn().mockReturnValue(deleteBuilder);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const kyselyPg = { updateTable, deleteFrom } as unknown as Kysely<any>;
+  return { kyselyPg, updateExecuteTakeFirst, deleteFrom, deleteWhere };
+}
+
+describe('UserAPI', () => {
+  describe('#changePassword', () => {
+    const testWithFixtures = makeTestWithFixture(() => ({}));
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    testWithFixtures(
+      'invalidates the user other sessions but preserves the caller session',
+      async () => {
+        const currentPassword = 'current-password';
+        const userId = 'user-123';
+        const currentSid = 'sid-abc';
+        const passwordHash = await hashPassword(currentPassword);
+
+        const { kyselyPg, updateExecuteTakeFirst, deleteFrom, deleteWhere } =
+          makeMockKyselyPg();
+
+        // kyselyUserUpdate succeeds (returns a non-undefined row).
+        updateExecuteTakeFirst.mockResolvedValue({
+          id: userId,
+          email: 'test@example.com',
+          password: 'new-hash',
+          first_name: 'Test',
+          last_name: 'User',
+          org_id: 'org-456',
+          role: 'ADMIN',
+          approved_by_admin: true,
+          rejected_by_admin: false,
+          login_methods: ['password'],
+          permissions: [],
+          created_at: new Date(),
+          updated_at: new Date(),
+        });
+
+        // Remaining constructor deps are unused by changePassword.
+        /* eslint-disable @typescript-eslint/no-explicit-any */
+        const sut = new UserAPI(
+          kyselyPg,
+          {} as any,
+          {} as any,
+          {} as any,
+          {} as any,
+        );
+        /* eslint-enable @typescript-eslint/no-explicit-any */
+
+        const user = {
+          id: userId,
+          loginMethods: ['password'],
+          password: passwordHash,
+        } as unknown as GraphQLUserParent;
+
+        await sut.changePassword(
+          user,
+          { currentPassword, newPassword: 'new-password' },
+          currentSid,
+        );
+
+        // The caller's own session is preserved; all others are invalidated
+        // (GHSA-g5xq-67g7-36r2).
+        expect(deleteFrom).toHaveBeenCalledWith('public.session');
+        expect(deleteWhere).toHaveBeenCalledWith('sid', '!=', currentSid);
+      },
+    );
+  });
+});

--- a/server/graphql/datasources/UserApi.ts
+++ b/server/graphql/datasources/UserApi.ts
@@ -2,6 +2,7 @@ import { type Exception } from '@opentelemetry/api';
 import { uid } from 'uid';
 
 import { inject, type Dependencies } from '../../iocContainer/index.js';
+import { type CombinedPg } from '../../services/combinedDbTypes.js';
 import { type LoginMethod } from '../../services/coreAppTables.js';
 import {
   deleteSessionsForUser,
@@ -13,6 +14,7 @@ import {
   makeNotFoundError,
   makeUnauthorizedError,
 } from '../../utils/errors.js';
+import { makeKyselyTransactionWithRetry } from '../../utils/kyselyTransactionWithRetry.js';
 import { safePick } from '../../utils/misc.js';
 import { WEEK_MS } from '../../utils/time.js';
 import {
@@ -266,21 +268,24 @@ class UserAPI {
     }
 
     const hashedNewPassword = await hashPassword(newPassword);
-    const updated = await kyselyUserUpdate(this.kyselyPg, user.id, {
-      password: hashedNewPassword,
-    });
-    if (updated == null) {
-      // Row went missing between load and update (e.g. concurrent delete).
-      throw makeNotFoundError(`User ${user.id} not found`, {
-        shouldErrorSpan: true,
-      });
-    }
+    // Update the password and invalidate the user's other sessions atomically:
+    // if the session purge failed independently, a phished/attacker session
+    // could outlive the password change. Keep the caller's own session.
+    await makeKyselyTransactionWithRetry<CombinedPg>(this.kyselyPg)(
+      async (trx) => {
+        const updated = await kyselyUserUpdate(trx, user.id, {
+          password: hashedNewPassword,
+        });
+        if (updated == null) {
+          // Row went missing between load and update (e.g. concurrent delete).
+          throw makeNotFoundError(`User ${user.id} not found`, {
+            shouldErrorSpan: true,
+          });
+        }
 
-    // Invalidate the user's other sessions so a phished/attacker session can't
-    // outlive the change; keep the caller's own session.
-    await deleteSessionsForUser(this.kyselyPg, user.id, {
-      exceptSid: currentSid,
-    });
+        await deleteSessionsForUser(trx, user.id, { exceptSid: currentSid });
+      },
+    );
 
     return {
       __typename: 'ChangePasswordSuccessResponse' as const,

--- a/server/graphql/datasources/UserApi.ts
+++ b/server/graphql/datasources/UserApi.ts
@@ -277,7 +277,7 @@ class UserAPI {
     }
 
     // Invalidate the user's other sessions so a phished/attacker session can't
-    // outlive the change (GHSA-g5xq-67g7-36r2); keep the caller's own session.
+    // outlive the change; keep the caller's own session.
     await deleteSessionsForUser(this.kyselyPg, user.id, {
       exceptSid: currentSid,
     });

--- a/server/graphql/datasources/UserApi.ts
+++ b/server/graphql/datasources/UserApi.ts
@@ -4,6 +4,7 @@ import { uid } from 'uid';
 import { inject, type Dependencies } from '../../iocContainer/index.js';
 import { type LoginMethod } from '../../services/coreAppTables.js';
 import {
+  deleteSessionsForUser,
   hashPassword,
   passwordMatchesHash,
 } from '../../services/userManagementService/index.js';
@@ -233,6 +234,9 @@ class UserAPI {
   async changePassword(
     user: GraphQLUserParent,
     params: { currentPassword: string; newPassword: string },
+    // The caller's current session id, preserved so the user isn't logged out
+    // of the session they're changing their password from.
+    currentSid?: string,
   ) {
     const { currentPassword, newPassword } = params;
 
@@ -271,6 +275,12 @@ class UserAPI {
         shouldErrorSpan: true,
       });
     }
+
+    // Invalidate the user's other sessions so a phished/attacker session can't
+    // outlive the change (GHSA-g5xq-67g7-36r2); keep the caller's own session.
+    await deleteSessionsForUser(this.kyselyPg, user.id, {
+      exceptSid: currentSid,
+    });
 
     return {
       __typename: 'ChangePasswordSuccessResponse' as const,

--- a/server/graphql/modules/user.ts
+++ b/server/graphql/modules/user.ts
@@ -213,7 +213,11 @@ const Mutation: GQLMutationResolvers = {
     if (user == null) {
       throw unauthenticatedError('Authenticated user required');
     }
-    return context.dataSources.userAPI.changePassword(user, params.input);
+    return context.dataSources.userAPI.changePassword(
+      user,
+      params.input,
+      context.req.sessionID,
+    );
   },
   async deleteUser(_, params, context) {
     const user = context.getUser();

--- a/server/services/userManagementService/index.ts
+++ b/server/services/userManagementService/index.ts
@@ -4,6 +4,7 @@ export {
   type UserManagementService,
 } from './userManagementService.js';
 export { hashPassword, passwordMatchesHash } from './utils.js';
+export { deleteSessionsForUser } from './sessionPersistence.js';
 export {
   Invoker,
   UserPermission,

--- a/server/services/userManagementService/sessionPersistence.test.ts
+++ b/server/services/userManagementService/sessionPersistence.test.ts
@@ -1,0 +1,44 @@
+import { type Kysely } from 'kysely';
+
+import { deleteSessionsForUser } from './sessionPersistence.js';
+
+// Build a mock Kysely whose `deleteFrom(...)` returns a chainable
+// `{ where, execute }`, so we can assert the issued query shape.
+function makeMockDb() {
+  const execute = jest.fn().mockResolvedValue([]);
+  const where = jest.fn();
+  const builder = { where, execute };
+  where.mockReturnValue(builder);
+  const deleteFrom = jest.fn().mockReturnValue(builder);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const db = { deleteFrom } as unknown as Kysely<any>;
+  return { db, deleteFrom, where, execute };
+}
+
+describe('deleteSessionsForUser', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deletes session rows matching the user id', async () => {
+    const { db, deleteFrom, where, execute } = makeMockDb();
+
+    await deleteSessionsForUser(db, 'user-123');
+
+    expect(deleteFrom).toHaveBeenCalledWith('public.session');
+    // Matches on the passport user id; no `sid` exclusion when none requested.
+    expect(where).toHaveBeenCalledTimes(1);
+    expect(where).toHaveBeenCalledWith(expect.anything(), '=', 'user-123');
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves the caller session when exceptSid is given', async () => {
+    const { db, where, execute } = makeMockDb();
+
+    await deleteSessionsForUser(db, 'user-123', { exceptSid: 'sid-abc' });
+
+    expect(where).toHaveBeenCalledWith(expect.anything(), '=', 'user-123');
+    expect(where).toHaveBeenCalledWith('sid', '!=', 'sid-abc');
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/services/userManagementService/sessionPersistence.ts
+++ b/server/services/userManagementService/sessionPersistence.ts
@@ -1,0 +1,28 @@
+import { sql, type Kysely } from 'kysely';
+
+/**
+ * Delete connect-pg-simple session rows for a user, to force re-authentication
+ * after a password change (GHSA-g5xq-67g7-36r2). Passport stores the user id at
+ * `sess -> 'passport' ->> 'user'` (see `passport.serializeUser` in
+ * `server/api.ts`, which serializes `user.id`).
+ *
+ * Pass `exceptSid` to keep one session alive — e.g. the caller's own session on
+ * a self-service password change, so they aren't logged out mid-request.
+ */
+export async function deleteSessionsForUser(
+  // `Kysely<any>` because the session table is managed by connect-pg-simple and
+  // is intentionally absent from our typed schema; injected instances are
+  // themselves `Kysely<any>` (see `server/iocContainer/index.ts`).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  db: Kysely<any>,
+  userId: string,
+  opts: { exceptSid?: string } = {},
+): Promise<void> {
+  let query = db
+    .deleteFrom('public.session')
+    .where(sql`sess -> 'passport' ->> 'user'`, '=', userId);
+  if (opts.exceptSid != null) {
+    query = query.where('sid', '!=', opts.exceptSid);
+  }
+  await query.execute();
+}

--- a/server/services/userManagementService/sessionPersistence.ts
+++ b/server/services/userManagementService/sessionPersistence.ts
@@ -2,7 +2,7 @@ import { sql, type Kysely } from 'kysely';
 
 /**
  * Delete connect-pg-simple session rows for a user, to force re-authentication
- * after a password change (GHSA-g5xq-67g7-36r2). Passport stores the user id at
+ * after a password change. Passport stores the user id at
  * `sess -> 'passport' ->> 'user'` (see `passport.serializeUser` in
  * `server/api.ts`, which serializes `user.id`).
  *

--- a/server/services/userManagementService/sessionPersistence.ts
+++ b/server/services/userManagementService/sessionPersistence.ts
@@ -12,7 +12,7 @@ import { sql, type Kysely } from 'kysely';
 export async function deleteSessionsForUser(
   // `Kysely<any>` because the session table is managed by connect-pg-simple and
   // is intentionally absent from our typed schema; injected instances are
-  // themselves `Kysely<any>` (see `server/iocContainer/index.ts`).
+  // themselves `Kysely<any>`.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   db: Kysely<any>,
   userId: string,

--- a/server/services/userManagementService/userManagementService.test.ts
+++ b/server/services/userManagementService/userManagementService.test.ts
@@ -247,7 +247,7 @@ describe('UserManagementService', () => {
         // The password row is updated...
         expect(mockDb.updateTable).toHaveBeenCalledWith('public.users');
         // ...and the user's sessions are deleted so a phished session can't
-        // outlive the reset (GHSA-g5xq-67g7-36r2).
+        // outlive the reset.
         expect(mockDb.deleteFrom).toHaveBeenCalledWith('public.session');
       },
     );

--- a/server/services/userManagementService/userManagementService.test.ts
+++ b/server/services/userManagementService/userManagementService.test.ts
@@ -1,13 +1,14 @@
 import { type Kysely } from 'kysely';
 
 import { makeTestWithFixture } from '../../test/utils.js';
-import UserManagementService from './userManagementService.js';
 import type { UserManagementPg } from './index.js';
+import UserManagementService from './userManagementService.js';
 
 // Mock dependencies
 const mockDb = {
   selectFrom: jest.fn(),
   insertInto: jest.fn(),
+  updateTable: jest.fn(),
   deleteFrom: jest.fn(),
 } as unknown as Kysely<UserManagementPg>;
 
@@ -201,6 +202,53 @@ describe('UserManagementService', () => {
 
         expect(token).toMatch(/^[a-f0-9]{64}$/);
         expect(mockSendEmail).toHaveBeenCalled();
+      },
+    );
+  });
+
+  describe('#resetPasswordForToken', () => {
+    testWithFixtures(
+      'invalidates all sessions for the user after resetting the password',
+      async ({ sut }) => {
+        const userId = 'user-123';
+
+        // Valid, non-expired reset token.
+        const mockSelect = {
+          selectAll: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          executeTakeFirst: jest.fn().mockResolvedValue({
+            hashed_token: 'hashed',
+            user_id: userId,
+            org_id: 'org-456',
+            created_at: new Date(),
+          }),
+        };
+
+        const mockUpdate = {
+          set: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          execute: jest.fn().mockResolvedValue([]),
+        };
+
+        const mockDelete = {
+          where: jest.fn().mockReturnThis(),
+          execute: jest.fn().mockResolvedValue([]),
+        };
+
+        (mockDb.selectFrom as jest.Mock).mockReturnValue(mockSelect);
+        (mockDb.updateTable as jest.Mock).mockReturnValue(mockUpdate);
+        (mockDb.deleteFrom as jest.Mock).mockReturnValue(mockDelete);
+
+        await sut.resetPasswordForToken({
+          token: 'plaintext-token',
+          newPassword: 'new-password',
+        });
+
+        // The password row is updated...
+        expect(mockDb.updateTable).toHaveBeenCalledWith('public.users');
+        // ...and the user's sessions are deleted so a phished session can't
+        // outlive the reset (GHSA-g5xq-67g7-36r2).
+        expect(mockDb.deleteFrom).toHaveBeenCalledWith('public.session');
       },
     );
   });

--- a/server/services/userManagementService/userManagementService.test.ts
+++ b/server/services/userManagementService/userManagementService.test.ts
@@ -10,6 +10,7 @@ const mockDb = {
   insertInto: jest.fn(),
   updateTable: jest.fn(),
   deleteFrom: jest.fn(),
+  transaction: jest.fn(),
 } as unknown as Kysely<UserManagementPg>;
 
 const mockSendEmail = jest.fn();
@@ -238,6 +239,11 @@ describe('UserManagementService', () => {
         (mockDb.selectFrom as jest.Mock).mockReturnValue(mockSelect);
         (mockDb.updateTable as jest.Mock).mockReturnValue(mockUpdate);
         (mockDb.deleteFrom as jest.Mock).mockReturnValue(mockDelete);
+        // Steps 2-4 run inside makeKyselyTransactionWithRetry, which calls
+        // `pgQuery.transaction().execute(cb)`. Run the callback against mockDb.
+        (mockDb.transaction as jest.Mock).mockReturnValue({
+          execute: (cb: (trx: typeof mockDb) => unknown) => cb(mockDb),
+        });
 
         await sut.resetPasswordForToken({
           token: 'plaintext-token',

--- a/server/services/userManagementService/userManagementService.ts
+++ b/server/services/userManagementService/userManagementService.ts
@@ -17,6 +17,7 @@ import {
   type Invoker,
   type UserRole,
 } from './permissioning.js';
+import { deleteSessionsForUser } from './sessionPersistence.js';
 import { hashPassword } from './utils.js';
 
 class UserManagementService {
@@ -464,7 +465,11 @@ class UserManagementService {
       .where('id', '=', fetchedToken.user_id)
       .execute();
 
-    // Step 3: Delete all tokens for the user
+    // Step 3: Invalidate all of the user's sessions so a phished/attacker
+    // session can't outlive the reset (GHSA-g5xq-67g7-36r2).
+    await deleteSessionsForUser(this.pgQuery, fetchedToken.user_id);
+
+    // Step 4: Delete all tokens for the user
     await this.pgQuery
       .deleteFrom('user_management_service.password_reset_tokens')
       .where('user_id', '=', fetchedToken.user_id)

--- a/server/services/userManagementService/userManagementService.ts
+++ b/server/services/userManagementService/userManagementService.ts
@@ -7,6 +7,7 @@ import {
   makeNotFoundError,
   makeUnauthorizedError,
 } from '../../utils/errors.js';
+import { makeKyselyTransactionWithRetry } from '../../utils/kyselyTransactionWithRetry.js';
 import { asyncRandomBytes } from '../../utils/misc.js';
 import { HOUR_MS } from '../../utils/time.js';
 import { CoopEmailAddress } from '../sendEmailService/sendEmailService.js';
@@ -458,22 +459,21 @@ class UserManagementService {
       return;
     }
 
-    // Step 2: reset password for that token's user
-    await this.pgQuery
-      .updateTable('public.users')
-      .set({ password: await hashPassword(newPassword) })
-      .where('id', '=', fetchedToken.user_id)
-      .execute();
-
-    // Step 3: Invalidate all of the user's sessions so a phished/attacker
-    // session can't outlive the reset.
-    await deleteSessionsForUser(this.pgQuery, fetchedToken.user_id);
-
-    // Step 4: Delete all tokens for the user
-    await this.pgQuery
-      .deleteFrom('user_management_service.password_reset_tokens')
-      .where('user_id', '=', fetchedToken.user_id)
-      .execute();
+    const hashedPassword = await hashPassword(newPassword);
+    // Atomic: a committed password change must not leave the user's sessions
+    // or reset tokens alive.
+    await makeKyselyTransactionWithRetry(this.pgQuery)(async (trx) => {
+      await trx
+        .updateTable('public.users')
+        .set({ password: hashedPassword })
+        .where('id', '=', fetchedToken.user_id)
+        .execute();
+      await deleteSessionsForUser(trx, fetchedToken.user_id);
+      await trx
+        .deleteFrom('user_management_service.password_reset_tokens')
+        .where('user_id', '=', fetchedToken.user_id)
+        .execute();
+    });
   }
 
   async getUsersForOrg(orgId: string) {

--- a/server/services/userManagementService/userManagementService.ts
+++ b/server/services/userManagementService/userManagementService.ts
@@ -466,7 +466,7 @@ class UserManagementService {
       .execute();
 
     // Step 3: Invalidate all of the user's sessions so a phished/attacker
-    // session can't outlive the reset (GHSA-g5xq-67g7-36r2).
+    // session can't outlive the reset.
     await deleteSessionsForUser(this.pgQuery, fetchedToken.user_id);
 
     // Step 4: Delete all tokens for the user


### PR DESCRIPTION
## Summary

This PR fixes **GHSA-g5xq-67g7-36r2**.

As of this PR:
- when a user changes their password, all *other* sessions are invalidated, and
- when a user *resets* their password (via a password reset email, while logged out), then *all* sessions are invalidated.

## Testing

- I added tests for this, and verified that it works manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updating your password now keeps your current session active while logging out all other active sessions.
  * Password reset now invalidates all your active sessions for improved security consistency.
* **Tests**
  * Added/expanded Jest coverage to verify session invalidation behavior for password changes and password resets, including transactional execution paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->