### PR TITLE
Make clickhouse configs for spillover on queries

### DIFF
--- a/client/src/webpages/dashboard/Dashboard.tsx
+++ b/client/src/webpages/dashboard/Dashboard.tsx
@@ -61,6 +61,13 @@ const lazyRoute =
     Component: (await importFn()).default,
   });
 
+// Redirects to `to` while preserving the current query string, so legacy
+// links carrying params (e.g. ?id=…&typeId=…) don't lose them on redirect.
+function RedirectPreservingSearch({ to }: { to: string }) {
+  const { search } = useLocation();
+  return <Navigate replace to={`${to}${search}`} />;
+}
+
 export function DashboardRoutes() {
   return {
     path: 'dashboard',
@@ -336,7 +343,9 @@ export function DashboardRoutes() {
       },
       {
         path: 'investigation',
-        element: <Navigate replace to="../manual_review/investigation" />,
+        element: (
+          <RedirectPreservingSearch to="../manual_review/investigation" />
+        ),
         handle: { isUsingLegacyCSS: true },
       },
 

--- a/client/src/webpages/dashboard/userStrikes/StrikeAnalyticsTab.tsx
+++ b/client/src/webpages/dashboard/userStrikes/StrikeAnalyticsTab.tsx
@@ -217,7 +217,7 @@ function RecentUserStrikeActionsTable() {
           user: (
             <Link
               className="cursor-pointer shrink-0"
-              to={`/dashboard/investigation?id=${values.itemId}&typeId=${values.itemTypeId}`}
+              to={`/dashboard/manual_review/investigation?id=${values.itemId}&typeId=${values.itemTypeId}`}
               target="_blank"
             >
               {values.itemId}

--- a/server/.env.example
+++ b/server/.env.example
@@ -61,6 +61,13 @@ CLICKHOUSE_PROTOCOL=http
 # CLICKHOUSE_INSERT_RETRY_INITIAL_MS=100
 # CLICKHOUSE_INSERT_RETRY_MAX_MS=1000
 
+# ClickHouse query memory limits (bytes). When a GROUP BY / ORDER BY exceeds the
+# threshold, ClickHouse spills to disk instead of holding everything in RAM,
+# avoiding server-wide OOM kills by the OvercommitTracker. Defaults to ~1.5 GB;
+# tune to the ClickHouse host's available RAM.
+# CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY=1500000000
+# CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_SORT=1500000000
+
 HMA_SERVICE_URL=http://localhost:9876
 
 # Scylla Cluster Details

--- a/server/.env.example
+++ b/server/.env.example
@@ -68,6 +68,11 @@ CLICKHOUSE_PROTOCOL=http
 # CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY=1500000000
 # CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_SORT=1500000000
 
+# Lookback window (in days) for the Rule Insights dashboard aggregations. These
+# queries scan ACTION_EXECUTIONS, so a smaller window scans less data and uses
+# less memory. Defaults to 90 days; lower it on memory-constrained instances.
+# CLICKHOUSE_RULE_INSIGHTS_LOOKBACK_DAYS=90
+
 HMA_SERVICE_URL=http://localhost:9876
 
 # Scylla Cluster Details

--- a/server/graphql/datasources/RuleApi.ts
+++ b/server/graphql/datasources/RuleApi.ts
@@ -6,6 +6,7 @@ import { type Kysely } from 'kysely';
 import { uid } from 'uid';
 
 import { inject, type Dependencies } from '../../iocContainer/index.js';
+import { safeGetEnvInt } from '../../iocContainer/utils.js';
 import { type ActionCountsInput } from '../../services/actionStatisticsService/index.js';
 import { type AggregationClause } from '../../services/aggregationsService/index.js';
 import { type ConditionSetWithResultAsLogged } from '../../services/analyticsLoggers/index.js';
@@ -45,6 +46,7 @@ import {
 } from '../../utils/kyselyTransactionWithRetry.js';
 import { assertUnreachable } from '../../utils/misc.js';
 import { takeLast } from '../../utils/sql.js';
+import { DAY_MS } from '../../utils/time.js';
 import {
   type NonEmptyString,
   type RequiredWithoutNull,
@@ -603,28 +605,53 @@ class RuleAPI {
   }
 
   async getAllRuleInsights(orgId: string) {
-    const results = await Promise.allSettled([
-      this.actionStats.getActionedSubmissionCountsByDay(orgId),
-      this.actionStats.getActionedSubmissionCountsByPolicyByDay(orgId),
-      this.actionStats.getActionedSubmissionCountsByTagByDay(orgId),
-      this.actionStats.getActionedSubmissionCountsByActionByDay(orgId),
-      this.ruleInsights.getContentSubmissionCountsByDay(orgId),
-    ]);
+    // Each of these scans ACTION_EXECUTIONS over the lookback window. Run them
+    // sequentially so peak ClickHouse memory is one query's worth rather than
+    // all five at once, and bound the window (env-tunable, default 90 days) so
+    // a memory-constrained instance scans far less than a full year. The client
+    // filters further client-side and defaults to a one-week view.
+    const lookbackDays = safeGetEnvInt(
+      'CLICKHOUSE_RULE_INSIGHTS_LOOKBACK_DAYS',
+      90,
+    );
+    const startAt = new Date(Date.now() - lookbackDays * DAY_MS);
 
-    const valueOrEmpty = <T>(
-      r: PromiseSettledResult<readonly T[]>,
-    ): readonly T[] => (r.status === 'fulfilled' ? r.value : []);
+    const runSafely = async <T>(
+      fn: () => Promise<readonly T[]>,
+    ): Promise<readonly T[]> => {
+      try {
+        return await fn();
+      } catch {
+        return [];
+      }
+    };
+
+    const actionedSubmissionsByDay = await runSafely(async () =>
+      this.actionStats.getActionedSubmissionCountsByDay(orgId, startAt),
+    );
+    const actionedSubmissionsByPolicyByDay = await runSafely(async () =>
+      this.actionStats.getActionedSubmissionCountsByPolicyByDay(orgId, startAt),
+    );
+    const actionedSubmissionsByTagByDay = await runSafely(async () =>
+      this.actionStats.getActionedSubmissionCountsByTagByDay(orgId, startAt),
+    );
+    const actionedSubmissionsByActionByDay = await runSafely(async () =>
+      this.actionStats.getActionedSubmissionCountsByActionByDay(orgId, startAt),
+    );
+    const totalSubmissionsByDay = await runSafely(
+      async () =>
+        this.ruleInsights.getContentSubmissionCountsByDay(
+          orgId,
+          startAt,
+        ) as Promise<readonly { date: string; count: number }[]>,
+    );
 
     return {
-      actionedSubmissionsByDay: valueOrEmpty(results[0]),
-      actionedSubmissionsByPolicyByDay: valueOrEmpty(results[1]),
-      actionedSubmissionsByTagByDay: valueOrEmpty(results[2]),
-      actionedSubmissionsByActionByDay: valueOrEmpty(results[3]),
-      totalSubmissionsByDay: valueOrEmpty(
-        results[4] as PromiseSettledResult<
-          readonly { date: string; count: number }[]
-        >,
-      ),
+      actionedSubmissionsByDay,
+      actionedSubmissionsByPolicyByDay,
+      actionedSubmissionsByTagByDay,
+      actionedSubmissionsByActionByDay,
+      totalSubmissionsByDay,
     };
   }
 

--- a/server/graphql/datasources/RuleApi.ts
+++ b/server/graphql/datasources/RuleApi.ts
@@ -44,6 +44,7 @@ import {
   makeKyselyTransactionWithRetry,
   type KyselyTransactionWithRetry,
 } from '../../utils/kyselyTransactionWithRetry.js';
+import { logErrorJson } from '../../utils/logging.js';
 import { assertUnreachable } from '../../utils/misc.js';
 import { takeLast } from '../../utils/sql.js';
 import { DAY_MS } from '../../utils/time.js';
@@ -621,7 +622,9 @@ class RuleAPI {
     ): Promise<readonly T[]> => {
       try {
         return await fn();
-      } catch {
+      } catch (err) {
+        // eslint-disable-next-line no-restricted-syntax
+        logErrorJson({ message: 'rule insights query failed', error: err });
         return [];
       }
     };

--- a/server/graphql/modules/insights.ts
+++ b/server/graphql/modules/insights.ts
@@ -313,7 +313,7 @@ const Query: GQLQueryResolvers = {
         user.orgId,
       );
     const bucketedStrikeCounts = lodash.countBy(
-      allUserStrikeCounts,
+      allUserStrikeCounts.filter((it) => it.strike_count > 0),
       (it) => it.strike_count,
     );
     return Object.entries(bucketedStrikeCounts).map((bucket) => ({

--- a/server/plugins/analytics/adapters/ClickhouseAnalyticsAdapter.ts
+++ b/server/plugins/analytics/adapters/ClickhouseAnalyticsAdapter.ts
@@ -1,15 +1,16 @@
 import { createClient, type ClickHouseClient } from '@clickhouse/client';
 
-import type SafeTracer from '../../../utils/SafeTracer.js';
 import { jsonStringify, tryJsonParse } from '../../../utils/encoding.js';
 import { logErrorJson } from '../../../utils/logging.js';
+import type SafeTracer from '../../../utils/SafeTracer.js';
+import { getClickhouseMemorySettings } from '../../warehouse/utils/clickhouseSettings.js';
+import { formatClickhouseQuery } from '../../warehouse/utils/clickhouseSql.js';
 import type { IAnalyticsAdapter } from '../IAnalyticsAdapter.js';
 import {
   type AnalyticsEventInput,
   type AnalyticsQueryResult,
   type AnalyticsWriteOptions,
 } from '../types.js';
-import { formatClickhouseQuery } from '../../warehouse/utils/clickhouseSql.js';
 import {
   isTransientNetworkError,
   withClickhouseInsertRetries,
@@ -35,18 +36,9 @@ export class ClickhouseAnalyticsAdapter implements IAnalyticsAdapter {
     string,
     ReadonlySet<string>
   >([
-    [
-      'content_api_requests',
-      new Set(['item_type_schema_field_roles']),
-    ],
-    [
-      'item_model_scores_log',
-      new Set(['item_type_schema_field_roles']),
-    ],
-    [
-      'appeals',
-      new Set(['actioned_item_type_schema_field_roles']),
-    ],
+    ['content_api_requests', new Set(['item_type_schema_field_roles'])],
+    ['item_model_scores_log', new Set(['item_type_schema_field_roles'])],
+    ['appeals', new Set(['actioned_item_type_schema_field_roles'])],
     [
       'reporting_rule_executions',
       new Set(['result', 'item_type_schema_field_roles']),
@@ -61,18 +53,9 @@ export class ClickhouseAnalyticsAdapter implements IAnalyticsAdapter {
     string,
     ReadonlySet<string>
   >([
-    [
-      'action_executions',
-      new Set(['rules', 'policies', 'rule_tags']),
-    ],
-    [
-      'reporting_rule_executions',
-      new Set([]),
-    ],
-    [
-      'reports',
-      new Set([]),
-    ],
+    ['action_executions', new Set(['rules', 'policies', 'rule_tags'])],
+    ['reporting_rule_executions', new Set([])],
+    ['reports', new Set([])],
   ]);
 
   private static readonly DATE_TIME_FIELDS = new Set([
@@ -120,10 +103,19 @@ export class ClickhouseAnalyticsAdapter implements IAnalyticsAdapter {
       username: options.connection.username,
       ...(password ? { password } : {}),
       database: options.connection.database,
+      clickhouse_settings: {
+        ...getClickhouseMemorySettings(),
+      },
     });
 
     this.insertWithRetries = withClickhouseInsertRetries(
-      async ({ table, values }: { table: string; values: AnalyticsEventInput[] }) => {
+      async ({
+        table,
+        values,
+      }: {
+        table: string;
+        values: AnalyticsEventInput[];
+      }) => {
         await this.client.insert({ table, values, format: 'JSONEachRow' });
       },
     );
@@ -173,7 +165,7 @@ export class ClickhouseAnalyticsAdapter implements IAnalyticsAdapter {
         format: 'JSONEachRow',
       });
 
-      const rows = (await result.json());
+      const rows = await result.json();
       return rows as readonly T[];
     };
 
@@ -225,13 +217,19 @@ export class ClickhouseAnalyticsAdapter implements IAnalyticsAdapter {
       // rules, policies, rule_tags are String columns storing JSON
       const regularArrayFields = ['policy_names', 'policy_ids', 'tags'];
       const jsonStringFields = ['rules', 'policies', 'rule_tags'];
-      
-      if (regularArrayFields.includes(key) && (value === null || value === undefined)) {
+
+      if (
+        regularArrayFields.includes(key) &&
+        (value === null || value === undefined)
+      ) {
         normalized[key] = [];
         continue;
       }
-      
-      if (jsonStringFields.includes(key) && (value === null || value === undefined)) {
+
+      if (
+        jsonStringFields.includes(key) &&
+        (value === null || value === undefined)
+      ) {
         normalized[key] = '[]';
         continue;
       }
@@ -269,7 +267,10 @@ export class ClickhouseAnalyticsAdapter implements IAnalyticsAdapter {
           // Already a string, keep it
           continue;
         }
-        if (value !== null && (typeof value === 'object' || Array.isArray(value))) {
+        if (
+          value !== null &&
+          (typeof value === 'object' || Array.isArray(value))
+        ) {
           normalized[fieldKey] = jsonStringify(value);
         } else {
           normalized[fieldKey] = defaultValue;
@@ -350,8 +351,7 @@ export class ClickhouseAnalyticsAdapter implements IAnalyticsAdapter {
       return this.normalizeJsonArray(value);
     }
 
-    const dateKind =
-      ClickhouseAnalyticsAdapter.DATE_FIELD_KINDS.get(lowerKey);
+    const dateKind = ClickhouseAnalyticsAdapter.DATE_FIELD_KINDS.get(lowerKey);
     if (dateKind) {
       return this.normalizeDateField(value, dateKind);
     }
@@ -382,7 +382,7 @@ export class ClickhouseAnalyticsAdapter implements IAnalyticsAdapter {
     // For ClickHouse JSON columns with experimental object type enabled,
     // we should pass objects/arrays directly. The ClickHouse client will
     // handle serialization when using JSONEachRow format.
-    
+
     if (Array.isArray(value)) {
       if (stringifyFields.includes(key)) {
         return jsonStringify(value);
@@ -403,10 +403,7 @@ export class ClickhouseAnalyticsAdapter implements IAnalyticsAdapter {
     return value;
   }
 
-  private normalizeDateField(
-    value: unknown,
-    kind: DateFieldKind,
-  ): unknown {
+  private normalizeDateField(value: unknown, kind: DateFieldKind): unknown {
     if (value == null) {
       return value;
     }
@@ -451,9 +448,13 @@ export class ClickhouseAnalyticsAdapter implements IAnalyticsAdapter {
     return value;
   }
 
-  private parseAndFormatDate(value: string, column: string): string | undefined {
-    const kind =
-      ClickhouseAnalyticsAdapter.DATE_FIELD_KINDS.get(column.toLowerCase());
+  private parseAndFormatDate(
+    value: string,
+    column: string,
+  ): string | undefined {
+    const kind = ClickhouseAnalyticsAdapter.DATE_FIELD_KINDS.get(
+      column.toLowerCase(),
+    );
     if (!kind) {
       return undefined;
     }

--- a/server/plugins/warehouse/queries/ClickhouseActionStatisticsAdapter.ts
+++ b/server/plugins/warehouse/queries/ClickhouseActionStatisticsAdapter.ts
@@ -1,11 +1,11 @@
-import {
-  type ActionCountsInput,
-  type IActionStatisticsAdapter,
-  type ActionStatisticsTimeDivisionOptions,
-} from './IActionStatisticsAdapter.js';
 import type { IDataWarehouse } from '../../../storage/dataWarehouse/IDataWarehouse.js';
 import type SafeTracer from '../../../utils/SafeTracer.js';
 import { YEAR_MS } from '../../../utils/time.js';
+import {
+  type ActionCountsInput,
+  type ActionStatisticsTimeDivisionOptions,
+  type IActionStatisticsAdapter,
+} from './IActionStatisticsAdapter.js';
 
 type ActionedSubmissionCountRow = {
   ds: string;
@@ -48,9 +48,7 @@ type ActionCountRow = {
   date: string;
 };
 
-export class ClickhouseActionStatisticsAdapter
-  implements IActionStatisticsAdapter
-{
+export class ClickhouseActionStatisticsAdapter implements IActionStatisticsAdapter {
   constructor(
     private readonly dataWarehouse: IDataWarehouse,
     private readonly tracer: SafeTracer,
@@ -86,7 +84,7 @@ export class ClickhouseActionStatisticsAdapter
       `
         SELECT 
           ds,
-          uniqExact(item_submission_id) AS num_submissions
+          uniq(item_submission_id) AS num_submissions
         FROM analytics.ACTION_EXECUTIONS
         WHERE org_id = ?
           AND ds > ?
@@ -112,7 +110,7 @@ export class ClickhouseActionStatisticsAdapter
         SELECT 
           ds,
           arrayJoin(JSONExtractArrayRaw(rule_tags)) AS tag,
-          uniqExact(item_submission_id) AS count
+          uniq(item_submission_id) AS count
         FROM analytics.ACTION_EXECUTIONS
         WHERE org_id = ?
           AND ds > ?
@@ -141,7 +139,7 @@ export class ClickhouseActionStatisticsAdapter
           ds,
           JSONExtractString(policy_json, 'id') AS policy_id,
           JSONExtractString(policy_json, 'name') AS policy_name,
-          uniqExact(item_submission_id) AS num_submissions
+          uniq(item_submission_id) AS num_submissions
         FROM analytics.ACTION_EXECUTIONS
         ARRAY JOIN JSONExtractArrayRaw(policies) AS policy_json
         WHERE org_id = ?
@@ -444,12 +442,16 @@ export class ClickhouseActionStatisticsAdapter
     ];
 
     if (filterBy.actionIds.length > 0) {
-      filters.push(`action_id IN (${filterBy.actionIds.map(() => '?').join(', ')})`);
+      filters.push(
+        `action_id IN (${filterBy.actionIds.map(() => '?').join(', ')})`,
+      );
       params.push(...filterBy.actionIds);
     }
 
     if (filterBy.itemTypeIds.length > 0) {
-      filters.push(`item_type_id IN (${filterBy.itemTypeIds.map(() => '?').join(', ')})`);
+      filters.push(
+        `item_type_id IN (${filterBy.itemTypeIds.map(() => '?').join(', ')})`,
+      );
       params.push(...filterBy.itemTypeIds);
     }
 
@@ -466,7 +468,8 @@ export class ClickhouseActionStatisticsAdapter
         ? `multiIf(action_source IN ('post-items','post-content'), 'automated-rule', action_source) AS action_source`
         : `${groupBy} AS ${groupBy.toLowerCase()}`;
 
-    const groupByColumn = groupBy === 'ACTION_SOURCE' ? 'action_source' : groupBy;
+    const groupByColumn =
+      groupBy === 'ACTION_SOURCE' ? 'action_source' : groupBy;
 
     const rows = await this.query<GroupByResultRow>(
       `
@@ -479,11 +482,7 @@ export class ClickhouseActionStatisticsAdapter
         GROUP BY ${groupByColumn}, time
         ORDER BY time
       `,
-      [
-        this.toTimeDivisionValue(timeDivision),
-        timeZone,
-        ...params,
-      ],
+      [this.toTimeDivisionValue(timeDivision), timeZone, ...params],
     );
 
     return rows.map((row) => ({
@@ -495,4 +494,3 @@ export class ClickhouseActionStatisticsAdapter
     }));
   }
 }
-

--- a/server/plugins/warehouse/utils/clickhouseSettings.ts
+++ b/server/plugins/warehouse/utils/clickhouseSettings.ts
@@ -1,0 +1,34 @@
+import { safeGetEnvInt } from '../../../iocContainer/utils.js';
+
+// Spilling large GROUP BY / ORDER BY operations to disk keeps a heavy query
+// below the server-wide memory limit, so it degrades gracefully instead of being
+// killed by ClickHouse's OvercommitTracker. Default ~1.5 GB; override per
+// deployment via env vars to match the ClickHouse host's available RAM.
+const DEFAULT_MAX_BYTES_BEFORE_EXTERNAL = 1_500_000_000;
+
+export interface ClickhouseMemorySettings {
+  max_bytes_before_external_group_by: string;
+  max_bytes_before_external_sort: string;
+}
+
+/**
+ * Builds the ClickHouse client memory settings from env vars, falling back to
+ * sane defaults. Values are returned as strings because the client types
+ * `UInt64` settings as `string`.
+ */
+export function getClickhouseMemorySettings(): ClickhouseMemorySettings {
+  return {
+    max_bytes_before_external_group_by: String(
+      safeGetEnvInt(
+        'CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY',
+        DEFAULT_MAX_BYTES_BEFORE_EXTERNAL,
+      ),
+    ),
+    max_bytes_before_external_sort: String(
+      safeGetEnvInt(
+        'CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_SORT',
+        DEFAULT_MAX_BYTES_BEFORE_EXTERNAL,
+      ),
+    ),
+  };
+}

--- a/server/services/manualReviewToolService/manualReviewToolService.test.ts
+++ b/server/services/manualReviewToolService/manualReviewToolService.test.ts
@@ -13,6 +13,8 @@ import {
   type NcmecContentItemSubmission,
   type ReportHistory,
 } from './manualReviewToolService.js';
+import { AUTOMATED_DECISION_REVIEWER_ID } from './modules/JobDecisioning.js';
+import { jobIdToGuid } from './modules/QueueOperations.js';
 
 function makeDummyJob() {
   return {
@@ -268,6 +270,59 @@ describe('Manual Review Tool Service', () => {
     });
 
     it.skip('should reject duplicate decisions on jobs dequeued again after the lock expires', async () => {});
+  });
+
+  // Regression: AUTOMATIC_CLOSE decisions have no human reviewer, but
+  // `manual_review_decisions.reviewer_id` is NOT NULL. Passing undefined
+  // through used to insert a null and fail with 23502, which left the job
+  // stuck in a retry loop. The decision must record the empty-string
+  // reviewer id (rendered as "Automatic" client-side) and not throw.
+  describe('automatic close decisions', () => {
+    it('records an AUTOMATIC_CLOSE decision with no human reviewer', async () => {
+      const orgId = 'e7c89ce7729';
+      const queueId = '1';
+      const jobPayload = makeDummyJob();
+
+      await mrtService['queueOps']['addJob']({
+        jobPayload,
+        orgId,
+        queueId,
+        enqueueSourceInfo: { kind: 'REPORT' },
+      });
+
+      const dequeuedJob = await mrtService.dequeueNextJob({
+        orgId,
+        queueId,
+        userId: uuidv1(),
+      });
+
+      if (!dequeuedJob) {
+        throw new Error("should've returned a job");
+      }
+
+      // Used to throw 23502 (null reviewer_id) before the sentinel fix.
+      await mrtService.submitDecision({
+        queueId,
+        reportHistory: [],
+        jobId: dequeuedJob.job.id,
+        lockToken: dequeuedJob.lockToken,
+        relatedActions: [],
+        orgId,
+        automaticCloseDecision: {
+          type: 'AUTOMATIC_CLOSE',
+          reason: 'ITEM_DELETED_BEFORE_REVIEW',
+        },
+      });
+
+      const row = await mrtService['pgQuery']
+        .selectFrom('manual_review_tool.manual_review_decisions')
+        .where('id', '=', jobIdToGuid(dequeuedJob.job.id))
+        .where('org_id', '=', orgId)
+        .select(['reviewer_id'])
+        .executeTakeFirst();
+
+      expect(row?.reviewer_id).toBe(AUTOMATED_DECISION_REVIEWER_ID);
+    });
   });
 
   // Issue #616: when an org sets `mrt_requires_decision_reason_on_action`,

--- a/server/services/manualReviewToolService/modules/JobDecisioning.ts
+++ b/server/services/manualReviewToolService/modules/JobDecisioning.ts
@@ -64,6 +64,17 @@ type MRTJobAutoCloseReason =
   // reports (issue #650).
   | 'USER_ACTIONED';
 
+/**
+ * `reviewer_id` recorded for decisions the system makes with no human reviewer
+ * (e.g. AUTOMATIC_CLOSE). `manual_review_decisions.reviewer_id` is NOT NULL, so
+ * we can't store null; we store the empty string instead. The MRT client treats
+ * a falsy reviewer id as "Automatic" (see getReviewerName in
+ * ManualReviewRecentDecisions.tsx), and the reviewer-grouped analytics table
+ * drops ids that don't match an org user, so the empty string renders correctly
+ * everywhere without a schema migration or any client change.
+ */
+export const AUTOMATED_DECISION_REVIEWER_ID = '';
+
 export type ManualReviewDecisionComponent =
   | { type: 'IGNORE' }
   | {
@@ -623,7 +634,10 @@ export default class JobDecisioning {
         id,
         job_payload: job,
         queue_id: queueId,
-        reviewer_id: reviewerId,
+        // Automatic decisions (AUTOMATIC_CLOSE) have no human reviewer, but the
+        // column is NOT NULL; record a sentinel instead of letting undefined
+        // become a null and fail the insert (23502).
+        reviewer_id: reviewerId ?? AUTOMATED_DECISION_REVIEWER_ID,
         org_id: orgId,
         decision_components: decisionComponents,
         related_actions: relatedActions,

--- a/server/storage/dataWarehouse/ClickhouseAdapter.ts
+++ b/server/storage/dataWarehouse/ClickhouseAdapter.ts
@@ -14,6 +14,7 @@ import {
   type TransactionSettings,
 } from 'kysely';
 
+import { getClickhouseMemorySettings } from '../../plugins/warehouse/utils/clickhouseSettings.js';
 import { formatClickhouseQuery } from '../../plugins/warehouse/utils/clickhouseSql.js';
 import type {
   DataWarehousePoolSettings,
@@ -133,6 +134,7 @@ export class ClickhouseKyselyAdapter implements IDataWarehouseDialect {
       database: connectionSettings.database,
       clickhouse_settings: {
         allow_experimental_object_type: 1,
+        ...getClickhouseMemorySettings(),
       },
     });
 


### PR DESCRIPTION
## Context & Requests for Reviewers

This helps with graceful degradation on groupby queries when they are too big so they spillover to the disk and not OOM the machine.