### PR TITLE
ci: make image pulls resilient to Docker Hub flakiness

### DIFF
--- a/.github/actions/prepare-docker-images/action.yml
+++ b/.github/actions/prepare-docker-images/action.yml
@@ -1,0 +1,51 @@
+name: Prepare Docker images
+description: >
+  Pull (and optionally build) images from a docker-compose
+  file, with special handling to avoid flakiness (since Docker Hub
+  sometimes returns errors for no good reason).
+
+inputs:
+  pull:
+    description: Space-separated compose services whose images should be pulled.
+    required: false
+    default: ''
+  build:
+    description: Space-separated compose services that should be built.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Configure Docker Hub mirror
+      # Route docker.io pulls through Google's pull-through cache to avoid
+      # transient Docker Hub registry/auth timeouts.
+      shell: bash
+      run: |
+        sudo mkdir -p /etc/docker
+        echo '{"registry-mirrors":["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
+        sudo systemctl restart docker
+
+    - name: Pre-pull images (with retry)
+      shell: bash
+      env:
+        PULL_SERVICES: ${{ inputs.pull }}
+        BUILD_SERVICES: ${{ inputs.build }}
+      run: |
+        # In addition to using the registry mirror above, we also
+        # retry Docker image pulls a few times to handle flakiness.
+        for attempt in 1 2 3; do
+          ok=true
+          if [ -n "$PULL_SERVICES" ]; then
+            docker compose pull --quiet $PULL_SERVICES || ok=false
+          fi
+          if [ "$ok" = true ] && [ -n "$BUILD_SERVICES" ]; then
+            docker compose build --quiet $BUILD_SERVICES || ok=false
+          fi
+          if [ "$ok" = true ]; then exit 0; fi
+          if [ "$attempt" -lt 3 ]; then
+            echo "::warning::image prep attempt $attempt failed; retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          fi
+        done
+        echo "::error::image prep failed after 3 attempts"; exit 1

--- a/.github/workflows/apply_pr_checks.yaml
+++ b/.github/workflows/apply_pr_checks.yaml
@@ -31,10 +31,21 @@ jobs:
         id: filter
         with:
           filters: |
+            # Changes to the dockerised CI plumbing re-run the jobs that
+            # depend on it, so this workflow, the compose file, and the
+            # Dockerfile are exercised even when no app code changed.
+            docker: &docker
+              - 'docker-compose.yaml'
+              - 'Dockerfile'
+              - '.env.githubci'
+              - '.github/workflows/apply_pr_checks.yaml'
+              - '.github/actions/prepare-docker-images/**'
             server:
               - 'server/**'
+              - *docker
             client:
               - 'client/**'
+              - *docker
             db:
               - 'db/**'
             migrator:

--- a/.github/workflows/apply_pr_checks.yaml
+++ b/.github/workflows/apply_pr_checks.yaml
@@ -49,6 +49,25 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+      - name: Configure Docker Hub mirror
+        # Route docker.io pulls through Google's pull-through cache to avoid
+        # transient Docker Hub registry/auth timeouts. Fork-safe (no secrets).
+        run: |
+          sudo mkdir -p /etc/docker
+          echo '{"registry-mirrors":["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+      - name: Pre-pull images (with retry)
+        # Fetch images before the real step so a transient pull failure is
+        # retried here and never masks a genuine codegen failure below.
+        run: |
+          for attempt in 1 2 3; do
+            if docker compose build --quiet codegen-check; then exit 0; fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "::warning::image prep attempt $attempt failed; retrying in $((attempt * 15))s"
+              sleep $((attempt * 15))
+            fi
+          done
+          echo "::error::image prep failed after 3 attempts"; exit 1
       - name: Check generated GraphQL is up to date
         run: docker compose run --rm --quiet-pull codegen-check
 
@@ -151,6 +170,28 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Configure Docker Hub mirror
+        # Route docker.io pulls through Google's pull-through cache to avoid
+        # transient Docker Hub registry/auth timeouts. Fork-safe (no secrets).
+        run: |
+          sudo mkdir -p /etc/docker
+          echo '{"registry-mirrors":["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+
+      - name: Pre-pull images (with retry)
+        # Fetch images before the real steps so a transient pull failure is
+        # retried here and never masks a genuine lint/build/test failure below.
+        run: |
+          for attempt in 1 2 3; do
+            if docker compose pull --quiet postgres scylla clickhouse redis \
+              && docker compose build --quiet backend test; then exit 0; fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "::warning::image prep attempt $attempt failed; retrying in $((attempt * 15))s"
+              sleep $((attempt * 15))
+            fi
+          done
+          echo "::error::image prep failed after 3 attempts"; exit 1
+
       - name: Lint
         run: docker compose run --rm --quiet-pull backend npm run lint
 
