### PR TITLE
client: Validate email address format for invites

### DIFF
--- a/client/src/webpages/dashboard/components/CoopInput.tsx
+++ b/client/src/webpages/dashboard/components/CoopInput.tsx
@@ -8,7 +8,7 @@ export default function CoopInput(props: {
   value?: string;
   error?: boolean;
 }) {
-  const { type, placeholder, onChange, disabled, error } = props;
+  const { type, placeholder, onChange, disabled, value, error } = props;
   return (
     <input
       className={`block w-full px-3 py-2 ring-2 text-base border-solid rounded placeholder:text-gray-500 disabled:opacity-50 disabled:pointer-events-none ${
@@ -20,7 +20,8 @@ export default function CoopInput(props: {
       placeholder={placeholder}
       onChange={onChange}
       disabled={disabled}
-      value={props.value ?? ''}
+      aria-invalid={error}
+      value={value ?? ''}
     />
   );
 }

--- a/client/src/webpages/dashboard/components/CoopInput.tsx
+++ b/client/src/webpages/dashboard/components/CoopInput.tsx
@@ -6,11 +6,17 @@ export default function CoopInput(props: {
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   disabled?: boolean;
   value?: string;
+  error?: boolean;
 }) {
-  const { placeholder, onChange, disabled } = props;
+  const { type, placeholder, onChange, disabled, error } = props;
   return (
     <input
-      className="block w-full px-3 py-2 ring-2 text-base border-gray-200 border-solid rounded ring-gray-200 placeholder:text-gray-500 focus:border-primary focus:ring-primary/20 disabled:opacity-50 disabled:pointer-events-none"
+      className={`block w-full px-3 py-2 ring-2 text-base border-solid rounded placeholder:text-gray-500 disabled:opacity-50 disabled:pointer-events-none ${
+        error
+          ? 'border-red-400 ring-red-400 focus:border-red-400 focus:ring-red-400/20'
+          : 'border-gray-200 ring-gray-200 focus:border-primary focus:ring-primary/20'
+      }`}
+      type={type}
       placeholder={placeholder}
       onChange={onChange}
       disabled={disabled}

--- a/client/src/webpages/settings/ManageUsersInviteUserSection.test.tsx
+++ b/client/src/webpages/settings/ManageUsersInviteUserSection.test.tsx
@@ -1,0 +1,127 @@
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import '@testing-library/jest-dom/extend-expect';
+
+import {
+  GQLHasNcmecReportingEnabledDocument,
+  GQLRolesForOrgDocument,
+  GQLUserRole,
+} from '@/graphql/generated';
+
+import ManageUsersInviteUserSection from './ManageUsersInviteUserSection';
+
+const ncmecMock: MockedResponse = {
+  request: { query: GQLHasNcmecReportingEnabledDocument },
+  maxUsageCount: Infinity,
+  result: {
+    data: {
+      myOrg: { __typename: 'Organization', hasNCMECReportingEnabled: false },
+    },
+  },
+};
+
+const rolesMock: MockedResponse = {
+  request: { query: GQLRolesForOrgDocument },
+  maxUsageCount: Infinity,
+  result: {
+    data: {
+      rolesForOrg: [
+        {
+          __typename: 'Role',
+          id: 'role-1',
+          key: GQLUserRole.Admin,
+          displayName: 'Admin',
+          description: '',
+          isSystem: true,
+          isFallback: false,
+          permissions: [],
+          userCount: 1,
+        },
+      ],
+    },
+  },
+};
+
+function renderSection() {
+  return render(
+    <MockedProvider mocks={[ncmecMock, rolesMock]}>
+      <MemoryRouter>
+        <ManageUsersInviteUserSection />
+      </MemoryRouter>
+    </MockedProvider>,
+  );
+}
+
+async function waitForLoaded() {
+  await waitFor(() => {
+    expect(
+      screen.getByRole('button', { name: /send invite link/i }),
+    ).toBeInTheDocument();
+  });
+}
+
+function getEmailInput() {
+  return screen.getByPlaceholderText('Email address');
+}
+
+function getSubmitButton() {
+  return screen.getByRole('button', { name: /send invite link/i });
+}
+
+describe('ManageUsersInviteUserSection', () => {
+  it('disables the button with no input', async () => {
+    renderSection();
+    await waitForLoaded();
+    expect(getSubmitButton()).toBeDisabled();
+  });
+
+  it('disables the button for a plainly invalid email', async () => {
+    renderSection();
+    await waitForLoaded();
+    fireEvent.change(getEmailInput(), { target: { value: 'notanemail' } });
+    expect(getSubmitButton()).toBeDisabled();
+  });
+
+  it('disables the button for a comma-separated email list', async () => {
+    renderSection();
+    await waitForLoaded();
+    fireEvent.change(getEmailInput(), {
+      target: { value: 'foo@bar.com,baz@qux.com' },
+    });
+    expect(getSubmitButton()).toBeDisabled();
+  });
+
+  it('disables the button when email is valid but no role is selected', async () => {
+    renderSection();
+    await waitForLoaded();
+    fireEvent.change(getEmailInput(), {
+      target: { value: 'user@example.com' },
+    });
+    expect(getSubmitButton()).toBeDisabled();
+  });
+
+  it('enables the button with a valid email and a role selected', async () => {
+    renderSection();
+    await waitForLoaded();
+    fireEvent.change(getEmailInput(), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.click(screen.getByRole('radio', { name: /admin/i }));
+    expect(getSubmitButton()).not.toBeDisabled();
+  });
+
+  it('marks the email input as invalid and re-enables after correction', async () => {
+    renderSection();
+    await waitForLoaded();
+
+    fireEvent.change(getEmailInput(), { target: { value: 'bad-email' } });
+    expect(getEmailInput()).toHaveClass('ring-red-400');
+
+    fireEvent.change(getEmailInput(), {
+      target: { value: 'good@example.com' },
+    });
+    expect(getEmailInput()).not.toHaveClass('ring-red-400');
+  });
+});

--- a/client/src/webpages/settings/ManageUsersInviteUserSection.tsx
+++ b/client/src/webpages/settings/ManageUsersInviteUserSection.tsx
@@ -154,6 +154,16 @@ export default function ManageUsersInviteUserSection() {
     });
   };
 
+  const emailIsInvalid =
+    Boolean(email?.length) &&
+    !/^[^\s@,]+@[^\s@,]+\.[^\s@,]+$/.test(email ?? '');
+  const isDisabled = !email?.length || emailIsInvalid || !role;
+  const disabledReason = !email?.length
+    ? 'Enter an email address to continue'
+    : emailIsInvalid
+      ? 'Enter a valid email address'
+      : 'Select a role to continue';
+
   return (
     <div className="flex flex-col items-start mb-8 text-start">
       <FormSectionHeader
@@ -166,6 +176,7 @@ export default function ManageUsersInviteUserSection() {
           placeholder="Email address"
           onChange={(e) => setEmail(e.target.value)}
           value={email}
+          error={emailIsInvalid}
         />
       </div>
       <div className="mt-8 mb-4 text-base text-zinc-900">
@@ -193,7 +204,9 @@ export default function ManageUsersInviteUserSection() {
           size="middle"
           onClick={onInviteUser}
           loading={loading}
-          disabled={!email?.length || !role}
+          disabled={isDisabled}
+          disabledTooltipTitle={disabledReason}
+          disabledTooltipPlacement="top"
         />
       </div>
       {roleModalVisible && (


### PR DESCRIPTION
## Context & Requests for Reviewers

Adds UI side email validation for user invite flow. Forces a single valid email address per-invite.

Fixes #411
Depends on #785

## Tests

Had Claude Code add a regression test for user invite page. Seems fine at first glance. 

Screenshots show new behavior:

Invalid email: button disabled
<img width="515" height="447" alt="Screenshot 2026-06-15 at 16 03 31" src="https://github.com/user-attachments/assets/61da97fc-36bb-455c-9853-80e4b076972d" />

Valid email: button enabled
<img width="506" height="437" alt="Screenshot 2026-06-15 at 16 00 19" src="https://github.com/user-attachments/assets/2b6328be-74ce-41ad-9807-04501ed96f0b" />

Valid email with comma: button disabled
<img width="516" height="450" alt="Screenshot 2026-06-15 at 16 00 27" src="https://github.com/user-attachments/assets/c222e52f-e3f1-4365-bcfd-09b3a92ce37a" />

Two valid emails: button disabled
<img width="509" height="441" alt="Screenshot 2026-06-15 at 16 00 37" src="https://github.com/user-attachments/assets/6aa2e97d-4fc1-4cd5-9312-f7717a9c835f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local email validation for user invites, blocking submission until the email is valid and a role is selected.
  * Invite button now disables with user-facing explanatory tooltips when inputs are incomplete or invalid.
  * Form input validation visuals were improved, including accessible invalid state indication.
* **Tests**
  * Added coverage for the invite flow: disabled/enabled states, invalid email scenarios, role selection gating, and validation styling changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->