### PR TITLE
[Easy] Fix clickhouse container_name conflict across git worktrees

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -176,7 +176,6 @@ services:
 
   clickhouse:
     image: clickhouse/clickhouse-server:24.3
-    container_name: clickhouse
     ports:
       - '8123:8123' # HTTP interface
       - '9000:9000' # Native TCP interface


### PR DESCRIPTION
The clickhouse service had an explicit container_name: clickhouse, overriding Docker Compose's default project-prefixed naming. Every other service relies on the default (e.g. coop-1), which is unique per worktree directory. With the fixed name, any two worktrees running simultaneously — or even sequentially without a docker compose down — collide on the container name.

Removing the override lets Compose derive the name from the project, consistent with all other services.

## Tests

`npm run up` from multiple checkouts of `coop` on the same system now works. Note: you still can't have them running at the same time due to port conflicts, but you can have the containers stick around without needing to destroy them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal service configuration in deployment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->