### PR TITLE
fix: close express-session store on api shutdown

### DIFF
--- a/server/api.ts
+++ b/server/api.ts
@@ -128,10 +128,11 @@ export default async function makeApiServer(deps: Dependencies) {
   /**
    * Passport & User Session Configuration
    */
+  const sessionStoreInstance = new sessionStore({ pool: KyselyPgPool });
   app.use(
     session({
       secret: process.env.SESSION_SECRET!,
-      store: new sessionStore({ pool: KyselyPgPool }),
+      store: sessionStoreInstance,
       cookie: {
         secure: process.env.NODE_ENV === 'production',
         httpOnly: true,
@@ -419,6 +420,7 @@ export default async function makeApiServer(deps: Dependencies) {
       await Promise.all([
         apolloServer.stop(),
         deps.closeSharedResourcesForShutdown(),
+        sessionStoreInstance.close(),
       ]);
     },
   };


### PR DESCRIPTION
## Context & Requests for Reviewers

While refactoring tests I came across a leak: when we create a `sessionStore` it starts a recurring job via `setInterval`. Because we weren't tearing this down properly, tests leave this orphaned timer running.

In another refactor I tried running a real Express server per-test and this meant that this leak caused problems.

## Tests

We're really only changing shutdown behavior here; pretty safe. `npm run server:start` still shuts down cleanly when you Ctrl-C.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved session store management by reusing a single Postgres-backed session store instance.
  * Enhanced server shutdown to explicitly close the session store for cleaner resource cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->