### PR TITLE
Add self-hosted CoPE model support to Zentropi integration

### DIFF
--- a/client/src/coop-ui/DateInput.tsx
+++ b/client/src/coop-ui/DateInput.tsx
@@ -71,24 +71,25 @@ const DateInput: React.FC<DateInputProps> = ({ value, onChange }) => {
 
   const initialDate = useRef<DateParts>(date);
 
-  const handleBlur =
-    (field: keyof DateParts) =>
-    (e: React.FocusEvent<HTMLInputElement>): void => {
-      if (!e.target.value) {
-        setDate(initialDate.current);
-        return;
-      }
+  const handleBlur = (
+    field: keyof DateParts,
+    e: React.FocusEvent<HTMLInputElement>,
+  ): void => {
+    if (!e.target.value) {
+      setDate(initialDate.current);
+      return;
+    }
 
-      const newValue = Number(e.target.value);
-      const isValid = validateDate(field, newValue);
+    const newValue = Number(e.target.value);
+    const isValid = validateDate(field, newValue);
 
-      if (!isValid) {
-        setDate(initialDate.current);
-      } else {
-        // If the new value is valid, update the initial value
-        initialDate.current = { ...date, [field]: newValue };
-      }
-    };
+    if (!isValid) {
+      setDate(initialDate.current);
+    } else {
+      // If the new value is valid, update the initial value
+      initialDate.current = { ...date, [field]: newValue };
+    }
+  };
 
   const handleKeyDown =
     (field: keyof DateParts) => (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -213,7 +214,7 @@ const DateInput: React.FC<DateInputProps> = ({ value, onChange }) => {
             e.target.select();
           }
         }}
-        onBlur={handleBlur('month')}
+        onBlur={(e) => handleBlur('month', e)}
         className="p-0 outline-none w-6 border-none text-center"
         placeholder="M"
       />
@@ -231,7 +232,7 @@ const DateInput: React.FC<DateInputProps> = ({ value, onChange }) => {
             e.target.select();
           }
         }}
-        onBlur={handleBlur('day')}
+        onBlur={(e) => handleBlur('day', e)}
         className="p-0 outline-none w-7 border-none text-center"
         placeholder="D"
       />
@@ -249,7 +250,7 @@ const DateInput: React.FC<DateInputProps> = ({ value, onChange }) => {
             e.target.select();
           }
         }}
-        onBlur={handleBlur('year')}
+        onBlur={(e) => handleBlur('year', e)}
         className="p-0 outline-none w-12 border-none text-center"
         placeholder="YYYY"
       />

--- a/client/src/graphql/generated.ts
+++ b/client/src/graphql/generated.ts
@@ -5177,13 +5177,15 @@ export type GQLZentropiIntegrationApiCredential = {
   readonly __typename: 'ZentropiIntegrationApiCredential';
   readonly apiKey: Scalars['String']['output'];
   readonly labelerVersions: ReadonlyArray<GQLZentropiLabelerVersion>;
+  readonly selfHosted?: Maybe<GQLZentropiSelfHostedConfig>;
 };
 
 export type GQLZentropiIntegrationApiCredentialInput = {
-  readonly apiKey: Scalars['String']['input'];
+  readonly apiKey?: InputMaybe<Scalars['String']['input']>;
   readonly labelerVersions?: InputMaybe<
     ReadonlyArray<GQLZentropiLabelerVersionInput>
   >;
+  readonly selfHosted?: InputMaybe<GQLZentropiSelfHostedConfigInput>;
 };
 
 export type GQLZentropiLabelerVersion = {
@@ -5195,6 +5197,25 @@ export type GQLZentropiLabelerVersion = {
 export type GQLZentropiLabelerVersionInput = {
   readonly id: Scalars['String']['input'];
   readonly label: Scalars['String']['input'];
+};
+
+export type GQLZentropiSelfHostedConfig = {
+  readonly __typename: 'ZentropiSelfHostedConfig';
+  readonly apiKey?: Maybe<Scalars['String']['output']>;
+  readonly baseUrl: Scalars['String']['output'];
+  readonly format: Scalars['String']['output'];
+  readonly model: Scalars['String']['output'];
+  readonly systemPromptTemplate?: Maybe<Scalars['String']['output']>;
+  readonly userMessageTemplate?: Maybe<Scalars['String']['output']>;
+};
+
+export type GQLZentropiSelfHostedConfigInput = {
+  readonly apiKey?: InputMaybe<Scalars['String']['input']>;
+  readonly baseUrl: Scalars['String']['input'];
+  readonly format: Scalars['String']['input'];
+  readonly model: Scalars['String']['input'];
+  readonly systemPromptTemplate?: InputMaybe<Scalars['String']['input']>;
+  readonly userMessageTemplate?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type GQLApiAuthQueryVariables = Exact<{ [key: string]: never }>;
@@ -6414,6 +6435,15 @@ export type GQLIntegrationConfigQuery = {
                   readonly id: string;
                   readonly label: string;
                 }>;
+                readonly selfHosted?: {
+                  readonly __typename: 'ZentropiSelfHostedConfig';
+                  readonly format: string;
+                  readonly baseUrl: string;
+                  readonly model: string;
+                  readonly apiKey?: string | null;
+                  readonly systemPromptTemplate?: string | null;
+                  readonly userMessageTemplate?: string | null;
+                } | null;
               };
         } | null;
       }
@@ -29891,6 +29921,14 @@ export const GQLIntegrationConfigDocument = gql`
               labelerVersions {
                 id
                 label
+              }
+              selfHosted {
+                format
+                baseUrl
+                model
+                apiKey
+                systemPromptTemplate
+                userMessageTemplate
               }
             }
             ... on PluginIntegrationApiCredential {

--- a/client/src/models/signal.ts
+++ b/client/src/models/signal.ts
@@ -1,41 +1,11 @@
 import {
   GQLIntegration,
   GQLScalarType,
-  GQLSignal,
   GQLSignalOutputType,
   GQLSignalType,
   GQLValueComparator,
 } from '../graphql/generated';
 import { assertUnreachable } from '../utils/misc';
-
-/**
- * Legacy-ish type for the core set of keys that signal keys that much of the
- * code currently assumes will be present on fetched signals.
- * @deprecated
- */
-export type CoreSignal = Pick<
-  GQLSignal,
-  | 'id'
-  | 'type'
-  | 'name'
-  | 'description'
-  | 'disabledInfo'
-  | 'shouldPromptForMatchingValues'
-  | 'outputType'
-  | 'eligibleSubcategories'
-  | 'eligibleInputs'
-  | 'subcategory'
-  | 'integration'
-  | 'integrationTitle'
-  | 'integrationLogoUrl'
-  | 'integrationLogoWithBackgroundUrl'
-  | 'pricingStructure'
-  | 'docsUrl'
-  | 'recommendedThresholds'
-  | 'supportedLanguages'
-  | 'args'
-  | 'allowedInAutomatedRules'
->;
 
 /** Signal type is string to support plugin signal types (e.g. RANDOM_SIGNAL_SELECTION). */
 export function receivesRegexInput(type: string) {

--- a/client/src/utils/time.ts
+++ b/client/src/utils/time.ts
@@ -29,7 +29,7 @@ export function formatDate(date = new Date()): string {
 }
 
 function toDate(date: string | DateString | Date): Date {
-  return date instanceof Date ? date : new Date(date as string);
+  return date instanceof Date ? date : new Date(date);
 }
 
 export function parseDatetimeToReadableStringInUTC(
@@ -100,7 +100,7 @@ export function getDateRange(start: Date, end: Date, interval: 'HOUR' | 'DAY') {
   while (isBefore(currentDate, end)) {
     datesArray.push({
       ds: format(currentDate, formatStr),
-    } as { [key: string]: any });
+    });
     currentDate = advanceFn(currentDate, 1);
   }
 

--- a/client/src/utils/tree.ts
+++ b/client/src/utils/tree.ts
@@ -248,7 +248,7 @@ export function multilevelListFromFlatList<
 
   // Initialize map with all nodes
   nodeList.forEach((node) => {
-    map.set(node.id, { ...node } as T & { children?: T[] });
+    map.set(node.id, { ...node });
   });
 
   // Build the tree

--- a/client/src/webpages/dashboard/components/CoopInput.tsx
+++ b/client/src/webpages/dashboard/components/CoopInput.tsx
@@ -6,15 +6,22 @@ export default function CoopInput(props: {
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   disabled?: boolean;
   value?: string;
+  error?: boolean;
 }) {
-  const { placeholder, onChange, disabled } = props;
+  const { type, placeholder, onChange, disabled, value, error } = props;
   return (
     <input
-      className="block w-full px-3 py-2 ring-2 text-base border-gray-200 border-solid rounded ring-gray-200 placeholder:text-gray-500 focus:border-primary focus:ring-primary/20 disabled:opacity-50 disabled:pointer-events-none"
+      className={`block w-full px-3 py-2 ring-2 text-base border-solid rounded placeholder:text-gray-500 disabled:opacity-50 disabled:pointer-events-none ${
+        error
+          ? 'border-red-400 ring-red-400 focus:border-red-400 focus:ring-red-400/20'
+          : 'border-gray-200 ring-gray-200 focus:border-primary focus:ring-primary/20'
+      }`}
+      type={type}
       placeholder={placeholder}
       onChange={onChange}
       disabled={disabled}
-      value={props.value ?? ''}
+      aria-invalid={error}
+      value={value ?? ''}
     />
   );
 }

--- a/client/src/webpages/dashboard/integrations/IntegrationConfigApiCredentialsSection.tsx
+++ b/client/src/webpages/dashboard/integrations/IntegrationConfigApiCredentialsSection.tsx
@@ -1,4 +1,4 @@
-import { Button, Input } from 'antd';
+import { Button, Input, Select } from 'antd';
 import { Plus, Trash2 } from 'lucide-react';
 
 import {
@@ -6,6 +6,7 @@ import {
   GQLIntegrationApiCredential,
   GQLOpenAiIntegrationApiCredential,
   GQLZentropiIntegrationApiCredential,
+  GQLZentropiSelfHostedConfig,
 } from '../../../graphql/generated';
 
 export default function IntegrationConfigApiCredentialsSection(props: {
@@ -59,6 +60,8 @@ export default function IntegrationConfigApiCredentialsSection(props: {
     apiCredential: GQLZentropiIntegrationApiCredential,
   ) => {
     const labelerVersions = apiCredential.labelerVersions ?? [];
+    const selfHosted = apiCredential.selfHosted ?? null;
+    const isHosted = selfHosted == null;
 
     const updateLabelerVersion = (
       index: number,
@@ -88,61 +91,203 @@ export default function IntegrationConfigApiCredentialsSection(props: {
       });
     };
 
+    const updateSelfHosted = (patch: Partial<GQLZentropiSelfHostedConfig>) => {
+      setApiCredential({
+        ...apiCredential,
+        selfHosted: {
+          __typename: 'ZentropiSelfHostedConfig' as const,
+          format: 'cope',
+          baseUrl: '',
+          model: '',
+          ...selfHosted,
+          ...patch,
+        },
+      });
+    };
+
+    const switchToHosted = () => {
+      setApiCredential({ ...apiCredential, selfHosted: null });
+    };
+
+    const switchToSelfHosted = () => {
+      setApiCredential({
+        ...apiCredential,
+        selfHosted: {
+          __typename: 'ZentropiSelfHostedConfig' as const,
+          format: 'cope',
+          baseUrl: '',
+          model: '',
+        },
+      });
+    };
+
     return (
       <div className="flex flex-col gap-4">
         <div className={`flex flex-col ${inputWidthClass}`}>
-          <div className="mb-1">API Key</div>
-          <Input
-            value={apiCredential.apiKey}
-            onChange={(event) =>
-              setApiCredential({
-                ...apiCredential,
-                apiKey: event.target.value,
-              })
-            }
+          <div className="mb-1 font-semibold">Mode</div>
+          <Select
+            value={isHosted ? 'hosted' : 'self_hosted'}
+            onChange={(value) => {
+              if (value === 'hosted') {
+                switchToHosted();
+              } else {
+                switchToSelfHosted();
+              }
+            }}
+            options={[
+              { value: 'hosted', label: 'Hosted (Zentropi API)' },
+              { value: 'self_hosted', label: 'Self-hosted (vLLM)' },
+            ]}
           />
         </div>
-        <div className={`flex flex-col ${inputWidthClass}`}>
-          <div className="mb-2 font-semibold">Labeler Versions</div>
-          {labelerVersions.map((version, index) => (
-            <div
-              key={index}
-              className={`flex gap-2 mb-2 ${compact ? 'flex-col' : 'flex-row items-center'}`}
-            >
+
+        {isHosted ? (
+          <>
+            <div className={`flex flex-col ${inputWidthClass}`}>
+              <div className="mb-1">API Key</div>
               <Input
-                placeholder="Version ID"
-                value={version.id}
+                value={apiCredential.apiKey}
                 onChange={(event) =>
-                  updateLabelerVersion(index, 'id', event.target.value)
+                  setApiCredential({
+                    ...apiCredential,
+                    apiKey: event.target.value,
+                  })
                 }
-                className="flex-1"
-              />
-              <Input
-                placeholder="Labeler Name"
-                value={version.label}
-                onChange={(event) =>
-                  updateLabelerVersion(index, 'label', event.target.value)
-                }
-                className="flex-1"
-              />
-              <Button
-                type="text"
-                icon={<Trash2 size={14} />}
-                onClick={() => removeLabelerVersion(index)}
-                danger
-                className={compact ? 'self-end' : ''}
               />
             </div>
-          ))}
-          <Button
-            type="dashed"
-            icon={<Plus size={14} className="inline-block" />}
-            onClick={addLabelerVersion}
-            className={compact ? 'w-full' : 'w-fit'}
-          >
-            Add Labeler Version
-          </Button>
-        </div>
+            <div className={`flex flex-col ${inputWidthClass}`}>
+              <div className="mb-2 font-semibold">Labeler Versions</div>
+              {labelerVersions.map((version, index) => (
+                <div
+                  key={index}
+                  className={`flex gap-2 mb-2 ${compact ? 'flex-col' : 'flex-row items-center'}`}
+                >
+                  <Input
+                    placeholder="Version ID"
+                    value={version.id}
+                    onChange={(event) =>
+                      updateLabelerVersion(index, 'id', event.target.value)
+                    }
+                    className="flex-1"
+                  />
+                  <Input
+                    placeholder="Labeler Name"
+                    value={version.label}
+                    onChange={(event) =>
+                      updateLabelerVersion(index, 'label', event.target.value)
+                    }
+                    className="flex-1"
+                  />
+                  <Button
+                    type="text"
+                    icon={<Trash2 size={14} />}
+                    onClick={() => removeLabelerVersion(index)}
+                    danger
+                    className={compact ? 'self-end' : ''}
+                  />
+                </div>
+              ))}
+              <Button
+                type="dashed"
+                icon={<Plus size={14} className="inline-block" />}
+                onClick={addLabelerVersion}
+                className={compact ? 'w-full' : 'w-fit'}
+              >
+                Add Labeler Version
+              </Button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className={`flex flex-col ${inputWidthClass}`}>
+              <div className="mb-1">
+                Base URL <span className="text-red-500">*</span>
+              </div>
+              <Input
+                placeholder="http://localhost:8000"
+                value={selfHosted.baseUrl}
+                onChange={(event) =>
+                  updateSelfHosted({ baseUrl: event.target.value })
+                }
+              />
+            </div>
+            <div className={`flex flex-col ${inputWidthClass}`}>
+              <div className="mb-1">
+                Model <span className="text-red-500">*</span>
+              </div>
+              <Input
+                placeholder="cope-model"
+                value={selfHosted.model}
+                onChange={(event) =>
+                  updateSelfHosted({ model: event.target.value })
+                }
+              />
+            </div>
+            <div className={`flex flex-col ${inputWidthClass}`}>
+              <div className="mb-1">Format</div>
+              <Select
+                value={selfHosted.format}
+                onChange={(value) => updateSelfHosted({ format: value })}
+                options={[
+                  { value: 'cope', label: 'CoPE (vLLM completions)' },
+                  { value: 'openai_chat', label: 'OpenAI Chat' },
+                ]}
+              />
+            </div>
+            <div className={`flex flex-col ${inputWidthClass}`}>
+              <div className="mb-1">API Key (optional)</div>
+              <Input
+                placeholder="Leave empty if no auth required"
+                value={selfHosted.apiKey ?? ''}
+                onChange={(event) =>
+                  updateSelfHosted({
+                    apiKey: event.target.value || undefined,
+                  })
+                }
+              />
+            </div>
+            {selfHosted.format === 'openai_chat' && (
+              <>
+                <div className={`flex flex-col ${inputWidthClass}`}>
+                  <div className="mb-1">
+                    System Prompt Template
+                    <span className="ml-1 text-gray-400 text-xs">
+                      (use {'{criteria}'} for policy text)
+                    </span>
+                  </div>
+                  <Input.TextArea
+                    rows={3}
+                    placeholder="You are a content moderator. Policy: {criteria}"
+                    value={selfHosted.systemPromptTemplate ?? ''}
+                    onChange={(event) =>
+                      updateSelfHosted({
+                        systemPromptTemplate: event.target.value || undefined,
+                      })
+                    }
+                  />
+                </div>
+                <div className={`flex flex-col ${inputWidthClass}`}>
+                  <div className="mb-1">
+                    User Message Template
+                    <span className="ml-1 text-gray-400 text-xs">
+                      (use {'{content}'} for content text)
+                    </span>
+                  </div>
+                  <Input.TextArea
+                    rows={3}
+                    placeholder="Content to evaluate: {content}"
+                    value={selfHosted.userMessageTemplate ?? ''}
+                    onChange={(event) =>
+                      updateSelfHosted({
+                        userMessageTemplate: event.target.value || undefined,
+                      })
+                    }
+                  />
+                </div>
+              </>
+            )}
+          </>
+        )}
       </div>
     );
   };
@@ -151,9 +296,10 @@ export default function IntegrationConfigApiCredentialsSection(props: {
     truePercentage: 'True percentage (0–100)',
   };
 
-  const renderPluginCredential = (
-    pluginCredential: { __typename: 'PluginIntegrationApiCredential'; credential: Record<string, unknown> },
-  ) => {
+  const renderPluginCredential = (pluginCredential: {
+    __typename: 'PluginIntegrationApiCredential';
+    credential: Record<string, unknown>;
+  }) => {
     const credential = pluginCredential.credential ?? {};
     const entries = Object.entries(credential).filter(
       ([key]) => key !== 'name',
@@ -166,16 +312,15 @@ export default function IntegrationConfigApiCredentialsSection(props: {
       <div className="flex flex-col gap-4">
         {fieldsToShow.map(([key, value]) => (
           <div key={key} className={`flex flex-col ${inputWidthClass}`}>
-            <div className="mb-1">
-              {PLUGIN_FIELD_LABELS[key] ?? key}
-            </div>
+            <div className="mb-1">{PLUGIN_FIELD_LABELS[key] ?? key}</div>
             <Input
               value={String(value ?? '')}
               onChange={(event) => {
                 const next = { ...credential, [key]: event.target.value };
                 setApiCredential({
                   __typename: 'PluginIntegrationApiCredential',
-                  credential: next as import('../../../graphql/generated').Scalars['JSONObject'],
+                  credential:
+                    next as import('../../../graphql/generated').Scalars['JSONObject'],
                 });
               }}
             />

--- a/client/src/webpages/dashboard/integrations/IntegrationConfigForm.tsx
+++ b/client/src/webpages/dashboard/integrations/IntegrationConfigForm.tsx
@@ -49,7 +49,9 @@ gql`
     }
   }
 
