### PR TITLE
fix: don't hide empty threads

### DIFF
--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/threads/ManualReviewJobThreadComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/threads/ManualReviewJobThreadComponent.tsx
@@ -234,7 +234,7 @@ export function ManualReviewJobThreadComponent(props: {
         )?.data
       : undefined;
   };
-  if (!data || data.threadHistory.length === 0) {
+  if (!data) {
     return null;
   }
   const newMessages = data.threadHistory
@@ -441,7 +441,13 @@ export function ManualReviewJobThreadComponent(props: {
           className="flex flex-col w-full overflow-auto max-h-[600px] gap-2 p-5"
           ref={scrollViewRef}
         >
-          {threadComponent}
+          {threadComponent.length > 0 ? (
+            threadComponent
+          ) : (
+            <div className="text-left text-gray-500">
+              There is no content in this thread yet
+            </div>
+          )}
         </div>
       </div>
       {isActionable && (

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/threads/ManualReviewJobThreadComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/threads/ManualReviewJobThreadComponent.tsx
@@ -234,6 +234,14 @@ export function ManualReviewJobThreadComponent(props: {
         )?.data
       : undefined;
   };
+  if (loading) {
+    return <ComponentLoading />;
+  }
+
+  if (error) {
+    return <div>Error loading user submissions: {error.message}</div>;
+  }
+
   if (!data) {
     return null;
   }
@@ -353,14 +361,6 @@ export function ManualReviewJobThreadComponent(props: {
         : threadTypeName
           ? `${threadTypeName} ID: ${thread.id}`
           : `Thread ID: ${thread.id}`;
-
-  if (loading) {
-    return <ComponentLoading />;
-  }
-
-  if (error) {
-    return <div>Error loading user submissions: {error.message}</div>;
-  }
 
   return (
     <>

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/threads/ManualReviewJobThreadComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/threads/ManualReviewJobThreadComponent.tsx
@@ -450,7 +450,7 @@ export function ManualReviewJobThreadComponent(props: {
           )}
         </div>
       </div>
-      {isActionable && (
+      {isActionable && newMessages.length > 0 && (
         <>
           <div className="flex flex-row self-end mt-2">
             <Button


### PR DESCRIPTION
## Context & Requests for Reviewers

Resolves https://github.com/roostorg/coop/issues/802

## Tests

1) Create a user and thread item type.
2) Upload a user and thread:
```
{
    "items": [{
        "id": "test-user-1",
        "typeId": "e1f82d8b3b1",
        "data": {
            "name": "test user 1"
        }
    }, {
        "id": "thread-1",
        "typeId": "5f2aba00aac",
        "data": {
            "title": "test thread",
            "creator": {
                "id": "test-user-1",
                "typeId": "e1f82d8b3b1"
            }
        }
    }]
}
```
3) Pull up "test-user-1" in investigation UI.  See thread item now appears even if no content is under it.

## (Optional) Rollout Plan

N/A. Client only change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty threads by displaying a "no content" placeholder message instead of a blank state, ensuring users receive clear feedback when a thread has no messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->