@@ -188,6 +229,27 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - name: Configure Docker Hub mirror
+        # Route docker.io pulls through Google's pull-through cache to avoid
+        # transient Docker Hub registry/auth timeouts. Fork-safe (no secrets).
+        run: |
+          sudo mkdir -p /etc/docker
+          echo '{"registry-mirrors":["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+
+      - name: Pre-pull images (with retry)
+        # Fetch images before the real steps so a transient pull failure is
+        # retried here and never masks a genuine lint/build failure below.
+        run: |
+          for attempt in 1 2 3; do
+            if docker compose build --quiet client; then exit 0; fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "::warning::image prep attempt $attempt failed; retrying in $((attempt * 15))s"
+              sleep $((attempt * 15))
+            fi
+          done
+          echo "::error::image prep failed after 3 attempts"; exit 1
 
       - name: Lint client
         run: docker compose run --rm --quiet-pull client npm run lint

--- a/.github/workflows/apply_pr_checks.yaml
+++ b/.github/workflows/apply_pr_checks.yaml
@@ -49,25 +49,10 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - name: Configure Docker Hub mirror
-        # Route docker.io pulls through Google's pull-through cache to avoid
-        # transient Docker Hub registry/auth timeouts. Fork-safe (no secrets).
-        run: |
-          sudo mkdir -p /etc/docker
-          echo '{"registry-mirrors":["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
-          sudo systemctl restart docker
-      - name: Pre-pull images (with retry)
-        # Fetch images before the real step so a transient pull failure is
-        # retried here and never masks a genuine codegen failure below.
-        run: |
-          for attempt in 1 2 3; do
-            if docker compose build --quiet codegen-check; then exit 0; fi
-            if [ "$attempt" -lt 3 ]; then
-              echo "::warning::image prep attempt $attempt failed; retrying in $((attempt * 15))s"
-              sleep $((attempt * 15))
-            fi
-          done
-          echo "::error::image prep failed after 3 attempts"; exit 1
+      - name: Prepare Docker images
+        uses: ./.github/actions/prepare-docker-images
+        with:
+          build: codegen-check
       - name: Check generated GraphQL is up to date
         run: docker compose run --rm --quiet-pull codegen-check
 
@@ -170,27 +155,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Configure Docker Hub mirror
-        # Route docker.io pulls through Google's pull-through cache to avoid
-        # transient Docker Hub registry/auth timeouts. Fork-safe (no secrets).
-        run: |
-          sudo mkdir -p /etc/docker
-          echo '{"registry-mirrors":["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
-          sudo systemctl restart docker
-
-      - name: Pre-pull images (with retry)
-        # Fetch images before the real steps so a transient pull failure is
-        # retried here and never masks a genuine lint/build/test failure below.
-        run: |
-          for attempt in 1 2 3; do
-            if docker compose pull --quiet postgres scylla clickhouse redis \
-              && docker compose build --quiet backend test; then exit 0; fi
-            if [ "$attempt" -lt 3 ]; then
-              echo "::warning::image prep attempt $attempt failed; retrying in $((attempt * 15))s"
-              sleep $((attempt * 15))
-            fi
-          done
-          echo "::error::image prep failed after 3 attempts"; exit 1
+      - name: Prepare Docker images
+        uses: ./.github/actions/prepare-docker-images
+        with:
+          pull: postgres scylla clickhouse redis
+          build: backend test
 
       - name: Lint
         run: docker compose run --rm --quiet-pull backend npm run lint
@@ -230,26 +199,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Configure Docker Hub mirror
-        # Route docker.io pulls through Google's pull-through cache to avoid
-        # transient Docker Hub registry/auth timeouts. Fork-safe (no secrets).
-        run: |
-          sudo mkdir -p /etc/docker
-          echo '{"registry-mirrors":["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
-          sudo systemctl restart docker
-
-      - name: Pre-pull images (with retry)
-        # Fetch images before the real steps so a transient pull failure is
-        # retried here and never masks a genuine lint/build failure below.
-        run: |
-          for attempt in 1 2 3; do
-            if docker compose build --quiet client; then exit 0; fi
-            if [ "$attempt" -lt 3 ]; then
-              echo "::warning::image prep attempt $attempt failed; retrying in $((attempt * 15))s"
-              sleep $((attempt * 15))
-            fi
-          done
-          echo "::error::image prep failed after 3 attempts"; exit 1
+      - name: Prepare Docker images
+        uses: ./.github/actions/prepare-docker-images
+        with:
+          build: client
 
       - name: Lint client
         run: docker compose run --rm --quiet-pull client npm run lint


### PR DESCRIPTION
## Context & Requests for Reviewers

I was hitting occassional errors from Docker Hub when running CI. This PR tries to avoid this kind of flakiness in two ways:

- by using `mirror.gcr.io`, Google's pull-through mirror of Docker Hub
- and also by retrying pulls a few times.

Hopefully this makes CI less flaky.

I made one other change to test this: CI now runs when we modify files like `apply_pr_changes.yaml` so we don't accidentally merge anything that breaks CI.

## Tests

You can see CI passing on this PR!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD infrastructure for Docker image handling and dependency management in automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->