-  mutation SetPluginIntegrationConfig($input: SetPluginIntegrationConfigInput!) {
+  mutation SetPluginIntegrationConfig(
+    $input: SetPluginIntegrationConfigInput!
+  ) {
     setPluginIntegrationConfig(input: $input) {
       ... on SetIntegrationConfigSuccessResponse {
         config {
@@ -112,6 +114,14 @@ gql`
                 id
                 label
               }
+              selfHosted {
+                format
+                baseUrl
+                model
+                apiKey
+                systemPromptTemplate
+                userMessageTemplate
+              }
             }
             ... on PluginIntegrationApiCredential {
               credential
@@ -136,9 +146,7 @@ gql`
  * This function returns an empty API credential config (type is
  * IntegrationConfigApiCredential), so the UI can display the proper empty inputs.
  */
-export function getNewEmptyApiKey(
-  name: string,
-): GQLIntegrationApiCredential {
+export function getNewEmptyApiKey(name: string): GQLIntegrationApiCredential {
   switch (name) {
     case 'GOOGLE_CONTENT_SAFETY_API': {
       return {
@@ -154,6 +162,7 @@ export function getNewEmptyApiKey(
         __typename: 'ZentropiIntegrationApiCredential',
         apiKey: '',
         labelerVersions: [],
+        selfHosted: null,
       };
     }
     default: {
@@ -258,8 +267,7 @@ export default function IntegrationConfigForm() {
     response?.__typename === 'IntegrationConfigSuccessResult'
       ? response.config
       : undefined;
-  const formattedName =
-    apiConfig?.title ?? integrationName.replace(/_/g, ' ');
+  const formattedName = apiConfig?.title ?? integrationName.replace(/_/g, ' ');
   const logo = apiConfig
     ? (apiConfig.logoUrl ??
       INTEGRATION_LOGO_FALLBACKS[apiConfig.name]?.logo ??
@@ -290,7 +298,7 @@ export default function IntegrationConfigForm() {
       'googleContentSafetyApi' in mappedApiCredential &&
       !(
         mappedApiCredential[
-        'googleContentSafetyApi'
+          'googleContentSafetyApi'
         ] as GQLGoogleContentSafetyApiIntegrationApiCredential
       ).apiKey
     ) {
@@ -305,15 +313,15 @@ export default function IntegrationConfigForm() {
       return 'Please input the OpenAI API key';
     }
 
-    if (
-      'zentropi' in mappedApiCredential &&
-      !(
-        mappedApiCredential[
-          'zentropi'
-        ] as GQLZentropiIntegrationApiCredential
-      ).apiKey
-    ) {
-      return 'Please input the Zentropi API key';
+    if ('zentropi' in mappedApiCredential) {
+      const zentropiCred = mappedApiCredential[
+        'zentropi'
+      ] as GQLZentropiIntegrationApiCredential;
+      const hasSelfHosted =
+        zentropiCred.selfHosted?.baseUrl && zentropiCred.selfHosted?.model;
+      if (!zentropiCred.apiKey && !hasSelfHosted) {
+        return 'Please input either a Zentropi API key or a self-hosted model URL and model name';
+      }
     }
 
     return undefined;
@@ -334,7 +342,7 @@ export default function IntegrationConfigForm() {
         if (isPluginIntegration) {
           const cred =
             apiCredential.__typename === 'PluginIntegrationApiCredential'
-              ? apiCredential.credential ?? {}
+              ? (apiCredential.credential ?? {})
               : {};
           await setPluginConfig({
             variables: {
@@ -361,15 +369,15 @@ export default function IntegrationConfigForm() {
   const [modalTitle, modalBody, modalButtonText] =
     mutationError == null
       ? [
-        `${formattedName} Config Saved`,
-        `Your ${formattedName} Config was successfully saved!`,
-        'Done',
-      ]
+          `${formattedName} Config Saved`,
+          `Your ${formattedName} Config was successfully saved!`,
+          'Done',
+        ]
       : [
-        `Error Saving ${formattedName} Config`,
-        `We encountered an error trying to save your ${formattedName} Config. Please try again.`,
-        'OK',
-      ];
+          `Error Saving ${formattedName} Config`,
+          `We encountered an error trying to save your ${formattedName} Config. Please try again.`,
+          'OK',
+        ];
 
   const onHideModal = () => {
     hideModal();
@@ -403,11 +411,11 @@ export default function IntegrationConfigForm() {
       case 'GOOGLE_CONTENT_SAFETY_API':
         return (
           <>
-            The Content Safety API is an AI classifier which issues a Child 
-            Safety prioritization recommendation on content sent to it. Content Safety API users
-            must conduct their own manual review in order to determine whether to take
-            action on the content, and comply with applicable local reporting
-            laws. Apply for API keys{' '}
+            The Content Safety API is an AI classifier which issues a Child
+            Safety prioritization recommendation on content sent to it. Content
+            Safety API users must conduct their own manual review in order to
+            determine whether to take action on the content, and comply with
+            applicable local reporting laws. Apply for API keys{' '}
             <a
               href="https://protectingchildren.google/tools-for-partners/"
               target="_blank"
@@ -415,11 +423,11 @@ export default function IntegrationConfigForm() {
               className="text-blue-600 hover:underline"
             >
               here
-            </a>
-            {' '}
+            </a>{' '}
             and mention in your application that you are using the Coop
             moderation tool. Upon reviewing your application, Google will be
-            back in touch shortly to take the application forward if you qualify.
+            back in touch shortly to take the application forward if you
+            qualify.
           </>
         );
       case 'OPEN_AI':
@@ -441,11 +449,7 @@ export default function IntegrationConfigForm() {
       <div className="flex flex-col justify-between w-4/5 mb-4">
         <div className="flex items-center gap-3 mb-1">
           <div className="w-12 h-12 rounded-full bg-slate-200 flex items-center justify-center shrink-0 overflow-hidden">
-            <img
-              src={logo}
-              alt=""
-              className="w-full h-full object-contain"
-            />
+            <img src={logo} alt="" className="w-full h-full object-contain" />
           </div>
           <div className="text-2xl font-bold">{`${formattedName} Integration`}</div>
         </div>
@@ -473,7 +477,9 @@ export default function IntegrationConfigForm() {
                 <span>Learn more about how to read model cards</span>
               </a>
             )}
-            <div className="font-semibold text-zinc-800 mb-2">Configuration</div>
+            <div className="font-semibold text-zinc-800 mb-2">
+              Configuration
+            </div>
             <div className="text-sm text-zinc-600 mb-3">
               Configure your integration settings below.
             </div>

--- a/client/src/webpages/dashboard/integrations/integrationConfigs.ts
+++ b/client/src/webpages/dashboard/integrations/integrationConfigs.ts
@@ -21,7 +21,7 @@ export type IntegrationConfig = {
 
 export const INTEGRATION_CONFIGS: IntegrationConfig[] = [
   {
-    name: 'GOOGLE_CONTENT_SAFETY_API' as GQLIntegration,
+    name: 'GOOGLE_CONTENT_SAFETY_API',
     title: 'Google Content Safety API',
     logo: GoogleLogo,
     logoWithBackground: GoogleLogoWithBackground,
@@ -29,7 +29,7 @@ export const INTEGRATION_CONFIGS: IntegrationConfig[] = [
     requiresInfo: true,
   },
   {
-    name: 'OPEN_AI' as GQLIntegration,
+    name: 'OPEN_AI',
     title: 'OpenAI Moderation API',
     logo: OpenAILogo,
     logoWithBackground: OpenAILogoWithBackground,
@@ -37,7 +37,7 @@ export const INTEGRATION_CONFIGS: IntegrationConfig[] = [
     requiresInfo: true,
   },
   {
-    name: 'ZENTROPI' as GQLIntegration,
+    name: 'ZENTROPI',
     title: 'Zentropi',
     logo: ZentropiLogo,
     logoWithBackground: ZentropiLogo,

--- a/client/src/webpages/dashboard/mrt/manual_review_job/IframeContentDisplayComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/IframeContentDisplayComponent.tsx
@@ -3,11 +3,8 @@ import { Switch } from '@/coop-ui/Switch';
 import { useGQLPersonalSafetySettingsQuery } from '@/graphql/generated';
 import { LoaderCircle } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
-import * as React from 'react';
 
 import FullScreenLoading from '@/components/common/FullScreenLoading';
-
-import { type BlurStrength } from './v2/ncmec/NCMECMediaViewer';
 
 export default function IframeContentDisplayComponent(props: {
   contentUrl: string;
@@ -37,10 +34,8 @@ export default function IframeContentDisplayComponent(props: {
   const { blur, grayscale, shouldTranslate } = state;
 
   const { loading, data } = useGQLPersonalSafetySettingsQuery();
-  const {
-    moderatorSafetyBlurLevel = 2 as BlurStrength,
-    moderatorSafetyGrayscale = true,
-  } = data?.me?.interfacePreferences ?? {};
+  const { moderatorSafetyBlurLevel = 2, moderatorSafetyGrayscale = true } =
+    data?.me?.interfacePreferences ?? {};
 
   useEffect(() => {
     setState({

--- a/client/src/webpages/dashboard/mrt/manual_review_job/ManualReviewJobReview.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/ManualReviewJobReview.tsx
@@ -1027,7 +1027,7 @@ function ManualReviewJobReviewImpl(props: {
       (a) => !('type' in a) && a.id === actionId,
     );
     if (!found || 'type' in found || !('parameters' in found)) return [];
-    return (found.parameters ?? []) as ReadonlyArray<GQLActionParameter>;
+    return found.parameters ?? [];
   };
 
   // Adds an action to `selectedPrimaryActions` while preserving the existing
@@ -1039,7 +1039,7 @@ function ManualReviewJobReviewImpl(props: {
     customMrtApiParamDecisionPayload?: Record<string, unknown>,
   ) => {
     const newAction: ManualReviewJobEnqueuedPrimaryActionData = {
-      action: action as ManualReviewJobEnqueuedPrimaryActionData['action'],
+      action,
       target: reportedItemTarget(),
       policies: selectedPrimaryPolicies,
       ...(customMrtApiParamDecisionPayload
@@ -1291,9 +1291,7 @@ function ManualReviewJobReviewImpl(props: {
                         actionName: action.name,
                         parameters,
                         initialValues:
-                          (current?.customMrtApiParamDecisionPayload as
-                            | ActionParameterValues
-                            | undefined) ?? {},
+                          current?.customMrtApiParamDecisionPayload ?? {},
                       });
                     }}
                   >

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobFieldsComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobFieldsComponent.tsx
@@ -250,9 +250,14 @@ function TableRowComponent(props: {
         return <NotProvidedComponent />;
       }
 
-      // Extract matched banks if available
-      const matchedBanks = (value as any)?.matchedBanks;
-      const hasMatches = Array.isArray(matchedBanks) && matchedBanks.length > 0;
+      // Extract matched banks if available, normalizing to a string[] so the
+      // render path below always has a concrete array to map over.
+      const rawMatchedBanks = (value as { matchedBanks?: string[] })
+        .matchedBanks;
+      const matchedBanks = Array.isArray(rawMatchedBanks)
+        ? rawMatchedBanks
+        : [];
+      const hasMatches = matchedBanks.length > 0;
 
       return (
         <div className="flex flex-col px-2 align-top text-start">
@@ -275,7 +280,7 @@ function TableRowComponent(props: {
           {label ? <div className="font-bold">{label}</div> : null}
           {hasMatches && (
             <div className="flex flex-wrap gap-1 mt-1">
-              {matchedBanks.map((bankName: string) => (
+              {matchedBanks.map((bankName) => (
                 <span
                   key={bankName}
                   className="inline-block px-2 py-0.5 text-s font-large bg-gray-200 rounded"
@@ -591,7 +596,7 @@ function ContainerComponent(props: {
             }));
       }
       case 'MAP': {
-        const mapValue = data.value as { [key: string]: ScalarTypeRuntimeType };
+        const mapValue = data.value;
         return isPlainObject(mapValue)
           ? Object.keys(mapValue).map((key) => ({
               value: mapValue[key],

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/threads/ManualReviewJobThreadComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/threads/ManualReviewJobThreadComponent.tsx
@@ -234,7 +234,15 @@ export function ManualReviewJobThreadComponent(props: {
         )?.data
       : undefined;
   };
-  if (!data || data.threadHistory.length === 0) {
+  if (loading) {
+    return <ComponentLoading />;
+  }
+
+  if (error) {
+    return <div>Error loading user submissions: {error.message}</div>;
+  }
+
+  if (!data) {
     return null;
   }
   const newMessages = data.threadHistory
@@ -354,14 +362,6 @@ export function ManualReviewJobThreadComponent(props: {
           ? `${threadTypeName} ID: ${thread.id}`
           : `Thread ID: ${thread.id}`;
 
-  if (loading) {
-    return <ComponentLoading />;
-  }
-
-  if (error) {
-    return <div>Error loading user submissions: {error.message}</div>;
-  }
-
   return (
     <>
       <div className="flex flex-col items-start w-full bg-white border border-gray-200 border-solid rounded-lg grow">
@@ -441,10 +441,16 @@ export function ManualReviewJobThreadComponent(props: {
           className="flex flex-col w-full overflow-auto max-h-[600px] gap-2 p-5"
           ref={scrollViewRef}
         >
-          {threadComponent}
+          {threadComponent.length > 0 ? (
+            threadComponent
+          ) : (
+            <div className="text-left text-gray-500">
+              There is no content in this thread yet
+            </div>
+          )}
         </div>
       </div>
-      {isActionable && (
+      {isActionable && newMessages.length > 0 && (
         <>
           <div className="flex flex-row self-end mt-2">
             <Button

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/useEnqueueActionGate.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/useEnqueueActionGate.tsx
@@ -1,12 +1,11 @@
+import { type GQLActionParameter } from '@/graphql/generated';
+import groupBy from 'lodash/groupBy';
+import { useCallback, useState, type ReactNode } from 'react';
+
+import { type ActionParameterValues } from '@/components/ActionParameterInputs';
 import ActionParametersModal, {
   defaultValuesForParameters,
 } from '@/components/ActionParametersModal';
-import {
-  type ActionParameterValues,
-} from '@/components/ActionParameterInputs';
-import { type GQLActionParameter } from '@/graphql/generated';
-import groupBy from 'lodash/groupBy';
-import { type ReactNode, useCallback, useState } from 'react';
 
 import { type ManualReviewJobEnqueuedActionData } from '../ManualReviewJobReview';
 
@@ -117,9 +116,8 @@ export function useEnqueueActionGate(args: {
       const parameters = actionMeta?.parameters ?? [];
       if (parameters.length === 0) return;
       const initialValues =
-        (entry.customMrtApiParamDecisionPayload as
-          | ActionParameterValues
-          | undefined) ?? defaultValuesForParameters(parameters);
+        entry.customMrtApiParamDecisionPayload ??
+        defaultValuesForParameters(parameters);
       const match = (it: ManualReviewJobEnqueuedActionData) =>
         it.action.id === entry.action.id &&
         it.target.identifier.itemId === entry.target.identifier.itemId &&

--- a/client/src/webpages/dashboard/mrt/queue_routing/ManualReviewQueueRoutingRule.tsx
+++ b/client/src/webpages/dashboard/mrt/queue_routing/ManualReviewQueueRoutingRule.tsx
@@ -10,7 +10,7 @@ import { Input, Tooltip } from 'antd';
 import React, { useState } from 'react';
 import { DraggableProvidedDragHandleProps } from 'react-beautiful-dnd';
 
-import { CoreSignal } from '../../../../models/signal';
+import { GQLSignal } from '../../../../graphql/generated';
 import {
   getInvalidRegexesInCondition,
   isConditionComplete,
@@ -100,7 +100,7 @@ export default function ManualReviewQueueRoutingRule(props: {
   isEditing: boolean;
   setRuleEditingState: (isEditing: boolean) => void;
   itemTypes: readonly RoutingRuleItemType[];
-  signals: readonly CoreSignal[];
+  signals: readonly GQLSignal[];
   queues: readonly RoutingRuleQueue[];
   isReordering: boolean;
   isLoading: boolean;

--- a/client/src/webpages/dashboard/mrt/queue_routing/ManualReviewQueueRoutingRuleForm.tsx
+++ b/client/src/webpages/dashboard/mrt/queue_routing/ManualReviewQueueRoutingRuleForm.tsx
@@ -4,8 +4,7 @@ import cloneDeep from 'lodash/cloneDeep';
 
 import { selectFilterByLabelOption } from '../../components/antDesignUtils';
 
-import { GQLConditionConjunction } from '../../../../graphql/generated';
-import { CoreSignal } from '../../../../models/signal';
+import { GQLConditionConjunction, GQLSignal } from '../../../../graphql/generated';
 import {
   hasNestedConditionSets,
   removeConditionSet,
@@ -33,7 +32,7 @@ const { Option } = Select;
 export default function ManualReviewQueueRoutingRuleForm(props: {
   rule: EditableRoutingRule;
   itemTypes: readonly RoutingRuleItemType[];
-  signals: readonly CoreSignal[];
+  signals: readonly GQLSignal[];
   queues: readonly RoutingRuleQueue[];
   editing: boolean;
   addSelectedItemTypeId: (itemTypeId: string) => void;
@@ -152,7 +151,7 @@ export default function ManualReviewQueueRoutingRuleForm(props: {
   const renderConditionSet = (opts: {
     conditionSet: RuleFormConditionSet;
     conditionSetIndex: number;
-    signals: readonly CoreSignal[];
+    signals: readonly GQLSignal[];
     parentConditionSet?: RuleFormConditionSet;
   }) => {
     const { conditionSet, conditionSetIndex, signals, parentConditionSet } = opts;

--- a/client/src/webpages/dashboard/mrt/queue_routing/ManualReviewQueueRuleFormCondition.tsx
+++ b/client/src/webpages/dashboard/mrt/queue_routing/ManualReviewQueueRuleFormCondition.tsx
@@ -1,8 +1,7 @@
 import { DeleteOutlined, InfoCircleOutlined } from '@ant-design/icons';
 import { Button, Select, Tooltip } from 'antd';
 
-import { GQLConditionConjunction } from '../../../../graphql/generated';
-import { CoreSignal } from '../../../../models/signal';
+import { GQLConditionConjunction, GQLSignal } from '../../../../graphql/generated';
 import {
   hasNestedConditionSets,
   removeCondition,
@@ -88,7 +87,7 @@ export default function ManualReviewQueueRuleFormCondition(props: {
   parentConditionSet: RuleFormConditionSet;
   eligibleInputs: Map<string, ConditionInput[]>;
   selectedItemTypes: RoutingRuleItemType[];
-  allSignals: readonly CoreSignal[];
+  allSignals: readonly GQLSignal[];
   editing: boolean;
   onUpdateConditionSet: (conditionSet: RuleFormConditionSet) => void;
 }) {
@@ -183,7 +182,7 @@ export default function ManualReviewQueueRuleFormCondition(props: {
         condition={condition}
         location={location}
         editing={editing}
-        onUpdateSignal={(signal: CoreSignal, subcategory?: string) => {
+        onUpdateSignal={(signal: GQLSignal, subcategory?: string) => {
           // Do this manually instead of having a helper function to avoid
           // setting the state multiple times in the case of the signal having a subcategory
           let newConditionSet = updateConditionComponent(

--- a/client/src/webpages/dashboard/mrt/queue_routing/condition/signal/ManualReviewQueueRuleConditionSignal.tsx
+++ b/client/src/webpages/dashboard/mrt/queue_routing/condition/signal/ManualReviewQueueRuleConditionSignal.tsx
@@ -2,7 +2,7 @@ import { DownOutlined } from '@ant-design/icons';
 import { Button } from 'antd';
 import { useState } from 'react';
 
-import { CoreSignal } from '../../../../../../models/signal';
+import { GQLSignal } from '@/graphql/generated';
 import RuleFormSignalModal from '../../../../rules/rule_form/signal_modal/RuleFormSignalModal';
 import {
   ConditionLocation,
@@ -15,13 +15,13 @@ export default function ManualReviewQueueRuleConditionSignal(props: {
   condition: RuleFormLeafCondition;
   location: ConditionLocation;
   editing: boolean;
-  onUpdateSignal: (signal: CoreSignal, subcategory?: string) => void;
+  onUpdateSignal: (signal: GQLSignal, subcategory?: string) => void;
 }) {
   const { condition, location, editing, onUpdateSignal } = props;
   const eligibleSignals = condition.eligibleSignals;
   const [modalInfo, setModalInfo] = useState<{
     visible: boolean;
-    initialSelectedSignal: CoreSignal | undefined;
+    initialSelectedSignal: GQLSignal | undefined;
   }>({
     visible: false,
     initialSelectedSignal: undefined,

--- a/client/src/webpages/dashboard/mrt/queue_routing/types.ts
+++ b/client/src/webpages/dashboard/mrt/queue_routing/types.ts
@@ -1,8 +1,7 @@
 import {
-  GQLConditionSetFieldsFragment,
   GQLManualReviewQueueRoutingRulesQuery,
+  GQLSignal,
 } from '../../../../graphql/generated';
-import { CoreSignal } from '../../../../models/signal';
 import { getTypedConditionSetFromGQL } from '../../rules/rule_form/RuleFormUtils';
 import { RuleFormConditionSet } from '../../rules/types';
 
@@ -32,14 +31,14 @@ export function editableRoutingRuleFromRoutingRule(
   rule: RoutingRule,
   index: number,
   selectedItemTypeIds: string[],
-  allSignals: readonly CoreSignal[],
+  allSignals: readonly GQLSignal[],
 ) {
   return {
     id: rule.id,
     name: rule.name,
     destinationQueue: rule.destinationQueue,
     conditionSet: getTypedConditionSetFromGQL(
-      rule.conditionSet as GQLConditionSetFieldsFragment,
+      rule.conditionSet,
       rule.itemTypes.filter((it) => selectedItemTypeIds.includes(it.id)),
       allSignals,
     ),

--- a/client/src/webpages/dashboard/mrt/queue_routing/utils.test.ts
+++ b/client/src/webpages/dashboard/mrt/queue_routing/utils.test.ts
@@ -1,0 +1,126 @@
+import { vi } from 'vitest';
+
+import {
+  GQLConditionConjunction,
+  GQLScalarType,
+  GQLSignal,
+  GQLSignalPricingStructureType,
+  GQLSignalType,
+} from '../../../../graphql/generated';
+import {
+  getConditionInputScalarType,
+  getEligibleSignalsForInput,
+  SimplifiedConditionInput,
+} from '../../rules/rule_form/RuleFormUtils';
+import { RuleFormConditionSet, RuleFormLeafCondition } from '../../rules/types';
+import { updateConditionInput } from './utils';
+
+vi.mock('../../rules/rule_form/RuleFormUtils', async () => {
+  const origin = await vi.importActual<
+    typeof import('../../rules/rule_form/RuleFormUtils')
+  >('../../rules/rule_form/RuleFormUtils');
+  return {
+    ...origin,
+    getConditionInputScalarType: vi.fn(),
+    getEligibleSignalsForInput: vi.fn(),
+  };
+});
+
+const makeSignal = (id: string, type: GQLSignalType): GQLSignal => ({
+  __typename: 'Signal',
+  id,
+  type,
+  shouldPromptForMatchingValues: false,
+  eligibleSubcategories: [],
+  eligibleInputs: [],
+  name: `signal-${id}`,
+  description: 'Some description',
+  disabledInfo: { __typename: 'DisabledInfo', disabled: false },
+  outputType: {
+    __typename: 'ScalarSignalOutputType',
+    scalarType: GQLScalarType.Number,
+  },
+  pricingStructure: {
+    __typename: 'SignalPricingStructure',
+    type: GQLSignalPricingStructureType.Free,
+  },
+  supportedLanguages: { __typename: 'AllLanguages', _: true },
+  allowedInAutomatedRules: true,
+});
+
+describe('updateConditionInput signal eligibility', () => {
+  const oldInput: SimplifiedConditionInput = {
+    type: 'CONTENT_FIELD',
+    name: 'old_field',
+    contentTypeId: '12345',
+  };
+  const newInput: SimplifiedConditionInput = {
+    type: 'CONTENT_FIELD',
+    name: 'new_field',
+    contentTypeId: '12345',
+  };
+  const location = { conditionIndex: 0, conditionSetIndex: 0 };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Keep the input scalar type stable so the input-type-change reset path
+    // (which clears the whole condition) is not what's being exercised here.
+    vi.mocked(getConditionInputScalarType).mockReturnValue(
+      GQLScalarType.Number,
+    );
+  });
+
+  it('clears a stale custom signal that is no longer eligible, even when other custom signals remain', () => {
+    // All custom signals share GQLSignalType.Custom, so a type-based check would
+    // incorrectly keep custom1 selected. The ID-based check must clear it.
+    const custom1 = makeSignal('custom-1', GQLSignalType.Custom);
+    const custom2 = makeSignal('custom-2', GQLSignalType.Custom);
+    const custom3 = makeSignal('custom-3', GQLSignalType.Custom);
+
+    vi.mocked(getEligibleSignalsForInput).mockReturnValue([custom2, custom3]);
+
+    const conditionSet: RuleFormConditionSet = {
+      conjunction: GQLConditionConjunction.And,
+      conditions: [
+        { input: oldInput, signal: custom1, eligibleSignals: [custom1] },
+      ],
+    };
+
+    const result = updateConditionInput({
+      currentConditionSet: conditionSet,
+      location,
+      input: newInput,
+      selectedItemTypes: [],
+      allSignals: [custom1, custom2, custom3],
+    });
+
+    const updatedLeaf = result.conditions[0] as RuleFormLeafCondition;
+    expect(updatedLeaf.signal).toBeUndefined();
+    expect(updatedLeaf.input).toEqual(newInput);
+  });
+
+  it('keeps the selected signal when it is still eligible for the new input', () => {
+    const custom2 = makeSignal('custom-2', GQLSignalType.Custom);
+    const custom3 = makeSignal('custom-3', GQLSignalType.Custom);
+
+    vi.mocked(getEligibleSignalsForInput).mockReturnValue([custom2, custom3]);
+
+    const conditionSet: RuleFormConditionSet = {
+      conjunction: GQLConditionConjunction.And,
+      conditions: [
+        { input: oldInput, signal: custom2, eligibleSignals: [custom2] },
+      ],
+    };
+
+    const result = updateConditionInput({
+      currentConditionSet: conditionSet,
+      location,
+      input: newInput,
+      selectedItemTypes: [],
+      allSignals: [custom2, custom3],
+    });
+
+    const updatedLeaf = result.conditions[0] as RuleFormLeafCondition;
+    expect(updatedLeaf.signal).toEqual(custom2);
+  });
+});

--- a/client/src/webpages/dashboard/mrt/queue_routing/utils.ts
+++ b/client/src/webpages/dashboard/mrt/queue_routing/utils.ts
@@ -5,10 +5,10 @@ import uniqBy from 'lodash/uniqBy';
 import {
   GQLConditionConjunction,
   GQLScalarType,
+  GQLSignal,
   GQLSignalType,
   GQLValueComparator,
 } from '../../../../graphql/generated';
-import { CoreSignal } from '../../../../models/signal';
 import { getDerivedFieldOutputType } from '../../rules/rule_form/condition/input/derivedField';
 import {
   getConditionInputScalarType,
@@ -37,7 +37,7 @@ import { RoutingRuleItemType } from './types';
  */
 export function getNewEligibleInputs(
   selectedItemTypes: readonly RoutingRuleItemType[],
-  allSignals: readonly CoreSignal[],
+  allSignals: readonly GQLSignal[],
 ) {
   const allBaseFields = selectedItemTypes.flatMap((it) => it.baseFields);
   const allDerivedFields = selectedItemTypes.flatMap((it) => it.derivedFields);
@@ -155,7 +155,7 @@ export function updateConditionInput(params: {
   location: ConditionLocation;
   input: SimplifiedConditionInput;
   selectedItemTypes: RoutingRuleItemType[];
-  allSignals: readonly CoreSignal[];
+  allSignals: readonly GQLSignal[];
 }) {
   const {
     currentConditionSet,
@@ -225,12 +225,11 @@ export function updateConditionInput(params: {
   // If the previously selected signal on this condition is no
   // longer compatible with the newly selected input, clear it out,
   // and clear out all subsequent fields in the condition
+  const currentSignal = newConditions[conditionIndex].signal;
   if (
-    newConditions[conditionIndex].signal != null &&
-    // Need to compare IDs instead of objects
-    !allNewSignals
-      .map((s) => s.type)
-      .includes(newConditions[conditionIndex].signal!.type)
+    currentSignal != null &&
+    // Compare by ID: type-based comparison fails for custom signals, which all share GQLSignalType.Custom
+    !allNewSignals.some((s) => s.id === currentSignal.id)
   ) {
     // Clear out all other fields on the Condition
     newConditions[conditionIndex] = {

--- a/client/src/webpages/dashboard/mrt/visualization/ManualReviewDashboardInsightsChart.tsx
+++ b/client/src/webpages/dashboard/mrt/visualization/ManualReviewDashboardInsightsChart.tsx
@@ -719,7 +719,8 @@ export default function ManualReviewDashboardInsightsChart(props: {
     ...allDatesArray,
   ];
 
-  const groupedData = formattedDataWithAllDates.reduce((result, item) => {
+  type ChartRow = Record<string, string | number>;
+  const groupedData = formattedDataWithAllDates.reduce<Record<string, ChartRow>>((result, item) => {
     const ds = item.ds;
 
     if (!(ds in result)) {

--- a/client/src/webpages/dashboard/mrt/visualization/ManualReviewDashboardInsightsFilterBy.tsx
+++ b/client/src/webpages/dashboard/mrt/visualization/ManualReviewDashboardInsightsFilterBy.tsx
@@ -90,7 +90,7 @@ export function groupByColumnToFilterByColumns(
   groupBy: ManualReviewDashboardInsightsGroupByColumns[],
 ): FilterByColumnName[] {
   return groupBy.flatMap((groupByColumn) => {
-    return (() => {
+    return ((): FilterByColumnName[] => {
       switch (groupByColumn) {
         case GQLDecisionCountGroupByColumns.PolicyId:
         case GQLJobCreationGroupByColumns.PolicyId:
@@ -106,8 +106,10 @@ export function groupByColumnToFilterByColumns(
           return ['itemTypeIds'];
         case GQLJobCreationGroupByColumns.Source:
           return ['sources', 'ruleIds'];
+        default:
+          return [];
       }
-    })() as FilterByColumnName[];
+    })();
   });
 }
 
@@ -231,8 +233,8 @@ export default function ManualReviewDashboardInsightsFilterBy(props: {
             id === 'IGNORE'
               ? 'IGNORE'
               : id === 'SUBMIT_NCMEC_REPORT'
-              ? 'SUBMIT_NCMEC_REPORT'
-              : undefined,
+                ? 'SUBMIT_NCMEC_REPORT'
+                : undefined,
           ),
         ),
         actionIds: filterNullOrUndefined(
@@ -240,8 +242,8 @@ export default function ManualReviewDashboardInsightsFilterBy(props: {
             id === 'IGNORE'
               ? undefined
               : id === 'SUBMIT_NCMEC_REPORT'
-              ? undefined
-              : id,
+                ? undefined
+                : id,
           ),
         ),
       });
@@ -360,17 +362,19 @@ export default function ManualReviewDashboardInsightsFilterBy(props: {
       'sources' in unsavedFilterValues
         ? unsavedFilterValues[column as GQLJobCreationFilterByColumnName]
         : 'actionIds' in unsavedFilterValues
-        ? [
-            ...(unsavedFilterValues[
-              column as GQLDecisionCountFilterByColumnName
-            ] ?? []),
-            ...(unsavedFilterValues.type ?? []),
-          ]
-        : metric === 'REVIEWED_JOBS' && 'reviewerIds' in unsavedFilterValues
-        ? unsavedFilterValues[column as GQLJobCountFilterByColumnName]
-        : metric === 'SKIPPED_JOBS' && 'reviewerIds' in unsavedFilterValues
-        ? unsavedFilterValues[column as GQLSkippedJobCountFilterByColumnName]
-        : [];
+          ? [
+              ...(unsavedFilterValues[
+                column as GQLDecisionCountFilterByColumnName
+              ] ?? []),
+              ...(unsavedFilterValues.type ?? []),
+            ]
+          : metric === 'REVIEWED_JOBS' && 'reviewerIds' in unsavedFilterValues
+            ? unsavedFilterValues[column as GQLJobCountFilterByColumnName]
+            : metric === 'SKIPPED_JOBS' && 'reviewerIds' in unsavedFilterValues
+              ? unsavedFilterValues[
+                  column as GQLSkippedJobCountFilterByColumnName
+                ]
+              : [];
 
     return (
       <Select

--- a/client/src/webpages/dashboard/overview/OverviewChart.tsx
+++ b/client/src/webpages/dashboard/overview/OverviewChart.tsx
@@ -346,7 +346,8 @@ export default function OverviewChart(props: {
     ...allDatesArray,
   ];
 
-  const groupedData = formattedDataWithAllDates.reduce((result, item) => {
+  type ChartRow = Record<string, string | number>;
+  const groupedData = formattedDataWithAllDates.reduce<Record<string, ChartRow>>((result, item) => {
     const ds = item.ds;
 
     if (!(ds in result)) {

--- a/client/src/webpages/dashboard/policies/MarkdownTextInput.tsx
+++ b/client/src/webpages/dashboard/policies/MarkdownTextInput.tsx
@@ -1,6 +1,6 @@
 import { Editor, EditorContent, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 
 export default function MarkdownTextInput(props: {
   text?: string;
@@ -46,7 +46,9 @@ export default function MarkdownTextInput(props: {
 
   // NB: This is needed because the editor only focuses when the user clicks on
   // the editor content, and not when the user clicks elsewhere in the editor.
-  editorRef.current = editor;
+  useLayoutEffect(() => {
+    editorRef.current = editor;
+  }, [editor]);
   const focusEditor = () => {
     if (editorRef.current && !disabled) {
       editorRef.current.commands.focus();

--- a/client/src/webpages/dashboard/rules/dashboard/visualization/rulesDashboardInsightsChart.tsx
+++ b/client/src/webpages/dashboard/rules/dashboard/visualization/rulesDashboardInsightsChart.tsx
@@ -218,7 +218,8 @@ export default function RuleDashboardInsightsChart(props: {
     ...allDatesArray,
   ];
 
-  const groupedData = formattedDataWithAllDates.reduce((result, item) => {
+  type ChartRow = Record<string, string | number>;
+  const groupedData = formattedDataWithAllDates.reduce<Record<string, ChartRow>>((result, item) => {
     const ds = item.ds;
 
     if (!(ds in result)) {

--- a/client/src/webpages/dashboard/rules/info/insights/sample_details/RuleInsightsSampleDetailResults.tsx
+++ b/client/src/webpages/dashboard/rules/info/insights/sample_details/RuleInsightsSampleDetailResults.tsx
@@ -340,7 +340,14 @@ export function RuleInsightsSampleDetailResultsImpl(props: {
           }`}
         >
           {conditionSet.conditions.map((condition, conditionIndex) => {
-            condition = condition as LeafConditionWithResult;
+            if ('conditions' in condition) {
+              return (
+                <div key={conditionIndex} className="flex items-start py-3">
+                  {renderPrefix(conditionSet.conjunction, conditionIndex)}
+                  {renderConditionSet(condition)}
+                </div>
+              );
+            }
             return (
               <div key={conditionIndex} className="flex items-start py-3">
                 {renderConditionOutcome(condition.result?.outcome)}

--- a/client/src/webpages/dashboard/rules/rule_form/ReportingRuleForm.tsx
+++ b/client/src/webpages/dashboard/rules/rule_form/ReportingRuleForm.tsx
@@ -29,8 +29,8 @@ import {
   useGQLReportingRuleFormOrgDataQuery,
   useGQLReportingRuleQuery,
   useGQLUpdateReportingRuleMutation,
+  GQLSignal,
 } from '../../../../graphql/generated';
-import { CoreSignal } from '../../../../models/signal';
 import { userHasPermissions } from '../../../../routing/permissions';
 import useRouteQueryParams from '../../../../routing/useRouteQueryParams';
 import { ModalInfo } from '../../types/ModalInfo';
@@ -282,7 +282,7 @@ export default function RuleForm() {
           selectedItemTypes: rule.itemTypes,
           allActions,
           conditionSet: rule.conditionSet,
-          allSignals: allSignals satisfies readonly CoreSignal[],
+          allSignals: allSignals satisfies readonly GQLSignal[],
           policyIds: rule.policies.map((it) => it.id),
         },
       });
@@ -480,7 +480,7 @@ export default function RuleForm() {
           (id) => allItemTypes.find((itemType) => itemType.id === id)!,
         ),
         allActions,
-        allSignals: allSignals satisfies readonly CoreSignal[],
+        allSignals: allSignals satisfies readonly GQLSignal[],
         form,
       },
     });

--- a/client/src/webpages/dashboard/rules/rule_form/ReportingRuleFormReducers.tsx
+++ b/client/src/webpages/dashboard/rules/rule_form/ReportingRuleFormReducers.tsx
@@ -8,10 +8,10 @@ import {
   GQLConditionSetFieldsFragment,
   GQLReportingRuleFormOrgDataQuery,
   GQLScalarType,
+  GQLSignal,
   GQLSignalType,
   GQLValueComparator,
 } from '../../../../graphql/generated';
-import { CoreSignal } from '../../../../models/signal';
 import { CoopInput } from '../../types/enums';
 import { ModalInfo } from '../../types/ModalInfo';
 import {
@@ -99,7 +99,7 @@ export type ReportingRuleFormReducerAction =
       payload: {
         selectedItemTypes: ReportingRuleFormOrgDataResponse['itemTypes'];
         allActions: ReportingRuleFormOrgDataResponse['actions'];
-        allSignals: readonly CoreSignal[];
+        allSignals: readonly GQLSignal[];
         form: FormInstance<any>;
       };
     }
@@ -108,16 +108,16 @@ export type ReportingRuleFormReducerAction =
       payload: {
         location: ConditionLocation;
         input: SimplifiedConditionInput;
-        allSignals: readonly CoreSignal[];
+        allSignals: readonly GQLSignal[];
       };
     }
   | {
       type: ReportingRuleFormReducerActionType.UpdateSignal;
-      payload: { location: ConditionLocation; signal: CoreSignal };
+      payload: { location: ConditionLocation; signal: GQLSignal };
     }
   | {
       type: ReportingRuleFormReducerActionType.UpdateSignalArgs;
-      payload: { location: ConditionLocation; args: CoreSignal['args'] };
+      payload: { location: ConditionLocation; args: GQLSignal['args'] };
     }
   | {
       type: ReportingRuleFormReducerActionType.UpdateSignalSubcategory;
@@ -156,7 +156,7 @@ export type ReportingRuleFormReducerAction =
         selectedItemTypes: ReportingRuleFormOrgDataResponse['itemTypes'];
         allActions: ReportingRuleFormOrgDataResponse['actions'];
         conditionSet: GQLConditionSetFieldsFragment;
-        allSignals: readonly CoreSignal[];
+        allSignals: readonly GQLSignal[];
         policyIds: string[];
       };
     }
@@ -394,7 +394,7 @@ function deleteConditionSet(
  */
 export function getNewEligibleInputs(
   selectedItemTypes: ReportingRuleFormOrgDataResponse['itemTypes'],
-  allSignals: readonly CoreSignal[],
+  allSignals: readonly GQLSignal[],
 ) {
   const allBaseFields = selectedItemTypes.flatMap((it) => it.baseFields);
   const allDerivedFields = selectedItemTypes.flatMap((it) => it.derivedFields);
@@ -663,12 +663,11 @@ export function updateInput(
   // If the previously selected signal on this condition is no
   // longer compatible with the newly selected input, clear it out,
   // and clear out all subsequent fields in the condition
+  const currentSignal = newConditions[conditionIndex].signal;
   if (
-    newConditions[conditionIndex].signal != null &&
-    // Need to compare IDs instead of objects
-    !allNewSignals
-      .map((s) => s.type)
-      .includes(newConditions[conditionIndex].signal!.type)
+    currentSignal != null &&
+    // Compare by ID: type-based comparison fails for custom signals, which all share GQLSignalType.Custom
+    !allNewSignals.some((s) => s.id === currentSignal.id)
   ) {
     // Clear out all other fields on the Condition
     newConditions[conditionIndex] = {

--- a/client/src/webpages/dashboard/rules/rule_form/RuleForm.tsx
+++ b/client/src/webpages/dashboard/rules/rule_form/RuleForm.tsx
@@ -36,8 +36,8 @@ import {
   useGQLRuleQuery,
   useGQLUpdateContentRuleMutation,
   useGQLUpdateUserRuleMutation,
-} from '../../../../graphql/generated';
-import { CoreSignal } from '../../../../models/signal';
+  GQLSignal,
+} from '@/graphql/generated';
 import { userHasPermissions } from '../../../../routing/permissions';
 import useRouteQueryParams from '../../../../routing/useRouteQueryParams';
 import { DAY, HOUR, MONTH, WEEK } from '../../../../utils/time';
@@ -676,7 +676,7 @@ export default function RuleForm() {
             rule.__typename === 'ContentRule' ? rule.itemTypes : [],
           conditionSet: rule.conditionSet,
           allActions,
-          allSignals: allSignals satisfies readonly CoreSignal[],
+          allSignals: allSignals satisfies readonly GQLSignal[],
           policyIds: rule.policies.map((it) => it.id),
           tags: (rule.tags ?? []).filter((tag) => tag) as string[],
           maxDailyActions: rule.maxDailyActions ?? null,
@@ -1021,7 +1021,7 @@ export default function RuleForm() {
           (id: string) => allItemTypes.find((itemType) => itemType.id === id)!,
         ),
         allActions,
-        allSignals: allSignals satisfies readonly CoreSignal[],
+        allSignals: allSignals satisfies readonly GQLSignal[],
         form,
       },
     });

--- a/client/src/webpages/dashboard/rules/rule_form/RuleFormCondition.tsx
+++ b/client/src/webpages/dashboard/rules/rule_form/RuleFormCondition.tsx
@@ -5,8 +5,8 @@ import {
   GQLConditionConjunction,
   GQLScalarType,
   GQLValueComparator,
+  GQLSignal,
 } from '../../../../graphql/generated';
-import { CoreSignal } from '../../../../models/signal';
 import { CoopInput } from '../../types/enums';
 import {
   ConditionInput,
@@ -120,11 +120,11 @@ export default function RuleFormCondition(props: {
   isAutomatedRule?: boolean;
   onUpdateInput: (
     input: SimplifiedConditionInput,
-    allSignals: readonly CoreSignal[],
+    allSignals: readonly GQLSignal[],
   ) => void;
-  onUpdateSignal: (signal: CoreSignal) => void;
+  onUpdateSignal: (signal: GQLSignal) => void;
   onUpdateSignalSubcategory: (subcategory: string) => void;
-  onUpdateSignalArgs: (args: CoreSignal['args']) => void;
+  onUpdateSignalArgs: (args: GQLSignal['args']) => void;
   onUpdateMatchingValues: (
     matchingValues: RuleFormLeafCondition['matchingValues'],
   ) => void;

--- a/client/src/webpages/dashboard/rules/rule_form/RuleFormReducers.test.ts
+++ b/client/src/webpages/dashboard/rules/rule_form/RuleFormReducers.test.ts
@@ -1,0 +1,136 @@
+import { vi } from 'vitest';
+
+import {
+  GQLConditionConjunction,
+  GQLScalarType,
+  GQLSignal,
+  GQLSignalPricingStructureType,
+  GQLSignalType,
+} from '../../../../graphql/generated';
+import { RuleFormConditionSet, RuleFormLeafCondition } from '../types';
+import { initialState, RuleFormState } from './RuleForm';
+import { RuleFormReducerActionType, updateInput } from './RuleFormReducers';
+import {
+  getConditionInputScalarType,
+  getEligibleSignalsForInput,
+  SimplifiedConditionInput,
+} from './RuleFormUtils';
+
+vi.mock('./RuleFormUtils', async () => {
+  const origin =
+    await vi.importActual<typeof import('./RuleFormUtils')>('./RuleFormUtils');
+  return {
+    ...origin,
+    getConditionInputScalarType: vi.fn(),
+    getEligibleSignalsForInput: vi.fn(),
+  };
+});
+
+const makeSignal = (id: string, type: GQLSignalType): GQLSignal => ({
+  __typename: 'Signal',
+  id,
+  type,
+  shouldPromptForMatchingValues: false,
+  eligibleSubcategories: [],
+  eligibleInputs: [],
+  name: `signal-${id}`,
+  description: 'Some description',
+  disabledInfo: { __typename: 'DisabledInfo', disabled: false },
+  outputType: {
+    __typename: 'ScalarSignalOutputType',
+    scalarType: GQLScalarType.Number,
+  },
+  pricingStructure: {
+    __typename: 'SignalPricingStructure',
+    type: GQLSignalPricingStructureType.Free,
+  },
+  supportedLanguages: { __typename: 'AllLanguages', _: true },
+  allowedInAutomatedRules: true,
+});
+
+describe('updateInput signal eligibility', () => {
+  const oldInput: SimplifiedConditionInput = {
+    type: 'CONTENT_FIELD',
+    name: 'old_field',
+    contentTypeId: '12345',
+  };
+  const newInput: SimplifiedConditionInput = {
+    type: 'CONTENT_FIELD',
+    name: 'new_field',
+    contentTypeId: '12345',
+  };
+  const location = { conditionIndex: 0, conditionSetIndex: 0 };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Keep the input scalar type stable so the input-type-change reset path
+    // (which clears the whole condition) is not what's being exercised here.
+    vi.mocked(getConditionInputScalarType).mockReturnValue(
+      GQLScalarType.Number,
+    );
+  });
+
+  it('clears a stale custom signal that is no longer eligible, even when other custom signals remain', () => {
+    // All custom signals share GQLSignalType.Custom, so a type-based check would
+    // incorrectly keep custom1 selected. The ID-based check must clear it.
+    const custom1 = makeSignal('custom-1', GQLSignalType.Custom);
+    const custom2 = makeSignal('custom-2', GQLSignalType.Custom);
+    const custom3 = makeSignal('custom-3', GQLSignalType.Custom);
+
+    vi.mocked(getEligibleSignalsForInput).mockReturnValue([custom2, custom3]);
+
+    const state: RuleFormState = {
+      ...initialState,
+      conditionSet: {
+        conjunction: GQLConditionConjunction.And,
+        conditions: [
+          { input: oldInput, signal: custom1, eligibleSignals: [custom1] },
+        ],
+      } as RuleFormConditionSet,
+    };
+
+    const result = updateInput(state, {
+      type: RuleFormReducerActionType.UpdateInput,
+      payload: {
+        location,
+        input: newInput,
+        allSignals: [custom1, custom2, custom3],
+      },
+    });
+
+    const updatedLeaf = result.conditionSet
+      .conditions[0] as RuleFormLeafCondition;
+    expect(updatedLeaf.signal).toBeUndefined();
+    expect(updatedLeaf.input).toEqual(newInput);
+  });
+
+  it('keeps the selected signal when it is still eligible for the new input', () => {
+    const custom2 = makeSignal('custom-2', GQLSignalType.Custom);
+    const custom3 = makeSignal('custom-3', GQLSignalType.Custom);
+
+    vi.mocked(getEligibleSignalsForInput).mockReturnValue([custom2, custom3]);
+
+    const state: RuleFormState = {
+      ...initialState,
+      conditionSet: {
+        conjunction: GQLConditionConjunction.And,
+        conditions: [
+          { input: oldInput, signal: custom2, eligibleSignals: [custom2] },
+        ],
+      } as RuleFormConditionSet,
+    };
+
+    const result = updateInput(state, {
+      type: RuleFormReducerActionType.UpdateInput,
+      payload: {
+        location,
+        input: newInput,
+        allSignals: [custom2, custom3],
+      },
+    });
+
+    const updatedLeaf = result.conditionSet
+      .conditions[0] as RuleFormLeafCondition;
+    expect(updatedLeaf.signal).toEqual(custom2);
+  });
+});

--- a/client/src/webpages/dashboard/rules/rule_form/RuleFormReducers.tsx
+++ b/client/src/webpages/dashboard/rules/rule_form/RuleFormReducers.tsx
@@ -8,10 +8,10 @@ import {
   GQLConditionSetFieldsFragment,
   GQLContentRuleFormConfigQuery,
   GQLScalarType,
+  GQLSignal,
   GQLSignalType,
   GQLValueComparator,
 } from '../../../../graphql/generated';
-import { CoreSignal } from '../../../../models/signal';
 import { DAY } from '../../../../utils/time';
 import { CoopInput } from '../../types/enums';
 import { ModalInfo } from '../../types/ModalInfo';
@@ -120,7 +120,7 @@ export type RuleFormReducerAction =
       payload: {
         selectedItemTypes: RuleFormConfigResponse['itemTypes'];
         allActions: RuleFormConfigResponse['actions'];
-        allSignals: readonly CoreSignal[];
+        allSignals: readonly GQLSignal[];
         form: FormInstance<any>;
       };
     }
@@ -129,16 +129,16 @@ export type RuleFormReducerAction =
       payload: {
         location: ConditionLocation;
         input: SimplifiedConditionInput;
-        allSignals: readonly CoreSignal[];
+        allSignals: readonly GQLSignal[];
       };
     }
   | {
       type: RuleFormReducerActionType.UpdateSignal;
-      payload: { location: ConditionLocation; signal: CoreSignal };
+      payload: { location: ConditionLocation; signal: GQLSignal };
     }
   | {
       type: RuleFormReducerActionType.UpdateSignalArgs;
-      payload: { location: ConditionLocation; args: CoreSignal['args'] };
+      payload: { location: ConditionLocation; args: GQLSignal['args'] };
     }
   | {
       type: RuleFormReducerActionType.UpdateSignalSubcategory;
@@ -188,7 +188,7 @@ export type RuleFormReducerAction =
         selectedItemTypes: RuleFormConfigResponse['itemTypes'];
         allActions: RuleFormConfigResponse['actions'];
         conditionSet: GQLConditionSetFieldsFragment;
-        allSignals: readonly CoreSignal[];
+        allSignals: readonly GQLSignal[];
         policyIds: string[];
         tags: string[];
         maxDailyActions: number | null;
@@ -492,7 +492,7 @@ function deleteConditionSet(
  */
 export function getNewEligibleInputs(
   selectedItemTypes: RuleFormConfigResponse['itemTypes'],
-  allSignals: readonly CoreSignal[],
+  allSignals: readonly GQLSignal[],
 ) {
   const allBaseFields = selectedItemTypes.flatMap((it) => it.baseFields);
   const allDerivedFields = selectedItemTypes.flatMap((it) => it.derivedFields);
@@ -763,12 +763,11 @@ export function updateInput(
   // If the previously selected signal on this condition is no
   // longer compatible with the newly selected input, clear it out,
   // and clear out all subsequent fields in the condition
+  const currentSignal = newConditions[conditionIndex].signal;
   if (
-    newConditions[conditionIndex].signal != null &&
-    // Need to compare IDs instead of objects
-    !allNewSignals
-      .map((s) => s.type)
-      .includes(newConditions[conditionIndex].signal!.type)
+    currentSignal != null &&
+    // Compare by ID: type-based comparison fails for custom signals, which all share GQLSignalType.Custom
+    !allNewSignals.some((s) => s.id === currentSignal.id)
   ) {
     // Clear out all other fields on the Condition
     newConditions[conditionIndex] = {

--- a/client/src/webpages/dashboard/rules/rule_form/RuleFormReducers.tsx
+++ b/client/src/webpages/dashboard/rules/rule_form/RuleFormReducers.tsx
@@ -568,10 +568,8 @@ export function getNewEligibleInputs(
       // Note: this filter isn't technically needed, but in the future we might
       // allow non-custom signals to run on content types, so we keep it here
       // so future devs don't need to remember to add it.
-      return eligibleSignals.filter(
-        (it) =>
-          it.type === GQLSignalType.Custom,
-      ).length;
+      return eligibleSignals.filter((it) => it.type === GQLSignalType.Custom)
+        .length;
     })
     .map((itemType) => ({
       type: 'FULL_ITEM' as const,
@@ -898,7 +896,7 @@ export function updateSignalSubcategory(
   },
 ): RuleFormState {
   const { location, subcategory } = action.payload;
-  return updateConditionComponent(
+  const next = updateConditionComponent(
     state,
     location,
     subcategory,
@@ -907,6 +905,15 @@ export function updateSignalSubcategory(
       return condition;
     },
   );
+
+  // When a policy is chosen as signal criteria and no policies are assigned yet,
+  // default the rule's policy assignment to that same policy.
+  if (subcategory.startsWith('policy:') && next.policyIds.length === 0) {
+    const policyId = subcategory.slice('policy:'.length);
+    return { ...next, policyIds: [policyId] };
+  }
+
+  return next;
 }
 
 export function updateMatchingValues(

--- a/client/src/webpages/dashboard/rules/rule_form/RuleFormUtils.test.ts
+++ b/client/src/webpages/dashboard/rules/rule_form/RuleFormUtils.test.ts
@@ -3,10 +3,10 @@ import { vi } from 'vitest';
 import {
   GQLConditionConjunction,
   GQLScalarType,
+  GQLSignal,
   GQLSignalPricingStructureType,
   GQLSignalType,
 } from '../../../../graphql/generated';
-import { CoreSignal } from '../../../../models/signal';
 import { RuleFormConditionSet, RuleFormLeafCondition } from '../types';
 import {
   getConditionInputScalarType,
@@ -23,7 +23,8 @@ vi.mock('./RuleFormUtils', async () => {
 // NB: See docs above shouldConditionPromptForComparatorAndThreshold
 // above the caveats for this particular implementation
 describe('Test Rule Form Utils', () => {
-  const sampleSignal: CoreSignal = {
+  const sampleSignal: GQLSignal = {
+    __typename: 'Signal',
     id: '1234',
     type: GQLSignalType.TextMatchingContainsRegex,
     shouldPromptForMatchingValues: false,
@@ -104,21 +105,26 @@ describe('Test Rule Form Utils', () => {
     });
 
     it('Condition with input and selected signal with non-boolean output should show comparator/threshold', () => {
+      const nonBooleanSignal = {
+        ...sampleSignal,
+        outputType: {
+          __typename: 'ScalarSignalOutputType' as const,
+          scalarType: GQLScalarType.Number,
+        },
+      };
+
       const condition: RuleFormLeafCondition = {
         input: {
           type: 'CONTENT_FIELD',
           name: 'num_likes',
           contentTypeId: '12345',
         },
-        eligibleSignals: [sampleSignal],
-        signal: sampleSignal,
+        eligibleSignals: [nonBooleanSignal],
+        signal: nonBooleanSignal,
       };
 
-      vi.mocked(getConditionInputScalarType).mockReturnValue(
-        GQLScalarType.Number,
-      );
       expect(shouldConditionPromptForComparatorAndThreshold(condition)).toEqual(
-        false,
+        true,
       );
     });
   });

--- a/client/src/webpages/dashboard/rules/rule_form/RuleFormUtils.ts
+++ b/client/src/webpages/dashboard/rules/rule_form/RuleFormUtils.ts
@@ -18,10 +18,10 @@ import {
   GQLSignalType,
   GQLValueComparator,
   type GQLConditionInput,
+  GQLSignal,
 } from '../../../../graphql/generated';
 import { taggedUnionToOneOfInput } from '../../../../graphql/inputHelpers';
 import { locationAreaToLocationAreaInput } from '../../../../models/locationBank';
-import { CoreSignal } from '../../../../models/signal';
 import { safePick } from '../../../../utils/misc';
 import { isValidRegexString } from '../../../../utils/regex';
 import { CoopInput } from '../../types/enums';
@@ -54,7 +54,7 @@ export type RuleFormItemType = Pick<GQLContentType, 'id'> & {
 export function getEligibleSignalsForInput(
   input: SimplifiedConditionInput,
   ruleContentTypes: readonly RuleFormItemType[],
-  allSignals: readonly CoreSignal[],
+  allSignals: readonly GQLSignal[],
   isAutomatedRule = false,
 ) {
   let eligibleSignals = allSignals;
@@ -529,7 +529,7 @@ export function ruleHasValidConditions(conditionSet: RuleFormConditionSet) {
 function getTypedLeafConditionFromGQL(
   condition: GQLLeafConditionFieldsFragment,
   selectedContentTypes: readonly RuleFormItemType[],
-  allSignals: readonly CoreSignal[],
+  allSignals: readonly GQLSignal[],
 ): RuleFormCondition {
   /** Unfortunately in the RuleFormConfig query, when we query for a
    * derived field spec and fetch different fields based on the
@@ -623,7 +623,7 @@ function getTypedLeafConditionFromGQL(
 export function getTypedConditionSetFromGQL(
   conditionSet: GQLConditionSetFieldsFragment,
   selectedContentTypes: readonly RuleFormItemType[],
-  allSignals: readonly CoreSignal[],
+  allSignals: readonly GQLSignal[],
 ): RuleFormConditionSet {
   return {
     ...conditionSet,
@@ -635,7 +635,7 @@ export function getTypedConditionSetFromGQL(
             allSignals,
           )
         : getTypedLeafConditionFromGQL(
-            condition as GQLLeafConditionFieldsFragment,
+            condition,
             selectedContentTypes,
             allSignals,
           ),

--- a/client/src/webpages/dashboard/rules/rule_form/condition/input/RuleFormConditionInput.tsx
+++ b/client/src/webpages/dashboard/rules/rule_form/condition/input/RuleFormConditionInput.tsx
@@ -2,7 +2,7 @@ import { Form, Select } from 'antd';
 
 import { selectFilterByLabelOption } from '@/webpages/dashboard/components/antDesignUtils';
 
-import { CoreSignal } from '../../../../../../models/signal';
+import { GQLSignal } from '@/graphql/generated';
 import { safePick } from '../../../../../../utils/misc';
 import {
   jsonParse,
@@ -53,7 +53,7 @@ export default function RuleFormConditionInput(props: {
   allSignals: RuleFormConfigResponse['signals'];
   onUpdateInput: (
     input: SimplifiedConditionInput,
-    allSignals: readonly CoreSignal[],
+    allSignals: readonly GQLSignal[],
   ) => void;
 }) {
   const {
@@ -159,7 +159,7 @@ export default function RuleFormConditionInput(props: {
             onSelect={(input: ReturnType<typeof getOptionValue>) =>
               onUpdateInput(
                 jsonParse(input),
-                allSignals satisfies readonly CoreSignal[],
+                allSignals satisfies readonly GQLSignal[],
               )
             }
             optionLabelProp="label"

--- a/client/src/webpages/dashboard/rules/rule_form/condition/signal/RuleFormConditionSignal.tsx
+++ b/client/src/webpages/dashboard/rules/rule_form/condition/signal/RuleFormConditionSignal.tsx
@@ -2,7 +2,7 @@ import { DownOutlined } from '@ant-design/icons';
 import { Button } from 'antd';
 import { useState } from 'react';
 
-import { CoreSignal } from '../../../../../../models/signal';
+import { GQLSignal } from '@/graphql/generated';
 import { ConditionLocation, RuleFormLeafCondition } from '../../../types';
 import RuleFormSignalModal from '../../signal_modal/RuleFormSignalModal';
 import RuleFormConditionSignalSubcategory from './RuleFormConditionSignalSubcategory';
@@ -10,7 +10,7 @@ import RuleFormConditionSignalSubcategory from './RuleFormConditionSignalSubcate
 export default function RuleFormConditionSignal(props: {
   condition: RuleFormLeafCondition;
   location: ConditionLocation;
-  onUpdateSignal: (signal: CoreSignal) => void;
+  onUpdateSignal: (signal: GQLSignal) => void;
   onUpdateSignalSubcategory: (subcategory: string) => void;
   isAutomatedRule?: boolean;
 }) {
@@ -19,7 +19,7 @@ export default function RuleFormConditionSignal(props: {
   const eligibleSignals = condition.eligibleSignals;
   const [modalInfo, setModalInfo] = useState<{
     visible: boolean;
-    initialSelectedSignal: CoreSignal | undefined;
+    initialSelectedSignal: GQLSignal | undefined;
   }>({
     visible: false,
     initialSelectedSignal: undefined,
@@ -84,7 +84,7 @@ export default function RuleFormConditionSignal(props: {
         visible={modalInfo.visible}
         selectedSignal={modalInfo.initialSelectedSignal}
         allSignals={eligibleSignals}
-        onSelectSignal={(signal: CoreSignal, subcategoryOption?: string) => {
+        onSelectSignal={(signal: GQLSignal, subcategoryOption?: string) => {
           if (
             signal &&
             signal.eligibleSubcategories.length &&

--- a/client/src/webpages/dashboard/rules/rule_form/condition/signal/RuleFormConditionSignalArgs.tsx
+++ b/client/src/webpages/dashboard/rules/rule_form/condition/signal/RuleFormConditionSignalArgs.tsx
@@ -1,11 +1,11 @@
-import type { CoreSignal } from '@/models/signal';
+import type { GQLSignal } from '@/graphql/generated';
 
 import type { ConditionLocation, RuleFormLeafCondition } from '../../../types';
 
 export default function RuleFormConditionSignalArgs(_props: {
   condition: RuleFormLeafCondition;
   location: ConditionLocation;
-  onUpdateSignalArgs: (args: CoreSignal['args']) => void;
+  onUpdateSignalArgs: (args: GQLSignal['args']) => void;
 }) {
   // This component was used for GPT4O_MINI signal args, which have been removed.
   // The AGGREGATED signal will need signal args in the future, but they'll be

--- a/client/src/webpages/dashboard/rules/rule_form/condition/signal/RuleFormConditionSignalSubcategory.tsx
+++ b/client/src/webpages/dashboard/rules/rule_form/condition/signal/RuleFormConditionSignalSubcategory.tsx
@@ -20,6 +20,20 @@ export default function RuleFormConditionSignalSubcategory(props: {
   }
   const { conditionIndex, conditionSetIndex } = location;
 
+  const isFreeText =
+    eligibleSubcategories.length === 1 &&
+    eligibleSubcategories[0].id === '__free_text__';
+
+  const displayValue = signal.subcategory
+    ? isFreeText
+      ? signal.subcategory.length > 40
+        ? signal.subcategory.slice(0, 40) + '…'
+        : signal.subcategory
+      : signal.subcategory
+    : isFreeText
+      ? 'Enter Criteria'
+      : 'Select Subcategory';
+
   return (
     <div
       key={
@@ -30,7 +44,9 @@ export default function RuleFormConditionSignalSubcategory(props: {
       }
       className="!mb-0 !pl-4 !align-middle flex flex-col items-start"
     >
-      <div className="pb-1 text-xs font-bold">Signal Subcategory</div>
+      <div className="pb-1 text-xs font-bold">
+        {isFreeText ? 'Policy Criteria' : 'Signal Subcategory'}
+      </div>
       <Button
         className={`px-3 cursor-text ${
           condition.signal
@@ -38,11 +54,16 @@ export default function RuleFormConditionSignalSubcategory(props: {
             : '!text-[#bfbfbf] !hover:text-[#bfbfbf] !focus:text-[#bfbfbf]'
         }`}
         onClick={onClick}
+        title={
+          isFreeText && signal.subcategory ? signal.subcategory : undefined
+        }
       >
-        {signal.subcategory ?? 'Select Subcategory'}{' '}
+        {displayValue}{' '}
         <DownOutlined className="!text-xs !text-[#bfbfbf] !hover:text-[#bfbfbf]" />
       </Button>
-      <div className="invisible pb-1 text-xs font-bold">Signal Subcategory</div>
+      <div className="invisible pb-1 text-xs font-bold">
+        {isFreeText ? 'Policy Criteria' : 'Signal Subcategory'}
+      </div>
     </div>
   );
 }

--- a/client/src/webpages/dashboard/rules/rule_form/condition/signal/RuleFormConditionSignalSubcategory.tsx
+++ b/client/src/webpages/dashboard/rules/rule_form/condition/signal/RuleFormConditionSignalSubcategory.tsx
@@ -20,19 +20,37 @@ export default function RuleFormConditionSignalSubcategory(props: {
   }
   const { conditionIndex, conditionSetIndex } = location;
 
-  const isFreeText =
-    eligibleSubcategories.length === 1 &&
-    eligibleSubcategories[0].id === '__free_text__';
+  const hasFreeTextSentinel = eligibleSubcategories.some(
+    (s) => s.id === '__free_text__',
+  );
+  const hasPolicyOptions = eligibleSubcategories.some((s) =>
+    s.id.startsWith('policy:'),
+  );
+  const isSelfHosted = hasFreeTextSentinel;
 
-  const displayValue = signal.subcategory
-    ? isFreeText
-      ? signal.subcategory.length > 40
-        ? signal.subcategory.slice(0, 40) + '…'
-        : signal.subcategory
-      : signal.subcategory
-    : isFreeText
-      ? 'Enter Criteria'
-      : 'Select Subcategory';
+  // Look up the label for the stored subcategory ID (e.g. policy name).
+  const matchingOption = signal.subcategory
+    ? eligibleSubcategories.find((s) => s.id === signal.subcategory)
+    : undefined;
+
+  let displayValue: string;
+  let tooltipText: string | undefined;
+
+  if (!signal.subcategory) {
+    displayValue = hasPolicyOptions
+      ? 'Select Policy or Criteria'
+      : 'Enter Criteria';
+  } else if (matchingOption) {
+    // Subcategory is a known option (e.g. a policy) — show its label.
+    displayValue = matchingOption.label;
+  } else {
+    // Subcategory is raw free text — truncate for display, full text as tooltip.
+    const text = signal.subcategory;
+    displayValue = text.length > 40 ? text.slice(0, 40) + '…' : text;
+    tooltipText = text;
+  }
+
+  const label = isSelfHosted ? 'Policy Criteria' : 'Signal Subcategory';
 
   return (
     <div
@@ -44,9 +62,7 @@ export default function RuleFormConditionSignalSubcategory(props: {
       }
       className="!mb-0 !pl-4 !align-middle flex flex-col items-start"
     >
-      <div className="pb-1 text-xs font-bold">
-        {isFreeText ? 'Policy Criteria' : 'Signal Subcategory'}
-      </div>
+      <div className="pb-1 text-xs font-bold">{label}</div>
       <Button
         className={`px-3 cursor-text ${
           condition.signal
@@ -54,16 +70,12 @@ export default function RuleFormConditionSignalSubcategory(props: {
             : '!text-[#bfbfbf] !hover:text-[#bfbfbf] !focus:text-[#bfbfbf]'
         }`}
         onClick={onClick}
-        title={
-          isFreeText && signal.subcategory ? signal.subcategory : undefined
-        }
+        title={tooltipText}
       >
         {displayValue}{' '}
         <DownOutlined className="!text-xs !text-[#bfbfbf] !hover:text-[#bfbfbf]" />
       </Button>
-      <div className="invisible pb-1 text-xs font-bold">
-        {isFreeText ? 'Policy Criteria' : 'Signal Subcategory'}
-      </div>
+      <div className="invisible pb-1 text-xs font-bold">{label}</div>
     </div>
   );
 }

--- a/client/src/webpages/dashboard/rules/rule_form/signal_modal/RuleFormSignalModal.tsx
+++ b/client/src/webpages/dashboard/rules/rule_form/signal_modal/RuleFormSignalModal.tsx
@@ -2,8 +2,7 @@ import { useEffect, useState } from 'react';
 
 import CoopModal from '../../../components/CoopModal';
 
-import { GQLSignalSubcategory } from '../../../../../graphql/generated';
-import { CoreSignal } from '../../../../../models/signal';
+import { GQLSignal, GQLSignalSubcategory } from '@/graphql/generated';
 import { rebuildSubcategoryTreeFromGraphQLResponse } from '../../../../../utils/signalUtils';
 import RuleFormSignalModalSignalDetailView from './RuleFormSignalModalSignalDetailView';
 import RuleFormSignalModalSignalGallery from './RuleFormSignalModalSignalGallery';
@@ -11,10 +10,10 @@ import { RuleFormSignalModalSubcategoryGallery } from './RuleFormSignalModalSubc
 
 export default function RuleFormSignalModal(props: {
   visible: boolean;
-  allSignals: CoreSignal[];
-  onSelectSignal: (signal: CoreSignal, subcategoryOption?: string) => void;
+  allSignals: GQLSignal[];
+  onSelectSignal: (signal: GQLSignal, subcategoryOption?: string) => void;
   onClose: () => void;
-  selectedSignal?: CoreSignal;
+  selectedSignal?: GQLSignal;
   isAutomatedRule?: boolean;
 }) {
   const { visible, allSignals, onSelectSignal, onClose, selectedSignal, isAutomatedRule } =
@@ -27,12 +26,12 @@ export default function RuleFormSignalModal(props: {
   };
 
   // This state holds the signal selected for detail page
-  const [detailViewSignal, setDetailViewSignal] = useState<CoreSignal | null>(
+  const [detailViewSignal, setDetailViewSignal] = useState<GQLSignal | null>(
     null,
   );
   // This state holds the signal selected for the subcategory gallery page
   const [subcategoryGallerySignal, setSubcategoryGallerySignal] =
-    useState<CoreSignal | null>(null);
+    useState<GQLSignal | null>(null);
 
   useEffect(() => {
     if (selectedSignal) {
@@ -77,7 +76,7 @@ export default function RuleFormSignalModal(props: {
             detailViewSignal.eligibleSubcategories,
           )}
           onSelectSignal={(
-            signal: CoreSignal,
+            signal: GQLSignal,
             _subcategory?: GQLSignalSubcategory,
           ) => {
             if (signal.eligibleSubcategories.length > 0) {
@@ -91,10 +90,10 @@ export default function RuleFormSignalModal(props: {
       ) : (
         <RuleFormSignalModalSignalGallery
           allSignals={allSignals}
-          onSignalInfoSelected={(signal: CoreSignal) => {
+          onSignalInfoSelected={(signal: GQLSignal) => {
             setDetailViewSignal(signal);
           }}
-          onSelectSignal={(signal: CoreSignal) => {
+          onSelectSignal={(signal: GQLSignal) => {
             if (signal.eligibleSubcategories.length > 0) {
               setSubcategoryGallerySignal(signal);
             } else {

--- a/client/src/webpages/dashboard/rules/rule_form/signal_modal/RuleFormSignalModalMenuItem.tsx
+++ b/client/src/webpages/dashboard/rules/rule_form/signal_modal/RuleFormSignalModalMenuItem.tsx
@@ -5,13 +5,13 @@ import startCase from 'lodash/startCase';
 import {
   GQLDisabledInfo,
   GQLSignalType,
-} from '../../../../../graphql/generated';
+  GQLSignal,
+} from '@/graphql/generated';
 import LogoWhiteWithBackground from '../../../../../images/LogoWhiteWithBackground.png';
-import { CoreSignal } from '../../../../../models/signal';
 import { INTEGRATION_CONFIGS } from '../../../integrations/integrationConfigs';
 
 /** Vendor/company name for display. Uses signal.integrationTitle (from API) when set, else static config, else formatted id. */
-export function vendorName(signal: CoreSignal) {
+export function vendorName(signal: GQLSignal) {
   if (signal.type === GQLSignalType.Custom) {
     return 'Custom';
   }
@@ -32,7 +32,7 @@ export function vendorName(signal: CoreSignal) {
     : 'Plugin';
 }
 
-export function signalDisplayName(signal: CoreSignal, _hideVendor = true) {
+export function signalDisplayName(signal: GQLSignal, _hideVendor = true) {
   const { integration, name } = signal;
   if (!integration) {
     return name;
@@ -49,9 +49,9 @@ export function signalDisplayName(signal: CoreSignal, _hideVendor = true) {
 }
 
 export default function RuleFormSignalModalMenuItem(props: {
-  signal: CoreSignal;
+  signal: GQLSignal;
   infoButtonTapped: () => void;
-  onClick: (signal: CoreSignal) => void;
+  onClick: (signal: GQLSignal) => void;
   imagePath?: string;
   disabledInfo: GQLDisabledInfo;
 }) {

--- a/client/src/webpages/dashboard/rules/rule_form/signal_modal/RuleFormSignalModalSignalDetailView.tsx
+++ b/client/src/webpages/dashboard/rules/rule_form/signal_modal/RuleFormSignalModalSignalDetailView.tsx
@@ -6,17 +6,17 @@ import CoopButton from '@/webpages/dashboard/components/CoopButton';
 import {
   GQLSignalPricingStructureType,
   GQLSignalSubcategory,
-} from '../../../../../graphql/generated';
+  GQLSignal,
+} from '@/graphql/generated';
 import LogoWhiteWithBackground from '../../../../../images/LogoWhiteWithBackground.png';
-import { CoreSignal } from '../../../../../models/signal';
 import { INTEGRATION_CONFIGS } from '../../../integrations/integrationConfigs';
 import { signalDisplayName } from './RuleFormSignalModalMenuItem';
 
 export default function RuleFormSignalModalSignalDetailView(props: {
-  signal: CoreSignal;
+  signal: GQLSignal;
   subcategories: SignalSubcategory[];
   onSelectSignal: (
-    signal: CoreSignal,
+    signal: GQLSignal,
     subcategory?: GQLSignalSubcategory,
   ) => void;
 }) {
@@ -106,7 +106,7 @@ export default function RuleFormSignalModalSignalDetailView(props: {
           },
         ]),
   ];
-  const subcategorySection = ((signal: CoreSignal) => {
+  const subcategorySection = ((signal: GQLSignal) => {
     if (!signal.eligibleSubcategories.length) {
       return null;
     }

--- a/client/src/webpages/dashboard/rules/rule_form/signal_modal/RuleFormSignalModalSignalGallery.tsx
+++ b/client/src/webpages/dashboard/rules/rule_form/signal_modal/RuleFormSignalModalSignalGallery.tsx
@@ -1,17 +1,15 @@
-import { useGQLIsDemoOrgQuery } from '@/graphql/generated';
+import { GQLSignal, useGQLIsDemoOrgQuery } from '@/graphql/generated';
 import { SearchOutlined } from '@ant-design/icons';
 import { Input } from 'antd';
 import { useMemo, useState } from 'react';
-
-import { CoreSignal } from '../../../../../models/signal';
 import { INTEGRATION_CONFIGS } from '../../../integrations/integrationConfigs';
 import RuleFormSignalModalMenuItem from './RuleFormSignalModalMenuItem';
 import RuleFormSignalModalNoSearchResults from './RuleFormSignalModalNoSearchResults';
 
 export default function RuleFormSignalModalSignalGallery(props: {
-  allSignals: CoreSignal[];
-  onSelectSignal: (signal: CoreSignal) => void;
-  onSignalInfoSelected: (signal: CoreSignal) => void;
+  allSignals: GQLSignal[];
+  onSelectSignal: (signal: GQLSignal) => void;
+  onSignalInfoSelected: (signal: GQLSignal) => void;
   isAutomatedRule?: boolean;
 }) {
   const { allSignals, onSelectSignal, onSignalInfoSelected, isAutomatedRule } = props;

--- a/client/src/webpages/dashboard/rules/rule_form/signal_modal/RuleFormSignalModalSubcategoryGallery.tsx
+++ b/client/src/webpages/dashboard/rules/rule_form/signal_modal/RuleFormSignalModalSubcategoryGallery.tsx
@@ -3,8 +3,7 @@ import { Button, Input, Radio, Select } from 'antd';
 import omit from 'lodash/omit';
 import { useState } from 'react';
 
-import { GQLSignalSubcategory } from '../../../../../graphql/generated';
-import { CoreSignal } from '../../../../../models/signal';
+import { GQLSignal, GQLSignalSubcategory } from '@/graphql/generated';
 import { rebuildSubcategoryTreeFromGraphQLResponse } from '../../../../../utils/signalUtils';
 import RuleFormSignalModalNoSearchResults from './RuleFormSignalModalNoSearchResults';
 import { RuleFormSignalModalSubcategory } from './RuleFormSignalModalSubcategory';
@@ -17,7 +16,7 @@ function initialMode(signal: CoreSignal): Mode {
 }
 
 export function RuleFormSignalModalSubcategoryGallery(props: {
-  signal: CoreSignal;
+  signal: GQLSignal;
   subcategories: readonly GQLSignalSubcategory[];
   onSelectSubcategoryOption: (option: string) => void;
 }) {

--- a/client/src/webpages/dashboard/rules/rule_form/signal_modal/RuleFormSignalModalSubcategoryGallery.tsx
+++ b/client/src/webpages/dashboard/rules/rule_form/signal_modal/RuleFormSignalModalSubcategoryGallery.tsx
@@ -1,5 +1,5 @@
 import { SearchOutlined } from '@ant-design/icons';
-import { Button, Input, Select } from 'antd';
+import { Button, Input, Radio, Select } from 'antd';
 import omit from 'lodash/omit';
 import { useState } from 'react';
 
@@ -9,6 +9,13 @@ import { rebuildSubcategoryTreeFromGraphQLResponse } from '../../../../../utils/
 import RuleFormSignalModalNoSearchResults from './RuleFormSignalModalNoSearchResults';
 import { RuleFormSignalModalSubcategory } from './RuleFormSignalModalSubcategory';
 
+type Mode = 'policy' | 'free_text';
+
+function initialMode(signal: CoreSignal): Mode {
+  if (signal.subcategory?.startsWith('policy:')) return 'policy';
+  return 'free_text';
+}
+
 export function RuleFormSignalModalSubcategoryGallery(props: {
   signal: CoreSignal;
   subcategories: readonly GQLSignalSubcategory[];
@@ -16,23 +23,93 @@ export function RuleFormSignalModalSubcategoryGallery(props: {
 }) {
   const { signal, subcategories, onSelectSubcategoryOption } = props;
   const [searchTerm, setSearchTerm] = useState<string>('');
-  const [freeText, setFreeText] = useState<string>(signal.subcategory ?? '');
+  const [freeText, setFreeText] = useState<string>(
+    signal.subcategory && !signal.subcategory.startsWith('policy:')
+      ? signal.subcategory
+      : '',
+  );
 
   const stripped = subcategories.map((subcategory) =>
     omit(subcategory, '__typename'),
   );
 
-  // Check if subcategories are flat (no parent-child tree structure).
-  // Flat subcategories have no childrenIds, so the tree rebuild filters them all out.
   const hasTreeStructure = stripped.some((s) => s.childrenIds.length > 0);
 
-  // Sentinel used when a signal needs free-text criteria (e.g. Zentropi self-hosted).
-  const isFreeText =
-    !hasTreeStructure &&
-    stripped.length === 1 &&
-    stripped[0].id === '__free_text__';
+  // Sentinel for free-text criteria entry.
+  const hasFreeTextSentinel = stripped.some((s) => s.id === '__free_text__');
+  // Policy options are any subcategory whose id begins with "policy:".
+  const policyOptions = stripped.filter((s) => s.id.startsWith('policy:'));
+  const hasPolicyOptions = policyOptions.length > 0;
 
-  if (isFreeText) {
+  // Mixed mode: org has policies AND free-text entry, show a toggle.
+  const isMixed = hasFreeTextSentinel && hasPolicyOptions;
+
+  const [mode, setMode] = useState<Mode>(initialMode(signal));
+
+  if (isMixed) {
+    return (
+      <div className="flex flex-col gap-4">
+        <div className="pb-1 text-2xl font-medium">Select Policy Criteria</div>
+        <Radio.Group
+          value={mode}
+          onChange={(e) => setMode(e.target.value as Mode)}
+        >
+          <Radio.Button value="policy">Existing Policy</Radio.Button>
+          <Radio.Button value="free_text">Custom Text</Radio.Button>
+        </Radio.Group>
+
+        {mode === 'policy' && (
+          <div className="flex flex-col gap-2">
+            <div className="text-sm text-gray-500">
+              Select a policy — its text will be used as the classifier
+              criteria.
+            </div>
+            <Select
+              className="max-w-xs"
+              placeholder="Select a policy"
+              defaultValue={
+                signal.subcategory?.startsWith('policy:')
+                  ? signal.subcategory
+                  : undefined
+              }
+              onChange={(value: string) => onSelectSubcategoryOption(value)}
+              options={policyOptions.map((s) => ({
+                value: s.id,
+                label: s.label,
+              }))}
+            />
+          </div>
+        )}
+
+        {mode === 'free_text' && (
+          <div className="flex flex-col gap-2">
+            <div className="text-sm text-gray-500">
+              Describe the policy the model should evaluate content against.
+            </div>
+            <Input.TextArea
+              rows={6}
+              className="max-w-lg"
+              placeholder="e.g. The content contains hate speech targeting a protected group."
+              value={freeText}
+              onChange={(e) => setFreeText(e.target.value)}
+            />
+            <div>
+              <Button
+                type="primary"
+                disabled={!freeText.trim()}
+                onClick={() => onSelectSubcategoryOption(freeText.trim())}
+              >
+                Confirm
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Only the free-text sentinel (no policies configured yet).
+  if (!hasTreeStructure && hasFreeTextSentinel) {
     return (
       <div className="flex flex-col gap-3">
         <div className="pb-1 text-2xl font-medium">Enter Policy Criteria</div>

--- a/client/src/webpages/dashboard/rules/rule_form/signal_modal/RuleFormSignalModalSubcategoryGallery.tsx
+++ b/client/src/webpages/dashboard/rules/rule_form/signal_modal/RuleFormSignalModalSubcategoryGallery.tsx
@@ -1,5 +1,5 @@
 import { SearchOutlined } from '@ant-design/icons';
-import { Input, Select } from 'antd';
+import { Button, Input, Select } from 'antd';
 import omit from 'lodash/omit';
 import { useState } from 'react';
 
@@ -14,8 +14,9 @@ export function RuleFormSignalModalSubcategoryGallery(props: {
   subcategories: readonly GQLSignalSubcategory[];
   onSelectSubcategoryOption: (option: string) => void;
 }) {
-  const { subcategories, onSelectSubcategoryOption } = props;
+  const { signal, subcategories, onSelectSubcategoryOption } = props;
   const [searchTerm, setSearchTerm] = useState<string>('');
+  const [freeText, setFreeText] = useState<string>(signal.subcategory ?? '');
 
   const stripped = subcategories.map((subcategory) =>
     omit(subcategory, '__typename'),
@@ -24,6 +25,39 @@ export function RuleFormSignalModalSubcategoryGallery(props: {
   // Check if subcategories are flat (no parent-child tree structure).
   // Flat subcategories have no childrenIds, so the tree rebuild filters them all out.
   const hasTreeStructure = stripped.some((s) => s.childrenIds.length > 0);
+
+  // Sentinel used when a signal needs free-text criteria (e.g. Zentropi self-hosted).
+  const isFreeText =
+    !hasTreeStructure &&
+    stripped.length === 1 &&
+    stripped[0].id === '__free_text__';
+
+  if (isFreeText) {
+    return (
+      <div className="flex flex-col gap-3">
+        <div className="pb-1 text-2xl font-medium">Enter Policy Criteria</div>
+        <div className="text-sm text-gray-500">
+          Describe the policy the model should evaluate content against.
+        </div>
+        <Input.TextArea
+          rows={6}
+          className="max-w-lg"
+          placeholder="e.g. The content contains hate speech targeting a protected group."
+          value={freeText}
+          onChange={(e) => setFreeText(e.target.value)}
+        />
+        <div>
+          <Button
+            type="primary"
+            disabled={!freeText.trim()}
+            onClick={() => onSelectSubcategoryOption(freeText.trim())}
+          >
+            Confirm
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   if (!hasTreeStructure && stripped.length > 0) {
     // Render a simple dropdown for flat subcategories (e.g. Zentropi labeler versions)

--- a/client/src/webpages/dashboard/rules/types.ts
+++ b/client/src/webpages/dashboard/rules/types.ts
@@ -9,8 +9,8 @@ import {
   GQLMatchingValues,
   GQLScalarType,
   GQLValueComparator,
+  GQLSignal,
 } from '../../../graphql/generated';
-import { CoreSignal } from '../../../models/signal';
 import { CoopInput } from '../types/enums';
 import {
   isComparatorTerminal,
@@ -103,8 +103,8 @@ export type RuleFormConditionSet = {
 // The shape used to store each leaf condition in the rule form's state.
 export type RuleFormLeafCondition = {
   input?: SimplifiedConditionInput;
-  eligibleSignals?: CoreSignal[];
-  signal?: CoreSignal;
+  eligibleSignals?: GQLSignal[];
+  signal?: GQLSignal;
   matchingValues?: {
     strings?: readonly string[];
     textBankIds?: readonly string[];

--- a/client/src/webpages/settings/ManageUsersInviteUserSection.test.tsx
+++ b/client/src/webpages/settings/ManageUsersInviteUserSection.test.tsx
@@ -1,0 +1,127 @@
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import '@testing-library/jest-dom/extend-expect';
+
+import {
+  GQLHasNcmecReportingEnabledDocument,
+  GQLRolesForOrgDocument,
+  GQLUserRole,
+} from '@/graphql/generated';
+
+import ManageUsersInviteUserSection from './ManageUsersInviteUserSection';
+
+const ncmecMock: MockedResponse = {
+  request: { query: GQLHasNcmecReportingEnabledDocument },
+  maxUsageCount: Infinity,
+  result: {
+    data: {
+      myOrg: { __typename: 'Organization', hasNCMECReportingEnabled: false },
+    },
+  },
+};
+
+const rolesMock: MockedResponse = {
+  request: { query: GQLRolesForOrgDocument },
+  maxUsageCount: Infinity,
+  result: {
+    data: {
+      rolesForOrg: [
+        {
+          __typename: 'Role',
+          id: 'role-1',
+          key: GQLUserRole.Admin,
+          displayName: 'Admin',
+          description: '',
+          isSystem: true,
+          isFallback: false,
+          permissions: [],
+          userCount: 1,
+        },
+      ],
+    },
+  },
+};
+
+function renderSection() {
+  return render(
+    <MockedProvider mocks={[ncmecMock, rolesMock]}>
+      <MemoryRouter>
+        <ManageUsersInviteUserSection />
+      </MemoryRouter>
+    </MockedProvider>,
+  );
+}
+
+async function waitForLoaded() {
+  await waitFor(() => {
+    expect(
+      screen.getByRole('button', { name: /send invite link/i }),
+    ).toBeInTheDocument();
+  });
+}
+
+function getEmailInput() {
+  return screen.getByPlaceholderText('Email address');
+}
+
+function getSubmitButton() {
+  return screen.getByRole('button', { name: /send invite link/i });
+}
+
+describe('ManageUsersInviteUserSection', () => {
+  it('disables the button with no input', async () => {
+    renderSection();
+    await waitForLoaded();
+    expect(getSubmitButton()).toBeDisabled();
+  });
+
+  it('disables the button for a plainly invalid email', async () => {
+    renderSection();
+    await waitForLoaded();
+    fireEvent.change(getEmailInput(), { target: { value: 'notanemail' } });
+    expect(getSubmitButton()).toBeDisabled();
+  });
+
+  it('disables the button for a comma-separated email list', async () => {
+    renderSection();
+    await waitForLoaded();
+    fireEvent.change(getEmailInput(), {
+      target: { value: 'foo@bar.com,baz@qux.com' },
+    });
+    expect(getSubmitButton()).toBeDisabled();
+  });
+
+  it('disables the button when email is valid but no role is selected', async () => {
+    renderSection();
+    await waitForLoaded();
+    fireEvent.change(getEmailInput(), {
+      target: { value: 'user@example.com' },
+    });
+    expect(getSubmitButton()).toBeDisabled();
+  });
+
+  it('enables the button with a valid email and a role selected', async () => {
+    renderSection();
+    await waitForLoaded();
+    fireEvent.change(getEmailInput(), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.click(screen.getByRole('radio', { name: /admin/i }));
+    expect(getSubmitButton()).not.toBeDisabled();
+  });
+
+  it('marks the email input as invalid and re-enables after correction', async () => {
+    renderSection();
+    await waitForLoaded();
+
+    fireEvent.change(getEmailInput(), { target: { value: 'bad-email' } });
+    expect(getEmailInput()).toHaveClass('ring-red-400');
+
+    fireEvent.change(getEmailInput(), {
+      target: { value: 'good@example.com' },
+    });
+    expect(getEmailInput()).not.toHaveClass('ring-red-400');
+  });
+});

--- a/client/src/webpages/settings/ManageUsersInviteUserSection.tsx
+++ b/client/src/webpages/settings/ManageUsersInviteUserSection.tsx
@@ -154,6 +154,16 @@ export default function ManageUsersInviteUserSection() {
     });
   };
 
+  const emailIsInvalid =
+    Boolean(email?.length) &&
+    !/^[^\s@,]+@[^\s@,]+\.[^\s@,]+$/.test(email ?? '');
+  const isDisabled = !email?.length || emailIsInvalid || !role;
+  const disabledReason = !email?.length
+    ? 'Enter an email address to continue'
+    : emailIsInvalid
+      ? 'Enter a valid email address'
+      : 'Select a role to continue';
+
   return (
     <div className="flex flex-col items-start mb-8 text-start">
       <FormSectionHeader
@@ -166,6 +176,7 @@ export default function ManageUsersInviteUserSection() {
           placeholder="Email address"
           onChange={(e) => setEmail(e.target.value)}
           value={email}
+          error={emailIsInvalid}
         />
       </div>
       <div className="mt-8 mb-4 text-base text-zinc-900">
@@ -193,7 +204,9 @@ export default function ManageUsersInviteUserSection() {
           size="middle"
           onClick={onInviteUser}
           loading={loading}
-          disabled={!email?.length || !role}
+          disabled={isDisabled}
+          disabledTooltipTitle={disabledReason}
+          disabledTooltipPlacement="top"
         />
       </div>
       {roleModalVisible && (

--- a/db/src/scripts/api-server-pg/2026.06.17T00.00.00.add_self_hosted_to_zentropi_configs.sql
+++ b/db/src/scripts/api-server-pg/2026.06.17T00.00.00.add_self_hosted_to_zentropi_configs.sql
@@ -1,0 +1,13 @@
+-- Allow orgs that only use self-hosted CoPE to omit the hosted API key.
+ALTER TABLE signal_auth_service.zentropi_configs
+  ALTER COLUMN api_key DROP NOT NULL;
+
+-- Self-hosted model configuration columns. All nullable; presence of
+-- self_hosted_base_url indicates self-hosted mode is configured.
+ALTER TABLE signal_auth_service.zentropi_configs
+  ADD COLUMN IF NOT EXISTS self_hosted_base_url TEXT,
+  ADD COLUMN IF NOT EXISTS self_hosted_model TEXT,
+  ADD COLUMN IF NOT EXISTS self_hosted_api_key TEXT,
+  ADD COLUMN IF NOT EXISTS self_hosted_format TEXT,
+  ADD COLUMN IF NOT EXISTS self_hosted_system_prompt_template TEXT,
+  ADD COLUMN IF NOT EXISTS self_hosted_user_message_template TEXT;

--- a/server/graphql/datasources/IntegrationApi.ts
+++ b/server/graphql/datasources/IntegrationApi.ts
@@ -1,18 +1,19 @@
-
 import { inject, type Dependencies } from '../../iocContainer/index.js';
+
 import '../../services/signalAuthService/index.js';
+
+import { getIntegrationRegistry } from '../../services/integrationRegistry/index.js';
 import { Integration } from '../../services/signalsService/index.js';
 import {
   CoopError,
   ErrorType,
   type ErrorInstanceData,
 } from '../../utils/errors.js';
-import { getIntegrationRegistry } from '../../services/integrationRegistry/index.js';
+import { type GQLSetIntegrationConfigInput } from '../generated.js';
 import type {
   IntegrationManifestEntry,
   ModelCard,
 } from './integrationManifests.js';
-import { type GQLSetIntegrationConfigInput } from '../generated.js';
 
 export type TIntegrationConfigWithMetadata = Readonly<{
   name: string;
@@ -64,8 +65,7 @@ function mergeManifest(
 class IntegrationAPI {
   constructor(
     private readonly signalAuthService: Dependencies['SignalAuthService'],
-  ) {
-  }
+  ) {}
 
   async setConfig(
     params: GQLSetIntegrationConfigInput,
@@ -93,6 +93,7 @@ class IntegrationAPI {
         {
           apiKey: apiCredential.zentropi.apiKey,
           labelerVersions: [...(apiCredential.zentropi.labelerVersions ?? [])],
+          selfHosted: apiCredential.zentropi.selfHosted ?? undefined,
         },
         orgId,
       );

--- a/server/graphql/datasources/UserApi.test.ts
+++ b/server/graphql/datasources/UserApi.test.ts
@@ -31,7 +31,6 @@ function makeMockKyselyPg() {
     execute: (cb: (trx: any) => unknown) => cb(kyselyPg),
   });
 
-   
   const kyselyPg = {
     updateTable,
     deleteFrom,

--- a/server/graphql/generated.ts
+++ b/server/graphql/generated.ts
@@ -5245,13 +5245,15 @@ export type GQLZentropiIntegrationApiCredential = {
   readonly __typename?: 'ZentropiIntegrationApiCredential';
   readonly apiKey: Scalars['String']['output'];
   readonly labelerVersions: ReadonlyArray<GQLZentropiLabelerVersion>;
+  readonly selfHosted?: Maybe<GQLZentropiSelfHostedConfig>;
 };
 
 export type GQLZentropiIntegrationApiCredentialInput = {
-  readonly apiKey: Scalars['String']['input'];
+  readonly apiKey?: InputMaybe<Scalars['String']['input']>;
   readonly labelerVersions?: InputMaybe<
     ReadonlyArray<GQLZentropiLabelerVersionInput>
   >;
+  readonly selfHosted?: InputMaybe<GQLZentropiSelfHostedConfigInput>;
 };
 
 export type GQLZentropiLabelerVersion = {
@@ -5263,6 +5265,25 @@ export type GQLZentropiLabelerVersion = {
 export type GQLZentropiLabelerVersionInput = {
   readonly id: Scalars['String']['input'];
   readonly label: Scalars['String']['input'];
+};
+
+export type GQLZentropiSelfHostedConfig = {
+  readonly __typename?: 'ZentropiSelfHostedConfig';
+  readonly apiKey?: Maybe<Scalars['String']['output']>;
+  readonly baseUrl: Scalars['String']['output'];
+  readonly format: Scalars['String']['output'];
+  readonly model: Scalars['String']['output'];
+  readonly systemPromptTemplate?: Maybe<Scalars['String']['output']>;
+  readonly userMessageTemplate?: Maybe<Scalars['String']['output']>;
+};
+
+export type GQLZentropiSelfHostedConfigInput = {
+  readonly apiKey?: InputMaybe<Scalars['String']['input']>;
+  readonly baseUrl: Scalars['String']['input'];
+  readonly format: Scalars['String']['input'];
+  readonly model: Scalars['String']['input'];
+  readonly systemPromptTemplate?: InputMaybe<Scalars['String']['input']>;
+  readonly userMessageTemplate?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ResolverTypeWrapper<T> = Promise<T> | T;
@@ -6559,6 +6580,8 @@ export type GQLResolversTypes = {
   ZentropiIntegrationApiCredentialInput: GQLZentropiIntegrationApiCredentialInput;
   ZentropiLabelerVersion: ResolverTypeWrapper<GQLZentropiLabelerVersion>;
   ZentropiLabelerVersionInput: GQLZentropiLabelerVersionInput;
+  ZentropiSelfHostedConfig: ResolverTypeWrapper<GQLZentropiSelfHostedConfig>;
+  ZentropiSelfHostedConfigInput: GQLZentropiSelfHostedConfigInput;
 };
 
 /** Mapping between all available schema types and the resolvers parents */
@@ -7199,6 +7222,8 @@ export type GQLResolversParentTypes = {
   ZentropiIntegrationApiCredentialInput: GQLZentropiIntegrationApiCredentialInput;
   ZentropiLabelerVersion: GQLZentropiLabelerVersion;
   ZentropiLabelerVersionInput: GQLZentropiLabelerVersionInput;
+  ZentropiSelfHostedConfig: GQLZentropiSelfHostedConfig;
+  ZentropiSelfHostedConfigInput: GQLZentropiSelfHostedConfigInput;
 };
 
 export type GQLPublicResolverDirectiveArgs = {};
@@ -14923,6 +14948,11 @@ export type GQLZentropiIntegrationApiCredentialResolvers<
     ParentType,
     ContextType
   >;
+  selfHosted?: Resolver<
+    Maybe<GQLResolversTypes['ZentropiSelfHostedConfig']>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -14933,6 +14963,31 @@ export type GQLZentropiLabelerVersionResolvers<
 > = {
   id?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   label?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+};
+
+export type GQLZentropiSelfHostedConfigResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ZentropiSelfHostedConfig'] =
+    GQLResolversParentTypes['ZentropiSelfHostedConfig'],
+> = {
+  apiKey?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  baseUrl?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  format?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  model?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  systemPromptTemplate?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  userMessageTemplate?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
 };
 
 export type GQLResolvers<ContextType = Context> = {
@@ -15267,6 +15322,7 @@ export type GQLResolvers<ContextType = Context> = {
   WindowConfiguration?: GQLWindowConfigurationResolvers<ContextType>;
   ZentropiIntegrationApiCredential?: GQLZentropiIntegrationApiCredentialResolvers<ContextType>;
   ZentropiLabelerVersion?: GQLZentropiLabelerVersionResolvers<ContextType>;
+  ZentropiSelfHostedConfig?: GQLZentropiSelfHostedConfigResolvers<ContextType>;
 };
 
 export type GQLDirectiveResolvers<ContextType = Context> = {

--- a/server/graphql/modules/integration.ts
+++ b/server/graphql/modules/integration.ts
@@ -35,9 +35,19 @@ const typeDefs = /* GraphQL */ `
     label: String!
   }
 
+  type ZentropiSelfHostedConfig {
+    format: String!
+    baseUrl: String!
+    model: String!
+    apiKey: String
+    systemPromptTemplate: String
+    userMessageTemplate: String
+  }
+
   type ZentropiIntegrationApiCredential {
     apiKey: String!
     labelerVersions: [ZentropiLabelerVersion!]!
+    selfHosted: ZentropiSelfHostedConfig
   }
 
   union IntegrationApiCredential =
@@ -108,9 +118,19 @@ const typeDefs = /* GraphQL */ `
     label: String!
   }
 
+  input ZentropiSelfHostedConfigInput {
+    format: String!
+    baseUrl: String!
+    model: String!
+    apiKey: String
+    systemPromptTemplate: String
+    userMessageTemplate: String
+  }
+
   input ZentropiIntegrationApiCredentialInput {
-    apiKey: String!
+    apiKey: String
     labelerVersions: [ZentropiLabelerVersionInput!]
+    selfHosted: ZentropiSelfHostedConfigInput
   }
 
   input IntegrationApiCredentialInput {

--- a/server/graphql/modules/signal.ts
+++ b/server/graphql/modules/signal.ts
@@ -270,13 +270,36 @@ const Signal: GQLSignalResolvers = {
           'ZENTROPI',
         );
         if (config?.name === 'ZENTROPI') {
-          // Self-hosted mode: criteria text is entered free-form in the rule builder.
-          // Return a sentinel that tells the UI to show a free-text textarea.
+          // Self-hosted mode: offer existing org policies as selectable options
+          // plus a free-text sentinel for custom criteria.
           if (config.apiCredential.selfHosted != null) {
+            const policies =
+              await context.services.ModerationConfigService.getPolicies({
+                orgId: user.orgId,
+                readFromReplica: true,
+              });
+            // Only surface policies that have usable text after stripping HTML —
+            // policies with empty or HTML-only text would cause a
+            // SignalPermanentError at run time.
+            const policyOptions = policies
+              .filter((p) => {
+                if (!p.policyText) return false;
+                const stripped = p.policyText
+                  .replace(/<[^>]+>/g, ' ')
+                  .replace(/\s+/g, ' ')
+                  .trim();
+                return stripped.length > 0;
+              })
+              .map((p) => ({
+                id: `policy:${p.id}`,
+                label: p.name,
+                childrenIds: [],
+              }));
             return [
+              ...policyOptions,
               {
                 id: '__free_text__',
-                label: 'Enter policy criteria',
+                label: 'Enter custom criteria',
                 childrenIds: [],
               },
             ];

--- a/server/graphql/modules/signal.ts
+++ b/server/graphql/modules/signal.ts
@@ -262,7 +262,6 @@ const Signal: GQLSignalResolvers = {
     }
   },
   async eligibleSubcategories(signal, _, context) {
-    // For Zentropi signals, return org-specific labeler versions as subcategories
     if (signal.id.type === 'ZENTROPI_LABELER') {
       const user = context.getUser();
       if (user) {
@@ -271,6 +270,18 @@ const Signal: GQLSignalResolvers = {
           'ZENTROPI',
         );
         if (config?.name === 'ZENTROPI') {
+          // Self-hosted mode: criteria text is entered free-form in the rule builder.
+          // Return a sentinel that tells the UI to show a free-text textarea.
+          if (config.apiCredential.selfHosted != null) {
+            return [
+              {
+                id: '__free_text__',
+                label: 'Enter policy criteria',
+                childrenIds: [],
+              },
+            ];
+          }
+          // Hosted mode: return labeler versions configured in the integration.
           const versions = (config.apiCredential.labelerVersions ??
             []) as Array<{
             id: string;

--- a/server/knip.json
+++ b/server/knip.json
@@ -1,16 +1,9 @@
 {
   "$schema": "./node_modules/knip/schema.json",
-  "entry": [
-    "bin/www.ts",
-    "ts-reset.ts"
-  ],
+  "entry": ["bin/www.ts", "ts-reset.ts"],
   "project": ["**/*.ts"],
-  "ignore": [
-    "graphql/generated.ts"
-  ],
-  "ignoreDependencies": [
-    "@roostorg/coop-integration-example"
-  ],
+  "ignore": ["graphql/generated.ts"],
+  "ignoreDependencies": ["@roostorg/coop-integration-example"],
   "jest": {
     "config": ["jest.config.cjs", "jest.integ.config.cjs"]
   }

--- a/server/services/signalAuthService/dbTypes.ts
+++ b/server/services/signalAuthService/dbTypes.ts
@@ -29,12 +29,18 @@ export type SignalAuthServicePg = {
   };
   'signal_auth_service.zentropi_configs': {
     org_id: string;
-    api_key: string;
+    api_key: string | null;
     labeler_versions: ColumnType<
       string,
       string | undefined,
       string | undefined
     >;
+    self_hosted_base_url: string | null;
+    self_hosted_model: string | null;
+    self_hosted_api_key: string | null;
+    self_hosted_format: string | null;
+    self_hosted_system_prompt_template: string | null;
+    self_hosted_user_message_template: string | null;
     created_at: ColumnType<Date, never, never>;
     updated_at: ColumnType<Date, never, never>;
   };

--- a/server/services/signalAuthService/signalAuthService.ts
+++ b/server/services/signalAuthService/signalAuthService.ts
@@ -25,9 +25,20 @@ export type Credentials<T extends ConfigurableIntegration> = {
 export type GoogleContentSafetyCredential = { apiKey: string };
 export type OpenAICredential = { apiKey: string };
 export type ZentropiLabelerVersion = { id: string; label: string };
+export type ZentropiSelfHostedConfig = {
+  format: 'cope' | 'openai_chat';
+  baseUrl: string;
+  model: string;
+  apiKey?: string;
+  /** Only used when format === 'openai_chat'. May contain {criteria} placeholder. */
+  systemPromptTemplate?: string;
+  /** Only used when format === 'openai_chat'. May contain {content} placeholder. */
+  userMessageTemplate?: string;
+};
 export type ZentropiCredential = {
-  apiKey: string;
+  apiKey?: string;
   labelerVersions?: ZentropiLabelerVersion[];
+  selfHosted?: ZentropiSelfHostedConfig;
 };
 export type ClarifaiApiCredential = { apiKey: NonEmptyString };
 export type ClarifaiModelType = 'IMAGE' | 'TEXT';
@@ -135,7 +146,11 @@ class SignalAuthService {
     if (integrationId === Integration.ZENTROPI) {
       const c = await this.get(Integration.ZENTROPI, orgId);
       return c != null
-        ? { apiKey: c.apiKey, labelerVersions: c.labelerVersions }
+        ? {
+            apiKey: c.apiKey ?? '',
+            labelerVersions: c.labelerVersions,
+            selfHosted: c.selfHosted,
+          }
         : undefined;
     }
     const row = await this.pg
@@ -170,12 +185,21 @@ class SignalAuthService {
       return { apiKey };
     }
     if (integrationId === Integration.ZENTROPI) {
-      const apiKey = typeof config.apiKey === 'string' ? config.apiKey : '';
+      const apiKey =
+        typeof config.apiKey === 'string' ? config.apiKey : undefined;
       const labelerVersions = Array.isArray(config.labelerVersions)
         ? (config.labelerVersions as ZentropiLabelerVersion[])
         : [];
-      await this.set(Integration.ZENTROPI, orgId, { apiKey, labelerVersions });
-      return { apiKey, labelerVersions };
+      const selfHosted =
+        config.selfHosted != null && typeof config.selfHosted === 'object'
+          ? (config.selfHosted as ZentropiSelfHostedConfig)
+          : undefined;
+      await this.set(Integration.ZENTROPI, orgId, {
+        apiKey,
+        labelerVersions,
+        selfHosted,
+      });
+      return { apiKey, labelerVersions, selfHosted };
     }
     await this.pg
       .insertInto('signal_auth_service.integration_configs')
@@ -267,49 +291,116 @@ function makeImplementations(
       get: async (orgId: string) => {
         const row = await pg
           .selectFrom('signal_auth_service.zentropi_configs')
-          .select(['api_key', 'labeler_versions'])
+          .select([
+            'api_key',
+            'labeler_versions',
+            'self_hosted_base_url',
+            'self_hosted_model',
+            'self_hosted_api_key',
+            'self_hosted_format',
+            'self_hosted_system_prompt_template',
+            'self_hosted_user_message_template',
+          ])
           .where('org_id', '=', orgId)
           .executeTakeFirst();
         if (row == null) return undefined;
         const labelerVersions = row.labeler_versions;
+        const selfHosted: ZentropiSelfHostedConfig | undefined =
+          row.self_hosted_base_url != null && row.self_hosted_model != null
+            ? {
+                format: (row.self_hosted_format ?? 'cope') as
+                  | 'cope'
+                  | 'openai_chat',
+                baseUrl: row.self_hosted_base_url,
+                model: row.self_hosted_model,
+                apiKey: row.self_hosted_api_key ?? undefined,
+                systemPromptTemplate:
+                  row.self_hosted_system_prompt_template ?? undefined,
+                userMessageTemplate:
+                  row.self_hosted_user_message_template ?? undefined,
+              }
+            : undefined;
         return {
-          apiKey: row.api_key,
+          apiKey: row.api_key ?? undefined,
           labelerVersions: Array.isArray(labelerVersions)
             ? (labelerVersions as ZentropiLabelerVersion[])
             : typeof labelerVersions === 'string'
-            ? jsonParse(labelerVersions as JsonOf<ZentropiLabelerVersion[]>)
-            : [],
+              ? jsonParse(labelerVersions as JsonOf<ZentropiLabelerVersion[]>)
+              : [],
+          selfHosted,
         };
       },
       set: async (orgId: string, credential: ZentropiCredential) => {
         const labelerVersionsJson = jsonStringify(
           credential.labelerVersions ?? [],
         );
+        const sh = credential.selfHosted;
         const row = await pg
           .insertInto('signal_auth_service.zentropi_configs')
           .values([
             {
               org_id: orgId,
-              api_key: credential.apiKey,
+              api_key: credential.apiKey ?? null,
               labeler_versions: labelerVersionsJson,
+              self_hosted_base_url: sh?.baseUrl ?? null,
+              self_hosted_model: sh?.model ?? null,
+              self_hosted_api_key: sh?.apiKey ?? null,
+              self_hosted_format: sh?.format ?? null,
+              self_hosted_system_prompt_template:
+                sh?.systemPromptTemplate ?? null,
+              self_hosted_user_message_template:
+                sh?.userMessageTemplate ?? null,
             },
           ])
           .onConflict((oc) =>
             oc.column('org_id').doUpdateSet({
-              api_key: credential.apiKey,
+              api_key: credential.apiKey ?? null,
               labeler_versions: labelerVersionsJson,
+              self_hosted_base_url: sh?.baseUrl ?? null,
+              self_hosted_model: sh?.model ?? null,
+              self_hosted_api_key: sh?.apiKey ?? null,
+              self_hosted_format: sh?.format ?? null,
+              self_hosted_system_prompt_template:
+                sh?.systemPromptTemplate ?? null,
+              self_hosted_user_message_template:
+                sh?.userMessageTemplate ?? null,
             }),
           )
-          .returning(['api_key', 'labeler_versions'])
+          .returning([
+            'api_key',
+            'labeler_versions',
+            'self_hosted_base_url',
+            'self_hosted_model',
+            'self_hosted_api_key',
+            'self_hosted_format',
+            'self_hosted_system_prompt_template',
+            'self_hosted_user_message_template',
+          ])
           .executeTakeFirstOrThrow();
         const returnedVersions = row.labeler_versions;
+        const returnedSelfHosted: ZentropiSelfHostedConfig | undefined =
+          row.self_hosted_base_url != null && row.self_hosted_model != null
+            ? {
+                format: (row.self_hosted_format ?? 'cope') as
+                  | 'cope'
+                  | 'openai_chat',
+                baseUrl: row.self_hosted_base_url,
+                model: row.self_hosted_model,
+                apiKey: row.self_hosted_api_key ?? undefined,
+                systemPromptTemplate:
+                  row.self_hosted_system_prompt_template ?? undefined,
+                userMessageTemplate:
+                  row.self_hosted_user_message_template ?? undefined,
+              }
+            : undefined;
         return {
-          apiKey: row.api_key,
+          apiKey: row.api_key ?? undefined,
           labelerVersions: Array.isArray(returnedVersions)
             ? (returnedVersions as ZentropiLabelerVersion[])
             : typeof returnedVersions === 'string'
-            ? jsonParse(returnedVersions as JsonOf<ZentropiLabelerVersion[]>)
-            : [],
+              ? jsonParse(returnedVersions as JsonOf<ZentropiLabelerVersion[]>)
+              : [],
+          selfHosted: returnedSelfHosted,
         };
       },
       delete: async (orgId: string) => {

--- a/server/services/signalsService/SignalsService.ts
+++ b/server/services/signalsService/SignalsService.ts
@@ -142,6 +142,7 @@ export class SignalsService {
       this.userStrikeService,
       this.getPoliciesByIdEventuallyConsistent,
       this.hmaService,
+      this.moderationConfigService,
     );
 
     const pluginEntries = getIntegrationRegistry().getPluginEntries();

--- a/server/services/signalsService/helpers/instantiateBuiltInSignals.ts
+++ b/server/services/signalsService/helpers/instantiateBuiltInSignals.ts
@@ -3,6 +3,7 @@ import { type ItemIdentifier } from '@roostorg/coop-types';
 import type { AggregationsService } from '../../aggregationsService/index.js';
 import type { HmaService } from '../../hmaService/index.js';
 import type { GetPoliciesByIdEventuallyConsistent } from '../../manualReviewToolService/manualReviewToolQueries.js';
+import type { ModerationConfigService } from '../../moderationConfigService/index.js';
 import { type UserScore } from '../../userStatisticsService/userStatisticsService.js';
 import { type UserStrikeService } from '../../userStrikeService/index.js';
 import AggregationSignal from '../signals/aggregation/AggregationSignal.js';
@@ -53,6 +54,7 @@ export function instantiateBuiltInSignals(
   userStrikeService: UserStrikeService,
   _getPoliciesByIdEventuallyConsistent: GetPoliciesByIdEventuallyConsistent,
   hmaService: HmaService,
+  moderationConfigService: ModerationConfigService,
 ) {
   const {
     googleContentSafetyFetcher: getGoogleContentSafetyScores,
@@ -151,6 +153,15 @@ export function instantiateBuiltInSignals(
       credentialGetters.ZENTROPI,
       getZentropiScores,
       getOpenAICompatibleScore,
+      async (orgId, policyId) => {
+        const policy = (await moderationConfigService.getPolicy({
+          orgId,
+          policyId,
+        })) as
+          | Awaited<ReturnType<typeof moderationConfigService.getPolicy>>
+          | undefined;
+        return policy?.policyText ?? null;
+      },
     ),
     // Satisfies check to make sure we didn't forget any signals.
   } satisfies { [K in BuiltInSignalType]: SignalBase<SignalInputType> };

--- a/server/services/signalsService/helpers/instantiateBuiltInSignals.ts
+++ b/server/services/signalsService/helpers/instantiateBuiltInSignals.ts
@@ -59,6 +59,7 @@ export function instantiateBuiltInSignals(
     openAiModerationFetcher: getOpenAiScores,
     openAiWhisperTranscriptionFetcher: getOpenAiTranscription,
     zentropiFetcher: getZentropiScores,
+    openAICompatibleFetcher: getOpenAICompatibleScore,
   } = cachedFetchers;
 
   return {
@@ -149,6 +150,7 @@ export function instantiateBuiltInSignals(
     [SignalType.ZENTROPI_LABELER]: new ZentropiLabelerSignal(
       credentialGetters.ZENTROPI,
       getZentropiScores,
+      getOpenAICompatibleScore,
     ),
     // Satisfies check to make sure we didn't forget any signals.
   } satisfies { [K in BuiltInSignalType]: SignalBase<SignalInputType> };

--- a/server/services/signalsService/helpers/makeCachedFetchers.ts
+++ b/server/services/signalsService/helpers/makeCachedFetchers.ts
@@ -12,6 +12,7 @@ import { type JSON } from '../../../utils/json-schema-types.js';
 import { getGoogleContentSafetyScores } from '../signals/third_party_signals/google/content_safety/googleContentSafetyLib.js';
 import { getOpenAiModerationScores } from '../signals/third_party_signals/open_ai/moderation/openAIModerationUtils.js';
 import { getOpenAiTranscription } from '../signals/third_party_signals/open_ai/whisper/OpenAiWhisperTranscriptionSignal.js';
+import { getOpenAICompatibleScore } from '../signals/third_party_signals/openai_compatible/openaiCompatibleUtils.js';
 import { getZentropiScores } from '../signals/third_party_signals/zentropi/zentropiUtils.js';
 
 export type CachedFetchers = ReturnType<typeof makeCachedFetchers>;
@@ -42,6 +43,9 @@ export function makeCachedFetchers(
       getOpenAiTranscription.bind(null, fetchHTTP),
     ),
     zentropiFetcher: toCachedFetcher(getZentropiScores.bind(null, fetchHTTP)),
+    openAICompatibleFetcher: toCachedFetcher(
+      getOpenAICompatibleScore.bind(null, fetchHTTP),
+    ),
   };
 }
 

--- a/server/services/signalsService/signals/third_party_signals/openai_compatible/openaiCompatibleUtils.ts
+++ b/server/services/signalsService/signals/third_party_signals/openai_compatible/openaiCompatibleUtils.ts
@@ -1,0 +1,171 @@
+import { type Bind1 } from '../../../../../utils/typescript-types.js';
+import { makeSignalPermanentError } from '../../../../../utils/errors.js';
+import { jsonStringify } from '../../../../../utils/encoding.js';
+import { type FetchHTTP } from '../../../../networkingService/index.js';
+
+/**
+ * Prompt template used by the CoPE model (cope-a-9b) when self-hosted.
+ * Matches the template from the official Zentropi sample notebook exactly.
+ */
+const COPE_PROMPT_TEMPLATE = `INSTRUCTIONS
+============
+
+Examine the given POLICY and determine if the given CONTENT meets the criteria for ANY of the LABELS. Answer "1" if yes, and "0" if no.
+
+POLICY
+======
+
+{criteria}
+
+
+CONTENT
+=======
+
+{content}
+
+
+ANSWER
+======
+
+`;
+
+export type OpenAICompatibleFormat = 'cope' | 'openai_chat';
+
+export type OpenAICompatibleClassifierParams = {
+  baseUrl: string;
+  model: string;
+  apiKey?: string;
+  criteria: string;
+  content: string;
+} & (
+  | { format: 'cope' }
+  | {
+      format: 'openai_chat';
+      systemPromptTemplate: string;
+      userMessageTemplate: string;
+    }
+);
+
+export type FetchOpenAICompatibleScore = Bind1<
+  typeof getOpenAICompatibleScore,
+  FetchHTTP
+>;
+
+/**
+ * Converts a logprob (log probability) and the predicted label token to a
+ * 0–1 score matching the Zentropi hosted API convention:
+ *   label=1 → confidence (higher = more likely violating)
+ *   label=0 → 1 - confidence (higher = more likely violating)
+ */
+export function scoreFromLogprob(
+  label: '0' | '1',
+  logprob: number,
+): number {
+  const confidence = Math.exp(logprob);
+  return label === '1' ? confidence : 1 - confidence;
+}
+
+/**
+ * Calls an OpenAI-compatible completions or chat/completions endpoint to
+ * classify text against a policy, returning a 0–1 score.
+ *
+ * Reusable by any integration that self-hosts a classification model via
+ * vLLM or another OpenAI-compatible inference server.
+ */
+export async function getOpenAICompatibleScore(
+  fetchHTTP: FetchHTTP,
+  params: OpenAICompatibleClassifierParams,
+): Promise<{ score: number }> {
+  const { baseUrl, model, apiKey, criteria, content, format } = params;
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+  };
+
+  let response;
+
+  if (format === 'cope') {
+    const prompt = COPE_PROMPT_TEMPLATE.replace('{criteria}', criteria).replace(
+      '{content}',
+      content,
+    );
+
+    response = await fetchHTTP({
+      url: `${baseUrl}/v1/completions`,
+      method: 'post',
+      headers,
+      body: jsonStringify({ model, prompt, max_tokens: 1, logprobs: 1 }),
+      handleResponseBody: 'as-json',
+      timeoutMs: 10_000,
+    });
+
+    if (!response.ok) {
+      throwResponseError(response.status, baseUrl);
+    }
+
+    const body = response.body as {
+      choices: { text: string; logprobs: { token_logprobs: number[] } }[];
+    };
+    const choice = body.choices[0];
+    const label = choice.text.trim() as '0' | '1';
+    const logprob = choice.logprobs.token_logprobs[0];
+    return { score: scoreFromLogprob(label, logprob) };
+  } else {
+    // openai_chat format
+    const { systemPromptTemplate, userMessageTemplate } =
+      params;
+
+    const systemContent = systemPromptTemplate.replace('{criteria}', criteria);
+    const userContent = userMessageTemplate.replace('{content}', content);
+
+    response = await fetchHTTP({
+      url: `${baseUrl}/v1/chat/completions`,
+      method: 'post',
+      headers,
+      body: jsonStringify({
+        model,
+        messages: [
+          { role: 'system', content: systemContent },
+          { role: 'user', content: userContent },
+        ],
+        max_tokens: 1,
+        logprobs: true,
+        top_logprobs: 2,
+      }),
+      handleResponseBody: 'as-json',
+      timeoutMs: 10_000,
+    });
+
+    if (!response.ok) {
+      throwResponseError(response.status, baseUrl);
+    }
+
+    const body = response.body as {
+      choices: {
+        message: { content: string };
+        logprobs: { content: { token: string; logprob: number }[] };
+      }[];
+    };
+    const choice = body.choices[0];
+    const label = choice.message.content.trim() as '0' | '1';
+    const logprob = choice.logprobs.content[0]?.logprob ?? 0;
+    return { score: scoreFromLogprob(label, logprob) };
+  }
+}
+
+function throwResponseError(status: number, baseUrl: string): never {
+  if (status === 401 || status === 403) {
+    throw makeSignalPermanentError(
+      `Self-hosted model API error: ${status} (invalid API key for ${baseUrl})`,
+      { shouldErrorSpan: true },
+    );
+  }
+  if (status === 404) {
+    throw makeSignalPermanentError(
+      `Self-hosted model API error: 404 (check base URL and model name — ${baseUrl})`,
+      { shouldErrorSpan: true },
+    );
+  }
+  throw new Error(`Self-hosted model API error: ${status}`);
+}

--- a/server/services/signalsService/signals/third_party_signals/zentropi/ZentropiLabelerSignal.test.ts
+++ b/server/services/signalsService/signals/third_party_signals/zentropi/ZentropiLabelerSignal.test.ts
@@ -4,6 +4,7 @@ import { type CachedGetCredentials } from '../../../../signalAuthService/signalA
 import { Integration } from '../../../types/Integration.js';
 import { SignalType } from '../../../types/SignalType.js';
 import { type SignalInput } from '../../SignalBase.js';
+import { type FetchOpenAICompatibleScore } from '../openai_compatible/openaiCompatibleUtils.js';
 import ZentropiLabelerSignal from './ZentropiLabelerSignal.js';
 import {
   type FetchZentropiScores,
@@ -38,9 +39,22 @@ function makeInput(
   } as unknown as StringSignalInput;
 }
 
+function makeOpenAICompatibleFetcher(): FetchOpenAICompatibleScore {
+  return Object.assign(
+    jest
+      .fn()
+      .mockResolvedValue({ score: 0 }) as unknown as FetchOpenAICompatibleScore,
+    { close: jest.fn().mockResolvedValue(undefined) },
+  );
+}
+
 describe('ZentropiLabelerSignal', () => {
   it('has correct signal metadata', () => {
-    const signal = new ZentropiLabelerSignal(makeCredentialGetter(), jest.fn());
+    const signal = new ZentropiLabelerSignal(
+      makeCredentialGetter(),
+      jest.fn(),
+      makeOpenAICompatibleFetcher(),
+    );
 
     expect(signal.id).toEqual({ type: SignalType.ZENTROPI_LABELER });
     expect(signal.displayName).toBe('Zentropi Labeler');
@@ -59,6 +73,7 @@ describe('ZentropiLabelerSignal', () => {
     const signal = new ZentropiLabelerSignal(
       makeCredentialGetter(null),
       jest.fn(),
+      makeOpenAICompatibleFetcher(),
     );
 
     const info = await signal.getDisabledInfo('org-1');
@@ -70,6 +85,7 @@ describe('ZentropiLabelerSignal', () => {
     const signal = new ZentropiLabelerSignal(
       makeCredentialGetter('key'),
       jest.fn(),
+      makeOpenAICompatibleFetcher(),
     );
 
     const info = await signal.getDisabledInfo('org-1');
@@ -85,6 +101,7 @@ describe('ZentropiLabelerSignal', () => {
     const signal = new ZentropiLabelerSignal(
       makeCredentialGetter(),
       fetchScores,
+      makeOpenAICompatibleFetcher(),
     );
 
     const result = await signal.run(makeInput());

--- a/server/services/signalsService/signals/third_party_signals/zentropi/ZentropiLabelerSignal.test.ts
+++ b/server/services/signalsService/signals/third_party_signals/zentropi/ZentropiLabelerSignal.test.ts
@@ -8,6 +8,7 @@ import { type FetchOpenAICompatibleScore } from '../openai_compatible/openaiComp
 import ZentropiLabelerSignal from './ZentropiLabelerSignal.js';
 import {
   type FetchZentropiScores,
+  type GetPolicyText,
   type ZentropiResponse,
 } from './zentropiUtils.js';
 
@@ -48,12 +49,17 @@ function makeOpenAICompatibleFetcher(): FetchOpenAICompatibleScore {
   );
 }
 
+function makeGetPolicyText(): GetPolicyText {
+  return jest.fn().mockResolvedValue(null);
+}
+
 describe('ZentropiLabelerSignal', () => {
   it('has correct signal metadata', () => {
     const signal = new ZentropiLabelerSignal(
       makeCredentialGetter(),
       jest.fn(),
       makeOpenAICompatibleFetcher(),
+      makeGetPolicyText(),
     );
 
     expect(signal.id).toEqual({ type: SignalType.ZENTROPI_LABELER });
@@ -74,6 +80,7 @@ describe('ZentropiLabelerSignal', () => {
       makeCredentialGetter(null),
       jest.fn(),
       makeOpenAICompatibleFetcher(),
+      makeGetPolicyText(),
     );
 
     const info = await signal.getDisabledInfo('org-1');
@@ -86,6 +93,7 @@ describe('ZentropiLabelerSignal', () => {
       makeCredentialGetter('key'),
       jest.fn(),
       makeOpenAICompatibleFetcher(),
+      makeGetPolicyText(),
     );
 
     const info = await signal.getDisabledInfo('org-1');
@@ -102,6 +110,7 @@ describe('ZentropiLabelerSignal', () => {
       makeCredentialGetter(),
       fetchScores,
       makeOpenAICompatibleFetcher(),
+      makeGetPolicyText(),
     );
 
     const result = await signal.run(makeInput());

--- a/server/services/signalsService/signals/third_party_signals/zentropi/ZentropiLabelerSignal.ts
+++ b/server/services/signalsService/signals/third_party_signals/zentropi/ZentropiLabelerSignal.ts
@@ -5,6 +5,7 @@ import { Integration } from '../../../types/Integration.js';
 import { SignalPricingStructure } from '../../../types/SignalPricingStructure.js';
 import { SignalType } from '../../../types/SignalType.js';
 import SignalBase, { type SignalInput } from '../../SignalBase.js';
+import { type FetchOpenAICompatibleScore } from '../openai_compatible/openaiCompatibleUtils.js';
 import {
   runZentropiLabelerImpl,
   type FetchZentropiScores,
@@ -17,6 +18,7 @@ export default class ZentropiLabelerSignal extends SignalBase<
   constructor(
     protected readonly getZentropiCredentials: CachedGetCredentials<'ZENTROPI'>,
     protected readonly getZentropiScores: FetchZentropiScores,
+    protected readonly fetchOpenAICompatibleScore: FetchOpenAICompatibleScore,
   ) {
     super();
   }
@@ -31,10 +33,11 @@ export default class ZentropiLabelerSignal extends SignalBase<
 
   override get description() {
     return (
-      'Policy-steerable content classifier powered by Zentropi. ' +
-      'Evaluates text against a custom policy defined by a published labeler. ' +
+      'Policy-steerable content classifier powered by the CoPE model. ' +
+      'Evaluates text against a custom policy. ' +
       'Returns a composite score: 0 = confidently safe, 0.5 = uncertain, 1 = confidently violating. ' +
-      'Specify the labeler_version_id in the subcategory field.'
+      'For Zentropi hosted: specify the labeler_version_id in the subcategory field. ' +
+      'For self-hosted: specify the policy criteria text in the subcategory field.'
     );
   }
 
@@ -75,11 +78,14 @@ export default class ZentropiLabelerSignal extends SignalBase<
 
   override async getDisabledInfo(orgId: string) {
     const credential = await this.getZentropiCredentials(orgId);
+    if (credential?.selfHosted != null) {
+      return { disabled: false as const };
+    }
     return !credential?.apiKey
       ? {
           disabled: true as const,
           disabledMessage:
-            'You need to input your Zentropi API key to use Zentropi signals',
+            'You need to configure either a Zentropi API key or a self-hosted model endpoint to use this signal',
         }
       : { disabled: false as const };
   }
@@ -108,6 +114,7 @@ export default class ZentropiLabelerSignal extends SignalBase<
       this.getZentropiCredentials,
       input,
       this.getZentropiScores,
+      this.fetchOpenAICompatibleScore,
     );
   }
 }

--- a/server/services/signalsService/signals/third_party_signals/zentropi/ZentropiLabelerSignal.ts
+++ b/server/services/signalsService/signals/third_party_signals/zentropi/ZentropiLabelerSignal.ts
@@ -9,6 +9,7 @@ import { type FetchOpenAICompatibleScore } from '../openai_compatible/openaiComp
 import {
   runZentropiLabelerImpl,
   type FetchZentropiScores,
+  type GetPolicyText,
 } from './zentropiUtils.js';
 
 export default class ZentropiLabelerSignal extends SignalBase<
@@ -19,6 +20,7 @@ export default class ZentropiLabelerSignal extends SignalBase<
     protected readonly getZentropiCredentials: CachedGetCredentials<'ZENTROPI'>,
     protected readonly getZentropiScores: FetchZentropiScores,
     protected readonly fetchOpenAICompatibleScore: FetchOpenAICompatibleScore,
+    protected readonly getPolicyText: GetPolicyText,
   ) {
     super();
   }
@@ -115,6 +117,7 @@ export default class ZentropiLabelerSignal extends SignalBase<
       input,
       this.getZentropiScores,
       this.fetchOpenAICompatibleScore,
+      this.getPolicyText,
     );
   }
 }

--- a/server/services/signalsService/signals/third_party_signals/zentropi/zentropiUtils.test.ts
+++ b/server/services/signalsService/signals/third_party_signals/zentropi/zentropiUtils.test.ts
@@ -4,6 +4,7 @@ import { isCoopErrorOfType } from '../../../../../utils/errors.js';
 import { type FetchHTTP } from '../../../../networkingService/index.js';
 import { type CachedGetCredentials } from '../../../../signalAuthService/signalAuthService.js';
 import { type SignalInput } from '../../SignalBase.js';
+import { type FetchOpenAICompatibleScore } from '../openai_compatible/openaiCompatibleUtils.js';
 import {
   getZentropiScores,
   runZentropiLabelerImpl,
@@ -39,6 +40,15 @@ function makeCredentialGetter(
   );
 }
 
+function makeOpenAICompatibleFetcher(): FetchOpenAICompatibleScore {
+  return Object.assign(
+    jest
+      .fn()
+      .mockResolvedValue({ score: 0 }) as unknown as FetchOpenAICompatibleScore,
+    { close: jest.fn().mockResolvedValue(undefined) },
+  );
+}
+
 describe('zentropiUtils', () => {
   describe('score mapping', () => {
     it('maps label=1, high confidence to high score (violating)', async () => {
@@ -51,6 +61,7 @@ describe('zentropiUtils', () => {
         makeCredentialGetter(),
         makeInput(),
         fetchScores,
+        makeOpenAICompatibleFetcher(),
       );
 
       expect(result.score).toBe(0.95);
@@ -66,6 +77,7 @@ describe('zentropiUtils', () => {
         makeCredentialGetter(),
         makeInput(),
         fetchScores,
+        makeOpenAICompatibleFetcher(),
       );
 
       expect(result.score).toBeCloseTo(0.05);
@@ -81,6 +93,7 @@ describe('zentropiUtils', () => {
         makeCredentialGetter(),
         makeInput(),
         fetchScores,
+        makeOpenAICompatibleFetcher(),
       );
 
       expect(result.score).toBeCloseTo(0.4);
@@ -96,6 +109,7 @@ describe('zentropiUtils', () => {
         makeCredentialGetter(),
         makeInput(),
         fetchScores,
+        makeOpenAICompatibleFetcher(),
       );
 
       expect(result.score).toBe(0.6);
@@ -111,6 +125,7 @@ describe('zentropiUtils', () => {
         makeCredentialGetter(),
         makeInput(),
         fetchScores,
+        makeOpenAICompatibleFetcher(),
       );
 
       expect(result.score).toBe(0.95);
@@ -126,6 +141,7 @@ describe('zentropiUtils', () => {
         makeCredentialGetter(),
         makeInput(),
         fetchScores,
+        makeOpenAICompatibleFetcher(),
       );
 
       expect(result.score).toBeCloseTo(0.05);
@@ -141,6 +157,7 @@ describe('zentropiUtils', () => {
         makeCredentialGetter(),
         makeInput(),
         fetchScores,
+        makeOpenAICompatibleFetcher(),
       );
 
       expect(result.outputType).toEqual({ scalarType: ScalarTypes.NUMBER });
@@ -156,6 +173,7 @@ describe('zentropiUtils', () => {
           makeCredentialGetter(null),
           makeInput(),
           fetchScores,
+          makeOpenAICompatibleFetcher(),
         ),
       ).rejects.toThrow('Missing Zentropi API credentials');
     });
@@ -168,8 +186,9 @@ describe('zentropiUtils', () => {
           makeCredentialGetter(),
           makeInput({ subcategory: undefined }),
           fetchScores,
+          makeOpenAICompatibleFetcher(),
         ),
-      ).rejects.toThrow('Missing labeler_version_id in subcategory');
+      ).rejects.toThrow('Missing criteria in subcategory');
     });
 
     it('passes labelerVersionId from subcategory to fetcher', async () => {
@@ -182,6 +201,7 @@ describe('zentropiUtils', () => {
         makeCredentialGetter(),
         makeInput({ subcategory: 'lv_custom_123' }),
         fetchScores,
+        makeOpenAICompatibleFetcher(),
       );
 
       expect(fetchScores).toHaveBeenCalledWith({

--- a/server/services/signalsService/signals/third_party_signals/zentropi/zentropiUtils.test.ts
+++ b/server/services/signalsService/signals/third_party_signals/zentropi/zentropiUtils.test.ts
@@ -9,6 +9,7 @@ import {
   getZentropiScores,
   runZentropiLabelerImpl,
   type FetchZentropiScores,
+  type GetPolicyText,
   type ZentropiResponse,
 } from './zentropiUtils.js';
 
@@ -49,6 +50,10 @@ function makeOpenAICompatibleFetcher(): FetchOpenAICompatibleScore {
   );
 }
 
+function makeGetPolicyText(text: string | null = null): GetPolicyText {
+  return jest.fn().mockResolvedValue(text);
+}
+
 describe('zentropiUtils', () => {
   describe('score mapping', () => {
     it('maps label=1, high confidence to high score (violating)', async () => {
@@ -62,6 +67,7 @@ describe('zentropiUtils', () => {
         makeInput(),
         fetchScores,
         makeOpenAICompatibleFetcher(),
+        makeGetPolicyText(),
       );
 
       expect(result.score).toBe(0.95);
@@ -78,6 +84,7 @@ describe('zentropiUtils', () => {
         makeInput(),
         fetchScores,
         makeOpenAICompatibleFetcher(),
+        makeGetPolicyText(),
       );
 
       expect(result.score).toBeCloseTo(0.05);
@@ -94,6 +101,7 @@ describe('zentropiUtils', () => {
         makeInput(),
         fetchScores,
         makeOpenAICompatibleFetcher(),
+        makeGetPolicyText(),
       );
 
       expect(result.score).toBeCloseTo(0.4);
@@ -110,6 +118,7 @@ describe('zentropiUtils', () => {
         makeInput(),
         fetchScores,
         makeOpenAICompatibleFetcher(),
+        makeGetPolicyText(),
       );
 
       expect(result.score).toBe(0.6);
@@ -126,6 +135,7 @@ describe('zentropiUtils', () => {
         makeInput(),
         fetchScores,
         makeOpenAICompatibleFetcher(),
+        makeGetPolicyText(),
       );
 
       expect(result.score).toBe(0.95);
@@ -142,6 +152,7 @@ describe('zentropiUtils', () => {
         makeInput(),
         fetchScores,
         makeOpenAICompatibleFetcher(),
+        makeGetPolicyText(),
       );
 
       expect(result.score).toBeCloseTo(0.05);
@@ -158,6 +169,7 @@ describe('zentropiUtils', () => {
         makeInput(),
         fetchScores,
         makeOpenAICompatibleFetcher(),
+        makeGetPolicyText(),
       );
 
       expect(result.outputType).toEqual({ scalarType: ScalarTypes.NUMBER });
@@ -174,6 +186,7 @@ describe('zentropiUtils', () => {
           makeInput(),
           fetchScores,
           makeOpenAICompatibleFetcher(),
+          makeGetPolicyText(),
         ),
       ).rejects.toThrow('Missing Zentropi API credentials');
     });
@@ -187,6 +200,7 @@ describe('zentropiUtils', () => {
           makeInput({ subcategory: undefined }),
           fetchScores,
           makeOpenAICompatibleFetcher(),
+          makeGetPolicyText(),
         ),
       ).rejects.toThrow('Missing criteria in subcategory');
     });
@@ -202,6 +216,7 @@ describe('zentropiUtils', () => {
         makeInput({ subcategory: 'lv_custom_123' }),
         fetchScores,
         makeOpenAICompatibleFetcher(),
+        makeGetPolicyText(),
       );
 
       expect(fetchScores).toHaveBeenCalledWith({
@@ -209,6 +224,78 @@ describe('zentropiUtils', () => {
         apiKey: 'test-api-key',
         labelerVersionId: 'lv_custom_123',
       });
+    });
+
+    it('resolves policy:id to policy text for hosted mode', async () => {
+      const fetchScores: FetchZentropiScores = jest.fn().mockResolvedValue({
+        label: 1,
+        confidence: 0.9,
+      } satisfies ZentropiResponse);
+
+      await runZentropiLabelerImpl(
+        makeCredentialGetter(),
+        makeInput({ subcategory: 'policy:abc123' }),
+        fetchScores,
+        makeOpenAICompatibleFetcher(),
+        makeGetPolicyText('No hate speech allowed'),
+      );
+
+      expect(fetchScores).toHaveBeenCalledWith({
+        text: 'test content',
+        apiKey: 'test-api-key',
+        labelerVersionId: 'No hate speech allowed',
+      });
+    });
+
+    it('throws SignalPermanentError when policy has no text', async () => {
+      const fetchScores: FetchZentropiScores = jest.fn();
+
+      await expect(
+        runZentropiLabelerImpl(
+          makeCredentialGetter(),
+          makeInput({ subcategory: 'policy:missing' }),
+          fetchScores,
+          makeOpenAICompatibleFetcher(),
+          makeGetPolicyText(null),
+        ),
+      ).rejects.toThrow('not found or has no policy text');
+    });
+
+    it('strips HTML from policy text before sending', async () => {
+      const fetchScores: FetchZentropiScores = jest.fn().mockResolvedValue({
+        label: 0,
+        confidence: 0.8,
+      } satisfies ZentropiResponse);
+
+      await runZentropiLabelerImpl(
+        makeCredentialGetter(),
+        makeInput({ subcategory: 'policy:abc123' }),
+        fetchScores,
+        makeOpenAICompatibleFetcher(),
+        makeGetPolicyText('<p>No <strong>hate speech</strong> allowed.</p>'),
+      );
+
+      expect(fetchScores).toHaveBeenCalledWith({
+        text: 'test content',
+        apiKey: 'test-api-key',
+        labelerVersionId: 'No hate speech allowed.',
+      });
+    });
+
+    it('throws SignalPermanentError when policy text is HTML-only (e.g. tiptap empty state)', async () => {
+      const fetchScores: FetchZentropiScores = jest.fn();
+
+      await expect(
+        runZentropiLabelerImpl(
+          makeCredentialGetter(),
+          makeInput({ subcategory: 'policy:abc123' }),
+          fetchScores,
+          makeOpenAICompatibleFetcher(),
+          makeGetPolicyText('<p></p>'),
+        ),
+      ).rejects.toThrow(
+        'has no usable criteria text after removing HTML formatting',
+      );
     });
   });
 

--- a/server/services/signalsService/signals/third_party_signals/zentropi/zentropiUtils.ts
+++ b/server/services/signalsService/signals/third_party_signals/zentropi/zentropiUtils.ts
@@ -63,7 +63,6 @@ export async function runZentropiLabelerImpl(
   fetchOpenAICompatibleScore: FetchOpenAICompatibleScore,
 ) {
   const { value, orgId, subcategory } = input;
-
   const credential = await getZentropiCredentials(orgId);
 
   if (!subcategory) {

--- a/server/services/signalsService/signals/third_party_signals/zentropi/zentropiUtils.ts
+++ b/server/services/signalsService/signals/third_party_signals/zentropi/zentropiUtils.ts
@@ -6,6 +6,7 @@ import { type Bind1 } from '../../../../../utils/typescript-types.js';
 import { type FetchHTTP } from '../../../../networkingService/index.js';
 import { type CachedGetCredentials } from '../../../../signalAuthService/signalAuthService.js';
 import { type SignalInput } from '../../SignalBase.js';
+import { type FetchOpenAICompatibleScore } from '../openai_compatible/openaiCompatibleUtils.js';
 
 export interface ZentropiResponse {
   label: 0 | 1 | '0' | '1';
@@ -58,24 +59,49 @@ export async function getZentropiScores(
 export async function runZentropiLabelerImpl(
   getZentropiCredentials: CachedGetCredentials<'ZENTROPI'>,
   input: SignalInput<ScalarTypes['STRING']>,
-  fetchScores: FetchZentropiScores,
+  fetchZentropiScores: FetchZentropiScores,
+  fetchOpenAICompatibleScore: FetchOpenAICompatibleScore,
 ) {
   const { value, orgId, subcategory } = input;
 
   const credential = await getZentropiCredentials(orgId);
 
+  if (!subcategory) {
+    throw new Error(
+      'Missing criteria in subcategory. ' +
+        'Specify a Zentropi labeler_version_id (hosted) or policy criteria text (self-hosted) ' +
+        'in the condition subcategory field.',
+    );
+  }
+
+  if (credential?.selfHosted != null) {
+    const { selfHosted } = credential;
+    const base = {
+      baseUrl: selfHosted.baseUrl,
+      model: selfHosted.model,
+      apiKey: selfHosted.apiKey,
+      criteria: subcategory,
+      content: value.value,
+    };
+    const params =
+      selfHosted.format === 'openai_chat'
+        ? {
+            ...base,
+            format: 'openai_chat' as const,
+            systemPromptTemplate:
+              selfHosted.systemPromptTemplate ?? '{criteria}',
+            userMessageTemplate: selfHosted.userMessageTemplate ?? '{content}',
+          }
+        : { ...base, format: 'cope' as const };
+    const { score } = await fetchOpenAICompatibleScore(params);
+    return { score, outputType: { scalarType: ScalarTypes.NUMBER } };
+  }
+
   if (!credential?.apiKey) {
     throw new Error('Missing Zentropi API credentials');
   }
 
-  if (!subcategory) {
-    throw new Error(
-      'Missing labeler_version_id in subcategory. ' +
-        'Specify a Zentropi labeler_version_id in the condition subcategory field.',
-    );
-  }
-
-  const response = await fetchScores({
+  const response = await fetchZentropiScores({
     text: value.value,
     apiKey: credential.apiKey,
     labelerVersionId: subcategory,

--- a/server/services/signalsService/signals/third_party_signals/zentropi/zentropiUtils.ts
+++ b/server/services/signalsService/signals/third_party_signals/zentropi/zentropiUtils.ts
@@ -8,6 +8,11 @@ import { type CachedGetCredentials } from '../../../../signalAuthService/signalA
 import { type SignalInput } from '../../SignalBase.js';
 import { type FetchOpenAICompatibleScore } from '../openai_compatible/openaiCompatibleUtils.js';
 
+export type GetPolicyText = (
+  orgId: string,
+  policyId: string,
+) => Promise<string | null>;
+
 export interface ZentropiResponse {
   label: 0 | 1 | '0' | '1';
   confidence: number;
@@ -61,6 +66,7 @@ export async function runZentropiLabelerImpl(
   input: SignalInput<ScalarTypes['STRING']>,
   fetchZentropiScores: FetchZentropiScores,
   fetchOpenAICompatibleScore: FetchOpenAICompatibleScore,
+  getPolicyText: GetPolicyText,
 ) {
   const { value, orgId, subcategory } = input;
   const credential = await getZentropiCredentials(orgId);
@@ -73,13 +79,22 @@ export async function runZentropiLabelerImpl(
     );
   }
 
+  // Resolve policy reference to criteria text, stripping any HTML markup.
+  const resolvedCriteria = subcategory.startsWith('policy:')
+    ? await resolvePolicyCriteria(
+        getPolicyText,
+        orgId,
+        subcategory.slice('policy:'.length),
+      )
+    : subcategory;
+
   if (credential?.selfHosted != null) {
     const { selfHosted } = credential;
     const base = {
       baseUrl: selfHosted.baseUrl,
       model: selfHosted.model,
       apiKey: selfHosted.apiKey,
-      criteria: subcategory,
+      criteria: resolvedCriteria,
       content: value.value,
     };
     const params =
@@ -103,7 +118,7 @@ export async function runZentropiLabelerImpl(
   const response = await fetchZentropiScores({
     text: value.value,
     apiKey: credential.apiKey,
-    labelerVersionId: subcategory,
+    labelerVersionId: resolvedCriteria,
   });
 
   // Composite score mapping:
@@ -117,4 +132,30 @@ export async function runZentropiLabelerImpl(
     score,
     outputType: { scalarType: ScalarTypes.NUMBER },
   };
+}
+
+async function resolvePolicyCriteria(
+  getPolicyText: GetPolicyText,
+  orgId: string,
+  policyId: string,
+): Promise<string> {
+  const text = await getPolicyText(orgId, policyId);
+  if (!text) {
+    throw makeSignalPermanentError(
+      `Policy ${policyId} not found or has no policy text`,
+      { shouldErrorSpan: true },
+    );
+  }
+  // Strip HTML tags that may be present in rich-text policy descriptions.
+  const stripped = text
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!stripped) {
+    throw makeSignalPermanentError(
+      `Policy ${policyId} has no usable criteria text after removing HTML formatting`,
+      { shouldErrorSpan: true },
+    );
+  }
+  return stripped;
 }


### PR DESCRIPTION
Addresses #751

## Summary

- Adds support for self-hosted CoPE/vLLM inference within the existing Zentropi integration
- New `selfHosted` config fields (format, baseUrl, model, optional apiKey, prompt templates) stored in a new `self_hosted_*` column set on the `zentropi_configs` table
- Routes hosted vs. self-hosted at runtime: hosted calls the Zentropi API with a `labeler_version_id`; self-hosted calls an OpenAI-compatible completions or chat endpoint with configurable prompt templates
- Rule builder now shows a free-text "Policy Criteria" textarea (instead of a subcategory dropdown) when Zentropi is in self-hosted mode; hosted mode continues to surface configured labeler versions as a dropdown

## Test plan

- [ ] Configure Zentropi integration in hosted mode (API key + labeler versions) — verify labeler version dropdown appears in rule builder and scoring works
- [ ] Configure Zentropi integration in self-hosted mode (vLLM/OpenAI-compatible endpoint) — verify "Policy Criteria" textarea appears in rule builder
- [ ] Enter policy criteria text, save rule, run against items — verify score is returned from the self-hosted endpoint
- [ ] Verify `cope` format (completions endpoint) and `openai_chat` format (chat/completions endpoint) both work
- [ ] Verify disabled state when neither API key nor self-hosted config is present
- [ ] Run server unit tests: `cd server && npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)