### PR TITLE
ci: fix changes job on main

### DIFF
--- a/.github/workflows/apply_pr_checks.yaml
+++ b/.github/workflows/apply_pr_checks.yaml
@@ -24,6 +24,9 @@ jobs:
       db: ${{ steps.filter.outputs.db }}
       migrator: ${{ steps.filter.outputs.migrator }}
     steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:


### PR DESCRIPTION
## Context

The `changes` job in `apply_pr_checks.yaml` failed on `main` with `fatal: not a git repository (or any of the parent directories): .git` (exit 128). See [the failing run](https://github.com/roostorg/coop/actions/runs/27604346427/job/81612562884).

## Root cause

`dorny/paths-filter` resolves changed paths via the GitHub API for `pull_request` events (no checkout needed — which is why it passed on PRs), but for `push` events it diffs against git history and shells out to `git`. The `changes` job was the only job in the workflow without an `actions/checkout` step, so on push there was no `.git` directory.

## Tests

This is a pretty minor change but I ran it locally using [act](https://github.com/nektos/act) just in case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to enhance build process reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->