### PR TITLE
test: handle concurrent queries in the transactional test harness

### DIFF
--- a/server/test/harness/transactionalPgPool.integ.test.ts
+++ b/server/test/harness/transactionalPgPool.integ.test.ts
@@ -164,10 +164,6 @@ describe('createTransactionalTestDb', () => {
       });
       const transactionWithRetry = makeKyselyTransactionWithRetry(db);
 
-      // `seq` captures real write order (auto-assigned at INSERT). Ordering the
-      // final read by `seq` — not by `id`, which is the dispatch index and so
-      // would make the assertion trivially circular — proves the harness ran
-      // the concurrent transactions in FIFO dispatch order.
       await sql`create table concurrency_probe (id int primary key, seq serial)`.execute(
         db,
       );
@@ -197,6 +193,7 @@ describe('createTransactionalTestDb', () => {
       await tdb.end();
     }
   });
+
   it('isolates a concurrent rollback from sibling committed transactions', async () => {
     const tdb = createTransactionalTestDb(pgConfig);
     await tdb.begin();
@@ -252,6 +249,7 @@ describe('createTransactionalTestDb', () => {
       await tdb.end();
     }
   });
+
   it('supports nested application transactions without deadlocking', async () => {
     const tdb = createTransactionalTestDb(pgConfig);
     await tdb.begin();
@@ -264,10 +262,10 @@ describe('createTransactionalTestDb', () => {
       await sql`create table nested_probe (id int)`.execute(db);
 
       // An outer transaction that opens an inner transaction. Kysely issues a
-      // plain `begin` for the inner one (it does NOT auto-nest via savepoints),
+      // plain `begin` for the inner one,
       // so the harness must treat a BEGIN that arrives while a transaction
       // already holds the connection as a nested savepoint, not a concurrent
-      // transaction to wait on — otherwise this deadlocks.
+      // transaction to wait on.
       const result = await transactionWithRetry(async (trx) => {
         await sql`insert into nested_probe (id) values (1)`.execute(trx);
         const inner = await transactionWithRetry(async (innerTrx) => {

--- a/server/test/harness/transactionalPgPool.integ.test.ts
+++ b/server/test/harness/transactionalPgPool.integ.test.ts
@@ -164,7 +164,11 @@ describe('createTransactionalTestDb', () => {
       });
       const transactionWithRetry = makeKyselyTransactionWithRetry(db);
 
-      await sql`create table concurrency_probe (id int primary key)`.execute(
+      // `seq` captures real write order (auto-assigned at INSERT). Ordering the
+      // final read by `seq` — not by `id`, which is the dispatch index and so
+      // would make the assertion trivially circular — proves the harness ran
+      // the concurrent transactions in FIFO dispatch order.
+      await sql`create table concurrency_probe (id int primary key, seq serial)`.execute(
         db,
       );
 
@@ -182,7 +186,7 @@ describe('createTransactionalTestDb', () => {
 
       const rows = await sql<{
         id: number;
-      }>`select id from concurrency_probe order by id`.execute(db);
+      }>`select id from concurrency_probe order by seq`.execute(db);
       expect(rows.rows.map((r) => r.id)).toEqual(ids);
 
       await tdb.rollback();

--- a/server/test/harness/transactionalPgPool.integ.test.ts
+++ b/server/test/harness/transactionalPgPool.integ.test.ts
@@ -193,4 +193,96 @@ describe('createTransactionalTestDb', () => {
       await tdb.end();
     }
   });
+  it('isolates a concurrent rollback from sibling committed transactions', async () => {
+    const tdb = createTransactionalTestDb(pgConfig);
+    await tdb.begin();
+    try {
+      const db = new Kysely<Record<string, never>>({
+        dialect: new PostgresDialect({ pool: tdb.pool }),
+      });
+      const transactionWithRetry = makeKyselyTransactionWithRetry(db);
+
+      await sql`create table concurrency_probe (id int primary key)`.execute(
+        db,
+      );
+
+      // Run several transactions concurrently; one throws after its insert.
+      // Its row must be the only one missing — a concurrent rollback must
+      // never discard a sibling transaction's committed work.
+      const ids = [0, 1, 2, 3, 4];
+      const throwingId = 2;
+
+      await Promise.all(
+        ids.map(async (id) => {
+          if (id === throwingId) {
+            await expect(
+              transactionWithRetry(async (trx) => {
+                await sql`insert into concurrency_probe (id) values (${id})`.execute(
+                  trx,
+                );
+                throw new Error('boom');
+              }),
+            ).rejects.toThrow('boom');
+          } else {
+            await transactionWithRetry(async (trx) => {
+              await sql`insert into concurrency_probe (id) values (${id})`.execute(
+                trx,
+              );
+            });
+          }
+        }),
+      );
+
+      const rows = await sql<{
+        id: number;
+      }>`select id from concurrency_probe order by id`.execute(db);
+      expect(rows.rows.map((r) => r.id)).toEqual(
+        ids.filter((id) => id !== throwingId),
+      );
+
+      await tdb.rollback();
+      await db.destroy();
+    } finally {
+      // Always close the pinned connection so a mid-test throw can't leak it
+      // (and closing aborts any still-open outer transaction).
+      await tdb.end();
+    }
+  });
+  it('supports nested application transactions without deadlocking', async () => {
+    const tdb = createTransactionalTestDb(pgConfig);
+    await tdb.begin();
+    try {
+      const db = new Kysely<Record<string, never>>({
+        dialect: new PostgresDialect({ pool: tdb.pool }),
+      });
+      const transactionWithRetry = makeKyselyTransactionWithRetry(db);
+
+      await sql`create table nested_probe (id int)`.execute(db);
+
+      // An outer transaction that opens an inner transaction. Kysely issues a
+      // plain `begin` for the inner one (it does NOT auto-nest via savepoints),
+      // so the harness must treat a BEGIN that arrives while a transaction
+      // already holds the connection as a nested savepoint, not a concurrent
+      // transaction to wait on — otherwise this deadlocks.
+      const result = await transactionWithRetry(async (trx) => {
+        await sql`insert into nested_probe (id) values (1)`.execute(trx);
+        const inner = await transactionWithRetry(async (innerTrx) => {
+          await sql`insert into nested_probe (id) values (2)`.execute(innerTrx);
+          return 'inner-ok';
+        });
+        return `outer-${inner}`;
+      });
+      expect(result).toBe('outer-inner-ok');
+
+      const rows = await sql<{
+        id: number;
+      }>`select id from nested_probe order by id`.execute(db);
+      expect(rows.rows.map((r) => r.id)).toEqual([1, 2]);
+
+      await tdb.rollback();
+      await db.destroy();
+    } finally {
+      await tdb.end();
+    }
+  });
 });

--- a/server/test/harness/transactionalPgPool.integ.test.ts
+++ b/server/test/harness/transactionalPgPool.integ.test.ts
@@ -154,4 +154,43 @@ describe('createTransactionalTestDb', () => {
       await tdb.end();
     }
   });
+
+  it('serializes concurrent commits so they do not race the savepoint stack', async () => {
+    const tdb = createTransactionalTestDb(pgConfig);
+    await tdb.begin();
+    try {
+      const db = new Kysely<Record<string, never>>({
+        dialect: new PostgresDialect({ pool: tdb.pool }),
+      });
+      const transactionWithRetry = makeKyselyTransactionWithRetry(db);
+
+      await sql`create table concurrency_probe (id int primary key)`.execute(
+        db,
+      );
+
+      const ids = Array.from({ length: 16 }, (_, i) => i);
+
+      await Promise.all(
+        ids.map(async (id) =>
+          transactionWithRetry(async (trx) => {
+            await sql`insert into concurrency_probe (id) values (${id})`.execute(
+              trx,
+            );
+          }),
+        ),
+      );
+
+      const rows = await sql<{
+        id: number;
+      }>`select id from concurrency_probe order by id`.execute(db);
+      expect(rows.rows.map((r) => r.id)).toEqual(ids);
+
+      await tdb.rollback();
+      await db.destroy();
+    } finally {
+      // Always close the pinned connection so a mid-test throw can't leak it
+      // (and closing aborts any still-open outer transaction).
+      await tdb.end();
+    }
+  });
 });

--- a/server/test/harness/transactionalPgPool.ts
+++ b/server/test/harness/transactionalPgPool.ts
@@ -107,41 +107,41 @@ export function createTransactionalTestDb(
 
   // ─────────────────────────────────────────────────────────────────────
   // One test = one real Postgres connection (the `client` above). Every
-  // `pool.connect()` returns a thin facade forwarding to it. This lets a
-  // test read its own writes: everything runs in one outer transaction on
-  // one connection, rolled back at the end.
+  // `pool.connect()` returns a thin facade forwarding to it, so a test reads
+  // its own writes: everything runs in one outer transaction, rolled back at
+  // the end. Each test has its own pg.Client (see transactionalTest.ts), so
+  // this serializes concurrent work *within* one test, not across tests.
   //
-  // The catch: pg's node driver only keeps query order if WE await each
-  // drive before starting the next. Once two awaits run concurrently on
-  // the same connection (Promise.all, background cache refreshers, …),
-  // queries can interleave on the wire and our savepoint machinery races.
-  //
-  // So, we force one-at-a-time on every query to the pinned connection —
-  // tx control AND data. Each test already has its own pg.Client (see
-  // transactionalTest.ts), so this serializes concurrent work *within*
-  // one test, not across tests.
+  // A single connection can't safely serve overlapping work: pg's node driver
+  // only preserves query order if we await each drive before starting the next,
+  // AND the savepoint stack is strictly nested (LIFO) — if transaction A's
+  // COMMIT/ROLLBACK runs while transaction B is also open, A releases/rolls
+  // back B's savepoint, corrupting the stack and discarding B's committed
+  // work. So the mutex must be held for the whole logical transaction (BEGIN →
+  // COMMIT/ROLLBACK), not per statement. Overlapping application transactions
+  // then run strictly one-after-another and savepoints stay properly nested.
   // ─────────────────────────────────────────────────────────────────────
 
-  // Pending work, chained in arrival order. Each query appends onto this
-  // and awaits everything ahead of it before running, so queries execute
-  // one at a time in the order they arrive.
+  // FIFO chain used outside application transactions (ad-hoc queries, and a
+  // new transaction's BEGIN waiting for the previous transaction to finish).
+  // The catch threaded back into `queue` is separate from what callers await,
+  // so a failed operation can't poison every later one.
   let queue: Promise<unknown> = Promise.resolve();
-
-  // Run `thunk` once everything already on the queue has settled. The
-  // catcher threaded back into `queue` is separate from what we return,
-  // so a failed query can't poison every later query; the caller still
-  // sees its own error via `await`.
-  const runOneAtATime = async <T>(thunk: () => Promise<T>): Promise<T> => {
+  const runAfterPending = async <T>(thunk: () => Promise<T>): Promise<T> => {
     const next = queue.then(thunk);
     queue = next.catch(() => {});
     return next;
   };
 
+  // Held for the lifetime of one application transaction (BEGIN →
+  // COMMIT/ROLLBACK). `null` outside any application transaction.
+  let txMutex: Promise<void> | null = null;
+  let endTx: (() => void) | null = null;
+
   // The single place transaction-control statements are rewritten to
-  // savepoints; everything else passes straight through to the pinned
-  // client. Shared by both the per-connection facade (`connect().query`)
-  // and the pool-level `query` (used by consumers like the express-session
-  // store).
+  // savepoints; everything else passes straight through to the pinned client.
+  // Shared by both the per-connection facade (`connect().query`) and the
+  // pool-level `query` (used by consumers like the express-session store).
   const runQuery = async (
     textOrConfig: string | pg.QueryConfig,
     values?: unknown[],
@@ -152,20 +152,67 @@ export function createTransactionalTestDb(
       typeof text === 'string'
         ? text.trim().toLowerCase().replace(/;/g, '')
         : '';
-
     if (normalized === 'begin' || normalized.startsWith('start transaction')) {
-      return runOneAtATime(openSavepoint); // → SAVEPOINT coop_test_sp_<new depth>
+      // A BEGIN that arrives while a transaction already holds the connection
+      // is a *nested* transaction (Kysely issues a plain `begin` for nesting,
+      // not a savepoint). It runs directly — no queueing, no re-acquiring —
+      // because a concurrent (non-nested) BEGIN is still blocked inside
+      // `runAfterPending` waiting for the mutex. We just open another
+      // savepoint (LIFO), which is exactly what the old per-statement code did.
+      if (txMutex !== null) {
+        return openSavepoint(); // → SAVEPOINT coop_test_sp_<new depth>
+      }
+      // Top-level BEGIN: queue behind any in-flight work, wait for a prior
+      // transaction to finish, then acquire the connection for ours.
+      return runAfterPending(async () => {
+        while (txMutex !== null) {
+          await txMutex;
+        }
+        txMutex = new Promise<void>((resolve) => {
+          endTx = resolve;
+        });
+        try {
+          return await openSavepoint(); // → SAVEPOINT coop_test_sp_<new depth>
+        } catch (e) {
+          // BEGIN failed: release the mutex so we don't deadlock the queue.
+          endTx?.();
+          txMutex = null;
+          endTx = null;
+          throw e;
+        }
+      });
     }
-    if (normalized === 'commit') {
-      return runOneAtATime(async () => closeSavepoint('commit')); // RELEASE SAVEPOINT
-    }
-    if (normalized === 'rollback') {
-      return runOneAtATime(async () => closeSavepoint('rollback')); // ROLLBACK TO SAVEPOINT
+    if (normalized === 'commit' || normalized === 'rollback') {
+      const verb = normalized === 'commit' ? 'commit' : 'rollback';
+      // Runs while our own transaction holds the mutex (no queueing — that
+      // would wait on ourselves). Only release the mutex when the outermost
+      // savepoint closes (depth → 0), so a nested COMMIT/ROLLBACK doesn't
+      // hand the connection to a waiting transaction while an outer
+      // transaction is still open.
+      if (txMutex === null) {
+        throw new Error(
+          `${verb.toUpperCase()} without a matching application transaction`,
+        );
+      }
+      const result = await closeSavepoint(verb);
+      if (savepointDepth === 0) {
+        endTx?.();
+        txMutex = null;
+        endTx = null;
+      }
+      return result;
     }
 
     rejectUnsupportedTransactionControl(normalized, text);
 
-    return runOneAtATime(async () =>
+    // Inside a transaction it already owns the connection; outside, queue to
+    // preserve wire order against other ad-hoc queries.
+    if (txMutex !== null) {
+      return values === undefined
+        ? client.query(textOrConfig)
+        : client.query(textOrConfig, values);
+    }
+    return runAfterPending(async () =>
       values === undefined
         ? client.query(textOrConfig)
         : client.query(textOrConfig, values),

--- a/server/test/harness/transactionalPgPool.ts
+++ b/server/test/harness/transactionalPgPool.ts
@@ -105,10 +105,43 @@ export function createTransactionalTestDb(
     return result;
   };
 
+  // ─────────────────────────────────────────────────────────────────────
+  // One test = one real Postgres connection (the `client` above). Every
+  // `pool.connect()` returns a thin facade forwarding to it. This lets a
+  // test read its own writes: everything runs in one outer transaction on
+  // one connection, rolled back at the end.
+  //
+  // The catch: pg's node driver only keeps query order if WE await each
+  // drive before starting the next. Once two awaits run concurrently on
+  // the same connection (Promise.all, background cache refreshers, …),
+  // queries can interleave on the wire and our savepoint machinery races.
+  //
+  // So, we force one-at-a-time on every query to the pinned connection —
+  // tx control AND data. Each test already has its own pg.Client (see
+  // transactionalTest.ts), so this serializes concurrent work *within*
+  // one test, not across tests.
+  // ─────────────────────────────────────────────────────────────────────
+
+  // Pending work, chained in arrival order. Each query appends onto this
+  // and awaits everything ahead of it before running, so queries execute
+  // one at a time in the order they arrive.
+  let queue: Promise<unknown> = Promise.resolve();
+
+  // Run `thunk` once everything already on the queue has settled. The
+  // catcher threaded back into `queue` is separate from what we return,
+  // so a failed query can't poison every later query; the caller still
+  // sees its own error via `await`.
+  const runOneAtATime = async <T>(thunk: () => Promise<T>): Promise<T> => {
+    const next = queue.then(thunk);
+    queue = next.catch(() => {});
+    return next;
+  };
+
   // The single place transaction-control statements are rewritten to
-  // savepoints; everything else passes straight through to the pinned client.
-  // Shared by both the per-connection facade (`connect().query`) and the
-  // pool-level `query` (used by consumers like the express-session store).
+  // savepoints; everything else passes straight through to the pinned
+  // client. Shared by both the per-connection facade (`connect().query`)
+  // and the pool-level `query` (used by consumers like the express-session
+  // store).
   const runQuery = async (
     textOrConfig: string | pg.QueryConfig,
     values?: unknown[],
@@ -121,20 +154,22 @@ export function createTransactionalTestDb(
         : '';
 
     if (normalized === 'begin' || normalized.startsWith('start transaction')) {
-      return openSavepoint();
+      return runOneAtATime(openSavepoint); // → SAVEPOINT coop_test_sp_<new depth>
     }
     if (normalized === 'commit') {
-      return closeSavepoint('commit');
+      return runOneAtATime(async () => closeSavepoint('commit')); // RELEASE SAVEPOINT
     }
     if (normalized === 'rollback') {
-      return closeSavepoint('rollback');
+      return runOneAtATime(async () => closeSavepoint('rollback')); // ROLLBACK TO SAVEPOINT
     }
 
     rejectUnsupportedTransactionControl(normalized, text);
 
-    return values === undefined
-      ? client.query(textOrConfig)
-      : client.query(textOrConfig, values);
+    return runOneAtATime(async () =>
+      values === undefined
+        ? client.query(textOrConfig)
+        : client.query(textOrConfig, values),
+    );
   };
 
   const facadeClient = {

--- a/server/test/harness/transactionalPgPool.ts
+++ b/server/test/harness/transactionalPgPool.ts
@@ -105,27 +105,6 @@ export function createTransactionalTestDb(
     return result;
   };
 
-  // ─────────────────────────────────────────────────────────────────────
-  // One test = one real Postgres connection (the `client` above). Every
-  // `pool.connect()` returns a thin facade forwarding to it, so a test reads
-  // its own writes: everything runs in one outer transaction, rolled back at
-  // the end. Each test has its own pg.Client (see transactionalTest.ts), so
-  // this serializes concurrent work *within* one test, not across tests.
-  //
-  // A single connection can't safely serve overlapping work: pg's node driver
-  // only preserves query order if we await each drive before starting the next,
-  // AND the savepoint stack is strictly nested (LIFO) — if transaction A's
-  // COMMIT/ROLLBACK runs while transaction B is also open, A releases/rolls
-  // back B's savepoint, corrupting the stack and discarding B's committed
-  // work. So the mutex must be held for the whole logical transaction (BEGIN →
-  // COMMIT/ROLLBACK), not per statement. Overlapping application transactions
-  // then run strictly one-after-another and savepoints stay properly nested.
-  // ─────────────────────────────────────────────────────────────────────
-
-  // FIFO chain used outside application transactions (ad-hoc queries, and a
-  // new transaction's BEGIN waiting for the previous transaction to finish).
-  // The catch threaded back into `queue` is separate from what callers await,
-  // so a failed operation can't poison every later one.
   let queue: Promise<unknown> = Promise.resolve();
   const runAfterPending = async <T>(thunk: () => Promise<T>): Promise<T> => {
     const next = queue.then(thunk);
@@ -138,10 +117,6 @@ export function createTransactionalTestDb(
   let txMutex: Promise<void> | null = null;
   let endTx: (() => void) | null = null;
 
-  // The single place transaction-control statements are rewritten to
-  // savepoints; everything else passes straight through to the pinned client.
-  // Shared by both the per-connection facade (`connect().query`) and the
-  // pool-level `query` (used by consumers like the express-session store).
   const runQuery = async (
     textOrConfig: string | pg.QueryConfig,
     values?: unknown[],
@@ -155,10 +130,7 @@ export function createTransactionalTestDb(
     if (normalized === 'begin' || normalized.startsWith('start transaction')) {
       // A BEGIN that arrives while a transaction already holds the connection
       // is a *nested* transaction (Kysely issues a plain `begin` for nesting,
-      // not a savepoint). It runs directly — no queueing, no re-acquiring —
-      // because a concurrent (non-nested) BEGIN is still blocked inside
-      // `runAfterPending` waiting for the mutex. We just open another
-      // savepoint (LIFO), which is exactly what the old per-statement code did.
+      // not a savepoint).
       if (txMutex !== null) {
         return openSavepoint(); // → SAVEPOINT coop_test_sp_<new depth>
       }
@@ -184,11 +156,8 @@ export function createTransactionalTestDb(
     }
     if (normalized === 'commit' || normalized === 'rollback') {
       const verb = normalized === 'commit' ? 'commit' : 'rollback';
-      // Runs while our own transaction holds the mutex (no queueing — that
-      // would wait on ourselves). Only release the mutex when the outermost
-      // savepoint closes (depth → 0), so a nested COMMIT/ROLLBACK doesn't
-      // hand the connection to a waiting transaction while an outer
-      // transaction is still open.
+      // Only release the mutex when the outermost
+      // savepoint closes (i.e. depth is 0).
       if (txMutex === null) {
         throw new Error(
           `${verb.toUpperCase()} without a matching application transaction`,
@@ -205,7 +174,7 @@ export function createTransactionalTestDb(
 
     rejectUnsupportedTransactionControl(normalized, text);
 
-    // Inside a transaction it already owns the connection; outside, queue to
+    // Outside a transaction, queue to
     // preserve wire order against other ad-hoc queries.
     if (txMutex !== null) {
       return values === undefined


### PR DESCRIPTION
## Context & Requests for Reviewers

I found a bug in the new transaction-test harness I added: it broke when handling concurrent DB queries, e.g. via `Promise.all(...)`.

This PR fixes that by serializing such queries (in tests only).

## Tests

I added an integration test to verify that this works. Note that this test doesn't actually run in CI until we fix #221 but I am on that. It passes locally, of course.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new integration coverage for transactional database behavior, including concurrent commits, concurrent rollback isolation, and nested application transactions.
  * Validated correct ordering and isolation under parallel execution to prevent race conditions and reduce deadlock risk.

* **Bug Fixes**
  * Improved reliability of transactional query execution on the pinned connection by preventing interleaving and ensuring transaction-control operations behave correctly with nested and top-level flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->