### PR TITLE
auth: fix SAML cross-org authentication bypass

### DIFF
--- a/server/api.ts
+++ b/server/api.ts
@@ -21,10 +21,7 @@ import { GraphQLError, type GraphQLFormattedError } from 'graphql';
 import helmet from 'helmet';
 import passport from 'passport';
 
-import {
-  kyselyUserFindByEmailAndOrg,
-  kyselyUserFindById,
-} from './graphql/datasources/userKyselyPersistence.js';
+import { kyselyUserFindById } from './graphql/datasources/userKyselyPersistence.js';
 import resolvers, { type Context } from './graphql/resolvers.js';
 import typeDefs from './graphql/schema.js';
 import { authSchemaWrapper } from './graphql/utils/authorization.js';
@@ -194,19 +191,9 @@ export default async function makeApiServer(deps: Dependencies) {
       // assertion authenticating one org can never resolve a user from another
       // (GHSA-2v93-383c-9fw2). Same helper for the signon and logout verify.
       async (req, profile, done) =>
-        resolveSamlUser(
-          async (opts) => kyselyUserFindByEmailAndOrg(KyselyPg, opts),
-          req,
-          profile,
-          done,
-        ),
+        resolveSamlUser(KyselyPg, req, profile, done),
       async (req, profile, done) =>
-        resolveSamlUser(
-          async (opts) => kyselyUserFindByEmailAndOrg(KyselyPg, opts),
-          req,
-          profile,
-          done,
-        ),
+        resolveSamlUser(KyselyPg, req, profile, done),
     ),
   );
 

--- a/server/api.ts
+++ b/server/api.ts
@@ -6,7 +6,11 @@ import { ApolloServerPluginLandingPageDisabled } from '@apollo/server/plugin/dis
 import { expressMiddleware } from '@as-integrations/express5';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { MapperKind, mapSchema } from '@graphql-tools/utils';
-import { MultiSamlStrategy } from '@node-saml/passport-saml';
+import {
+  MultiSamlStrategy,
+  type Profile,
+  type VerifiedCallback,
+} from '@node-saml/passport-saml';
 import { SpanStatusCode } from '@opentelemetry/api';
 import {
   ATTR_EXCEPTION_MESSAGE,
@@ -15,7 +19,7 @@ import {
 } from '@opentelemetry/semantic-conventions';
 import connectPgSimple from 'connect-pg-simple';
 import cors from 'cors';
-import express, { type ErrorRequestHandler } from 'express';
+import express, { type ErrorRequestHandler, type Request } from 'express';
 import session from 'express-session';
 import { GraphQLError, type GraphQLFormattedError } from 'graphql';
 import helmet from 'helmet';
@@ -25,6 +29,7 @@ import { kyselyUserFindById } from './graphql/datasources/userKyselyPersistence.
 import resolvers, { type Context } from './graphql/resolvers.js';
 import typeDefs from './graphql/schema.js';
 import { authSchemaWrapper } from './graphql/utils/authorization.js';
+import { getOrgIdFromPath } from './graphql/utils/orgIdFromPath.js';
 import { buildPassportContext } from './graphql/utils/passportContext.js';
 import { resolveSamlUser } from './graphql/utils/resolveSamlUser.js';
 import { safeDepthLimit } from './graphql/utils/safeDepthLimit.js';
@@ -142,14 +147,22 @@ export default async function makeApiServer(deps: Dependencies) {
   app.use(passport.initialize());
   app.use(passport.session());
 
+  // Shared signon/logout verify: bind the user lookup to the org named in the
+  // callback path so an assertion authenticating one org can never resolve a
+  // user from another (GHSA-2v93-383c-9fw2).
+  const verify = async (
+    req: Request,
+    profile: Profile | null,
+    done: VerifiedCallback,
+  ) => resolveSamlUser(KyselyPg, deps.Tracer, req, profile, done);
+
   passport.use(
     new MultiSamlStrategy(
       {
         passReqToCallback: true,
         async getSamlOptions(req, done) {
           // orgId path param should be set in the /saml/* route handlers.
-          const rawOrgId = req.params['orgId'];
-          const orgId = typeof rawOrgId === 'string' ? rawOrgId : undefined;
+          const orgId = getOrgIdFromPath(req);
 
           if (!orgId) {
             return done(
@@ -187,13 +200,8 @@ export default async function makeApiServer(deps: Dependencies) {
           });
         },
       },
-      // Bind the user lookup to the org named in the callback path so an
-      // assertion authenticating one org can never resolve a user from another
-      // (GHSA-2v93-383c-9fw2). Same helper for the signon and logout verify.
-      async (req, profile, done) =>
-        resolveSamlUser(KyselyPg, req, profile, done),
-      async (req, profile, done) =>
-        resolveSamlUser(KyselyPg, req, profile, done),
+      verify,
+      verify,
     ),
   );
 

--- a/server/api.ts
+++ b/server/api.ts
@@ -21,15 +21,15 @@ import { GraphQLError, type GraphQLFormattedError } from 'graphql';
 import helmet from 'helmet';
 import passport from 'passport';
 
-import { makeLoginUserDoesNotExistError } from './graphql/datasources/userApiErrors.js';
 import {
-  kyselyUserFindByEmail,
+  kyselyUserFindByEmailAndOrg,
   kyselyUserFindById,
 } from './graphql/datasources/userKyselyPersistence.js';
 import resolvers, { type Context } from './graphql/resolvers.js';
 import typeDefs from './graphql/schema.js';
 import { authSchemaWrapper } from './graphql/utils/authorization.js';
 import { buildPassportContext } from './graphql/utils/passportContext.js';
+import { resolveSamlUser } from './graphql/utils/resolveSamlUser.js';
 import { safeDepthLimit } from './graphql/utils/safeDepthLimit.js';
 import { type Dependencies } from './iocContainer/index.js';
 import { safeGetEnvInt } from './iocContainer/utils.js';
@@ -190,52 +190,23 @@ export default async function makeApiServer(deps: Dependencies) {
           });
         },
       },
