### PR TITLE
docs: tell agents to use the PR template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,7 @@ Note: `check_migration_order` runs only in GitHub Actions — it's GitHub-specif
 
 - Keep diffs small and focused; split unrelated changes into separate PRs.
 - PR titles are descriptive and imperative ("Add X", "Fix Y").
+- When opening a GitHub PR, use the template at [`.github/pull_request_template.md`](.github/pull_request_template.md) but do not actually write anything in the PR description. Let your human operator do that.
 - New behavior requires a test. Bug fixes require a regression test.
 - All CI checks (above) must pass before requesting review.
 


### PR DESCRIPTION
## Context & Requests for Reviewers

I noticed that LLMs tend to a) be extremely wordy and b) ignore our pull request template.

This PR updates `AGENTS.md` in an attempt to steer agents in the right direction.

An alternative I considered: we could also tell agents to *never* fill in the PR description themselves. I'd probably prefer that but idunno if that's too strict.

## Tests

N/A

## Reviewers

@cassidyjames you might have opinions on this based on https://github.com/orgs/roostorg/discussions/62!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Updated internal contribution guidelines for how AI agents should handle pull request descriptions and reference the repository’s PR template.
  
**Note:** This release contains no user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->