### PR TITLE
Fix AGENTS.md first-run setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,10 +57,11 @@ cp db/.env.example db/.env
 cp client/.env.example client/.env
 
 # Create databases, then run migrations.
-# db:create is required before db:update for Scylla and ClickHouse;
-# Postgres creates its database automatically so db:create can be skipped there.
+
+npm run db:create -- --env staging --db api-server-pg
 npm run db:create -- --env staging --db scylla
 npm run db:create -- --env staging --db clickhouse
+
 npm run db:update -- --env staging --db api-server-pg
 npm run db:update -- --env staging --db scylla
 npm run db:update -- --env staging --db clickhouse

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,16 @@ npm install
 (cd server && npm install)
 (cd db && npm install)
 
-# Populate .env files for /server and /db, then run migrations
+# Copy .env files for /server, /db, and /client (defaults work for local dev)
+cp server/.env.example server/.env
+cp db/.env.example db/.env
+cp client/.env.example client/.env
+
+# Create databases, then run migrations.
+# db:create is required before db:update for Scylla and ClickHouse;
+# Postgres creates its database automatically so db:create can be skipped there.
+npm run db:create -- --env staging --db scylla
+npm run db:create -- --env staging --db clickhouse
 npm run db:update -- --env staging --db api-server-pg
 npm run db:update -- --env staging --db scylla
 npm run db:update -- --env staging --db clickhouse
@@ -60,7 +69,7 @@ npm run db:update -- --env staging --db clickhouse
 npm run create-org -- \
   --name "Test Org" \
   --email "admin@example.com" \
-  --website "example.com" \
+  --website "https://example.com" \
   --firstName "Admin" \
   --lastName "User" \
   --password "your-password"
@@ -71,7 +80,7 @@ npm run server:start        # Express + GraphQL API
 npm run generate:watch      # (optional) watch GraphQL changes
 ```
 
-Client: http://localhost:3001 · Server: http://localhost:3000
+Client: http://localhost:3000 · Server: http://localhost:8080
 
 ## Testing
 


### PR DESCRIPTION
## Context & Requests for Reviewers

AGENTS.md was missing instructions contained in other docs (e.g. docs/development/local.md).

1. Missing .env copy step for /client — only /server and /db were documented; client/.env.example exists and should be copied too.
1. db:create before db:update for Scylla and ClickHouse — both require the database/keyspace to exist before migrations can run. Omitting this
produces a "keyspace does not exist" error. Postgres auto-creates so it's unaffected.
1. Wrong ports — client is :3000, server is :8080; the file had :3001/:3000.
1. --website example — added https:// scheme, which create-org requires.
## Tests

Had Claude Code follow instructions, build and run ran fine.

## (Optional) Rollout Plan

n/a: dev doc only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development setup instructions with explicit database initialization steps
  * Corrected local development server URLs for client and server
  * Enhanced environment configuration guidelines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->