-      async (_req, profile, done) => {
-        try {
-          const user = await kyselyUserFindByEmail(
-            KyselyPg,
-            String(profile?.email),
-          );
-          // we should have already checked for this, but couldn't hurt to check
-          // again
-          if (user == null) {
-            return done(
-              makeLoginUserDoesNotExistError({ shouldErrorSpan: true }),
-            );
-          }
-
-          return done(null, user);
-        } catch (e) {
-          return done(
-            makeInternalServerError('Unknown error during login attempt', {
-              shouldErrorSpan: true,
-            }),
-          );
-        }
-      },
-      async (_req, profile, done) => {
-        try {
-          const user = await kyselyUserFindByEmail(
-            KyselyPg,
-            String(profile?.email),
-          );
-          // we should have already checked for this, but couldn't hurt to check
-          // again
-          if (user == null) {
-            return done(
-              makeLoginUserDoesNotExistError({ shouldErrorSpan: true }),
-            );
-          }
-
-          return done(null, user);
-        } catch (e) {
-          return done(
-            makeInternalServerError('Unknown error during login attempt', {
-              shouldErrorSpan: true,
-            }),
-          );
-        }
-      },
+      // Bind the user lookup to the org named in the callback path so an
+      // assertion authenticating one org can never resolve a user from another
+      // (GHSA-2v93-383c-9fw2). Same helper for the signon and logout verify.
+      async (req, profile, done) =>
+        resolveSamlUser(
+          async (opts) => kyselyUserFindByEmailAndOrg(KyselyPg, opts),
+          req,
+          profile,
+          done,
+        ),
+      async (req, profile, done) =>
+        resolveSamlUser(
+          async (opts) => kyselyUserFindByEmailAndOrg(KyselyPg, opts),
+          req,
+          profile,
+          done,
+        ),
     ),
   );
 

--- a/server/graphql/datasources/userKyselyPersistence.ts
+++ b/server/graphql/datasources/userKyselyPersistence.ts
@@ -189,6 +189,21 @@ export async function kyselyUserFindByEmail(
   return row === undefined ? undefined : rowToGraphQLUserParent(row);
 }
 
