### PR TITLE
ci: run coderabbit on draft PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,7 +14,7 @@ reviews:
 
   auto_review:
     enabled: true
-    drafts: false
+    drafts: true
     base_branches:
       - main
     ignore_usernames:


### PR DESCRIPTION
## Context & Requests for Reviewers

CodeRabbit is great. However, currently it does not run on draft PRs.

This causes a bit of a problem. Before I request a human's attention on my PRs, I'd like the AI to review it first so I can address any findings. However, to do that I have to mark a PR as ready -- which also requests a review from all code owners at the same time!

So, I suggest we run CodeRabbit on draft PRS, too.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->