### PR TITLE
Add CLAUDE.md symlinks to AGENTS.md

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Context

Claude Code doesn't read `AGENTS.md` files by default; it only reads `CLAUDE.md` (very annoying)!

This PR creates `CLAUDE.md`s that symlink to our `AGENTS.md`s.

This is the recommendation in the global ROOST `AGENTS.md`: https://github.com/roostorg/community/blob/main/software-development-practices/agents.md