### PR TITLE
(manual review) Show decision reason when a decision is opened via direct link

### DIFF
--- a/server/services/manualReviewToolService/modules/DecisionAnalytics.ts
+++ b/server/services/manualReviewToolService/modules/DecisionAnalytics.ts
@@ -470,6 +470,7 @@ export default class DecisionAnalytics {
         sql<string>`(((job_payload->'payload'::text)->'item'::text) -> 'itemTypeIdentifier'::text) ->> 'id'::text`.as(
           'item_type_id',
         ),
+        'decision_reason',
         sql<string>`(job_payload->>'id')::text`.as('job_id'),
       ])
       .where('created_at', '>=', new Date('2023-10-01'))
@@ -518,6 +519,7 @@ export default class DecisionAnalytics {
           type: 'RELATED_ACTION' as const,
         })),
         createdAt: decisionWithPayload.created_at,
+        decisionReason: decisionWithPayload.decision_reason,
         jobId: decisionWithPayload.job_id,
       },
     };


### PR DESCRIPTION
## Why

I noticed a small bug. The decision details page (accessible e.g. by going to the "recent decisions" tab and clicking into one) did not show the decision reason, even though the frontend is wired up to show it.

The issue was that the SQL query never actually selects this column. This PR fixes that, so now the decision reason appears as you'd expect.


<img width="2928" height="1760" alt="Screenshot 2026-06-15 at 15-12-49 Review Job" src="https://github.com/user-attachments/assets/8d64a49e-058a-47f6-a7ee-5852cdce4743" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Decision details now include the decision reason, providing greater transparency into decisions made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->