### PR TITLE
Add per-queue "clear other reports for a user" action sweep

### DIFF
--- a/client/src/graphql/generated.ts
+++ b/client/src/graphql/generated.ts
@@ -776,6 +776,11 @@ export type GQLCreateManualReviewJobCommentInput = {
 
 export type GQLCreateManualReviewQueueInput = {
   readonly autoCloseJobs: Scalars['Boolean']['input'];
+  readonly clearReportsDisposition?: InputMaybe<GQLMrtClearReportsDisposition>;
+  readonly clearReportsScope?: InputMaybe<GQLMrtClearReportsScope>;
+  readonly clearReportsTriggerActionIds?: InputMaybe<
+    ReadonlyArray<Scalars['ID']['input']>
+  >;
   readonly description?: InputMaybe<Scalars['String']['input']>;
   readonly hiddenActionIds: ReadonlyArray<Scalars['ID']['input']>;
   readonly isAppealsQueue: Scalars['Boolean']['input'];
@@ -2201,6 +2206,9 @@ export type GQLManualReviewJobWithDecisions = {
 export type GQLManualReviewQueue = {
   readonly __typename: 'ManualReviewQueue';
   readonly autoCloseJobs: Scalars['Boolean']['output'];
+  readonly clearReportsDisposition?: Maybe<GQLMrtClearReportsDisposition>;
+  readonly clearReportsScope: GQLMrtClearReportsScope;
+  readonly clearReportsTriggerActionIds: ReadonlyArray<Scalars['ID']['output']>;
   readonly description?: Maybe<Scalars['String']['output']>;
   readonly explicitlyAssignedReviewers: ReadonlyArray<GQLUser>;
   readonly hiddenActionIds: ReadonlyArray<Scalars['ID']['output']>;
@@ -2322,6 +2330,21 @@ export type GQLModeratorSafetySettingsInput = {
   readonly moderatorSafetyMuteVideo: Scalars['Boolean']['input'];
 };
 
+export const GQLMrtClearReportsDisposition = {
+  AutomaticClose: 'AUTOMATIC_CLOSE',
+  Ignore: 'IGNORE',
+  SameAction: 'SAME_ACTION',
+} as const;
+
+export type GQLMrtClearReportsDisposition =
+  (typeof GQLMrtClearReportsDisposition)[keyof typeof GQLMrtClearReportsDisposition];
+export const GQLMrtClearReportsScope = {
+  AllQueues: 'ALL_QUEUES',
+  CurrentQueue: 'CURRENT_QUEUE',
+} as const;
+
+export type GQLMrtClearReportsScope =
+  (typeof GQLMrtClearReportsScope)[keyof typeof GQLMrtClearReportsScope];
 export type GQLMrtJobEnqueueSourceInfo = {
   readonly __typename: 'MrtJobEnqueueSourceInfo';
   readonly kind: GQLJobCreationSourceOptions;
@@ -4756,6 +4779,11 @@ export type GQLUpdateManualReviewQueueInput = {
   readonly actionIdsToHide: ReadonlyArray<Scalars['ID']['input']>;
   readonly actionIdsToUnhide: ReadonlyArray<Scalars['ID']['input']>;
   readonly autoCloseJobs: Scalars['Boolean']['input'];
+  readonly clearReportsDisposition?: InputMaybe<GQLMrtClearReportsDisposition>;
+  readonly clearReportsScope?: InputMaybe<GQLMrtClearReportsScope>;
+  readonly clearReportsTriggerActionIds?: InputMaybe<
+    ReadonlyArray<Scalars['ID']['input']>
+  >;
   readonly description?: InputMaybe<Scalars['String']['input']>;
   readonly id: Scalars['ID']['input'];
   readonly name?: InputMaybe<Scalars['String']['input']>;
@@ -9812,6 +9840,9 @@ export type GQLManualReviewQueueQuery = {
     readonly hiddenActionIds: ReadonlyArray<string>;
     readonly isAppealsQueue: boolean;
     readonly autoCloseJobs: boolean;
+    readonly clearReportsDisposition?: GQLMrtClearReportsDisposition | null;
+    readonly clearReportsScope: GQLMrtClearReportsScope;
+    readonly clearReportsTriggerActionIds: ReadonlyArray<string>;
     readonly explicitlyAssignedReviewers: ReadonlyArray<{
       readonly __typename: 'User';
       readonly id: string;
@@ -32445,6 +32476,9 @@ export const GQLManualReviewQueueDocument = gql`
         hiddenActionIds
         isAppealsQueue
         autoCloseJobs
+        clearReportsDisposition
+        clearReportsScope
+        clearReportsTriggerActionIds
       }
     }
   }

--- a/client/src/webpages/dashboard/Dashboard.tsx
+++ b/client/src/webpages/dashboard/Dashboard.tsx
@@ -61,6 +61,13 @@ const lazyRoute =
     Component: (await importFn()).default,
   });
 
+// Redirects to `to` while preserving the current query string, so legacy
+// links carrying params (e.g. ?id=…&typeId=…) don't lose them on redirect.
+function RedirectPreservingSearch({ to }: { to: string }) {
+  const { search } = useLocation();
+  return <Navigate replace to={`${to}${search}`} />;
+}
+
 export function DashboardRoutes() {
   return {
     path: 'dashboard',
@@ -336,7 +343,9 @@ export function DashboardRoutes() {
       },
       {
         path: 'investigation',
-        element: <Navigate replace to="../manual_review/investigation" />,
+        element: (
+          <RedirectPreservingSearch to="../manual_review/investigation" />
+        ),
         handle: { isUsingLegacyCSS: true },
       },
 

--- a/client/src/webpages/dashboard/mrt/ManualReviewQueueForm.tsx
+++ b/client/src/webpages/dashboard/mrt/ManualReviewQueueForm.tsx
@@ -419,8 +419,8 @@ export default function ManualReviewQueueForm() {
 
   const isCreateForm = id == null;
 
-  // A disposition with no trigger actions is saved as "disabled" by the
-  // backend, so block that state to avoid a queue that looks enabled but isn't.
+  // The sweep never runs without at least one trigger action, so block this
+  // state to avoid a queue that looks enabled but does nothing.
   const clearReportsConfigInvalid =
     !isAppealsQueue &&
     clearReportsDisposition != null &&

--- a/client/src/webpages/dashboard/mrt/ManualReviewQueueForm.tsx
+++ b/client/src/webpages/dashboard/mrt/ManualReviewQueueForm.tsx
@@ -419,6 +419,13 @@ export default function ManualReviewQueueForm() {
 
   const isCreateForm = id == null;
 
+  // A disposition with no trigger actions is saved as "disabled" by the
+  // backend, so block that state to avoid a queue that looks enabled but isn't.
+  const clearReportsConfigInvalid =
+    !isAppealsQueue &&
+    clearReportsDisposition != null &&
+    clearReportsTriggerActionIds.length === 0;
+
   const divider = () => <div className="mt-5 divider mb-9" />;
   return (
     <div className="flex flex-col text-start">
@@ -626,11 +633,13 @@ export default function ManualReviewQueueForm() {
         <CoopButton
           title={id == null ? 'Create Queue' : 'Save Changes'}
           loading={createMutationLoading || updateMutationLoading}
-          disabled={queueName == null}
+          disabled={queueName == null || clearReportsConfigInvalid}
           disabledTooltipTitle={
             queueName == null
               ? 'Please provide a name for the queue.'
-              : undefined
+              : clearReportsConfigInvalid
+                ? 'Select at least one Trigger Action, or set Clear Other Reports to Disabled.'
+                : undefined
           }
           disabledTooltipPlacement="bottom"
           onClick={id == null ? onCreateQueue : onUpdateQueue}

--- a/client/src/webpages/dashboard/mrt/ManualReviewQueueForm.tsx
+++ b/client/src/webpages/dashboard/mrt/ManualReviewQueueForm.tsx
@@ -41,7 +41,7 @@ const CLEAR_REPORTS_DISPOSITION_LABELS: Record<
 
 const CLEAR_REPORTS_SCOPE_LABELS: Record<GQLMrtClearReportsScope, string> = {
   [GQLMrtClearReportsScope.CurrentQueue]: 'Only this queue',
-  [GQLMrtClearReportsScope.AllQueues]: 'All non-appeal queues',
+  [GQLMrtClearReportsScope.AllQueues]: 'All queues (except appeals)',
 };
 
 gql`

--- a/client/src/webpages/dashboard/mrt/ManualReviewQueueForm.tsx
+++ b/client/src/webpages/dashboard/mrt/ManualReviewQueueForm.tsx
@@ -16,6 +16,8 @@ import FormHeader from '../components/FormHeader';
 import NameDescriptionInput from '../components/NameDescriptionInput';
 
 import {
+  GQLMrtClearReportsDisposition,
+  GQLMrtClearReportsScope,
   namedOperations,
   useGQLCreateManualReviewQueueMutation,
   useGQLManualReviewQueueQuery,
@@ -26,6 +28,21 @@ import { titleCaseEnumStringWithArticle } from '../../../utils/string';
 import { optionWithTooltip } from './queue_routing/ManualReviewQueueRuleFormCondition';
 
 const { Option } = Select;
+
+const CLEAR_REPORTS_DISPOSITION_LABELS: Record<
+  GQLMrtClearReportsDisposition,
+  string
+> = {
+  [GQLMrtClearReportsDisposition.AutomaticClose]:
+    'Close them automatically (no action taken)',
+  [GQLMrtClearReportsDisposition.Ignore]: 'Mark them as ignored',
+  [GQLMrtClearReportsDisposition.SameAction]: 'Apply the same action',
+};
+
+const CLEAR_REPORTS_SCOPE_LABELS: Record<GQLMrtClearReportsScope, string> = {
+  [GQLMrtClearReportsScope.CurrentQueue]: 'Only this queue',
+  [GQLMrtClearReportsScope.AllQueues]: 'All non-appeal queues',
+};
 
 gql`
   query QueueFormData {
@@ -62,6 +79,9 @@ gql`
         hiddenActionIds
         isAppealsQueue
         autoCloseJobs
+        clearReportsDisposition
+        clearReportsScope
+        clearReportsTriggerActionIds
       }
     }
   }
@@ -132,6 +152,12 @@ export default function ManualReviewQueueForm() {
   const [hiddenActionIds, setHiddenActionIds] = useState<string[]>([]);
   const [autoCloseJobs, setAutoCloseJobs] = useState<boolean>(false);
   const [isAppealsQueue, setIsAppealsQueue] = useState<boolean>(false);
+  const [clearReportsDisposition, setClearReportsDisposition] =
+    useState<GQLMrtClearReportsDisposition | null>(null);
+  const [clearReportsScope, setClearReportsScope] =
+    useState<GQLMrtClearReportsScope>(GQLMrtClearReportsScope.CurrentQueue);
+  const [clearReportsTriggerActionIds, setClearReportsTriggerActionIds] =
+    useState<string[]>([]);
   const navigate = useNavigate();
 
   const [
@@ -274,6 +300,13 @@ export default function ManualReviewQueueForm() {
     setHiddenActionIds([...queue.hiddenActionIds]);
     setAutoCloseJobs(queue.autoCloseJobs);
     setIsAppealsQueue(queue.isAppealsQueue);
+    setClearReportsDisposition(queue.clearReportsDisposition ?? null);
+    setClearReportsScope(
+      queue.clearReportsScope ?? GQLMrtClearReportsScope.CurrentQueue,
+    );
+    setClearReportsTriggerActionIds([
+      ...(queue.clearReportsTriggerActionIds ?? []),
+    ]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [queue, queue?.autoCloseJobs]);
 
@@ -295,11 +328,20 @@ export default function ManualReviewQueueForm() {
             hiddenActionIds,
             isAppealsQueue,
             autoCloseJobs,
+            clearReportsDisposition,
+            clearReportsScope,
+            clearReportsTriggerActionIds:
+              clearReportsDisposition == null
+                ? []
+                : clearReportsTriggerActionIds,
           },
         },
       }),
     [
       autoCloseJobs,
+      clearReportsDisposition,
+      clearReportsScope,
+      clearReportsTriggerActionIds,
       createManualReviewQueue,
       hiddenActionIds,
       isAppealsQueue,
@@ -329,11 +371,20 @@ export default function ManualReviewQueueForm() {
               hiddenActionIds,
             ),
             autoCloseJobs,
+            clearReportsDisposition,
+            clearReportsScope,
+            clearReportsTriggerActionIds:
+              clearReportsDisposition == null
+                ? []
+                : clearReportsTriggerActionIds,
           },
         },
       }),
     [
       autoCloseJobs,
+      clearReportsDisposition,
+      clearReportsScope,
+      clearReportsTriggerActionIds,
       hiddenActionIds,
       id,
       initiallyHiddenActionIds,
@@ -474,6 +525,88 @@ export default function ManualReviewQueueForm() {
               already been deleted
             </Label>
           </div>
+        </div>
+      )}
+      {!isAppealsQueue && (
+        <div className="mt-8">
+          <div className="font-semibold">Clear Other Reports for a User</div>
+          <div className="mb-2 text-slate-500">
+            When a moderator takes one of the selected actions on a user, Coop
+            can also clear that user's other pending reports. CSAM reports are
+            never cleared.
+          </div>
+          <Select<GQLMrtClearReportsDisposition | 'DISABLED'>
+            className="self-start !min-w-[160px]"
+            dropdownMatchSelectWidth={false}
+            value={clearReportsDisposition ?? 'DISABLED'}
+            onChange={(value) =>
+              setClearReportsDisposition(value === 'DISABLED' ? null : value)
+            }
+          >
+            <Option value="DISABLED" label="Disabled">
+              Disabled
+            </Option>
+            {Object.values(GQLMrtClearReportsDisposition).map((disposition) => (
+              <Option
+                key={disposition}
+                value={disposition}
+                label={CLEAR_REPORTS_DISPOSITION_LABELS[disposition]}
+              >
+                {CLEAR_REPORTS_DISPOSITION_LABELS[disposition]}
+              </Option>
+            ))}
+          </Select>
+          {clearReportsDisposition != null && (
+            <div className="flex flex-col gap-4 mt-4">
+              <div>
+                <div className="mb-2 font-semibold">Trigger Actions</div>
+                <div className="mb-2 text-slate-500">
+                  Taking any of these actions on a user triggers clearing their
+                  other reports.
+                </div>
+                <Select<string[]>
+                  className="self-start !min-w-[160px]"
+                  mode="multiple"
+                  placeholder="Add Trigger Actions"
+                  dropdownMatchSelectWidth={false}
+                  allowClear
+                  showSearch
+                  filterOption={selectFilterByLabelOption}
+                  value={clearReportsTriggerActionIds}
+                  onChange={setClearReportsTriggerActionIds}
+                >
+                  {orderBy(orgActions, ['name']).map((action) => (
+                    <Option
+                      key={action.id}
+                      value={action.id}
+                      label={action.name}
+                    >
+                      {action.name}
+                    </Option>
+                  ))}
+                </Select>
+              </div>
+              <div>
+                <div className="mb-2 font-semibold">Scope</div>
+                <Select<GQLMrtClearReportsScope>
+                  className="self-start !min-w-[160px]"
+                  dropdownMatchSelectWidth={false}
+                  value={clearReportsScope}
+                  onChange={setClearReportsScope}
+                >
+                  {Object.values(GQLMrtClearReportsScope).map((scope) => (
+                    <Option
+                      key={scope}
+                      value={scope}
+                      label={CLEAR_REPORTS_SCOPE_LABELS[scope]}
+                    >
+                      {CLEAR_REPORTS_SCOPE_LABELS[scope]}
+                    </Option>
+                  ))}
+                </Select>
+              </div>
+            </div>
+          )}
         </div>
       )}
       {isCreateForm && data?.myOrg?.hasAppealsEnabled ? (

--- a/client/src/webpages/dashboard/userStrikes/StrikeAnalyticsTab.tsx
+++ b/client/src/webpages/dashboard/userStrikes/StrikeAnalyticsTab.tsx
@@ -217,7 +217,7 @@ function RecentUserStrikeActionsTable() {
           user: (
             <Link
               className="cursor-pointer shrink-0"
-              to={`/dashboard/investigation?id=${values.itemId}&typeId=${values.itemTypeId}`}
+              to={`/dashboard/manual_review/investigation?id=${values.itemId}&typeId=${values.itemTypeId}`}
               target="_blank"
             >
               {values.itemId}

--- a/db/src/scripts/api-server-pg/2026.06.20T00.50.19.add_mrt_clear_other_reports_config.sql
+++ b/db/src/scripts/api-server-pg/2026.06.20T00.50.19.add_mrt_clear_other_reports_config.sql
@@ -1,0 +1,36 @@
+-- Per-queue config for "clear all other reports for a user" (issue #650): when
+-- a trigger action is taken on a job, dispose of the user's other pending
+-- reports. The feature is off for a queue unless it has a non-null disposition
+-- and at least one trigger action, so existing queues are unaffected.
+
+ALTER TABLE manual_review_tool.manual_review_queues
+  ADD COLUMN IF NOT EXISTS clear_reports_disposition character varying(64),
+  ADD COLUMN IF NOT EXISTS clear_reports_scope character varying(64) NOT NULL DEFAULT 'CURRENT_QUEUE';
+
+ALTER TABLE manual_review_tool.manual_review_queues
+  ADD CONSTRAINT manual_review_queues_clear_reports_disposition_check
+    CHECK (
+      clear_reports_disposition IS NULL
+      OR clear_reports_disposition IN ('AUTOMATIC_CLOSE', 'IGNORE', 'SAME_ACTION')
+    );
+
+ALTER TABLE manual_review_tool.manual_review_queues
+  ADD CONSTRAINT manual_review_queues_clear_reports_scope_check
+    CHECK (clear_reports_scope IN ('CURRENT_QUEUE', 'ALL_QUEUES'));
+
+-- Action IDs that trigger the sweep for a queue (mirrors queues_and_hidden_actions).
+CREATE TABLE IF NOT EXISTS manual_review_tool.queues_and_clear_reports_trigger_actions (
+  queue_id character varying(255) NOT NULL,
+  action_id character varying(255) NOT NULL,
+  org_id character varying(255) NOT NULL,
+  CONSTRAINT queues_and_clear_reports_trigger_actions_pkey PRIMARY KEY (queue_id, action_id),
+  CONSTRAINT queues_and_clear_reports_trigger_actions_queue_fkey
+    FOREIGN KEY (queue_id)
+    REFERENCES manual_review_tool.manual_review_queues(id)
+    ON DELETE CASCADE
+);
+
+ALTER TABLE manual_review_tool.queues_and_clear_reports_trigger_actions OWNER TO CURRENT_USER;
+
+CREATE INDEX IF NOT EXISTS idx_queues_and_clear_reports_trigger_actions_org_id
+  ON manual_review_tool.queues_and_clear_reports_trigger_actions(org_id);

--- a/server/.env.example
+++ b/server/.env.example
@@ -61,6 +61,18 @@ CLICKHOUSE_PROTOCOL=http
 # CLICKHOUSE_INSERT_RETRY_INITIAL_MS=100
 # CLICKHOUSE_INSERT_RETRY_MAX_MS=1000
 
+# ClickHouse query memory limits (bytes). When a GROUP BY / ORDER BY exceeds the
+# threshold, ClickHouse spills to disk instead of holding everything in RAM,
+# avoiding server-wide OOM kills by the OvercommitTracker. Defaults to ~1.5 GB;
+# tune to the ClickHouse host's available RAM.
+# CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY=1500000000
+# CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_SORT=1500000000
+
+# Lookback window (in days) for the Rule Insights dashboard aggregations. These
+# queries scan ACTION_EXECUTIONS, so a smaller window scans less data and uses
+# less memory. Defaults to 90 days; lower it on memory-constrained instances.
+# CLICKHOUSE_RULE_INSIGHTS_LOOKBACK_DAYS=90
+
 HMA_SERVICE_URL=http://localhost:9876
 
 # Scylla Cluster Details

--- a/server/graphql/datasources/RuleApi.ts
+++ b/server/graphql/datasources/RuleApi.ts
@@ -6,6 +6,7 @@ import { type Kysely } from 'kysely';
 import { uid } from 'uid';
 
 import { inject, type Dependencies } from '../../iocContainer/index.js';
+import { safeGetEnvInt } from '../../iocContainer/utils.js';
 import { type ActionCountsInput } from '../../services/actionStatisticsService/index.js';
 import { type AggregationClause } from '../../services/aggregationsService/index.js';
 import { type ConditionSetWithResultAsLogged } from '../../services/analyticsLoggers/index.js';
@@ -43,8 +44,10 @@ import {
   makeKyselyTransactionWithRetry,
   type KyselyTransactionWithRetry,
 } from '../../utils/kyselyTransactionWithRetry.js';
+import { logErrorJson } from '../../utils/logging.js';
 import { assertUnreachable } from '../../utils/misc.js';
 import { takeLast } from '../../utils/sql.js';
+import { DAY_MS } from '../../utils/time.js';
 import {
   type NonEmptyString,
   type RequiredWithoutNull,
@@ -603,28 +606,55 @@ class RuleAPI {
   }
 
   async getAllRuleInsights(orgId: string) {
-    const results = await Promise.allSettled([
-      this.actionStats.getActionedSubmissionCountsByDay(orgId),
-      this.actionStats.getActionedSubmissionCountsByPolicyByDay(orgId),
-      this.actionStats.getActionedSubmissionCountsByTagByDay(orgId),
-      this.actionStats.getActionedSubmissionCountsByActionByDay(orgId),
-      this.ruleInsights.getContentSubmissionCountsByDay(orgId),
-    ]);
+    // Each of these scans ACTION_EXECUTIONS over the lookback window. Run them
+    // sequentially so peak ClickHouse memory is one query's worth rather than
+    // all five at once, and bound the window (env-tunable, default 90 days) so
+    // a memory-constrained instance scans far less than a full year. The client
+    // filters further client-side and defaults to a one-week view.
+    const lookbackDays = safeGetEnvInt(
+      'CLICKHOUSE_RULE_INSIGHTS_LOOKBACK_DAYS',
+      90,
+    );
+    const startAt = new Date(Date.now() - lookbackDays * DAY_MS);
 
-    const valueOrEmpty = <T>(
-      r: PromiseSettledResult<readonly T[]>,
-    ): readonly T[] => (r.status === 'fulfilled' ? r.value : []);
+    const runSafely = async <T>(
+      fn: () => Promise<readonly T[]>,
+    ): Promise<readonly T[]> => {
+      try {
+        return await fn();
+      } catch (err) {
+        // eslint-disable-next-line no-restricted-syntax
+        logErrorJson({ message: 'rule insights query failed', error: err });
+        return [];
+      }
+    };
+
+    const actionedSubmissionsByDay = await runSafely(async () =>
+      this.actionStats.getActionedSubmissionCountsByDay(orgId, startAt),
+    );
+    const actionedSubmissionsByPolicyByDay = await runSafely(async () =>
+      this.actionStats.getActionedSubmissionCountsByPolicyByDay(orgId, startAt),
+    );
+    const actionedSubmissionsByTagByDay = await runSafely(async () =>
+      this.actionStats.getActionedSubmissionCountsByTagByDay(orgId, startAt),
+    );
+    const actionedSubmissionsByActionByDay = await runSafely(async () =>
+      this.actionStats.getActionedSubmissionCountsByActionByDay(orgId, startAt),
+    );
+    const totalSubmissionsByDay = await runSafely(
+      async () =>
+        this.ruleInsights.getContentSubmissionCountsByDay(
+          orgId,
+          startAt,
+        ) as Promise<readonly { date: string; count: number }[]>,
+    );
 
     return {
-      actionedSubmissionsByDay: valueOrEmpty(results[0]),
-      actionedSubmissionsByPolicyByDay: valueOrEmpty(results[1]),
-      actionedSubmissionsByTagByDay: valueOrEmpty(results[2]),
-      actionedSubmissionsByActionByDay: valueOrEmpty(results[3]),
-      totalSubmissionsByDay: valueOrEmpty(
-        results[4] as PromiseSettledResult<
-          readonly { date: string; count: number }[]
-        >,
-      ),
+      actionedSubmissionsByDay,
+      actionedSubmissionsByPolicyByDay,
+      actionedSubmissionsByTagByDay,
+      actionedSubmissionsByActionByDay,
+      totalSubmissionsByDay,
     };
   }
 

--- a/server/graphql/generated.ts
+++ b/server/graphql/generated.ts
@@ -844,6 +844,11 @@ export type GQLCreateManualReviewJobCommentInput = {
 
 export type GQLCreateManualReviewQueueInput = {
   readonly autoCloseJobs: Scalars['Boolean']['input'];
+  readonly clearReportsDisposition?: InputMaybe<GQLMrtClearReportsDisposition>;
+  readonly clearReportsScope?: InputMaybe<GQLMrtClearReportsScope>;
+  readonly clearReportsTriggerActionIds?: InputMaybe<
+    ReadonlyArray<Scalars['ID']['input']>
+  >;
   readonly description?: InputMaybe<Scalars['String']['input']>;
   readonly hiddenActionIds: ReadonlyArray<Scalars['ID']['input']>;
   readonly isAppealsQueue: Scalars['Boolean']['input'];
@@ -2269,6 +2274,9 @@ export type GQLManualReviewJobWithDecisions = {
 export type GQLManualReviewQueue = {
   readonly __typename?: 'ManualReviewQueue';
   readonly autoCloseJobs: Scalars['Boolean']['output'];
+  readonly clearReportsDisposition?: Maybe<GQLMrtClearReportsDisposition>;
+  readonly clearReportsScope: GQLMrtClearReportsScope;
+  readonly clearReportsTriggerActionIds: ReadonlyArray<Scalars['ID']['output']>;
   readonly description?: Maybe<Scalars['String']['output']>;
   readonly explicitlyAssignedReviewers: ReadonlyArray<GQLUser>;
   readonly hiddenActionIds: ReadonlyArray<Scalars['ID']['output']>;
@@ -2390,6 +2398,21 @@ export type GQLModeratorSafetySettingsInput = {
   readonly moderatorSafetyMuteVideo: Scalars['Boolean']['input'];
 };
 
+export const GQLMrtClearReportsDisposition = {
+  AutomaticClose: 'AUTOMATIC_CLOSE',
+  Ignore: 'IGNORE',
+  SameAction: 'SAME_ACTION',
+} as const;
+
+export type GQLMrtClearReportsDisposition =
+  (typeof GQLMrtClearReportsDisposition)[keyof typeof GQLMrtClearReportsDisposition];
+export const GQLMrtClearReportsScope = {
+  AllQueues: 'ALL_QUEUES',
+  CurrentQueue: 'CURRENT_QUEUE',
+} as const;
+
+export type GQLMrtClearReportsScope =
+  (typeof GQLMrtClearReportsScope)[keyof typeof GQLMrtClearReportsScope];
 export type GQLMrtJobEnqueueSourceInfo = {
   readonly __typename?: 'MrtJobEnqueueSourceInfo';
   readonly kind: GQLJobCreationSourceOptions;
@@ -4824,6 +4847,11 @@ export type GQLUpdateManualReviewQueueInput = {
   readonly actionIdsToHide: ReadonlyArray<Scalars['ID']['input']>;
   readonly actionIdsToUnhide: ReadonlyArray<Scalars['ID']['input']>;
   readonly autoCloseJobs: Scalars['Boolean']['input'];
+  readonly clearReportsDisposition?: InputMaybe<GQLMrtClearReportsDisposition>;
+  readonly clearReportsScope?: InputMaybe<GQLMrtClearReportsScope>;
+  readonly clearReportsTriggerActionIds?: InputMaybe<
+    ReadonlyArray<Scalars['ID']['input']>
+  >;
   readonly description?: InputMaybe<Scalars['String']['input']>;
   readonly id: Scalars['ID']['input'];
   readonly name?: InputMaybe<Scalars['String']['input']>;
@@ -6121,6 +6149,8 @@ export type GQLResolversTypes = {
   ModelCardSection: ResolverTypeWrapper<GQLModelCardSection>;
   ModelCardSubsection: ResolverTypeWrapper<GQLModelCardSubsection>;
   ModeratorSafetySettingsInput: GQLModeratorSafetySettingsInput;
+  MrtClearReportsDisposition: GQLMrtClearReportsDisposition;
+  MrtClearReportsScope: GQLMrtClearReportsScope;
   MrtJobEnqueueSourceInfo: ResolverTypeWrapper<GQLMrtJobEnqueueSourceInfo>;
   MutateAccessibleQueuesForUserSuccessResponse: ResolverTypeWrapper<GQLMutateAccessibleQueuesForUserSuccessResponse>;
   MutateActionError: GQLMutateActionError;
@@ -10327,6 +10357,21 @@ export type GQLManualReviewQueueResolvers<
 > = {
   autoCloseJobs?: Resolver<
     GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >;
+  clearReportsDisposition?: Resolver<
+    Maybe<GQLResolversTypes['MrtClearReportsDisposition']>,
+    ParentType,
+    ContextType
+  >;
+  clearReportsScope?: Resolver<
+    GQLResolversTypes['MrtClearReportsScope'],
+    ParentType,
+    ContextType
+  >;
+  clearReportsTriggerActionIds?: Resolver<
+    ReadonlyArray<GQLResolversTypes['ID']>,
     ParentType,
     ContextType
   >;

--- a/server/graphql/modules/insights.ts
+++ b/server/graphql/modules/insights.ts
@@ -313,7 +313,7 @@ const Query: GQLQueryResolvers = {
         user.orgId,
       );
     const bucketedStrikeCounts = lodash.countBy(
-      allUserStrikeCounts,
+      allUserStrikeCounts.filter((it) => it.strike_count > 0),
       (it) => it.strike_count,
     );
     return Object.entries(bucketedStrikeCounts).map((bucket) => ({

--- a/server/graphql/modules/manualReviewTool.ts
+++ b/server/graphql/modules/manualReviewTool.ts
@@ -42,6 +42,17 @@ import { oneOfInputToTaggedUnion } from '../utils/inputHelpers.js';
 const { omit, sumBy } = _;
 
 const typeDefs = /* GraphQL */ `
+  enum MrtClearReportsDisposition {
+    AUTOMATIC_CLOSE
+    IGNORE
+    SAME_ACTION
+  }
+
+  enum MrtClearReportsScope {
+    CURRENT_QUEUE
+    ALL_QUEUES
+  }
+
   type ManualReviewQueue {
     id: ID!
     name: String!
@@ -55,6 +66,9 @@ const typeDefs = /* GraphQL */ `
     hiddenActionIds: [ID!]!
     isAppealsQueue: Boolean!
     autoCloseJobs: Boolean!
+    clearReportsDisposition: MrtClearReportsDisposition
+    clearReportsScope: MrtClearReportsScope!
+    clearReportsTriggerActionIds: [ID!]!
   }
 
   type ManualReviewJob {
@@ -401,6 +415,9 @@ const typeDefs = /* GraphQL */ `
     hiddenActionIds: [ID!]!
     isAppealsQueue: Boolean!
     autoCloseJobs: Boolean!
+    clearReportsDisposition: MrtClearReportsDisposition
+    clearReportsScope: MrtClearReportsScope
+    clearReportsTriggerActionIds: [ID!]
   }
 
   input UpdateManualReviewQueueInput {
@@ -411,6 +428,9 @@ const typeDefs = /* GraphQL */ `
     actionIdsToHide: [ID!]!
     actionIdsToUnhide: [ID!]!
     autoCloseJobs: Boolean!
+    clearReportsDisposition: MrtClearReportsDisposition
+    clearReportsScope: MrtClearReportsScope
+    clearReportsTriggerActionIds: [ID!]
   }
 
   input AddAccessibleQueuesToUserInput {
@@ -1756,6 +1776,18 @@ const ManualReviewQueue: GQLManualReviewQueueResolvers = {
       queueId,
     });
   },
+  async clearReportsTriggerActionIds(queue, _, context) {
+    const user = context.getUser();
+    if (user == null) {
+      throw unauthenticatedError('User required.');
+    }
+    return context.services.ManualReviewToolService.getClearReportsTriggerActionsForQueue(
+      {
+        orgId: user.orgId,
+        queueId: queue.id,
+      },
+    );
+  },
 };
 
 const ManualReviewJobComment: GQLManualReviewJobCommentResolvers = {
@@ -2317,6 +2349,9 @@ const Mutation: GQLMutationResolvers = {
       hiddenActionIds,
       isAppealsQueue,
       autoCloseJobs,
+      clearReportsDisposition,
+      clearReportsScope,
+      clearReportsTriggerActionIds,
     } = params.input;
     try {
       const queue =
@@ -2327,6 +2362,10 @@ const Mutation: GQLMutationResolvers = {
           hiddenActionIds,
           isAppealsQueue,
           autoCloseJobs,
+          clearReportsDisposition,
+          clearReportsScope: clearReportsScope ?? undefined,
+          clearReportsTriggerActionIds:
+            clearReportsTriggerActionIds ?? undefined,
           invokedBy: {
             userId: user.id,
             permissions: user.getPermissions(),
@@ -2364,6 +2403,9 @@ const Mutation: GQLMutationResolvers = {
       actionIdsToHide,
       actionIdsToUnhide,
       autoCloseJobs,
+      clearReportsDisposition,
+      clearReportsScope,
+      clearReportsTriggerActionIds,
     } = params.input;
     try {
       const queue =
@@ -2378,6 +2420,10 @@ const Mutation: GQLMutationResolvers = {
           actionIdsToHide,
           actionIdsToUnhide,
           autoCloseJobs,
+          clearReportsDisposition,
+          clearReportsScope: clearReportsScope ?? undefined,
+          clearReportsTriggerActionIds:
+            clearReportsTriggerActionIds ?? undefined,
         });
       return gqlSuccessResult(
         { data: queue },

--- a/server/iocContainer/index.ts
+++ b/server/iocContainer/index.ts
@@ -113,6 +113,7 @@ import {
   type NormalizedItemData,
 } from '../services/itemProcessingService/index.js';
 import {
+  isReportJob,
   ManualReviewToolService,
   type ManualReviewAppealJobInput,
   type ManualReviewJobInput,
@@ -924,9 +925,11 @@ export default async function getBottle() {
         decisionComponents,
         relatedActions,
         job,
+        queueId,
         reviewerId,
         reviewerEmail,
         decisionReason,
+        suppressUserReportSweep,
       }) {
         const { orgId } = job;
         const { itemId, itemTypeIdentifier, data } = job.payload.item;
@@ -1397,6 +1400,39 @@ export default async function getBottle() {
             }
           }),
         );
+
+        // Clear all other reports for this user. Skipped for
+        // sweep-applied dispositions (so SAME_ACTION can't recurse) and appeals.
+        if (!suppressUserReportSweep && isReportJob(job)) {
+          const reportJob = job;
+          const customActions = decisionComponents.flatMap((decision) =>
+            decision.type === 'CUSTOM_ACTION' ? [decision] : [],
+          );
+          if (customActions.length > 0) {
+            container.ManualReviewToolService.maybeClearOtherReportsForUser({
+              orgId,
+              actionedJob: reportJob,
+              actionedQueueId: queueId,
+              customActions,
+              reviewerId,
+              reviewerEmail,
+              decisionReason,
+            }).catch((error) => {
+              container.Tracer.addSpan(
+                {
+                  resource: 'mrtService',
+                  operation: 'clearOtherReportsForUser',
+                },
+                (span) => {
+                  span.setAttribute('job.id', reportJob.id);
+                  span.setAttribute('org.id', orgId);
+                  container.Tracer.logSpanFailed(span, error);
+                  return null;
+                },
+              );
+            });
+          }
+        }
       },
       async function onEnqueue(
         _input: ManualReviewJobInput | ManualReviewAppealJobInput,

--- a/server/iocContainer/index.ts
+++ b/server/iocContainer/index.ts
@@ -1046,391 +1046,398 @@ export default async function getBottle() {
           id: uuidv1(),
         });
 
-        await Promise.all(
-          // eslint-disable-next-line complexity
-          decisionComponents.map(async (decision) => {
-            switch (decision.type) {
-              // Don't need to do anything if the job is automatically closed
-              case 'AUTOMATIC_CLOSE':
-                break;
-              case 'IGNORE':
-                const ignoreCallback =
-                  await container.getIgnoreCallbackEventuallyConsistent(orgId);
-                if (ignoreCallback === undefined) {
+        try {
+          await Promise.all(
+            // eslint-disable-next-line complexity
+            decisionComponents.map(async (decision) => {
+              switch (decision.type) {
+                // Don't need to do anything if the job is automatically closed
+                case 'AUTOMATIC_CLOSE':
                   break;
-                }
-                const ignoreCallbackBody = {
-                  id: job.payload.item.itemId,
-                  typeId: job.payload.item.itemTypeIdentifier.id,
-                  data: job.payload.item.data,
-                  ...(job.payload.kind === 'NCMEC'
-                    ? {
-                        ncmecMedia: job.payload.allMediaItems.map((it) => ({
-                          id: it.contentItem.itemId,
-                          typeId: it.contentItem.itemTypeIdentifier,
-                        })),
-                      }
-                    : {}),
-                };
-
-                await container.fetchHTTP({
-                  url: ignoreCallback,
-                  method: 'post',
-                  body: jsonStringify(ignoreCallbackBody),
-                  logRequestAndResponseBody: 'ON_FAILURE',
-                  headers: {
-                    'Content-Type': 'application/json',
-                  },
-                  handleResponseBody: 'discard',
-                  signWith: container.SigningKeyPairService.sign.bind(
-                    container.SigningKeyPairService,
-                    orgId,
-                  ),
-                });
-                break;
-              // The difference in payload between reject/accept appeal
-              // is handled in the action publisher, so these cases have
-              // the same logic
-              case 'REJECT_APPEAL':
-              case 'ACCEPT_APPEAL':
-                const appealedItemType =
-                  await container.getItemTypeEventuallyConsistent({
-                    orgId,
-                    typeSelector: job.payload.item.itemTypeIdentifier,
-                  });
-                if (!appealedItemType) {
-                  throw new Error('Item Type does not exist');
-                }
-
-                const orgAppealSettings =
-                  await container.OrgSettingsService.getAppealSettings(orgId);
-
-                if (!orgAppealSettings.appealCallbackUrl) {
-                  throw Error(`No Appeal Callback URL set for org ${orgId}`);
-                }
-                const appealCustomBodyParams =
-                  orgAppealSettings.appealCallbackBody;
-                const appealHeaders = orgAppealSettings.appealCallbackHeaders;
-
-                const appealCallbackBody = {
-                  appealId: decision.appealId,
-                  appealedBy: {
-                    id:
-                      'appealerIdentifier' in job.payload
-                        ? job.payload.appealerIdentifier?.id
-                        : undefined,
-
-                    typeId:
-                      'appealerIdentifier' in job.payload
-                        ? job.payload.appealerIdentifier?.typeId
-                        : undefined,
-                  },
-                  appealDecision:
-                    decision.type === 'ACCEPT_APPEAL' ? 'ACCEPT' : 'REJECT',
-                  item: {
+                case 'IGNORE':
+                  const ignoreCallback =
+                    await container.getIgnoreCallbackEventuallyConsistent(
+                      orgId,
+                    );
+                  if (ignoreCallback === undefined) {
+                    break;
+                  }
+                  const ignoreCallbackBody = {
                     id: job.payload.item.itemId,
                     typeId: job.payload.item.itemTypeIdentifier.id,
-                  },
-                  ...(appealCustomBodyParams
-                    ? { custom: appealCustomBodyParams }
-                    : {}),
-                };
-
-                const appealResponse = await container.fetchHTTP({
-                  url: orgAppealSettings.appealCallbackUrl,
-                  method: 'post',
-                  body: jsonStringify(appealCallbackBody),
-                  logRequestAndResponseBody: 'ON_FAILURE',
-                  headers: {
-                    // TODO: We should make sure that there's no value a user
-                    // could provide that would have security implications when blindly fed
-                    // in here -- like something that would somehow lead fetch to do something
-                    // unexpected.
-
-                    ...((appealHeaders as JsonObject | undefined) ?? undefined),
-                    // Put this header last so customHeaders can't override it, which I
-                    // think makes sense, since there's no way for users to effect the
-                    // body in a way that would change the content type.
-                    'Content-Type': 'application/json',
-                  },
-                  handleResponseBody: 'discard',
-                  signWith: container.SigningKeyPairService.sign.bind(
-                    container.SigningKeyPairService,
-                    orgId,
-                  ),
-                });
-
-                if (!appealResponse.ok) {
-                  throw Error(`User's server returned non-success status`);
-                }
-                break;
-
-              case 'CUSTOM_ACTION':
-                const actions = decision.actions.map((action) => {
-                  const actionPayload = {
-                    actionId: action.id,
-                    ...(decision.actionIdsToMrtApiParamDecisionPayload !==
-                    undefined
+                    data: job.payload.item.data,
+                    ...(job.payload.kind === 'NCMEC'
                       ? {
-                          customMrtApiParamDecisionPayload: decision
-                            .actionIdsToMrtApiParamDecisionPayload[
-                            action.id
-                          ] as Record<string, string | boolean | unknown>,
+                          ncmecMedia: job.payload.allMediaItems.map((it) => ({
+                            id: it.contentItem.itemId,
+                            typeId: it.contentItem.itemTypeIdentifier,
+                          })),
                         }
                       : {}),
                   };
-                  // By default reportedForReasons as well as decision reason to the
-                  // custom action callback payload whether or not there is an
-                  // existing custom payload
-                  if (job.payload.kind === 'DEFAULT') {
-                    // TODO: this is unholy we have got to remove this as soon
-                    // as possible, specifically when the new report decision
-                    // API is in place
-                    const additionalPayload = job.payload.reportedForReasons
-                      ? {
-                          reportHistory: job.payload.reportedForReasons.map(
-                            (it) => ({
-                              reason: it.reason,
-                              reporter: it.reporterId,
-                            }),
-                          ),
-                          reason: decisionReason,
-                        }
-                      : { reason: decisionReason };
-                    actionPayload.customMrtApiParamDecisionPayload = {
-                      ...actionPayload.customMrtApiParamDecisionPayload,
-                      ...(additionalPayload.reportHistory
-                        ? additionalPayload
+
+                  await container.fetchHTTP({
+                    url: ignoreCallback,
+                    method: 'post',
+                    body: jsonStringify(ignoreCallbackBody),
+                    logRequestAndResponseBody: 'ON_FAILURE',
+                    headers: {
+                      'Content-Type': 'application/json',
+                    },
+                    handleResponseBody: 'discard',
+                    signWith: container.SigningKeyPairService.sign.bind(
+                      container.SigningKeyPairService,
+                      orgId,
+                    ),
+                  });
+                  break;
+                // The difference in payload between reject/accept appeal
+                // is handled in the action publisher, so these cases have
+                // the same logic
+                case 'REJECT_APPEAL':
+                case 'ACCEPT_APPEAL':
+                  const appealedItemType =
+                    await container.getItemTypeEventuallyConsistent({
+                      orgId,
+                      typeSelector: job.payload.item.itemTypeIdentifier,
+                    });
+                  if (!appealedItemType) {
+                    throw new Error('Item Type does not exist');
+                  }
+
+                  const orgAppealSettings =
+                    await container.OrgSettingsService.getAppealSettings(orgId);
+
+                  if (!orgAppealSettings.appealCallbackUrl) {
+                    throw Error(`No Appeal Callback URL set for org ${orgId}`);
+                  }
+                  const appealCustomBodyParams =
+                    orgAppealSettings.appealCallbackBody;
+                  const appealHeaders = orgAppealSettings.appealCallbackHeaders;
+
+                  const appealCallbackBody = {
+                    appealId: decision.appealId,
+                    appealedBy: {
+                      id:
+                        'appealerIdentifier' in job.payload
+                          ? job.payload.appealerIdentifier?.id
+                          : undefined,
+
+                      typeId:
+                        'appealerIdentifier' in job.payload
+                          ? job.payload.appealerIdentifier?.typeId
+                          : undefined,
+                    },
+                    appealDecision:
+                      decision.type === 'ACCEPT_APPEAL' ? 'ACCEPT' : 'REJECT',
+                    item: {
+                      id: job.payload.item.itemId,
+                      typeId: job.payload.item.itemTypeIdentifier.id,
+                    },
+                    ...(appealCustomBodyParams
+                      ? { custom: appealCustomBodyParams }
+                      : {}),
+                  };
+
+                  const appealResponse = await container.fetchHTTP({
+                    url: orgAppealSettings.appealCallbackUrl,
+                    method: 'post',
+                    body: jsonStringify(appealCallbackBody),
+                    logRequestAndResponseBody: 'ON_FAILURE',
+                    headers: {
+                      // TODO: We should make sure that there's no value a user
+                      // could provide that would have security implications when blindly fed
+                      // in here -- like something that would somehow lead fetch to do something
+                      // unexpected.
+
+                      ...((appealHeaders as JsonObject | undefined) ??
+                        undefined),
+                      // Put this header last so customHeaders can't override it, which I
+                      // think makes sense, since there's no way for users to effect the
+                      // body in a way that would change the content type.
+                      'Content-Type': 'application/json',
+                    },
+                    handleResponseBody: 'discard',
+                    signWith: container.SigningKeyPairService.sign.bind(
+                      container.SigningKeyPairService,
+                      orgId,
+                    ),
+                  });
+
+                  if (!appealResponse.ok) {
+                    throw Error(`User's server returned non-success status`);
+                  }
+                  break;
+
+                case 'CUSTOM_ACTION':
+                  const actions = decision.actions.map((action) => {
+                    const actionPayload = {
+                      actionId: action.id,
+                      ...(decision.actionIdsToMrtApiParamDecisionPayload !==
+                      undefined
+                        ? {
+                            customMrtApiParamDecisionPayload: decision
+                              .actionIdsToMrtApiParamDecisionPayload[
+                              action.id
+                            ] as Record<string, string | boolean | unknown>,
+                          }
                         : {}),
                     };
-                  }
-                  return actionPayload;
-                });
-                // TODO: make this illegal at the time the decision is submitted.
-                if (!isNonEmptyArray(actions)) {
-                  throw new Error(
-                    'Attempting to take a user action without any actions',
-                  );
-                }
-                await publishActions({
-                  decisionActions: actions,
-                  policyIds: decision.policies.map((policy) => policy.id),
-                  orgId,
-                  item: job.payload.item,
-                  actorId: reviewerId,
-                  actorEmail: reviewerEmail,
-                  decisionReason,
-                });
-                break;
-              case 'SUBMIT_NCMEC_REPORT': {
-                if (job.payload.kind !== 'NCMEC') {
-                  throw new Error(
-                    'Attempting to submit a NCMEC report for a non-NCMEC job',
-                  );
-                }
-                const itemType =
-                  await container.getItemTypeEventuallyConsistent({
-                    orgId,
-                    typeSelector: itemTypeIdentifier,
+                    // By default reportedForReasons as well as decision reason to the
+                    // custom action callback payload whether or not there is an
+                    // existing custom payload
+                    if (job.payload.kind === 'DEFAULT') {
+                      // TODO: this is unholy we have got to remove this as soon
+                      // as possible, specifically when the new report decision
+                      // API is in place
+                      const additionalPayload = job.payload.reportedForReasons
+                        ? {
+                            reportHistory: job.payload.reportedForReasons.map(
+                              (it) => ({
+                                reason: it.reason,
+                                reporter: it.reporterId,
+                              }),
+                            ),
+                            reason: decisionReason,
+                          }
+                        : { reason: decisionReason };
+                      actionPayload.customMrtApiParamDecisionPayload = {
+                        ...actionPayload.customMrtApiParamDecisionPayload,
+                        ...(additionalPayload.reportHistory
+                          ? additionalPayload
+                          : {}),
+                      };
+                    }
+                    return actionPayload;
                   });
-                if (itemType === undefined || itemType.kind !== 'USER') {
-                  throw new Error('Item Type for User does not exist');
-                }
-                const reportParams = await buildSubmitReportParamsFromDecision({
-                  orgId,
-                  reviewerId,
-                  reportedItemId: itemId,
-                  reportedItemTypeId: itemTypeIdentifier.id,
-                  reportedUserItemType: itemType,
-                  reportedUserData: data,
-                  allMediaItems: job.payload.allMediaItems,
-                  decisionComponent: decision,
-                  jobId: job.id,
-                  getItemTypeEventuallyConsistent:
-                    container.getItemTypeEventuallyConsistent,
-                });
-                // Submissions go to the NCMEC test endpoint
-                // (exttest.cybertip.org) unless the deployment is explicitly
-                // configured for production via NCMEC_ENV=production. Operators
-                // are responsible for matching this to whether the credentials
-                // configured in Settings → NCMEC are production or test
-                // credentials issued by NCMEC.
-                const isTest = process.env.NCMEC_ENV !== 'production';
-                await container.NcmecService.submitReport(reportParams, isTest);
-                const actionAndPolicy =
-                  await container.NcmecService.getNCMECActionsToRunAndPolicies(
-                    orgId,
-                  );
-                const decisionActions = actionAndPolicy?.actionsToRunIds
-                  ? actionAndPolicy.actionsToRunIds.map((a) => ({
-                      actionId: a,
-                    }))
-                  : [];
-                if (
-                  actionAndPolicy != null &&
-                  actionAndPolicy.actionsToRunIds != null &&
-                  isNonEmptyArray(decisionActions) &&
-                  !isTest
-                ) {
+                  // TODO: make this illegal at the time the decision is submitted.
+                  if (!isNonEmptyArray(actions)) {
+                    throw new Error(
+                      'Attempting to take a user action without any actions',
+                    );
+                  }
                   await publishActions({
-                    decisionActions,
-                    policyIds: actionAndPolicy.policyIds,
+                    decisionActions: actions,
+                    policyIds: decision.policies.map((policy) => policy.id),
                     orgId,
                     item: job.payload.item,
                     actorId: reviewerId,
                     actorEmail: reviewerEmail,
+                    decisionReason,
                   });
-                }
-                break;
-              }
-              case 'TRANSFORM_JOB_AND_RECREATE_IN_QUEUE': {
-                const reportHistory =
-                  'reportHistory' in job.payload
-                    ? job.payload.reportHistory
+                  break;
+                case 'SUBMIT_NCMEC_REPORT': {
+                  if (job.payload.kind !== 'NCMEC') {
+                    throw new Error(
+                      'Attempting to submit a NCMEC report for a non-NCMEC job',
+                    );
+                  }
+                  const itemType =
+                    await container.getItemTypeEventuallyConsistent({
+                      orgId,
+                      typeSelector: itemTypeIdentifier,
+                    });
+                  if (itemType === undefined || itemType.kind !== 'USER') {
+                    throw new Error('Item Type for User does not exist');
+                  }
+                  const reportParams =
+                    await buildSubmitReportParamsFromDecision({
+                      orgId,
+                      reviewerId,
+                      reportedItemId: itemId,
+                      reportedItemTypeId: itemTypeIdentifier.id,
+                      reportedUserItemType: itemType,
+                      reportedUserData: data,
+                      allMediaItems: job.payload.allMediaItems,
+                      decisionComponent: decision,
+                      jobId: job.id,
+                      getItemTypeEventuallyConsistent:
+                        container.getItemTypeEventuallyConsistent,
+                    });
+                  // Submissions go to the NCMEC test endpoint
+                  // (exttest.cybertip.org) unless the deployment is explicitly
+                  // configured for production via NCMEC_ENV=production. Operators
+                  // are responsible for matching this to whether the credentials
+                  // configured in Settings → NCMEC are production or test
+                  // credentials issued by NCMEC.
+                  const isTest = process.env.NCMEC_ENV !== 'production';
+                  await container.NcmecService.submitReport(
+                    reportParams,
+                    isTest,
+                  );
+                  const actionAndPolicy =
+                    await container.NcmecService.getNCMECActionsToRunAndPolicies(
+                      orgId,
+                    );
+                  const decisionActions = actionAndPolicy?.actionsToRunIds
+                    ? actionAndPolicy.actionsToRunIds.map((a) => ({
+                        actionId: a,
+                      }))
                     : [];
-                const reportedForReasons =
-                  'reportedForReasons' in job.payload &&
-                  job.payload.reportedForReasons != null &&
-                  job.payload.reportedForReasons.length > 0
-                    ? job.payload.reportedForReasons
-                    : reportHistory.map((entry) => ({
-                        reporterId: entry.reporterId,
-                        reason: entry.reason,
-                      }));
-                const defaultJobInput = {
-                  enqueueSource: 'MRT_JOB',
-                  enqueueSourceInfo: { kind: 'MRT_JOB' },
-                  reenqueuedFrom: { jobId: job.id },
-                  payload: {
-                    kind: 'DEFAULT' as const,
-                    item: job.payload.item,
-                    ...{
-                      reportIds:
-                        'reportIds' in job.payload
-                          ? (job.payload.reportIds ?? [])
-                          : [],
-                    },
-                    ...('reportedForReason' in job.payload
-                      ? { reportedForReason: job.payload.reportedForReason }
-                      : {}),
-                    ...('reporterIdentifier' in job.payload
-                      ? {
-                          reporterIdentifier: job.payload.reporterIdentifier,
-                        }
-                      : {}),
-                    reportedForReasons,
-                    reportHistory,
-                  },
-                  createdAt: new Date(),
-                  orgId,
-                  correlationId,
-                  policyIds: job.policyIds,
-                } as const;
-                switch (decision.newJobKind) {
-                  case 'DEFAULT':
-                    await container.ManualReviewToolService.enqueue(
-                      defaultJobInput,
-
-                      decision.newQueueId ?? undefined,
-                    );
-                    break;
-                  case 'NCMEC':
-                    // TODO: the NCMEC service is currently in charge of NCMEC job
-                    // enrichment, but once we replace the NCMEC warehouse job with
-                    // Scylla we should move it back into the MRT service
-                    await container.NcmecService.enqueueForHumanReviewIfApplicable(
-                      {
-                        orgId,
-                        createdAt: new Date(),
-                        enqueueSource: 'MRT_JOB',
-                        enqueueSourceInfo: { kind: 'MRT_JOB' },
-                        correlationId,
-                        item: job.payload.item,
-                        reenqueuedFrom: { jobId: job.id },
-                      },
-                    );
-                    break;
-                  default:
-                    assertUnreachable(decision.newJobKind);
+                  if (
+                    actionAndPolicy != null &&
+                    actionAndPolicy.actionsToRunIds != null &&
+                    isNonEmptyArray(decisionActions) &&
+                    !isTest
+                  ) {
+                    await publishActions({
+                      decisionActions,
+                      policyIds: actionAndPolicy.policyIds,
+                      orgId,
+                      item: job.payload.item,
+                      actorId: reviewerId,
+                      actorEmail: reviewerEmail,
+                    });
+                  }
+                  break;
                 }
-                break;
+                case 'TRANSFORM_JOB_AND_RECREATE_IN_QUEUE': {
+                  const reportHistory =
+                    'reportHistory' in job.payload
+                      ? job.payload.reportHistory
+                      : [];
+                  const reportedForReasons =
+                    'reportedForReasons' in job.payload &&
+                    job.payload.reportedForReasons != null &&
+                    job.payload.reportedForReasons.length > 0
+                      ? job.payload.reportedForReasons
+                      : reportHistory.map((entry) => ({
+                          reporterId: entry.reporterId,
+                          reason: entry.reason,
+                        }));
+                  const defaultJobInput = {
+                    enqueueSource: 'MRT_JOB',
+                    enqueueSourceInfo: { kind: 'MRT_JOB' },
+                    reenqueuedFrom: { jobId: job.id },
+                    payload: {
+                      kind: 'DEFAULT' as const,
+                      item: job.payload.item,
+                      ...{
+                        reportIds:
+                          'reportIds' in job.payload
+                            ? (job.payload.reportIds ?? [])
+                            : [],
+                      },
+                      ...('reportedForReason' in job.payload
+                        ? { reportedForReason: job.payload.reportedForReason }
+                        : {}),
+                      ...('reporterIdentifier' in job.payload
+                        ? {
+                            reporterIdentifier: job.payload.reporterIdentifier,
+                          }
+                        : {}),
+                      reportedForReasons,
+                      reportHistory,
+                    },
+                    createdAt: new Date(),
+                    orgId,
+                    correlationId,
+                    policyIds: job.policyIds,
+                  } as const;
+                  switch (decision.newJobKind) {
+                    case 'DEFAULT':
+                      await container.ManualReviewToolService.enqueue(
+                        defaultJobInput,
+
+                        decision.newQueueId ?? undefined,
+                      );
+                      break;
+                    case 'NCMEC':
+                      // TODO: the NCMEC service is currently in charge of NCMEC job
+                      // enrichment, but once we replace the NCMEC warehouse job with
+                      // Scylla we should move it back into the MRT service
+                      await container.NcmecService.enqueueForHumanReviewIfApplicable(
+                        {
+                          orgId,
+                          createdAt: new Date(),
+                          enqueueSource: 'MRT_JOB',
+                          enqueueSourceInfo: { kind: 'MRT_JOB' },
+                          correlationId,
+                          item: job.payload.item,
+                          reenqueuedFrom: { jobId: job.id },
+                        },
+                      );
+                      break;
+                    default:
+                      assertUnreachable(decision.newJobKind);
+                  }
+                  break;
+                }
+
+                default:
+                  assertUnreachable(decision);
+              }
+            }),
+          );
+
+          // Publish any related actions
+          const flattenedRelatedActions = relatedActions.flatMap((it) => {
+            return it.itemIds.map((itemId) => ({
+              ..._.omit(it, 'itemIds'),
+              itemId,
+            }));
+          });
+          await Promise.all(
+            flattenedRelatedActions.map(async (it) => {
+              const { actionIds, policyIds, itemId, itemTypeId } = it;
+              if (!isNonEmptyArray(actionIds)) {
+                return;
               }
 
-              default:
-                assertUnreachable(decision);
-            }
-          }),
-        );
-
-        // Publish any related actions
-        const flattenedRelatedActions = relatedActions.flatMap((it) => {
-          return it.itemIds.map((itemId) => ({
-            ..._.omit(it, 'itemIds'),
-            itemId,
-          }));
-        });
-        await Promise.all(
-          flattenedRelatedActions.map(async (it) => {
-            const { actionIds, policyIds, itemId, itemTypeId } = it;
-            if (!isNonEmptyArray(actionIds)) {
-              return;
-            }
-
-            const itemType = await container.getItemTypeEventuallyConsistent({
-              orgId,
-              typeSelector: { id: itemTypeId },
-            });
-
-            if (!itemType) {
-              return;
-            }
-            const decisionActions = actionIds.map((actionId) => ({
-              actionId,
-            }));
-
-            if (isNonEmptyArray(decisionActions)) {
-              await publishActions({
-                decisionActions,
-                policyIds,
+              const itemType = await container.getItemTypeEventuallyConsistent({
                 orgId,
-                item: { itemId, itemType },
-                actorId: reviewerId,
-                actorEmail: reviewerEmail,
+                typeSelector: { id: itemTypeId },
+              });
+
+              if (!itemType) {
+                return;
+              }
+              const decisionActions = actionIds.map((actionId) => ({
+                actionId,
+              }));
+
+              if (isNonEmptyArray(decisionActions)) {
+                await publishActions({
+                  decisionActions,
+                  policyIds,
+                  orgId,
+                  item: { itemId, itemType },
+                  actorId: reviewerId,
+                  actorEmail: reviewerEmail,
+                });
+              }
+            }),
+          );
+        } finally {
+          if (!suppressUserReportSweep && isReportJob(job)) {
+            const reportJob = job;
+            const customActions = decisionComponents.flatMap((decision) =>
+              decision.type === 'CUSTOM_ACTION' ? [decision] : [],
+            );
+            if (customActions.length > 0) {
+              container.ManualReviewToolService.maybeClearOtherReportsForUser({
+                orgId,
+                actionedJob: reportJob,
+                actionedQueueId: queueId,
+                customActions,
+                reviewerId,
+                reviewerEmail,
+                decisionReason,
+              }).catch((error) => {
+                container.Tracer.addSpan(
+                  {
+                    resource: 'mrtService',
+                    operation: 'clearOtherReportsForUser',
+                  },
+                  (span) => {
+                    span.setAttribute('job.id', reportJob.id);
+                    span.setAttribute('org.id', orgId);
+                    container.Tracer.logSpanFailed(span, error);
+                    return null;
+                  },
+                );
               });
             }
-          }),
-        );
-
-        // Clear all other reports for this user. Skipped for
-        // sweep-applied dispositions (so SAME_ACTION can't recurse) and appeals.
-        if (!suppressUserReportSweep && isReportJob(job)) {
-          const reportJob = job;
-          const customActions = decisionComponents.flatMap((decision) =>
-            decision.type === 'CUSTOM_ACTION' ? [decision] : [],
-          );
-          if (customActions.length > 0) {
-            container.ManualReviewToolService.maybeClearOtherReportsForUser({
-              orgId,
-              actionedJob: reportJob,
-              actionedQueueId: queueId,
-              customActions,
-              reviewerId,
-              reviewerEmail,
-              decisionReason,
-            }).catch((error) => {
-              container.Tracer.addSpan(
-                {
-                  resource: 'mrtService',
-                  operation: 'clearOtherReportsForUser',
-                },
-                (span) => {
-                  span.setAttribute('job.id', reportJob.id);
-                  span.setAttribute('org.id', orgId);
-                  container.Tracer.logSpanFailed(span, error);
-                  return null;
-                },
-              );
-            });
           }
         }
       },

--- a/server/plugins/analytics/adapters/ClickhouseAnalyticsAdapter.ts
+++ b/server/plugins/analytics/adapters/ClickhouseAnalyticsAdapter.ts
@@ -1,15 +1,16 @@
 import { createClient, type ClickHouseClient } from '@clickhouse/client';
 
-import type SafeTracer from '../../../utils/SafeTracer.js';
 import { jsonStringify, tryJsonParse } from '../../../utils/encoding.js';
 import { logErrorJson } from '../../../utils/logging.js';
+import type SafeTracer from '../../../utils/SafeTracer.js';
+import { getClickhouseMemorySettings } from '../../warehouse/utils/clickhouseSettings.js';
+import { formatClickhouseQuery } from '../../warehouse/utils/clickhouseSql.js';
 import type { IAnalyticsAdapter } from '../IAnalyticsAdapter.js';
 import {
   type AnalyticsEventInput,
   type AnalyticsQueryResult,
   type AnalyticsWriteOptions,
 } from '../types.js';
-import { formatClickhouseQuery } from '../../warehouse/utils/clickhouseSql.js';
 import {
   isTransientNetworkError,
   withClickhouseInsertRetries,
@@ -35,18 +36,9 @@ export class ClickhouseAnalyticsAdapter implements IAnalyticsAdapter {
     string,
     ReadonlySet<string>
   >([
-    [
-      'content_api_requests',
-      new Set(['item_type_schema_field_roles']),
-    ],
-    [
-      'item_model_scores_log',
-      new Set(['item_type_schema_field_roles']),
-    ],
-    [
-      'appeals',
-      new Set(['actioned_item_type_schema_field_roles']),
-    ],
+    ['content_api_requests', new Set(['item_type_schema_field_roles'])],
+    ['item_model_scores_log', new Set(['item_type_schema_field_roles'])],
+    ['appeals', new Set(['actioned_item_type_schema_field_roles'])],
     [
       'reporting_rule_executions',
       new Set(['result', 'item_type_schema_field_roles']),
@@ -61,18 +53,9 @@ export class ClickhouseAnalyticsAdapter implements IAnalyticsAdapter {
     string,
     ReadonlySet<string>
   >([
-    [
-      'action_executions',
-      new Set(['rules', 'policies', 'rule_tags']),
-    ],
-    [
-      'reporting_rule_executions',
-      new Set([]),
-    ],
-    [
-      'reports',
-      new Set([]),
-    ],
+    ['action_executions', new Set(['rules', 'policies', 'rule_tags'])],
+    ['reporting_rule_executions', new Set([])],
+    ['reports', new Set([])],
   ]);
 
   private static readonly DATE_TIME_FIELDS = new Set([
@@ -120,10 +103,19 @@ export class ClickhouseAnalyticsAdapter implements IAnalyticsAdapter {
       username: options.connection.username,
       ...(password ? { password } : {}),
       database: options.connection.database,
+      clickhouse_settings: {
+        ...getClickhouseMemorySettings(),
+      },
     });
 
     this.insertWithRetries = withClickhouseInsertRetries(
-      async ({ table, values }: { table: string; values: AnalyticsEventInput[] }) => {
+      async ({
+        table,
+        values,
+      }: {
+        table: string;
+        values: AnalyticsEventInput[];
+      }) => {
         await this.client.insert({ table, values, format: 'JSONEachRow' });
       },
     );
@@ -173,7 +165,7 @@ export class ClickhouseAnalyticsAdapter implements IAnalyticsAdapter {
         format: 'JSONEachRow',
       });
 
-      const rows = (await result.json());
+      const rows = await result.json();
       return rows as readonly T[];
     };
 
@@ -225,13 +217,19 @@ export class ClickhouseAnalyticsAdapter implements IAnalyticsAdapter {
       // rules, policies, rule_tags are String columns storing JSON
       const regularArrayFields = ['policy_names', 'policy_ids', 'tags'];
       const jsonStringFields = ['rules', 'policies', 'rule_tags'];
-      
-      if (regularArrayFields.includes(key) && (value === null || value === undefined)) {
+
+      if (
+        regularArrayFields.includes(key) &&
+        (value === null || value === undefined)
+      ) {
         normalized[key] = [];
         continue;
       }
-      
-      if (jsonStringFields.includes(key) && (value === null || value === undefined)) {
+
+      if (
+        jsonStringFields.includes(key) &&
+        (value === null || value === undefined)
+      ) {
         normalized[key] = '[]';
         continue;
       }
@@ -269,7 +267,10 @@ export class ClickhouseAnalyticsAdapter implements IAnalyticsAdapter {
           // Already a string, keep it
           continue;
         }
-        if (value !== null && (typeof value === 'object' || Array.isArray(value))) {
+        if (
+          value !== null &&
+          (typeof value === 'object' || Array.isArray(value))
+        ) {
           normalized[fieldKey] = jsonStringify(value);
         } else {
           normalized[fieldKey] = defaultValue;
@@ -350,8 +351,7 @@ export class ClickhouseAnalyticsAdapter implements IAnalyticsAdapter {
       return this.normalizeJsonArray(value);
     }
 
-    const dateKind =
-      ClickhouseAnalyticsAdapter.DATE_FIELD_KINDS.get(lowerKey);
+    const dateKind = ClickhouseAnalyticsAdapter.DATE_FIELD_KINDS.get(lowerKey);
     if (dateKind) {
       return this.normalizeDateField(value, dateKind);
     }
@@ -382,7 +382,7 @@ export class ClickhouseAnalyticsAdapter implements IAnalyticsAdapter {
     // For ClickHouse JSON columns with experimental object type enabled,
     // we should pass objects/arrays directly. The ClickHouse client will
     // handle serialization when using JSONEachRow format.
-    
+
     if (Array.isArray(value)) {
       if (stringifyFields.includes(key)) {
         return jsonStringify(value);
@@ -403,10 +403,7 @@ export class ClickhouseAnalyticsAdapter implements IAnalyticsAdapter {
     return value;
   }
 
-  private normalizeDateField(
-    value: unknown,
-    kind: DateFieldKind,
-  ): unknown {
+  private normalizeDateField(value: unknown, kind: DateFieldKind): unknown {
     if (value == null) {
       return value;
     }
@@ -451,9 +448,13 @@ export class ClickhouseAnalyticsAdapter implements IAnalyticsAdapter {
     return value;
   }
 
-  private parseAndFormatDate(value: string, column: string): string | undefined {
-    const kind =
-      ClickhouseAnalyticsAdapter.DATE_FIELD_KINDS.get(column.toLowerCase());
+  private parseAndFormatDate(
+    value: string,
+    column: string,
+  ): string | undefined {
+    const kind = ClickhouseAnalyticsAdapter.DATE_FIELD_KINDS.get(
+      column.toLowerCase(),
+    );
     if (!kind) {
       return undefined;
     }

--- a/server/plugins/warehouse/queries/ClickhouseActionStatisticsAdapter.ts
+++ b/server/plugins/warehouse/queries/ClickhouseActionStatisticsAdapter.ts
@@ -1,11 +1,11 @@
-import {
-  type ActionCountsInput,
-  type IActionStatisticsAdapter,
-  type ActionStatisticsTimeDivisionOptions,
-} from './IActionStatisticsAdapter.js';
 import type { IDataWarehouse } from '../../../storage/dataWarehouse/IDataWarehouse.js';
 import type SafeTracer from '../../../utils/SafeTracer.js';
 import { YEAR_MS } from '../../../utils/time.js';
+import {
+  type ActionCountsInput,
+  type ActionStatisticsTimeDivisionOptions,
+  type IActionStatisticsAdapter,
+} from './IActionStatisticsAdapter.js';
 
 type ActionedSubmissionCountRow = {
   ds: string;
@@ -48,9 +48,7 @@ type ActionCountRow = {
   date: string;
 };
 
-export class ClickhouseActionStatisticsAdapter
-  implements IActionStatisticsAdapter
-{
+export class ClickhouseActionStatisticsAdapter implements IActionStatisticsAdapter {
   constructor(
     private readonly dataWarehouse: IDataWarehouse,
     private readonly tracer: SafeTracer,
@@ -86,7 +84,7 @@ export class ClickhouseActionStatisticsAdapter
       `
         SELECT 
           ds,
-          uniqExact(item_submission_id) AS num_submissions
+          uniq(item_submission_id) AS num_submissions
         FROM analytics.ACTION_EXECUTIONS
         WHERE org_id = ?
           AND ds > ?
@@ -112,7 +110,7 @@ export class ClickhouseActionStatisticsAdapter
         SELECT 
           ds,
           arrayJoin(JSONExtractArrayRaw(rule_tags)) AS tag,
-          uniqExact(item_submission_id) AS count
+          uniq(item_submission_id) AS count
         FROM analytics.ACTION_EXECUTIONS
         WHERE org_id = ?
           AND ds > ?
@@ -141,7 +139,7 @@ export class ClickhouseActionStatisticsAdapter
           ds,
           JSONExtractString(policy_json, 'id') AS policy_id,
           JSONExtractString(policy_json, 'name') AS policy_name,
-          uniqExact(item_submission_id) AS num_submissions
+          uniq(item_submission_id) AS num_submissions
         FROM analytics.ACTION_EXECUTIONS
         ARRAY JOIN JSONExtractArrayRaw(policies) AS policy_json
         WHERE org_id = ?
@@ -444,12 +442,16 @@ export class ClickhouseActionStatisticsAdapter
     ];
 
     if (filterBy.actionIds.length > 0) {
-      filters.push(`action_id IN (${filterBy.actionIds.map(() => '?').join(', ')})`);
+      filters.push(
+        `action_id IN (${filterBy.actionIds.map(() => '?').join(', ')})`,
+      );
       params.push(...filterBy.actionIds);
     }
 
     if (filterBy.itemTypeIds.length > 0) {
-      filters.push(`item_type_id IN (${filterBy.itemTypeIds.map(() => '?').join(', ')})`);
+      filters.push(
+        `item_type_id IN (${filterBy.itemTypeIds.map(() => '?').join(', ')})`,
+      );
       params.push(...filterBy.itemTypeIds);
     }
 
@@ -466,7 +468,8 @@ export class ClickhouseActionStatisticsAdapter
         ? `multiIf(action_source IN ('post-items','post-content'), 'automated-rule', action_source) AS action_source`
         : `${groupBy} AS ${groupBy.toLowerCase()}`;
 
-    const groupByColumn = groupBy === 'ACTION_SOURCE' ? 'action_source' : groupBy;
+    const groupByColumn =
+      groupBy === 'ACTION_SOURCE' ? 'action_source' : groupBy;
 
     const rows = await this.query<GroupByResultRow>(
       `
@@ -479,11 +482,7 @@ export class ClickhouseActionStatisticsAdapter
         GROUP BY ${groupByColumn}, time
         ORDER BY time
       `,
-      [
-        this.toTimeDivisionValue(timeDivision),
-        timeZone,
-        ...params,
-      ],
+      [this.toTimeDivisionValue(timeDivision), timeZone, ...params],
     );
 
     return rows.map((row) => ({
@@ -495,4 +494,3 @@ export class ClickhouseActionStatisticsAdapter
     }));
   }
 }
-

--- a/server/plugins/warehouse/utils/clickhouseSettings.ts
+++ b/server/plugins/warehouse/utils/clickhouseSettings.ts
@@ -5,7 +5,7 @@ const DEFAULT_MAX_BYTES_BEFORE_EXTERNAL = 1_500_000_000;
 export interface ClickhouseMemorySettings {
   max_bytes_before_external_group_by: string;
   max_bytes_before_external_sort: string;
-  max_threads: string;
+  max_threads: number;
   max_block_size: string;
 }
 
@@ -23,7 +23,7 @@ export function getClickhouseMemorySettings(): ClickhouseMemorySettings {
         DEFAULT_MAX_BYTES_BEFORE_EXTERNAL,
       ),
     ),
-    max_threads: String(safeGetEnvInt('CLICKHOUSE_MAX_THREADS', 2)),
+    max_threads: safeGetEnvInt('CLICKHOUSE_MAX_THREADS', 2),
     max_block_size: String(safeGetEnvInt('CLICKHOUSE_MAX_BLOCK_SIZE', 32768)),
   };
 }

--- a/server/plugins/warehouse/utils/clickhouseSettings.ts
+++ b/server/plugins/warehouse/utils/clickhouseSettings.ts
@@ -1,0 +1,34 @@
+import { safeGetEnvInt } from '../../../iocContainer/utils.js';
+
+// Spilling large GROUP BY / ORDER BY operations to disk keeps a heavy query
+// below the server-wide memory limit, so it degrades gracefully instead of being
+// killed by ClickHouse's OvercommitTracker. Default ~1.5 GB; override per
+// deployment via env vars to match the ClickHouse host's available RAM.
+const DEFAULT_MAX_BYTES_BEFORE_EXTERNAL = 1_500_000_000;
+
+export interface ClickhouseMemorySettings {
+  max_bytes_before_external_group_by: string;
+  max_bytes_before_external_sort: string;
+}
+
+/**
+ * Builds the ClickHouse client memory settings from env vars, falling back to
+ * sane defaults. Values are returned as strings because the client types
+ * `UInt64` settings as `string`.
+ */
+export function getClickhouseMemorySettings(): ClickhouseMemorySettings {
+  return {
+    max_bytes_before_external_group_by: String(
+      safeGetEnvInt(
+        'CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY',
+        DEFAULT_MAX_BYTES_BEFORE_EXTERNAL,
+      ),
+    ),
+    max_bytes_before_external_sort: String(
+      safeGetEnvInt(
+        'CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_SORT',
+        DEFAULT_MAX_BYTES_BEFORE_EXTERNAL,
+      ),
+    ),
+  };
+}

--- a/server/plugins/warehouse/utils/clickhouseSettings.ts
+++ b/server/plugins/warehouse/utils/clickhouseSettings.ts
@@ -1,21 +1,14 @@
 import { safeGetEnvInt } from '../../../iocContainer/utils.js';
 
-// Spilling large GROUP BY / ORDER BY operations to disk keeps a heavy query
-// below the server-wide memory limit, so it degrades gracefully instead of being
-// killed by ClickHouse's OvercommitTracker. Default ~1.5 GB; override per
-// deployment via env vars to match the ClickHouse host's available RAM.
 const DEFAULT_MAX_BYTES_BEFORE_EXTERNAL = 1_500_000_000;
 
 export interface ClickhouseMemorySettings {
   max_bytes_before_external_group_by: string;
   max_bytes_before_external_sort: string;
+  max_threads: string;
+  max_block_size: string;
 }
 
-/**
- * Builds the ClickHouse client memory settings from env vars, falling back to
- * sane defaults. Values are returned as strings because the client types
- * `UInt64` settings as `string`.
- */
 export function getClickhouseMemorySettings(): ClickhouseMemorySettings {
   return {
     max_bytes_before_external_group_by: String(
@@ -30,5 +23,7 @@ export function getClickhouseMemorySettings(): ClickhouseMemorySettings {
         DEFAULT_MAX_BYTES_BEFORE_EXTERNAL,
       ),
     ),
+    max_threads: String(safeGetEnvInt('CLICKHOUSE_MAX_THREADS', 2)),
+    max_block_size: String(safeGetEnvInt('CLICKHOUSE_MAX_BLOCK_SIZE', 32768)),
   };
 }

--- a/server/services/manualReviewToolService/dbTypes.ts
+++ b/server/services/manualReviewToolService/dbTypes.ts
@@ -30,6 +30,15 @@ import {
 } from './modules/JobDecisioning.js';
 import { type RoutingRuleStatus } from './modules/JobRouting.js';
 
+// What to do with a user's other pending reports when a trigger action is
+// taken on one of their jobs (issue #650).
+export type ClearReportsDisposition =
+  | 'AUTOMATIC_CLOSE'
+  | 'IGNORE'
+  | 'SAME_ACTION';
+
+export type ClearReportsScope = 'CURRENT_QUEUE' | 'ALL_QUEUES';
+
 export type RoutingRuleExecutionsRow = {
   RULE: string; // rule name
   RULE_ID: string;
@@ -75,6 +84,14 @@ export type ManualReviewToolServicePg = {
     is_default_queue: boolean;
     is_appeals_queue: boolean;
     auto_close_jobs: boolean;
+    // Null disables "clear other reports for this user" for the queue.
+    clear_reports_disposition: ClearReportsDisposition | null;
+    // Has a DB default, so it's optional on insert.
+    clear_reports_scope: ColumnType<
+      ClearReportsScope,
+      ClearReportsScope | undefined,
+      ClearReportsScope
+    >;
   };
   'manual_review_tool.manual_review_decisions': {
     id: string;
@@ -225,6 +242,11 @@ export type ManualReviewToolServicePg = {
     updatedAt: GeneratedAlways<Date>;
   };
   'manual_review_tool.queues_and_hidden_actions': {
+    queue_id: string;
+    action_id: string;
+    org_id: string;
+  };
+  'manual_review_tool.queues_and_clear_reports_trigger_actions': {
     queue_id: string;
     action_id: string;
     org_id: string;

--- a/server/services/manualReviewToolService/index.ts
+++ b/server/services/manualReviewToolService/index.ts
@@ -7,6 +7,7 @@ import {
 
 export {
   ManualReviewToolService,
+  isReportJob,
   type JobId,
   type ManualReviewJob,
   type ManualReviewJobOrAppeal,

--- a/server/services/manualReviewToolService/manualReviewToolService.test.ts
+++ b/server/services/manualReviewToolService/manualReviewToolService.test.ts
@@ -13,6 +13,8 @@ import {
   type NcmecContentItemSubmission,
   type ReportHistory,
 } from './manualReviewToolService.js';
+import { AUTOMATED_DECISION_REVIEWER_ID } from './modules/JobDecisioning.js';
+import { jobIdToGuid } from './modules/QueueOperations.js';
 
 function makeDummyJob() {
   return {
@@ -268,6 +270,59 @@ describe('Manual Review Tool Service', () => {
     });
 
     it.skip('should reject duplicate decisions on jobs dequeued again after the lock expires', async () => {});
+  });
+
+  // Regression: AUTOMATIC_CLOSE decisions have no human reviewer, but
+  // `manual_review_decisions.reviewer_id` is NOT NULL. Passing undefined
+  // through used to insert a null and fail with 23502, which left the job
+  // stuck in a retry loop. The decision must record the empty-string
+  // reviewer id (rendered as "Automatic" client-side) and not throw.
+  describe('automatic close decisions', () => {
+    it('records an AUTOMATIC_CLOSE decision with no human reviewer', async () => {
+      const orgId = 'e7c89ce7729';
+      const queueId = '1';
+      const jobPayload = makeDummyJob();
+
+      await mrtService['queueOps']['addJob']({
+        jobPayload,
+        orgId,
+        queueId,
+        enqueueSourceInfo: { kind: 'REPORT' },
+      });
+
+      const dequeuedJob = await mrtService.dequeueNextJob({
+        orgId,
+        queueId,
+        userId: uuidv1(),
+      });
+
+      if (!dequeuedJob) {
+        throw new Error("should've returned a job");
+      }
+
+      // Used to throw 23502 (null reviewer_id) before the sentinel fix.
+      await mrtService.submitDecision({
+        queueId,
+        reportHistory: [],
+        jobId: dequeuedJob.job.id,
+        lockToken: dequeuedJob.lockToken,
+        relatedActions: [],
+        orgId,
+        automaticCloseDecision: {
+          type: 'AUTOMATIC_CLOSE',
+          reason: 'ITEM_DELETED_BEFORE_REVIEW',
+        },
+      });
+
+      const row = await mrtService['pgQuery']
+        .selectFrom('manual_review_tool.manual_review_decisions')
+        .where('id', '=', jobIdToGuid(dequeuedJob.job.id))
+        .where('org_id', '=', orgId)
+        .select(['reviewer_id'])
+        .executeTakeFirst();
+
+      expect(row?.reviewer_id).toBe(AUTOMATED_DECISION_REVIEWER_ID);
+    });
   });
 
   // Issue #616: when an org sets `mrt_requires_decision_reason_on_action`,

--- a/server/services/manualReviewToolService/manualReviewToolService.ts
+++ b/server/services/manualReviewToolService/manualReviewToolService.ts
@@ -31,7 +31,11 @@ import {
   type UserScore,
   type UserStatisticsService,
 } from '../userStatisticsService/userStatisticsService.js';
-import { type ManualReviewToolServicePg } from './dbTypes.js';
+import {
+  type ClearReportsDisposition,
+  type ClearReportsScope,
+  type ManualReviewToolServicePg,
+} from './dbTypes.js';
 import AppealsJobRouting from './modules/AppealsJobRouting.js';
 import CommentOperations from './modules/CommentOperations.js';
 import DecisionAnalytics, {
@@ -43,6 +47,7 @@ import DecisionAnalytics, {
   type TimeToActionInput,
 } from './modules/DecisionAnalytics.js';
 import JobDecisioning, {
+  type CustomActionDecisionComponent,
   type OnRecordDecisionInput,
   type SubmitDecisionInput,
 } from './modules/JobDecisioning.js';
@@ -68,6 +73,9 @@ import ReporterInvalidation, {
 import SkipOperations, {
   type SkippedJobCountInput,
 } from './modules/SkipOperations.js';
+import UserReportSweep, {
+  type ClearOtherReportsResult,
+} from './modules/UserReportSweep.js';
 
 // An id that's unique across all jobs ever added to any queue (pending or not).
 // This is the id that's passed into the MRT Service by callers to identify a
@@ -102,6 +110,12 @@ export type ManualReviewAppealJob = {
 };
 
 export type ManualReviewJobOrAppeal = ManualReviewJob | ManualReviewAppealJob;
+
+export function isReportJob(
+  job: ManualReviewJobOrAppeal,
+): job is ManualReviewJob {
+  return job.payload.kind !== 'APPEAL';
+}
 
 // Old MRT jobs (created before roughly Sept 2023) included this
 // "LegacyItemWithTypeIdentifier" type in their payloads, rather than including
@@ -291,6 +305,7 @@ export class ManualReviewToolService {
   private readonly commentOps: CommentOperations;
   private readonly skipOps: SkipOperations;
   private readonly reporterInvalidation: ReporterInvalidation;
+  private readonly userReportSweep: UserReportSweep;
 
   constructor(
     readonly redis: Dependencies['IORedis'],
@@ -349,6 +364,12 @@ export class ManualReviewToolService {
     this.skipOps = new SkipOperations(pgQuery);
     this.reporterInvalidation = new ReporterInvalidation(
       this.queueOps,
+      this.tracer,
+    );
+    this.userReportSweep = new UserReportSweep(
+      this.queueOps,
+      this.jobDecisioning,
+      moderationConfigService,
       this.tracer,
     );
   }
@@ -860,6 +881,9 @@ export class ManualReviewToolService {
     invokedBy: Invoker;
     isAppealsQueue: boolean;
     autoCloseJobs?: boolean;
+    clearReportsDisposition?: ClearReportsDisposition | null;
+    clearReportsScope?: ClearReportsScope;
+    clearReportsTriggerActionIds?: readonly string[];
   }): Promise<ManualReviewQueue> {
     return this.queueOps.createManualReviewQueue(input);
   }
@@ -873,8 +897,92 @@ export class ManualReviewToolService {
     actionIdsToHide: readonly string[];
     actionIdsToUnhide: readonly string[];
     autoCloseJobs?: boolean;
+    clearReportsDisposition?: ClearReportsDisposition | null;
+    clearReportsScope?: ClearReportsScope;
+    clearReportsTriggerActionIds?: readonly string[];
   }): Promise<ManualReviewQueue> {
     return this.queueOps.updateManualReviewQueue(input);
+  }
+
+  async getClearReportsTriggerActionsForQueue(opts: {
+    orgId: string;
+    queueId: string;
+  }): Promise<string[]> {
+    return this.queueOps.getClearReportsTriggerActionsForQueue(opts);
+  }
+
+  /**
+   * Post-decision hook for "clear all other reports for a user".
+   * Runs the sweep only if the queue's trigger actions intersect the decision's
+   * custom actions.
+   */
+  async maybeClearOtherReportsForUser(opts: {
+    orgId: string;
+    actionedJob: ManualReviewJob;
+    actionedQueueId: string;
+    customActions: readonly CustomActionDecisionComponent[];
+    reviewerId: string;
+    reviewerEmail: string;
+    decisionReason?: string;
+  }): Promise<ClearOtherReportsResult | undefined> {
+    const {
+      orgId,
+      actionedJob,
+      actionedQueueId,
+      customActions,
+      reviewerId,
+      reviewerEmail,
+      decisionReason,
+    } = opts;
+
+    if (customActions.length === 0) {
+      return undefined;
+    }
+
+    const queue =
+      await this.queueOps.getQueueForOrgAndDangerouslyBypassPermissioning({
+        orgId,
+        queueId: actionedQueueId,
+      });
+    const disposition = queue?.clearReportsDisposition;
+    const scope = queue?.clearReportsScope;
+    if (
+      queue == null ||
+      queue.isAppealsQueue ||
+      disposition == null ||
+      scope == null
+    ) {
+      return undefined;
+    }
+
+    const triggerActionIds =
+      await this.queueOps.getClearReportsTriggerActionsForQueue({
+        queueId: actionedQueueId,
+        orgId,
+      });
+    if (triggerActionIds.length === 0) {
+      return undefined;
+    }
+
+    const triggerActionIdSet = new Set(triggerActionIds);
+    const matchingCustomActions = customActions.filter((component) =>
+      component.actions.some((action) => triggerActionIdSet.has(action.id)),
+    );
+    if (matchingCustomActions.length === 0) {
+      return undefined;
+    }
+
+    return this.userReportSweep.clearOtherReportsForUser({
+      orgId,
+      actionedJob,
+      actionedQueueId,
+      disposition,
+      scope,
+      triggerCustomActions: matchingCustomActions,
+      reviewerId,
+      reviewerEmail,
+      decisionReason,
+    });
   }
 
   async getDefaultQueueIdForOrg(orgId: string) {

--- a/server/services/manualReviewToolService/manualReviewToolService.ts
+++ b/server/services/manualReviewToolService/manualReviewToolService.ts
@@ -964,10 +964,18 @@ export class ManualReviewToolService {
       return undefined;
     }
 
+    // Narrow each component to only the trigger actions, so a SAME_ACTION
+    // disposition re-applies just the configured action(s) and not other
+    // actions that happened to be part of the same decision.
     const triggerActionIdSet = new Set(triggerActionIds);
-    const matchingCustomActions = customActions.filter((component) =>
-      component.actions.some((action) => triggerActionIdSet.has(action.id)),
-    );
+    const matchingCustomActions = customActions
+      .map((component) => ({
+        ...component,
+        actions: component.actions.filter((action) =>
+          triggerActionIdSet.has(action.id),
+        ),
+      }))
+      .filter((component) => component.actions.length > 0);
     if (matchingCustomActions.length === 0) {
       return undefined;
     }

--- a/server/services/manualReviewToolService/modules/JobDecisioning.ts
+++ b/server/services/manualReviewToolService/modules/JobDecisioning.ts
@@ -455,8 +455,15 @@ export default class JobDecisioning {
 
   /**
    * Logs the decision and runs side effects for a job the clear-other-reports
-   * sweep chose to dispose of. The caller must have already
-   * removed the job from its queue; this never touches the queue.
+   * sweep chose to dispose of. This only records the decision (in pg) and runs
+   * side effects; the caller is responsible for removing the job from its queue
+   * *after* this resolves, so the decision is durably recorded first (matching
+   * the invariant in `submitDecision`).
+   *
+   * Returns:
+   *  - `'logged'`: a new decision was recorded by this call.
+   *  - `'already-logged'`: a concurrent decider beat us to it.
+   *  - `'skipped'`: there was nothing to record.
    */
   async recordSweptJobDisposition(opts: {
     orgId: string;
@@ -468,7 +475,7 @@ export default class JobDecisioning {
     reviewerId: string;
     reviewerEmail: string;
     decisionReason?: string;
-  }): Promise<void> {
+  }): Promise<'logged' | 'already-logged' | 'skipped'> {
     const {
       orgId,
       queueId,
@@ -486,7 +493,7 @@ export default class JobDecisioning {
       triggerCustomActions,
     });
     if (decisionComponents.length === 0) {
-      return;
+      return 'skipped';
     }
 
     try {
@@ -504,13 +511,13 @@ export default class JobDecisioning {
     } catch (error) {
       // A concurrent reviewer already decided this job; nothing left to do.
       if (isDecisionAlreadyLoggedError(error)) {
-        return;
+        return 'already-logged';
       }
       throw error;
     }
 
     if (disposition === 'AUTOMATIC_CLOSE') {
-      return;
+      return 'logged';
     }
 
     await this.onRecordDecision({
@@ -523,6 +530,7 @@ export default class JobDecisioning {
       decisionReason,
       suppressUserReportSweep: true,
     });
+    return 'logged';
   }
 
   #buildSweptDecisionComponents(opts: {

--- a/server/services/manualReviewToolService/modules/JobDecisioning.ts
+++ b/server/services/manualReviewToolService/modules/JobDecisioning.ts
@@ -10,10 +10,14 @@ import {
   ErrorType,
   type ErrorInstanceData,
 } from '../../../utils/errors.js';
+import { assertUnreachable } from '../../../utils/misc.js';
 import { isNonEmptyString } from '../../../utils/typescript-types.js';
 import { getFieldValueForRole } from '../../itemProcessingService/index.js';
 import { type NCMECMediaReport } from '../../ncmecService/ncmecReporting.js';
-import { type ManualReviewToolServicePg } from '../dbTypes.js';
+import {
+  type ClearReportsDisposition,
+  type ManualReviewToolServicePg,
+} from '../dbTypes.js';
 import { type GetActionsByIdEventuallyConsistent } from '../manualReviewToolQueries.js';
 import {
   type JobId,
@@ -54,7 +58,11 @@ export type NCMECThreadReport = {
   reportedContent: readonly NCMECReportedContentInThread[];
 };
 
-type MRTJobAutoCloseReason = 'ITEM_DELETED_BEFORE_REVIEW';
+type MRTJobAutoCloseReason =
+  | 'ITEM_DELETED_BEFORE_REVIEW'
+  // Another job for this user was actioned and the queue closes their other
+  // reports (issue #650).
+  | 'USER_ACTIONED';
 
 export type ManualReviewDecisionComponent =
   | { type: 'IGNORE' }
@@ -99,6 +107,11 @@ export type ManualReviewDecisionType =
   | ManualReviewDecisionComponent['type']
   | 'RELATED_ACTION';
 
+export type CustomActionDecisionComponent = Extract<
+  ManualReviewDecisionComponent,
+  { type: 'CUSTOM_ACTION' }
+>;
+
 export type SubmitDecisionInput = {
   queueId: string;
   reportHistory: ReportHistory;
@@ -122,6 +135,9 @@ export type SubmitDecisionInput = {
       decisionComponents: ManualReviewDecisionComponent[];
       reviewerId: string;
       reviewerEmail: string;
+      // Set by the sweep on its own disposition decisions so SAME_ACTION
+      // can't recurse.
+      suppressUserReportSweep?: boolean;
     }
 );
 
@@ -133,6 +149,7 @@ export type OnRecordDecisionInput = {
   reviewerId: string;
   reviewerEmail: string;
   decisionReason?: string;
+  suppressUserReportSweep?: boolean;
 };
 
 export default class JobDecisioning {
@@ -159,6 +176,10 @@ export default class JobDecisioning {
       decisionReason,
       automaticCloseDecision,
     } = opts;
+    const suppressUserReportSweep =
+      opts.automaticCloseDecision === undefined
+        ? opts.suppressUserReportSweep
+        : undefined;
 
     const [job] = await this.queueOps.getJobs({
       orgId,
@@ -408,6 +429,7 @@ export default class JobDecisioning {
         reviewerId,
         reviewerEmail,
         decisionReason,
+        suppressUserReportSweep,
       }).catch((error) => {
         this.tracer.addSpan(
           { resource: 'actionPublisher', operation: 'publishAction' },
@@ -428,6 +450,107 @@ export default class JobDecisioning {
 
     if (error) {
       throw error;
+    }
+  }
+
+  /**
+   * Logs the decision and runs side effects for a job the clear-other-reports
+   * sweep chose to dispose of. The caller must have already
+   * removed the job from its queue; this never touches the queue.
+   */
+  async recordSweptJobDisposition(opts: {
+    orgId: string;
+    queueId: string;
+    job: ManualReviewJob;
+    disposition: ClearReportsDisposition;
+    // Re-targeted at this job's item when the disposition is SAME_ACTION.
+    triggerCustomActions: readonly CustomActionDecisionComponent[];
+    reviewerId: string;
+    reviewerEmail: string;
+    decisionReason?: string;
+  }): Promise<void> {
+    const {
+      orgId,
+      queueId,
+      job,
+      disposition,
+      triggerCustomActions,
+      reviewerId,
+      reviewerEmail,
+      decisionReason,
+    } = opts;
+
+    const decisionComponents = this.#buildSweptDecisionComponents({
+      disposition,
+      job,
+      triggerCustomActions,
+    });
+    if (decisionComponents.length === 0) {
+      return;
+    }
+
+    try {
+      await this.#logDecision({
+        id: jobIdToGuid(job.id),
+        job,
+        queueId,
+        reviewerId,
+        orgId,
+        decisionComponents,
+        relatedActions: [],
+        enqueueSourceInfo: job.enqueueSourceInfo,
+        decisionReason,
+      });
+    } catch (error) {
+      // A concurrent reviewer already decided this job; nothing left to do.
+      if (isDecisionAlreadyLoggedError(error)) {
+        return;
+      }
+      throw error;
+    }
+
+    if (disposition === 'AUTOMATIC_CLOSE') {
+      return;
+    }
+
+    await this.onRecordDecision({
+      decisionComponents,
+      relatedActions: [],
+      job,
+      queueId,
+      reviewerId,
+      reviewerEmail,
+      decisionReason,
+      suppressUserReportSweep: true,
+    });
+  }
+
+  #buildSweptDecisionComponents(opts: {
+    disposition: ClearReportsDisposition;
+    job: ManualReviewJob;
+    triggerCustomActions: readonly CustomActionDecisionComponent[];
+  }): ManualReviewDecisionComponent[] {
+    const { disposition, job, triggerCustomActions } = opts;
+    switch (disposition) {
+      case 'AUTOMATIC_CLOSE':
+        return [{ type: 'AUTOMATIC_CLOSE', reason: 'USER_ACTIONED' }];
+      case 'IGNORE':
+        return [{ type: 'IGNORE' }];
+      case 'SAME_ACTION': {
+        // Re-target the moderator's custom action(s) at this job's own item.
+        const { item } = job.payload;
+        return triggerCustomActions.map((component) => ({
+          type: 'CUSTOM_ACTION',
+          actions: component.actions,
+          policies: component.policies,
+          itemIds: [item.itemId],
+          itemTypeId: item.itemTypeIdentifier.id,
+          actionIdsToMrtApiParamDecisionPayload:
+            component.actionIdsToMrtApiParamDecisionPayload,
+        }));
+      }
+      default:
+        return assertUnreachable(disposition);
     }
   }
 

--- a/server/services/manualReviewToolService/modules/JobDecisioning.ts
+++ b/server/services/manualReviewToolService/modules/JobDecisioning.ts
@@ -520,16 +520,31 @@ export default class JobDecisioning {
       return 'logged';
     }
 
-    await this.onRecordDecision({
-      decisionComponents,
-      relatedActions: [],
-      job,
-      queueId,
-      reviewerId,
-      reviewerEmail,
-      decisionReason,
-      suppressUserReportSweep: true,
-    });
+    // Best-effort: the decision is already persisted above, so a failure to
+    // publish actions (e.g. a transient DB/network error) must not prevent the
+    // caller from removing the job from the queue or continuing the sweep.
+    try {
+      await this.onRecordDecision({
+        decisionComponents,
+        relatedActions: [],
+        job,
+        queueId,
+        reviewerId,
+        reviewerEmail,
+        decisionReason,
+        suppressUserReportSweep: true,
+      });
+    } catch (error) {
+      this.tracer.addSpan(
+        { resource: 'mrtService', operation: 'sweptJob.onRecordDecision' },
+        (span) => {
+          span.setAttribute('job.id', job.id);
+          span.setAttribute('org.id', orgId);
+          this.tracer.logSpanFailed(span, error);
+          return null;
+        },
+      );
+    }
     return 'logged';
   }
 

--- a/server/services/manualReviewToolService/modules/JobDecisioning.ts
+++ b/server/services/manualReviewToolService/modules/JobDecisioning.ts
@@ -64,6 +64,17 @@ type MRTJobAutoCloseReason =
   // reports (issue #650).
   | 'USER_ACTIONED';
 
+/**
+ * `reviewer_id` recorded for decisions the system makes with no human reviewer
+ * (e.g. AUTOMATIC_CLOSE). `manual_review_decisions.reviewer_id` is NOT NULL, so
+ * we can't store null; we store the empty string instead. The MRT client treats
+ * a falsy reviewer id as "Automatic" (see getReviewerName in
+ * ManualReviewRecentDecisions.tsx), and the reviewer-grouped analytics table
+ * drops ids that don't match an org user, so the empty string renders correctly
+ * everywhere without a schema migration or any client change.
+ */
+export const AUTOMATED_DECISION_REVIEWER_ID = '';
+
 export type ManualReviewDecisionComponent =
   | { type: 'IGNORE' }
   | {
@@ -623,7 +634,10 @@ export default class JobDecisioning {
         id,
         job_payload: job,
         queue_id: queueId,
-        reviewer_id: reviewerId,
+        // Automatic decisions (AUTOMATIC_CLOSE) have no human reviewer, but the
+        // column is NOT NULL; record a sentinel instead of letting undefined
+        // become a null and fail the insert (23502).
+        reviewer_id: reviewerId ?? AUTOMATED_DECISION_REVIEWER_ID,
         org_id: orgId,
         decision_components: decisionComponents,
         related_actions: relatedActions,

--- a/server/services/manualReviewToolService/modules/QueueOperations.ts
+++ b/server/services/manualReviewToolService/modules/QueueOperations.ts
@@ -943,7 +943,10 @@ export default class QueueOperations {
         if (snapshotIds.length >= maxJobs) {
           break;
         }
-        snapshotIds.push(legacy.data.id);
+        const id = legacy?.data?.id;
+        if (id != null) {
+          snapshotIds.push(id);
+        }
       }
       if (legacyJobs.length < batchSize) {
         break;

--- a/server/services/manualReviewToolService/modules/QueueOperations.ts
+++ b/server/services/manualReviewToolService/modules/QueueOperations.ts
@@ -44,7 +44,11 @@ import {
   UserPermission,
   type Invoker,
 } from '../../userManagementService/index.js';
-import { type ManualReviewToolServicePg } from '../dbTypes.js';
+import {
+  type ClearReportsDisposition,
+  type ClearReportsScope,
+  type ManualReviewToolServicePg,
+} from '../dbTypes.js';
 import {
   type AppealEnqueueSourceInfo,
   type JobId,
@@ -67,6 +71,9 @@ export type ManualReviewQueue = {
   isDefaultQueue: boolean;
   isAppealsQueue: boolean;
   autoCloseJobs: boolean;
+  // Null disposition disables "clear other reports for this user" (issue #650).
+  clearReportsDisposition: ClearReportsDisposition | null;
+  clearReportsScope: ClearReportsScope;
 };
 
 const PgQueueSelection = [
@@ -78,6 +85,8 @@ const PgQueueSelection = [
   'created_at as createdAt',
   'is_appeals_queue as isAppealsQueue',
   'auto_close_jobs as autoCloseJobs',
+  'clear_reports_disposition as clearReportsDisposition',
+  'clear_reports_scope as clearReportsScope',
 ] as const;
 
 // BullJobId represents the ID we give a job within Bull. It's only unique among
@@ -232,6 +241,9 @@ export default class QueueOperations {
     invokedBy: Invoker;
     isAppealsQueue?: boolean;
     autoCloseJobs?: boolean;
+    clearReportsDisposition?: ClearReportsDisposition | null;
+    clearReportsScope?: ClearReportsScope;
+    clearReportsTriggerActionIds?: readonly string[];
   }) {
     const {
       name,
@@ -241,6 +253,9 @@ export default class QueueOperations {
       invokedBy,
       isAppealsQueue,
       autoCloseJobs,
+      clearReportsDisposition,
+      clearReportsScope,
+      clearReportsTriggerActionIds,
     } = input;
     const { orgId } = invokedBy;
 
@@ -276,6 +291,8 @@ export default class QueueOperations {
               description: replaceEmptyStringWithNull(description),
               is_appeals_queue: isAppealsQueue ?? false,
               auto_close_jobs: autoCloseJobs ?? false,
+              clear_reports_disposition: clearReportsDisposition ?? null,
+              clear_reports_scope: clearReportsScope ?? 'CURRENT_QUEUE',
             },
           ])
           .executeTakeFirstOrThrow();
@@ -297,6 +314,12 @@ export default class QueueOperations {
           actionIdsToUnhide: [],
           orgId,
         });
+        await this.setClearReportsTriggerActionsForQueue({
+          transaction,
+          queueId: queue.id,
+          orgId,
+          actionIds: clearReportsTriggerActionIds ?? [],
+        });
         return queue;
       });
     } catch (e) {
@@ -316,6 +339,10 @@ export default class QueueOperations {
     actionIdsToHide: readonly string[];
     actionIdsToUnhide: readonly string[];
     autoCloseJobs?: boolean;
+    clearReportsDisposition?: ClearReportsDisposition | null;
+    clearReportsScope?: ClearReportsScope;
+    // When provided, replaces the queue's full set of trigger actions.
+    clearReportsTriggerActionIds?: readonly string[];
   }) {
     const {
       queueId,
@@ -326,6 +353,9 @@ export default class QueueOperations {
       actionIdsToHide,
       actionIdsToUnhide,
       autoCloseJobs,
+      clearReportsDisposition,
+      clearReportsScope,
+      clearReportsTriggerActionIds,
     } = input;
 
     return this.transactionWithRetry(async (transaction) => {
@@ -337,6 +367,9 @@ export default class QueueOperations {
               name,
               description: replaceEmptyStringWithNull(description),
               auto_close_jobs: autoCloseJobs,
+              // null disables the feature and must survive removeUndefinedKeys.
+              clear_reports_disposition: clearReportsDisposition,
+              clear_reports_scope: clearReportsScope,
             }),
           )
           .where('id', '=', queueId)
@@ -367,6 +400,14 @@ export default class QueueOperations {
         actionIdsToHide,
         actionIdsToUnhide,
       });
+      if (clearReportsTriggerActionIds !== undefined) {
+        await this.setClearReportsTriggerActionsForQueue({
+          transaction,
+          queueId,
+          orgId,
+          actionIds: clearReportsTriggerActionIds,
+        });
+      }
       return updatedQueue;
     });
   }
@@ -542,6 +583,8 @@ export default class QueueOperations {
         'queues.created_at as createdAt',
         'queues.is_appeals_queue as isAppealsQueue',
         'queues.auto_close_jobs as autoCloseJobs',
+        'queues.clear_reports_disposition as clearReportsDisposition',
+        'queues.clear_reports_scope as clearReportsScope',
       ])
       .where('favorite_queues.user_id', '=', userId)
       .where('favorite_queues.org_id', '=', orgId)
@@ -1631,6 +1674,57 @@ export default class QueueOperations {
         .where('queue_id', '=', queueId)
         .where('org_id', '=', orgId)
         .where('action_id', 'in', actionIdsToUnhide)
+        .execute();
+    }
+  }
+
+  // Action IDs whose use triggers the clear-other-reports sweep (issue #650).
+  async getClearReportsTriggerActionsForQueue(opts: {
+    queueId: string;
+    orgId: string;
+  }): Promise<string[]> {
+    const { queueId, orgId } = opts;
+    return (
+      await this.pgQuery
+        .selectFrom(
+          'manual_review_tool.queues_and_clear_reports_trigger_actions',
+        )
+        .select(['action_id'])
+        .where('queue_id', '=', queueId)
+        .where('org_id', '=', orgId)
+        .execute()
+    ).map((it) => it.action_id);
+  }
+
+  // Replaces the queue's trigger actions with `actionIds` (pass [] to clear).
+  async setClearReportsTriggerActionsForQueue(opts: {
+    queueId: string;
+    orgId: string;
+    actionIds: readonly string[];
+    transaction?: Transaction<ManualReviewToolServicePg>;
+  }) {
+    const { queueId, orgId, actionIds, transaction } = opts;
+    const queryInterface = transaction ?? this.pgQuery;
+
+    await queryInterface
+      .deleteFrom('manual_review_tool.queues_and_clear_reports_trigger_actions')
+      .where('queue_id', '=', queueId)
+      .where('org_id', '=', orgId)
+      .execute();
+
+    const uniqueActionIds = [...new Set(actionIds)];
+    if (uniqueActionIds.length > 0) {
+      await queryInterface
+        .insertInto(
+          'manual_review_tool.queues_and_clear_reports_trigger_actions',
+        )
+        .values(
+          uniqueActionIds.map((actionId) => ({
+            queue_id: queueId,
+            action_id: actionId,
+            org_id: orgId,
+          })),
+        )
         .execute();
     }
   }

--- a/server/services/manualReviewToolService/modules/UserReportSweep.test.ts
+++ b/server/services/manualReviewToolService/modules/UserReportSweep.test.ts
@@ -1,0 +1,207 @@
+import { type ItemIdentifier } from '@roostorg/types';
+import { uid } from 'uid';
+import { v1 as uuidv1 } from 'uuid';
+
+import getBottle from '../../../iocContainer/index.js';
+import createContentItemTypes from '../../../test/fixtureHelpers/createContentItemTypes.js';
+import createMrtQueue from '../../../test/fixtureHelpers/createMrtQueue.js';
+import createOrg from '../../../test/fixtureHelpers/createOrg.js';
+import createUser from '../../../test/fixtureHelpers/createUser.js';
+import { makeTestWithFixture } from '../../../test/utils.js';
+import { instantiateOpaqueType } from '../../../utils/typescript-types.js';
+import {
+  makeSubmissionId,
+  type NormalizedItemData,
+} from '../../itemProcessingService/index.js';
+import { type ItemSubmissionWithTypeIdentifier } from '../../itemProcessingService/makeItemSubmissionWithTypeIdentifier.js';
+import { type CustomActionDecisionComponent } from './JobDecisioning.js';
+
+const TRIGGER_ACTION_ID = 'ban-action';
+
+const testWithQueue = () =>
+  makeTestWithFixture(async () => {
+    const container = (await getBottle()).container;
+    const { org, cleanup: orgCleanup } = await createOrg(
+      {
+        KyselyPg: container.KyselyPg,
+        ModerationConfigService: container.ModerationConfigService,
+        ApiKeyService: container.ApiKeyService,
+      },
+      uid(),
+    );
+    const { user, cleanup: userCleanup } = await createUser(
+      container.KyselyPg,
+      org.id,
+    );
+    const { itemTypes, cleanup: itemTypesCleanup } =
+      await createContentItemTypes({
+        moderationConfigService: container.ModerationConfigService,
+        orgId: org.id,
+        extra: {},
+      });
+    const { queue, cleanup: queueCleanup } = await createMrtQueue({
+      orgId: org.id,
+      mrtService: container.ManualReviewToolService,
+      userId: user.id,
+    });
+
+    const mrtService = container.ManualReviewToolService;
+    const queueOps = mrtService['queueOps'];
+
+    const addJob = async (opts: {
+      creator: ItemIdentifier;
+      queueId?: string;
+    }) => {
+      const item = instantiateOpaqueType<ItemSubmissionWithTypeIdentifier>({
+        submissionId: makeSubmissionId(),
+        submissionTime: new Date(),
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        data: {} as NormalizedItemData,
+        itemTypeIdentifier: {
+          id: itemTypes[0].id,
+          version: new Date().toISOString(),
+          schemaVariant: 'original',
+        },
+        creator: opts.creator,
+        itemId: uuidv1(),
+      });
+      return queueOps.addJob({
+        orgId: org.id,
+        queueId: opts.queueId ?? queue.id,
+        enqueueSourceInfo: { kind: 'REPORT' },
+        jobPayload: {
+          createdAt: new Date(),
+          policyIds: [],
+          payload: { kind: 'DEFAULT', item, reportHistory: [] },
+        },
+      });
+    };
+
+    const configureQueue = async (opts: {
+      disposition: 'AUTOMATIC_CLOSE' | 'IGNORE' | 'SAME_ACTION' | null;
+      scope?: 'CURRENT_QUEUE' | 'ALL_QUEUES';
+      triggerActionIds?: string[];
+      queueId?: string;
+    }) =>
+      mrtService.updateManualReviewQueue({
+        orgId: org.id,
+        queueId: opts.queueId ?? queue.id,
+        userIds: [user.id],
+        actionIdsToHide: [],
+        actionIdsToUnhide: [],
+        clearReportsDisposition: opts.disposition,
+        clearReportsScope: opts.scope ?? 'CURRENT_QUEUE',
+        clearReportsTriggerActionIds: opts.triggerActionIds ?? [
+          TRIGGER_ACTION_ID,
+        ],
+      });
+
+    return {
+      org,
+      user,
+      queue,
+      mrtService,
+      addJob,
+      configureQueue,
+      cleanup: async () => {
+        await queueCleanup();
+        await itemTypesCleanup();
+        await userCleanup();
+        await orgCleanup();
+        await container.KyselyPg.destroy();
+        await container.KyselyPgReadReplica.destroy();
+      },
+    };
+  });
+
+function triggerAction(
+  item: ItemSubmissionWithTypeIdentifier,
+): CustomActionDecisionComponent {
+  return {
+    type: 'CUSTOM_ACTION',
+    actions: [{ id: TRIGGER_ACTION_ID }],
+    policies: [],
+    itemIds: [item.itemId],
+    itemTypeId: item.itemTypeIdentifier.id,
+  };
+}
+
+describe('ManualReviewToolService.maybeClearOtherReportsForUser', () => {
+  const reportedUser: ItemIdentifier = { typeId: 'user_type', id: 'reported' };
+  const otherUser: ItemIdentifier = { typeId: 'user_type', id: 'other' };
+
+  const reviewerEmail = 'reviewer@example.com';
+
+  testWithQueue()(
+    'disposes other jobs for the same user, excluding the actioned job and other users',
+    async ({ org, user, queue, mrtService, addJob, configureQueue }) => {
+      await configureQueue({ disposition: 'AUTOMATIC_CLOSE' });
+
+      const actionedJob = await addJob({ creator: reportedUser });
+      await addJob({ creator: reportedUser });
+      await addJob({ creator: reportedUser });
+      await addJob({ creator: otherUser });
+
+      const result = await mrtService.maybeClearOtherReportsForUser({
+        orgId: org.id,
+        actionedJob,
+        actionedQueueId: queue.id,
+        customActions: [triggerAction(actionedJob.payload.item)],
+        reviewerId: user.id,
+        reviewerEmail,
+      });
+
+      expect(result?.jobsDisposed).toBe(2);
+    },
+  );
+
+  testWithQueue()(
+    'is a no-op when the decision actions do not match the trigger actions',
+    async ({ org, user, queue, mrtService, addJob, configureQueue }) => {
+      await configureQueue({ disposition: 'AUTOMATIC_CLOSE' });
+
+      const actionedJob = await addJob({ creator: reportedUser });
+      await addJob({ creator: reportedUser });
+
+      const result = await mrtService.maybeClearOtherReportsForUser({
+        orgId: org.id,
+        actionedJob,
+        actionedQueueId: queue.id,
+        customActions: [
+          {
+            type: 'CUSTOM_ACTION',
+            actions: [{ id: 'some-other-action' }],
+            policies: [],
+            itemIds: [actionedJob.payload.item.itemId],
+            itemTypeId: actionedJob.payload.item.itemTypeIdentifier.id,
+          },
+        ],
+        reviewerId: user.id,
+        reviewerEmail,
+      });
+
+      expect(result).toBeUndefined();
+    },
+  );
+
+  testWithQueue()(
+    'is a no-op when the feature is disabled (null disposition)',
+    async ({ org, user, queue, mrtService, addJob, configureQueue }) => {
+      await configureQueue({ disposition: null, triggerActionIds: [] });
+
+      const actionedJob = await addJob({ creator: reportedUser });
+      await addJob({ creator: reportedUser });
+
+      const result = await mrtService.maybeClearOtherReportsForUser({
+        orgId: org.id,
+        actionedJob,
+        actionedQueueId: queue.id,
+        customActions: [triggerAction(actionedJob.payload.item)],
+        reviewerId: user.id,
+        reviewerEmail,
+      });
+
+      expect(result).toBeUndefined();
+    },
+  );
+});

--- a/server/services/manualReviewToolService/modules/UserReportSweep.test.ts
+++ b/server/services/manualReviewToolService/modules/UserReportSweep.test.ts
@@ -59,7 +59,7 @@ const testWithQueue = () =>
         data: {} as NormalizedItemData,
         itemTypeIdentifier: {
           id: itemTypes[0].id,
-          version: new Date().toISOString(),
+          version: itemTypes[0].version,
           schemaVariant: 'original',
         },
         creator: opts.creator,
@@ -96,6 +96,20 @@ const testWithQueue = () =>
         ],
       });
 
+    const pendingJobIds = async (queueId?: string) => {
+      let ids: readonly string[] = [];
+      for await (const job of queueOps.iteratePendingJobsForQueue({
+        orgId: org.id,
+        queueId: queueId ?? queue.id,
+        batchSize: 100,
+        maxJobs: 1000,
+        progress: { truncated: false },
+      })) {
+        ids = [...ids, job.id];
+      }
+      return ids;
+    };
+
     return {
       org,
       user,
@@ -103,6 +117,7 @@ const testWithQueue = () =>
       mrtService,
       addJob,
       configureQueue,
+      pendingJobIds,
       cleanup: async () => {
         await queueCleanup();
         await itemTypesCleanup();
@@ -134,13 +149,21 @@ describe('ManualReviewToolService.maybeClearOtherReportsForUser', () => {
 
   testWithQueue()(
     'disposes other jobs for the same user, excluding the actioned job and other users',
-    async ({ org, user, queue, mrtService, addJob, configureQueue }) => {
+    async ({
+      org,
+      user,
+      queue,
+      mrtService,
+      addJob,
+      configureQueue,
+      pendingJobIds,
+    }) => {
       await configureQueue({ disposition: 'AUTOMATIC_CLOSE' });
 
       const actionedJob = await addJob({ creator: reportedUser });
       await addJob({ creator: reportedUser });
       await addJob({ creator: reportedUser });
-      await addJob({ creator: otherUser });
+      const otherUserJob = await addJob({ creator: otherUser });
 
       const result = await mrtService.maybeClearOtherReportsForUser({
         orgId: org.id,
@@ -152,6 +175,12 @@ describe('ManualReviewToolService.maybeClearOtherReportsForUser', () => {
       });
 
       expect(result?.jobsDisposed).toBe(2);
+
+      // Only the two other reported-user jobs are removed; the actioned job and
+      // the other user's job remain queued.
+      expect(new Set(await pendingJobIds())).toEqual(
+        new Set([actionedJob.id, otherUserJob.id]),
+      );
     },
   );
 

--- a/server/services/manualReviewToolService/modules/UserReportSweep.test.ts
+++ b/server/services/manualReviewToolService/modules/UserReportSweep.test.ts
@@ -51,6 +51,7 @@ const testWithQueue = () =>
     const addJob = async (opts: {
       creator: ItemIdentifier;
       queueId?: string;
+      kind?: 'DEFAULT' | 'NCMEC';
     }) => {
       const item = instantiateOpaqueType<ItemSubmissionWithTypeIdentifier>({
         submissionId: makeSubmissionId(),
@@ -72,7 +73,10 @@ const testWithQueue = () =>
         jobPayload: {
           createdAt: new Date(),
           policyIds: [],
-          payload: { kind: 'DEFAULT', item, reportHistory: [] },
+          payload:
+            opts.kind === 'NCMEC'
+              ? { kind: 'NCMEC', item, allMediaItems: [] }
+              : { kind: 'DEFAULT', item, reportHistory: [] },
         },
       });
     };
@@ -210,6 +214,40 @@ describe('ManualReviewToolService.maybeClearOtherReportsForUser', () => {
       });
 
       expect(result).toBeUndefined();
+    },
+  );
+
+  testWithQueue()(
+    'skips NCMEC jobs when sweeping other reports for the same user',
+    async ({
+      org,
+      user,
+      queue,
+      mrtService,
+      addJob,
+      configureQueue,
+      pendingJobIds,
+    }) => {
+      await configureQueue({ disposition: 'AUTOMATIC_CLOSE' });
+
+      const actionedJob = await addJob({ creator: reportedUser });
+      const ncmecJob = await addJob({ creator: reportedUser, kind: 'NCMEC' });
+      await addJob({ creator: reportedUser });
+
+      const result = await mrtService.maybeClearOtherReportsForUser({
+        orgId: org.id,
+        actionedJob,
+        actionedQueueId: queue.id,
+        customActions: [triggerAction(actionedJob.payload.item)],
+        reviewerId: user.id,
+        reviewerEmail,
+      });
+
+      // Only the DEFAULT job is swept; the NCMEC job remains.
+      expect(result?.jobsDisposed).toBe(1);
+      expect(new Set(await pendingJobIds())).toEqual(
+        new Set([actionedJob.id, ncmecJob.id]),
+      );
     },
   );
 

--- a/server/services/manualReviewToolService/modules/UserReportSweep.test.ts
+++ b/server/services/manualReviewToolService/modules/UserReportSweep.test.ts
@@ -75,7 +75,7 @@ const testWithQueue = () =>
           policyIds: [],
           payload:
             opts.kind === 'NCMEC'
-              ? { kind: 'NCMEC', item, allMediaItems: [] }
+              ? { kind: 'NCMEC', item, allMediaItems: [], reportHistory: [] }
               : { kind: 'DEFAULT', item, reportHistory: [] },
         },
       });

--- a/server/services/manualReviewToolService/modules/UserReportSweep.ts
+++ b/server/services/manualReviewToolService/modules/UserReportSweep.ts
@@ -219,19 +219,10 @@ export default class UserReportSweep {
     const { queueId, job, input } = opts;
     const { orgId, reviewerId } = input;
 
-    // Remove first, respecting locks: a job another reviewer is working on is
-    // left untouched, so we never steal their lock or double-decide a job.
-    const removed = await this.queueOps.removeJobAllowingInvokerLock({
-      orgId,
-      queueId,
-      jobId: job.id,
-      invokerUserId: reviewerId,
-    });
-    if (!removed) {
-      return false;
-    }
-
-    await this.jobDecisioning.recordSweptJobDisposition({
+    // Record the decision before removing the job, a job must never leave
+    // the queue without its decision, so it is durably logged first, or it
+    // could be lost if the recording step fails.
+    const outcome = await this.jobDecisioning.recordSweptJobDisposition({
       orgId,
       queueId,
       job,
@@ -241,7 +232,20 @@ export default class UserReportSweep {
       reviewerEmail: input.reviewerEmail,
       decisionReason: input.decisionReason,
     });
-    return true;
+    if (outcome === 'skipped') {
+      return false;
+    }
+
+    // Best-effort removal. If it fails (e.g. another reviewer holds the lock),
+    // the job now has a decision and is dropped the next time it's dequeued.
+    await this.queueOps.removeJobAllowingInvokerLock({
+      orgId,
+      queueId,
+      jobId: job.id,
+      invokerUserId: reviewerId,
+    });
+
+    return outcome === 'logged';
   }
 
   /**

--- a/server/services/manualReviewToolService/modules/UserReportSweep.ts
+++ b/server/services/manualReviewToolService/modules/UserReportSweep.ts
@@ -1,0 +1,280 @@
+import { type ItemIdentifier } from '@roostorg/types';
+
+import { type Dependencies } from '../../../iocContainer/index.js';
+import { jsonStringify } from '../../../utils/encoding.js';
+import { getFieldValueForRole } from '../../itemProcessingService/index.js';
+import { type ItemSubmissionWithTypeIdentifier } from '../../itemProcessingService/makeItemSubmissionWithTypeIdentifier.js';
+import {
+  type ClearReportsDisposition,
+  type ClearReportsScope,
+} from '../dbTypes.js';
+import { type ManualReviewJob } from '../manualReviewToolService.js';
+import type JobDecisioning from './JobDecisioning.js';
+import { type CustomActionDecisionComponent } from './JobDecisioning.js';
+import type QueueOperations from './QueueOperations.js';
+
+export type ClearOtherReportsInput = {
+  orgId: string;
+  // The job the moderator just took an action on; excluded from the sweep.
+  actionedJob: ManualReviewJob;
+  actionedQueueId: string;
+  disposition: ClearReportsDisposition;
+  scope: ClearReportsScope;
+  // The custom action(s) the moderator took; re-applied to other jobs when the
+  // disposition is SAME_ACTION.
+  triggerCustomActions: readonly CustomActionDecisionComponent[];
+  reviewerId: string;
+  reviewerEmail: string;
+  decisionReason?: string;
+  // Per-queue scan caps; overridable for tests and ops.
+  batchSize?: number;
+  maxJobsPerQueue?: number;
+};
+
+export type ClearOtherReportsResult = {
+  subjectUser: ItemIdentifier | undefined;
+  queuesScanned: number;
+  jobsScanned: number;
+  jobsDisposed: number;
+  // True when a queue hit the per-queue scan cap, so the sweep was partial.
+  truncated: boolean;
+};
+
+const DEFAULT_BATCH_SIZE = 200;
+const DEFAULT_MAX_JOBS_PER_QUEUE = 10_000;
+
+// In-flight sweeps keyed by (org, user), to coalesce a burst of actions on the
+// same user. Process-local, so the cap is per pod.
+const IN_FLIGHT_SWEEPS = new Set<string>();
+
+function inFlightKey(orgId: string, user: ItemIdentifier): string {
+  return `${orgId}\u241F${user.typeId}\u241F${user.id}`;
+}
+
+/**
+ * "Clear all other reports for a user" (issue #650): after a configured trigger
+ * action, dispose of every other pending job for the same user. A job's user is
+ * the reported USER item or a reported CONTENT item's creator. NCMEC (CSAM) jobs
+ * are never swept.
+ */
+export default class UserReportSweep {
+  constructor(
+    private readonly queueOps: QueueOperations,
+    private readonly jobDecisioning: JobDecisioning,
+    private readonly moderationConfigService: Dependencies['ModerationConfigService'],
+    private readonly tracer: Dependencies['Tracer'],
+  ) {}
+
+  async clearOtherReportsForUser(
+    input: ClearOtherReportsInput,
+  ): Promise<ClearOtherReportsResult> {
+    const { orgId, actionedJob, actionedQueueId, scope } = input;
+
+    return this.tracer.addActiveSpan(
+      {
+        resource: 'mrtService',
+        operation: 'clearOtherReportsForUser',
+        attributes: {
+          'clearOtherReports.orgId': orgId,
+          'clearOtherReports.disposition': input.disposition,
+          'clearOtherReports.scope': scope,
+        },
+      },
+      async (span) => {
+        const result: ClearOtherReportsResult = {
+          subjectUser: undefined,
+          queuesScanned: 0,
+          jobsScanned: 0,
+          jobsDisposed: 0,
+          truncated: false,
+        };
+
+        const subjectUser = await this.#resolveSubjectUser(
+          orgId,
+          actionedJob.payload.item,
+        );
+        result.subjectUser = subjectUser;
+        if (subjectUser == null) {
+          // No resolvable user (e.g. a thread report) — nothing to sweep.
+          return result;
+        }
+
+        const sweepKey = inFlightKey(orgId, subjectUser);
+        if (IN_FLIGHT_SWEEPS.has(sweepKey)) {
+          return result;
+        }
+        IN_FLIGHT_SWEEPS.add(sweepKey);
+
+        try {
+          const queueIds = await this.#queueIdsForScope({
+            orgId,
+            scope,
+            originQueueId: actionedQueueId,
+          });
+          result.queuesScanned = queueIds.length;
+
+          for (const queueId of queueIds) {
+            const perQueue = await this.#sweepQueue({
+              queueId,
+              subjectUser,
+              input,
+            });
+            result.jobsScanned += perQueue.jobsScanned;
+            result.jobsDisposed += perQueue.jobsDisposed;
+            result.truncated ||= perQueue.truncated;
+          }
+        } finally {
+          IN_FLIGHT_SWEEPS.delete(sweepKey);
+        }
+
+        span.setAttributes({
+          'clearOtherReports.subjectUser': jsonStringify({
+            typeId: subjectUser.typeId,
+            id: subjectUser.id,
+          }),
+          'clearOtherReports.jobsScanned': result.jobsScanned,
+          'clearOtherReports.jobsDisposed': result.jobsDisposed,
+          'clearOtherReports.truncated': result.truncated,
+        });
+
+        return result;
+      },
+    );
+  }
+
+  async #queueIdsForScope(opts: {
+    orgId: string;
+    scope: ClearReportsScope;
+    originQueueId: string;
+  }): Promise<string[]> {
+    const { orgId, scope, originQueueId } = opts;
+    if (scope === 'CURRENT_QUEUE') {
+      return [originQueueId];
+    }
+    const queues =
+      await this.queueOps.getAllQueuesForOrgAndDangerouslyBypassPermissioning(
+        orgId,
+      );
+    // Appeals queues hold appeal jobs, not user reports, so never sweep them.
+    return queues.filter((q) => !q.isAppealsQueue).map((q) => q.id);
+  }
+
+  async #sweepQueue(opts: {
+    queueId: string;
+    subjectUser: ItemIdentifier;
+    input: ClearOtherReportsInput;
+  }): Promise<{
+    jobsScanned: number;
+    jobsDisposed: number;
+    truncated: boolean;
+  }> {
+    const { queueId, subjectUser, input } = opts;
+    const { orgId, actionedJob } = input;
+
+    let jobsScanned = 0;
+    let jobsDisposed = 0;
+    const progress = { truncated: false };
+
+    for await (const job of this.queueOps.iteratePendingJobsForQueue({
+      orgId,
+      queueId,
+      batchSize: input.batchSize ?? DEFAULT_BATCH_SIZE,
+      maxJobs: input.maxJobsPerQueue ?? DEFAULT_MAX_JOBS_PER_QUEUE,
+      progress,
+    })) {
+      jobsScanned++;
+
+      // Never act on the job the moderator just decided.
+      if (job.id === actionedJob.id) {
+        continue;
+      }
+      // CSAM caveat: NCMEC jobs are never swept.
+      if (job.payload.kind === 'NCMEC') {
+        continue;
+      }
+
+      const jobUser = await this.#resolveSubjectUser(orgId, job.payload.item);
+      if (
+        jobUser == null ||
+        jobUser.id !== subjectUser.id ||
+        jobUser.typeId !== subjectUser.typeId
+      ) {
+        continue;
+      }
+
+      const disposed = await this.#disposeJob({ queueId, job, input });
+      if (disposed) {
+        jobsDisposed++;
+      }
+    }
+
+    return { jobsScanned, jobsDisposed, truncated: progress.truncated };
+  }
+
+  async #disposeJob(opts: {
+    queueId: string;
+    job: ManualReviewJob;
+    input: ClearOtherReportsInput;
+  }): Promise<boolean> {
+    const { queueId, job, input } = opts;
+    const { orgId, reviewerId } = input;
+
+    // Remove first, respecting locks: a job another reviewer is working on is
+    // left untouched, so we never steal their lock or double-decide a job.
+    const removed = await this.queueOps.removeJobAllowingInvokerLock({
+      orgId,
+      queueId,
+      jobId: job.id,
+      invokerUserId: reviewerId,
+    });
+    if (!removed) {
+      return false;
+    }
+
+    await this.jobDecisioning.recordSweptJobDisposition({
+      orgId,
+      queueId,
+      job,
+      disposition: input.disposition,
+      triggerCustomActions: input.triggerCustomActions,
+      reviewerId,
+      reviewerEmail: input.reviewerEmail,
+      decisionReason: input.decisionReason,
+    });
+    return true;
+  }
+
+  /**
+   * The user a job concerns: a reported USER item is itself the user; a
+   * reported CONTENT item's user is its creator. THREAD and other kinds have no
+   * single subject user, so they're never swept.
+   */
+  async #resolveSubjectUser(
+    orgId: string,
+    item: ItemSubmissionWithTypeIdentifier,
+  ): Promise<ItemIdentifier | undefined> {
+    const itemType = await this.moderationConfigService.getItemType({
+      orgId,
+      itemTypeSelector: item.itemTypeIdentifier,
+    });
+    if (!itemType) {
+      return undefined;
+    }
+    if (itemType.kind === 'USER') {
+      return { id: item.itemId, typeId: item.itemTypeIdentifier.id };
+    }
+    if (itemType.kind === 'CONTENT') {
+      if (item.creator?.id != null && item.creator.id !== '') {
+        return item.creator;
+      }
+      const fromData = getFieldValueForRole(
+        itemType.schema,
+        itemType.schemaFieldRoles,
+        'creatorId',
+        item.data,
+      );
+      return fromData?.id != null && fromData.id !== '' ? fromData : undefined;
+    }
+    return undefined;
+  }
+}

--- a/server/services/manualReviewToolService/modules/UserReportSweep.ts
+++ b/server/services/manualReviewToolService/modules/UserReportSweep.ts
@@ -193,18 +193,35 @@ export default class UserReportSweep {
         continue;
       }
 
-      const jobUser = await this.#resolveSubjectUser(orgId, job.payload.item);
-      if (
-        jobUser == null ||
-        jobUser.id !== subjectUser.id ||
-        jobUser.typeId !== subjectUser.typeId
-      ) {
-        continue;
-      }
+      try {
+        const jobUser = await this.#resolveSubjectUser(orgId, job.payload.item);
+        if (
+          jobUser == null ||
+          jobUser.id !== subjectUser.id ||
+          jobUser.typeId !== subjectUser.typeId
+        ) {
+          continue;
+        }
 
-      const disposed = await this.#disposeJob({ queueId, job, input });
-      if (disposed) {
-        jobsDisposed++;
+        const disposed = await this.#disposeJob({ queueId, job, input });
+        if (disposed) {
+          jobsDisposed++;
+        }
+      } catch (error) {
+        // A single job failure must not abort the entire sweep. Log the error
+        // for observability but continue processing remaining jobs.
+        this.tracer.addSpan(
+          {
+            resource: 'mrtService',
+            operation: 'clearOtherReports.disposeJob',
+          },
+          (span) => {
+            span.setAttribute('job.id', job.id);
+            span.setAttribute('queue.id', queueId);
+            this.tracer.logSpanFailed(span, error);
+            return null;
+          },
+        );
       }
     }
 

--- a/server/storage/dataWarehouse/ClickhouseAdapter.ts
+++ b/server/storage/dataWarehouse/ClickhouseAdapter.ts
@@ -14,6 +14,7 @@ import {
   type TransactionSettings,
 } from 'kysely';
 
+import { getClickhouseMemorySettings } from '../../plugins/warehouse/utils/clickhouseSettings.js';
 import { formatClickhouseQuery } from '../../plugins/warehouse/utils/clickhouseSql.js';
 import type {
   DataWarehousePoolSettings,
@@ -133,6 +134,7 @@ export class ClickhouseKyselyAdapter implements IDataWarehouseDialect {
       database: connectionSettings.database,
       clickhouse_settings: {
         allow_experimental_object_type: 1,
+        ...getClickhouseMemorySettings(),
       },
     });
 


### PR DESCRIPTION
## Context & Requests for Reviewers

Fixes #650. 

Adds an optional, per-queue configuration so that when a moderator takes a configured action on a user, Coop can also dispose of that user's *other* pending reports. Saving moderators from working through reports for a user who's already been actioned.

Each queue can now configure three things:
- **Trigger actions**" which custom action(s) set off the sweep.
- **Disposition**: what happens to the other reports:
  - `AUTOMATIC_CLOSE`. close them silently with a new `USER_ACTIONED` reason (no webhooks), the same way `autoCloseJobs` closes already-deleted items.
  - `IGNORE`. mark them ignored (fires the org's ignore callback if configured).
  - `SAME_ACTION`. re-apply the triggering custom action(s) to each report's item.
- **Scope**:`CURRENT_QUEUE` (only the queue the action was taken in) or `ALL_QUEUES` (every non-appeal queue in the org).

The feature is **off by default**: a queue does nothing unless it has a non-null disposition *and* at least one trigger action, so existing queues are unaffected.

<img width="1428" height="680" alt="Screenshot 2026-06-20 at 11 23 57 AM" src="https://github.com/user-attachments/assets/dc6cbe31-c4a5-4f28-b282-4fe0d4ee4166" />
<img width="1422" height="862" alt="Screenshot 2026-06-20 at 11 24 09 AM" src="https://github.com/user-attachments/assets/cdc858cf-44c3-4986-b1cb-328662ebf25e" />
<img width="1107" height="387" alt="Screenshot 2026-06-20 at 11 24 22 AM" src="https://github.com/user-attachments/assets/e6f874f8-117d-45b3-96b9-7624fc115c0c" />
<img width="499" height="299" alt="Screenshot 2026-06-20 at 11 24 29 AM" src="https://github.com/user-attachments/assets/31d4afb5-d7c3-4db8-8136-353af39b7c3c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Administrators can configure “Clear Other Reports for a User” on non-appeals manual review queues, including disposition, scope (current queue or all queues), and trigger actions.

* **UI Enhancements**
  * Added conditional “Trigger Actions” and “Scope” controls when the setting is enabled.
  * Save/Create is disabled with guidance when enabled but no trigger actions are selected.

* **Backend Improvements**
  * After moderator decisions, the system can automatically clear other matching pending jobs per the configured trigger logic.

* **Bug Fixes**
  * Improved handling of legacy pending job snapshots with missing IDs.

* **Tests**
  * Added Jest coverage for enabled/disabled and trigger-action behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->