+export async function kyselyUserFindByEmailAndOrg(
+  db: UsersDb,
+  opts: { email: string; orgId: string },
+): Promise<GraphQLUserParent | undefined> {
+  const row = await db
+    .selectFrom('public.users')
+    .select(USER_COLUMNS)
+    .select(loginMethodsAsTextArray)
+    .select(permissionsArray)
+    .where('email', '=', opts.email)
+    .where('org_id', '=', opts.orgId)
+    .executeTakeFirst();
+  return row === undefined ? undefined : rowToGraphQLUserParent(row);
+}
+
 export async function kyselyUserFindByIds(
   db: UsersDb,
   ids: readonly string[],

--- a/server/graphql/datasources/userKyselyPersistence.ts
+++ b/server/graphql/datasources/userKyselyPersistence.ts
@@ -58,7 +58,7 @@ export type GraphQLUserParent = {
 // Aligns with `ruleKyselyPersistence.ts`: persistence helpers operate on the
 // full app schema. Lets fixtures and `kyselyCreateRule` callers share a single
 // `Kysely<CombinedPg>` handle without running into Kysely's invariant generic.
-type UsersDb = Kysely<CombinedPg>;
+export type UsersDb = Kysely<CombinedPg>;
 
 type UserRow = {
   id: string;

--- a/server/graphql/datasources/userKyselyPersistenceFindByEmailAndOrg.test.ts
+++ b/server/graphql/datasources/userKyselyPersistenceFindByEmailAndOrg.test.ts
@@ -1,0 +1,94 @@
+import { faker } from '@faker-js/faker';
+import { uid } from 'uid';
+
+import { UserRole } from '../../services/userManagementService/index.js';
+import createOrg from '../../test/fixtureHelpers/createOrg.js';
+import { makeMockedServer } from '../../test/setupMockedServer.js';
+import { makeTestWithFixture } from '../../test/utils.js';
+import {
+  kyselyUserDeleteById,
+  kyselyUserFindByEmailAndOrg,
+  kyselyUserInsert,
+} from './userKyselyPersistence.js';
+
+function samlUserInput(orgId: string) {
+  return {
+    id: uid(),
+    orgId,
+    email: faker.internet.email(),
+    firstName: faker.name.firstName(),
+    lastName: faker.name.lastName(),
+    role: UserRole.ADMIN,
+    loginMethods: ['saml'] as const,
+    password: null,
+  };
+}
+
+describe('kyselyUserFindByEmailAndOrg', () => {
+  const testWithFixture = makeTestWithFixture(async () => {
+    const { deps, shutdown } = await makeMockedServer();
+    const { org, cleanup: orgCleanup } = await createOrg(
+      {
+        KyselyPg: deps.KyselyPg,
+        ModerationConfigService: deps.ModerationConfigService,
+        ApiKeyService: deps.ApiKeyService,
+      },
+      uid(),
+    );
+    return {
+      deps,
+      org,
+      async cleanup() {
+        await orgCleanup();
+        await shutdown();
+      },
+    };
+  });
+
+  testWithFixture(
+    'returns the row when email and org match',
+    async ({ deps, org }) => {
+      const input = samlUserInput(org.id);
+      await kyselyUserInsert({ db: deps.KyselyPg, ...input });
+      try {
+        const result = await kyselyUserFindByEmailAndOrg(deps.KyselyPg, {
+          email: input.email,
+          orgId: org.id,
+        });
+        expect(result).toMatchObject({ id: input.id, orgId: org.id });
+      } finally {
+        await kyselyUserDeleteById(deps.KyselyPg, input.id);
+      }
+    },
+  );
+
+  // Security regression (GHSA-2v93-383c-9fw2): a SAML assertion that
+  // authenticates `orgId` must never resolve a user who lives in another org.
+  testWithFixture(
+    'returns undefined when the email exists in a different org',
+    async ({ deps, org }) => {
+      const input = samlUserInput(org.id);
+      await kyselyUserInsert({ db: deps.KyselyPg, ...input });
+      try {
+        const result = await kyselyUserFindByEmailAndOrg(deps.KyselyPg, {
+          email: input.email,
+          orgId: `different-org-${uid()}`,
+        });
+        expect(result).toBeUndefined();
+      } finally {
+        await kyselyUserDeleteById(deps.KyselyPg, input.id);
+      }
+    },
+  );
+
+  testWithFixture(
+    'returns undefined when the email does not exist',
+    async ({ deps, org }) => {
+      const result = await kyselyUserFindByEmailAndOrg(deps.KyselyPg, {
+        email: `missing-${uid()}@example.com`,
+        orgId: org.id,
+      });
+      expect(result).toBeUndefined();
+    },
+  );
+});

--- a/server/graphql/utils/orgIdFromPath.ts
+++ b/server/graphql/utils/orgIdFromPath.ts
@@ -1,0 +1,13 @@
+import { type Request } from 'express';
+
+/**
+ * Read the `orgId` path param (e.g. `/saml/login/:orgId/callback`), returning
+ * `undefined` when it is missing or not a string. Callers decide how to handle
+ * its absence (typically a not-found error).
+ */
+export function getOrgIdFromPath(
+  req: Pick<Request, 'params'>,
+): string | undefined {
+  const rawOrgId = req.params['orgId'];
+  return typeof rawOrgId === 'string' ? rawOrgId : undefined;
+}

--- a/server/graphql/utils/resolveSamlUser.test.ts
+++ b/server/graphql/utils/resolveSamlUser.test.ts
@@ -1,0 +1,93 @@
+import { type Request } from 'express';
+
+import { type GraphQLUserParent } from '../datasources/userKyselyPersistence.js';
+import { resolveSamlUser } from './resolveSamlUser.js';
+
+const stubUser = { id: 'u1', orgId: 'org-a', email: 'a@x.com' };
+const userInOrgA = stubUser as unknown as GraphQLUserParent;
+
+function makeReq(orgId?: string): Pick<Request, 'params'> {
+  return { params: orgId === undefined ? {} : { orgId } };
+}
+
+describe('resolveSamlUser', () => {
+  it('passes the user to done when the email + path org match', async () => {
+    const findUser = jest.fn(async () => userInOrgA);
+    const done = jest.fn();
+
+    await resolveSamlUser(
+      findUser,
+      makeReq('org-a'),
+      { email: 'a@x.com' },
+      done,
+    );
+
+    expect(findUser).toHaveBeenCalledWith({ email: 'a@x.com', orgId: 'org-a' });
+    expect(done).toHaveBeenCalledWith(null, userInOrgA);
+  });
+
+  // Security regression (GHSA-2v93-383c-9fw2): an assertion authenticating
+  // org-b must not resolve a user who only exists in another org. The lookup
+  // is org-scoped, so a cross-org email yields no user and login is rejected.
+  it('rejects (error, no user) when the email belongs to a different org', async () => {
+    const findUser = jest.fn(async () => undefined);
+    const done = jest.fn();
+
+    await resolveSamlUser(
+      findUser,
+      makeReq('org-b'),
+      { email: 'a@x.com' },
+      done,
+    );
+
+    expect(findUser).toHaveBeenCalledWith({ email: 'a@x.com', orgId: 'org-b' });
+    const [err, user] = done.mock.calls[0];
+    expect(err).toBeInstanceOf(Error);
+    expect(user).toBeUndefined();
+  });
+
+  it('errors without looking up a user when orgId is missing from the path', async () => {
+    const findUser = jest.fn(async () => userInOrgA);
+    const done = jest.fn();
+
+    await resolveSamlUser(
+      findUser,
+      makeReq(undefined),
+      { email: 'a@x.com' },
+      done,
+    );
+
+    expect(findUser).not.toHaveBeenCalled();
+    expect(done.mock.calls[0][0]).toBeInstanceOf(Error);
+  });
+
+  it('errors when no user exists for the email in that org', async () => {
+    const findUser = jest.fn(async () => undefined);
+    const done = jest.fn();
+
+    await resolveSamlUser(
+      findUser,
+      makeReq('org-a'),
+      { email: 'missing@x.com' },
+      done,
+    );
+
+    expect(done.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(done.mock.calls[0][1]).toBeUndefined();
+  });
+
+  // A failed lookup must surface to passport via `done(err)`, never as an
+  // unhandled rejection out of the verify callback.
+  it('reports lookup failures through done instead of rejecting', async () => {
+    const findUser = jest.fn(async () => {
+      throw new Error('db down');
+    });
+    const done = jest.fn();
+
+    await expect(
+      resolveSamlUser(findUser, makeReq('org-a'), { email: 'a@x.com' }, done),
+    ).resolves.toBeUndefined();
+    expect(done.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(done.mock.calls[0][1]).toBeUndefined();
+  });
+});

--- a/server/graphql/utils/resolveSamlUser.test.ts
+++ b/server/graphql/utils/resolveSamlUser.test.ts
@@ -7,9 +7,11 @@ import { UserRole } from '../../services/userManagementService/index.js';
 import createOrg from '../../test/fixtureHelpers/createOrg.js';
 import { makeMockedServer } from '../../test/setupMockedServer.js';
 import { makeTestWithFixture } from '../../test/utils.js';
+import { type default as SafeTracer } from '../../utils/SafeTracer.js';
 import {
   kyselyUserDeleteById,
   kyselyUserInsert,
+  type UsersDb,
 } from '../datasources/userKyselyPersistence.js';
 import { resolveSamlUser } from './resolveSamlUser.js';
 
@@ -60,6 +62,7 @@ describe('resolveSamlUser', () => {
       try {
         await resolveSamlUser(
           deps.KyselyPg,
+          deps.Tracer,
           makeReq(org.id),
           { email: input.email },
           done,
@@ -85,6 +88,7 @@ describe('resolveSamlUser', () => {
       try {
         await resolveSamlUser(
           deps.KyselyPg,
+          deps.Tracer,
           makeReq(`different-org-${uid()}`),
           { email: input.email },
           done,
@@ -104,6 +108,7 @@ describe('resolveSamlUser', () => {
       const done = jest.fn();
       await resolveSamlUser(
         deps.KyselyPg,
+        deps.Tracer,
         makeReq(org.id),
         { email: `missing-${uid()}@example.com` },
         done,
@@ -119,6 +124,7 @@ describe('resolveSamlUser', () => {
       const done = jest.fn();
       await resolveSamlUser(
         deps.KyselyPg,
+        deps.Tracer,
         makeReq(undefined),
         { email: 'a@example.com' },
         done,
@@ -138,7 +144,13 @@ describe('resolveSamlUser', () => {
       `rejects without a match when the email claim is ${label}`,
       async ({ deps, org }) => {
         const done = jest.fn();
-        await resolveSamlUser(deps.KyselyPg, makeReq(org.id), profile, done);
+        await resolveSamlUser(
+          deps.KyselyPg,
+          deps.Tracer,
+          makeReq(org.id),
+          profile,
+          done,
+        );
         expect(done.mock.calls[0][0]).toBeInstanceOf(Error);
         expect(done.mock.calls[0][1]).toBeUndefined();
       },
@@ -154,6 +166,7 @@ describe('resolveSamlUser', () => {
       const done = jest.fn();
       await resolveSamlUser(
         deps.KyselyPg,
+        deps.Tracer,
         makeReq(org.id),
         arrayProfile as unknown as Pick<Profile, 'email'>,
         done,
@@ -162,4 +175,31 @@ describe('resolveSamlUser', () => {
       expect(done.mock.calls[0][1]).toBeUndefined();
     },
   );
+
+  // A genuine DB failure during the lookup must be logged to the tracer (so
+  // outages are observable) and surfaced as an internal error, not swallowed.
+  test('logs to the tracer and returns an internal error on a DB failure', async () => {
+    const dbError = new Error('connection refused');
+    const db = {
+      selectFrom() {
+        throw dbError;
+      },
+    } as unknown as UsersDb;
+    const tracer = {
+      logActiveSpanFailedIfAny: jest.fn(),
+    } as unknown as SafeTracer;
+    const done = jest.fn();
+
+    await resolveSamlUser(
+      db,
+      tracer,
+      makeReq('some-org'),
+      { email: 'a@example.com' },
+      done,
+    );
+
+    expect(tracer.logActiveSpanFailedIfAny).toHaveBeenCalledWith(dbError);
+    expect(done.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(done.mock.calls[0][1]).toBeUndefined();
+  });
 });

--- a/server/graphql/utils/resolveSamlUser.test.ts
+++ b/server/graphql/utils/resolveSamlUser.test.ts
@@ -1,3 +1,4 @@
+import { type Profile } from '@node-saml/passport-saml';
 import { type Request } from 'express';
 
 import { type GraphQLUserParent } from '../datasources/userKyselyPersistence.js';
@@ -59,6 +60,45 @@ describe('resolveSamlUser', () => {
 
     expect(findUser).not.toHaveBeenCalled();
     expect(done.mock.calls[0][0]).toBeInstanceOf(Error);
+  });
+
+  // A missing/blank email claim must be rejected outright, never coerced
+  // (e.g. String(undefined) === "undefined") and used as a lookup key.
+  it.each([
+    ['missing', {}],
+    ['undefined', { email: undefined }],
+    ['empty', { email: '' }],
+  ])(
+    'errors without looking up a user when the email claim is %s',
+    async (_label, profile) => {
+      const findUser = jest.fn(async () => userInOrgA);
+      const done = jest.fn();
+
+      await resolveSamlUser(findUser, makeReq('org-a'), profile, done);
+
+      expect(findUser).not.toHaveBeenCalled();
+      expect(done.mock.calls[0][0]).toBeInstanceOf(Error);
+      expect(done.mock.calls[0][1]).toBeUndefined();
+    },
+  );
+
+  // Defensive: node-saml types email as a string, but a multi-valued
+  // attribute could arrive as an array at runtime — reject, don't coerce.
+  it('errors without looking up a user when the email claim is not a string', async () => {
+    const arrayProfile = { email: ['a@x.com'] };
+    const findUser = jest.fn(async () => userInOrgA);
+    const done = jest.fn();
+
+    await resolveSamlUser(
+      findUser,
+      makeReq('org-a'),
+      arrayProfile as unknown as Pick<Profile, 'email'>,
+      done,
+    );
+
+    expect(findUser).not.toHaveBeenCalled();
+    expect(done.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(done.mock.calls[0][1]).toBeUndefined();
   });
 
   it('errors when no user exists for the email in that org', async () => {

--- a/server/graphql/utils/resolveSamlUser.test.ts
+++ b/server/graphql/utils/resolveSamlUser.test.ts
@@ -1,133 +1,165 @@
+import { faker } from '@faker-js/faker';
 import { type Profile } from '@node-saml/passport-saml';
 import { type Request } from 'express';
+import { uid } from 'uid';
 
-import { type GraphQLUserParent } from '../datasources/userKyselyPersistence.js';
+import { UserRole } from '../../services/userManagementService/index.js';
+import createOrg from '../../test/fixtureHelpers/createOrg.js';
+import { makeMockedServer } from '../../test/setupMockedServer.js';
+import { makeTestWithFixture } from '../../test/utils.js';
+import {
+  kyselyUserDeleteById,
+  kyselyUserInsert,
+} from '../datasources/userKyselyPersistence.js';
 import { resolveSamlUser } from './resolveSamlUser.js';
-
-const stubUser = { id: 'u1', orgId: 'org-a', email: 'a@x.com' };
-const userInOrgA = stubUser as unknown as GraphQLUserParent;
 
 function makeReq(orgId?: string): Pick<Request, 'params'> {
   return { params: orgId === undefined ? {} : { orgId } };
 }
 
+function samlUserInput(orgId: string) {
+  return {
+    id: uid(),
+    orgId,
+    email: faker.internet.email(),
+    firstName: faker.name.firstName(),
+    lastName: faker.name.lastName(),
+    role: UserRole.ADMIN,
+    loginMethods: ['saml'] as const,
+    password: null,
+  };
+}
+
 describe('resolveSamlUser', () => {
-  it('passes the user to done when the email + path org match', async () => {
-    const findUser = jest.fn(async () => userInOrgA);
-    const done = jest.fn();
-
-    await resolveSamlUser(
-      findUser,
-      makeReq('org-a'),
-      { email: 'a@x.com' },
-      done,
+  const testWithFixture = makeTestWithFixture(async () => {
+    const { deps, shutdown } = await makeMockedServer();
+    const { org, cleanup: orgCleanup } = await createOrg(
+      {
+        KyselyPg: deps.KyselyPg,
+        ModerationConfigService: deps.ModerationConfigService,
+        ApiKeyService: deps.ApiKeyService,
+      },
+      uid(),
     );
-
-    expect(findUser).toHaveBeenCalledWith({ email: 'a@x.com', orgId: 'org-a' });
-    expect(done).toHaveBeenCalledWith(null, userInOrgA);
+    return {
+      deps,
+      org,
+      async cleanup() {
+        await orgCleanup();
+        await shutdown();
+      },
+    };
   });
 
-  // Security regression (GHSA-2v93-383c-9fw2): an assertion authenticating
-  // org-b must not resolve a user who only exists in another org. The lookup
-  // is org-scoped, so a cross-org email yields no user and login is rejected.
-  it('rejects (error, no user) when the email belongs to a different org', async () => {
-    const findUser = jest.fn(async () => undefined);
-    const done = jest.fn();
-
-    await resolveSamlUser(
-      findUser,
-      makeReq('org-b'),
-      { email: 'a@x.com' },
-      done,
-    );
-
-    expect(findUser).toHaveBeenCalledWith({ email: 'a@x.com', orgId: 'org-b' });
-    const [err, user] = done.mock.calls[0];
-    expect(err).toBeInstanceOf(Error);
-    expect(user).toBeUndefined();
-  });
-
-  it('errors without looking up a user when orgId is missing from the path', async () => {
-    const findUser = jest.fn(async () => userInOrgA);
-    const done = jest.fn();
-
-    await resolveSamlUser(
-      findUser,
-      makeReq(undefined),
-      { email: 'a@x.com' },
-      done,
-    );
-
-    expect(findUser).not.toHaveBeenCalled();
-    expect(done.mock.calls[0][0]).toBeInstanceOf(Error);
-  });
-
-  // A missing/blank email claim must be rejected outright, never coerced
-  // (e.g. String(undefined) === "undefined") and used as a lookup key.
-  it.each([
-    ['missing', {}],
-    ['undefined', { email: undefined }],
-    ['empty', { email: '' }],
-  ])(
-    'errors without looking up a user when the email claim is %s',
-    async (_label, profile) => {
-      const findUser = jest.fn(async () => userInOrgA);
+  testWithFixture(
+    'passes the user to done when the email belongs to the path org',
+    async ({ deps, org }) => {
+      const input = samlUserInput(org.id);
+      await kyselyUserInsert({ db: deps.KyselyPg, ...input });
       const done = jest.fn();
+      try {
+        await resolveSamlUser(
+          deps.KyselyPg,
+          makeReq(org.id),
+          { email: input.email },
+          done,
+        );
+        expect(done).toHaveBeenCalledTimes(1);
+        const [err, user] = done.mock.calls[0];
+        expect(err).toBeNull();
+        expect(user).toMatchObject({ id: input.id, orgId: org.id });
+      } finally {
+        await kyselyUserDeleteById(deps.KyselyPg, input.id);
+      }
+    },
+  );
 
-      await resolveSamlUser(findUser, makeReq('org-a'), profile, done);
+  // Security regression (GHSA-2v93-383c-9fw2): an assertion authenticating one
+  // org must never resolve a user who lives in another org.
+  testWithFixture(
+    'rejects when the email belongs to a different org',
+    async ({ deps, org }) => {
+      const input = samlUserInput(org.id);
+      await kyselyUserInsert({ db: deps.KyselyPg, ...input });
+      const done = jest.fn();
+      try {
+        await resolveSamlUser(
+          deps.KyselyPg,
+          makeReq(`different-org-${uid()}`),
+          { email: input.email },
+          done,
+        );
+        const [err, user] = done.mock.calls[0];
+        expect(err).toBeInstanceOf(Error);
+        expect(user).toBeUndefined();
+      } finally {
+        await kyselyUserDeleteById(deps.KyselyPg, input.id);
+      }
+    },
+  );
 
-      expect(findUser).not.toHaveBeenCalled();
+  testWithFixture(
+    'rejects when no user exists for the email in that org',
+    async ({ deps, org }) => {
+      const done = jest.fn();
+      await resolveSamlUser(
+        deps.KyselyPg,
+        makeReq(org.id),
+        { email: `missing-${uid()}@example.com` },
+        done,
+      );
       expect(done.mock.calls[0][0]).toBeInstanceOf(Error);
       expect(done.mock.calls[0][1]).toBeUndefined();
     },
   );
 
-  // Defensive: node-saml types email as a string, but a multi-valued
-  // attribute could arrive as an array at runtime — reject, don't coerce.
-  it('errors without looking up a user when the email claim is not a string', async () => {
-    const arrayProfile = { email: ['a@x.com'] };
-    const findUser = jest.fn(async () => userInOrgA);
-    const done = jest.fn();
+  testWithFixture(
+    'rejects when orgId is missing from the path',
+    async ({ deps }) => {
+      const done = jest.fn();
+      await resolveSamlUser(
+        deps.KyselyPg,
+        makeReq(undefined),
+        { email: 'a@example.com' },
+        done,
+      );
+      expect(done.mock.calls[0][0]).toBeInstanceOf(Error);
+    },
+  );
 
-    await resolveSamlUser(
-      findUser,
-      makeReq('org-a'),
-      arrayProfile as unknown as Pick<Profile, 'email'>,
-      done,
+  // A missing/blank email claim must be rejected outright, never coerced
+  // (e.g. String(undefined) === "undefined") and used as a lookup key.
+  for (const [label, profile] of [
+    ['missing', {}],
+    ['undefined', { email: undefined }],
+    ['empty', { email: '' }],
+  ] as const) {
+    testWithFixture(
+      `rejects without a match when the email claim is ${label}`,
+      async ({ deps, org }) => {
+        const done = jest.fn();
+        await resolveSamlUser(deps.KyselyPg, makeReq(org.id), profile, done);
+        expect(done.mock.calls[0][0]).toBeInstanceOf(Error);
+        expect(done.mock.calls[0][1]).toBeUndefined();
+      },
     );
+  }
 
-    expect(findUser).not.toHaveBeenCalled();
-    expect(done.mock.calls[0][0]).toBeInstanceOf(Error);
-    expect(done.mock.calls[0][1]).toBeUndefined();
-  });
-
-  it('errors when no user exists for the email in that org', async () => {
-    const findUser = jest.fn(async () => undefined);
-    const done = jest.fn();
-
-    await resolveSamlUser(
-      findUser,
-      makeReq('org-a'),
-      { email: 'missing@x.com' },
-      done,
-    );
-
-    expect(done.mock.calls[0][0]).toBeInstanceOf(Error);
-    expect(done.mock.calls[0][1]).toBeUndefined();
-  });
-
-  // A failed lookup must surface to passport via `done(err)`, never as an
-  // unhandled rejection out of the verify callback.
-  it('reports lookup failures through done instead of rejecting', async () => {
-    const findUser = jest.fn(async () => {
-      throw new Error('db down');
-    });
-    const done = jest.fn();
-
-    await expect(
-      resolveSamlUser(findUser, makeReq('org-a'), { email: 'a@x.com' }, done),
-    ).resolves.toBeUndefined();
-    expect(done.mock.calls[0][0]).toBeInstanceOf(Error);
-    expect(done.mock.calls[0][1]).toBeUndefined();
-  });
+  // Defensive: node-saml types email as a string, but a multi-valued attribute
+  // could arrive as an array at runtime — reject, don't coerce.
+  testWithFixture(
+    'rejects when the email claim is not a string',
+    async ({ deps, org }) => {
+      const arrayProfile = { email: ['a@example.com'] };
+      const done = jest.fn();
+      await resolveSamlUser(
+        deps.KyselyPg,
+        makeReq(org.id),
+        arrayProfile as unknown as Pick<Profile, 'email'>,
+        done,
+      );
+      expect(done.mock.calls[0][0]).toBeInstanceOf(Error);
+      expect(done.mock.calls[0][1]).toBeUndefined();
+    },
+  );
 });

--- a/server/graphql/utils/resolveSamlUser.ts
+++ b/server/graphql/utils/resolveSamlUser.ts
@@ -38,8 +38,15 @@ export async function resolveSamlUser(
     );
   }
 
+  // Reject a missing/blank/non-string email claim instead of coercing it
+  // (e.g. String(undefined) === "undefined") into a lookup key.
+  const email = profile?.email;
+  if (typeof email !== 'string' || email.length === 0) {
+    return done(makeLoginUserDoesNotExistError({ shouldErrorSpan: true }));
+  }
+
   try {
-    const user = await findUser({ email: String(profile?.email), orgId });
+    const user = await findUser({ email, orgId });
     // we should have already checked for this, but couldn't hurt to check again
     if (user == null) {
       return done(makeLoginUserDoesNotExistError({ shouldErrorSpan: true }));

--- a/server/graphql/utils/resolveSamlUser.ts
+++ b/server/graphql/utils/resolveSamlUser.ts
@@ -1,0 +1,56 @@
+import { type Profile, type VerifiedCallback } from '@node-saml/passport-saml';
+import { type Request } from 'express';
+
+import {
+  makeInternalServerError,
+  makeNotFoundError,
+} from '../../utils/errors.js';
+import { makeLoginUserDoesNotExistError } from '../datasources/userApiErrors.js';
+import { type GraphQLUserParent } from '../datasources/userKyselyPersistence.js';
+
+type FindUserByEmailAndOrg = (opts: {
+  email: string;
+  orgId: string;
+}) => Promise<GraphQLUserParent | undefined>;
+
+/**
+ * Resolves the authenticated user for a SAML assertion, binding the lookup to
+ * the org named in the callback path (`/saml/login/:orgId/callback`).
+ *
+ * Security (GHSA-2v93-383c-9fw2): the assertion's signature is verified against
+ * the path org's IdP cert, but the user must also belong to that same org.
+ * Looking up by email alone would let an assertion signed by org A's IdP
+ * resolve a user who lives in org B (same email across tenants), creating a
+ * session as that cross-tenant user. Scoping the lookup to the path org closes
+ * the bypass: a user from another org simply isn't found, and login fails.
+ */
+export async function resolveSamlUser(
+  findUser: FindUserByEmailAndOrg,
+  req: Pick<Request, 'params'>,
+  profile: Pick<Profile, 'email'> | null,
+  done: VerifiedCallback,
+): Promise<void> {
+  const rawOrgId = req.params['orgId'];
+  const orgId = typeof rawOrgId === 'string' ? rawOrgId : undefined;
+  if (!orgId) {
+    return done(
+      makeNotFoundError('orgId not found in path.', { shouldErrorSpan: true }),
+    );
+  }
+
+  try {
+    const user = await findUser({ email: String(profile?.email), orgId });
+    // we should have already checked for this, but couldn't hurt to check again
+    if (user == null) {
+      return done(makeLoginUserDoesNotExistError({ shouldErrorSpan: true }));
+    }
+
+    return done(null, user);
+  } catch {
+    return done(
+      makeInternalServerError('Unknown error during login attempt', {
+        shouldErrorSpan: true,
+      }),
+    );
+  }
+}

--- a/server/graphql/utils/resolveSamlUser.ts
+++ b/server/graphql/utils/resolveSamlUser.ts
@@ -5,31 +5,27 @@ import {
   makeInternalServerError,
   makeNotFoundError,
 } from '../../utils/errors.js';
+import { type default as SafeTracer } from '../../utils/SafeTracer.js';
 import { makeLoginUserDoesNotExistError } from '../datasources/userApiErrors.js';
 import {
   kyselyUserFindByEmailAndOrg,
+  type GraphQLUserParent,
   type UsersDb,
 } from '../datasources/userKyselyPersistence.js';
+import { getOrgIdFromPath } from './orgIdFromPath.js';
 
 /**
  * Resolves the authenticated user for a SAML assertion, binding the lookup to
  * the org named in the callback path (`/saml/login/:orgId/callback`).
- *
- * Security (GHSA-2v93-383c-9fw2): the assertion's signature is verified against
- * the path org's IdP cert, but the user must also belong to that same org.
- * Looking up by email alone would let an assertion signed by org A's IdP
- * resolve a user who lives in org B (same email across tenants), creating a
- * session as that cross-tenant user. Scoping the lookup to the path org closes
- * the bypass: a user from another org simply isn't found, and login fails.
  */
 export async function resolveSamlUser(
   db: UsersDb,
+  tracer: SafeTracer,
   req: Pick<Request, 'params'>,
   profile: Pick<Profile, 'email'> | null,
   done: VerifiedCallback,
 ): Promise<void> {
-  const rawOrgId = req.params['orgId'];
-  const orgId = typeof rawOrgId === 'string' ? rawOrgId : undefined;
+  const orgId = getOrgIdFromPath(req);
   if (!orgId) {
     return done(
       makeNotFoundError('orgId not found in path.', { shouldErrorSpan: true }),
@@ -43,19 +39,24 @@ export async function resolveSamlUser(
     return done(makeLoginUserDoesNotExistError({ shouldErrorSpan: true }));
   }
 
+  // Scope the catch to the DB lookup so a genuine outage is logged and surfaced
+  // as an internal error, while the `done` dispatch below isn't swallowed.
+  let user: GraphQLUserParent | undefined;
   try {
-    const user = await kyselyUserFindByEmailAndOrg(db, { email, orgId });
-    // we should have already checked for this, but couldn't hurt to check again
-    if (user == null) {
-      return done(makeLoginUserDoesNotExistError({ shouldErrorSpan: true }));
-    }
-
-    return done(null, user);
-  } catch {
+    user = await kyselyUserFindByEmailAndOrg(db, { email, orgId });
+  } catch (e) {
+    tracer.logActiveSpanFailedIfAny(e);
     return done(
       makeInternalServerError('Unknown error during login attempt', {
         shouldErrorSpan: true,
       }),
     );
   }
+
+  // we should have already checked for this, but couldn't hurt to check again
+  if (user == null) {
+    return done(makeLoginUserDoesNotExistError({ shouldErrorSpan: true }));
+  }
+
+  return done(null, user);
 }

--- a/server/graphql/utils/resolveSamlUser.ts
+++ b/server/graphql/utils/resolveSamlUser.ts
@@ -6,12 +6,10 @@ import {
   makeNotFoundError,
 } from '../../utils/errors.js';
 import { makeLoginUserDoesNotExistError } from '../datasources/userApiErrors.js';
-import { type GraphQLUserParent } from '../datasources/userKyselyPersistence.js';
-
-type FindUserByEmailAndOrg = (opts: {
-  email: string;
-  orgId: string;
-}) => Promise<GraphQLUserParent | undefined>;
+import {
+  kyselyUserFindByEmailAndOrg,
+  type UsersDb,
+} from '../datasources/userKyselyPersistence.js';
 
 /**
  * Resolves the authenticated user for a SAML assertion, binding the lookup to
@@ -25,7 +23,7 @@ type FindUserByEmailAndOrg = (opts: {
  * the bypass: a user from another org simply isn't found, and login fails.
  */
 export async function resolveSamlUser(
-  findUser: FindUserByEmailAndOrg,
+  db: UsersDb,
   req: Pick<Request, 'params'>,
   profile: Pick<Profile, 'email'> | null,
   done: VerifiedCallback,
@@ -46,7 +44,7 @@ export async function resolveSamlUser(
   }
 
   try {
-    const user = await findUser({ email, orgId });
+    const user = await kyselyUserFindByEmailAndOrg(db, { email, orgId });
     // we should have already checked for this, but couldn't hurt to check again
     if (user == null) {
       return done(makeLoginUserDoesNotExistError({ shouldErrorSpan: true }));


### PR DESCRIPTION
## Summary

Fixes GHSA-2v93-383c-9fw2.

## Testing

I verified that SAML login still works locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved SAML sign-in to strictly scope user resolution to the organization from the callback route, preventing cross-organization authentication.
  * Added clearer handling for missing/invalid organization identifiers and missing/invalid email claims during SAML login.

* **Tests**
  * Added coverage to verify correct behavior when email and organization match, and when they don’t (including expected failure scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->