### PR TITLE
ci: typecheck db and migrator in CI

### DIFF
--- a/.github/workflows/apply_pr_checks.yaml
+++ b/.github/workflows/apply_pr_checks.yaml
@@ -2,6 +2,8 @@ name: Run all PR checks
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
 
 permissions:
   contents: read
@@ -190,9 +192,7 @@ jobs:
       - name: Build client
         run: docker compose run --rm --quiet-pull client npm run build
 
-  # db and migrator have no ESLint setup, so CI only typechecks them. They're
-  # standalone npm packages, so we install and run tsc directly rather than
-  # going through docker compose (as the server/client jobs do).
+  # db and migrator have no ESLint setup, so CI only typechecks them.
   typecheck_db:
     needs: changes
     if: needs.changes.outputs.db == 'true'

--- a/.github/workflows/apply_pr_checks.yaml
+++ b/.github/workflows/apply_pr_checks.yaml
@@ -19,6 +19,8 @@ jobs:
     outputs:
       server: ${{ steps.filter.outputs.server }}
       client: ${{ steps.filter.outputs.client }}
+      db: ${{ steps.filter.outputs.db }}
+      migrator: ${{ steps.filter.outputs.migrator }}
     steps:
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
@@ -28,6 +30,10 @@ jobs:
               - 'server/**'
             client:
               - 'client/**'
+            db:
+              - 'db/**'
+            migrator:
+              - 'migrator/**'
 
   check_generated_graphql:
     timeout-minutes: 4
@@ -35,7 +41,7 @@ jobs:
     if: needs.changes.outputs.server == 'true' || needs.changes.outputs.client == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Check generated GraphQL is up to date
@@ -44,14 +50,14 @@ jobs:
   check_migration_order:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           # this is needed to fetch the main branch
           ref: ${{ github.base_ref || 'main' }}
           fetch-depth: 1
           sparse-checkout: 'db/src/scripts'
           persist-credentials: false
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           # this is needed to fetch the main branch
           fetch-depth: 1
@@ -133,10 +139,10 @@ jobs:
     permissions:
       contents: read
       actions: read
-      checks: write  # for dorny/test-reporter to create a check run
+      checks: write # for dorny/test-reporter to create a check run
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
@@ -160,7 +166,7 @@ jobs:
 
       - name: Test Report
         if: always() # run this step even if previous step failed
-        uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5  # v1.9.1
+        uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5 # v1.9.1
         continue-on-error: true
         with:
           name: JEST Tests # Name of the check run which will be created
@@ -174,7 +180,7 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
@@ -184,4 +190,53 @@ jobs:
       - name: Build client
         run: docker compose run --rm --quiet-pull client npm run build
 
+  # db and migrator have no ESLint setup, so CI only typechecks them. They're
+  # standalone npm packages, so we install and run tsc directly rather than
+  # going through docker compose (as the server/client jobs do).
+  typecheck_db:
+    needs: changes
+    if: needs.changes.outputs.db == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: 'db/package-lock.json'
+
+      - name: Typecheck db
+        run: |
+          cd db
+          npm ci
+          npm run typecheck
+
+  typecheck_migrator:
+    needs: changes
+    if: needs.changes.outputs.migrator == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: 'migrator/package-lock.json'
+
+      - name: Typecheck migrator
+        run: |
+          cd migrator
+          npm ci
+          npm run typecheck

--- a/db/package.json
+++ b/db/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc && cp -R src/scripts package.json build/",
+    "typecheck": "tsc --noEmit",
     "test": "echo \"Error: no test specified\" && exit 1",
     "db:add": "node build/index.js add",
     "db:clean": "node build/index.js clean",

--- a/migrator/cli/index.ts
+++ b/migrator/cli/index.ts
@@ -166,6 +166,10 @@ export function makeCli(dbs: { [k: string]: DatabaseConfig<string, any> }) {
             choices: ['remaining', 'next', 'only', 'until'],
             default: 'remaining',
           })
+          .positional('name', {
+            describe: 'Name of a specific script, for use with "only"/"until".',
+            type: 'string',
+          })
           .check(({ target, name, db, env }) => {
             const needsSpecificScript = target === 'only' || target === 'until';
             if (!needsSpecificScript && name) {
@@ -245,10 +249,11 @@ export function makeCli(dbs: { [k: string]: DatabaseConfig<string, any> }) {
                   await migrator.up({ step: 1 });
                   break;
                 case 'only':
-                  await migrator.up({ migrations: [name] });
+                  // `name` presence for only/until is guaranteed by the check() above.
+                  await migrator.up({ migrations: [name!] });
                   break;
                 case 'until':
-                  await migrator.up({ to: name });
+                  await migrator.up({ to: name! });
               }
             } finally {
               // Await not return so that any errors from the try aren't swallowed.

--- a/migrator/package.json
+++ b/migrator/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit",
     "test": "echo \"Error: no test specified\" && exit 1",
     "prepublishOnly": "rm -rf ./build && npm run build && cp -r script-templates build/script-templates"
   },


### PR DESCRIPTION
## What

Adds typecheck coverage for the `db` and `migrator` packages in CI. I noticed that `npm run build` would fail locally due to typechecking errors -- this PR fixes those and ensures it won't happen again.


## Migrator type errors

`migrator` had two pre-existing type errors in the `apply-scripts` command: its `name` positional was never declared, so yargs typed it `unknown`. Declared it as a string (mirroring the `add` command) and asserted non-null where the existing `check()` already guarantees presence.