### PR TITLE
[Fix] Ensure sweep also handles related items

### DIFF
--- a/server/iocContainer/index.ts
+++ b/server/iocContainer/index.ts
@@ -1426,7 +1426,7 @@ export default async function getBottle() {
                 .map((ra) => ({
                   type: 'CUSTOM_ACTION' as const,
                   actions: ra.actionIds.map((id) => ({ id })),
-                  policies: [] as { id: string }[],
+                  policies: ra.policyIds.map((id) => ({ id })),
                   itemIds: [...ra.itemIds],
                   itemTypeId: ra.itemTypeId,
                 })),

--- a/server/iocContainer/index.ts
+++ b/server/iocContainer/index.ts
@@ -1417,9 +1417,20 @@ export default async function getBottle() {
         } finally {
           if (!suppressUserReportSweep && isReportJob(job)) {
             const reportJob = job;
-            const customActions = decisionComponents.flatMap((decision) =>
-              decision.type === 'CUSTOM_ACTION' ? [decision] : [],
-            );
+            const customActions = [
+              ...decisionComponents.flatMap((decision) =>
+                decision.type === 'CUSTOM_ACTION' ? [decision] : [],
+              ),
+              ...relatedActions
+                .filter((ra) => ra.actionIds.length > 0)
+                .map((ra) => ({
+                  type: 'CUSTOM_ACTION' as const,
+                  actions: ra.actionIds.map((id) => ({ id })),
+                  policies: [] as { id: string }[],
+                  itemIds: [...ra.itemIds],
+                  itemTypeId: ra.itemTypeId,
+                })),
+            ];
             if (customActions.length > 0) {
               container.ManualReviewToolService.maybeClearOtherReportsForUser({
                 orgId,

--- a/server/services/manualReviewToolService/modules/UserReportSweep.test.ts
+++ b/server/services/manualReviewToolService/modules/UserReportSweep.test.ts
@@ -252,6 +252,46 @@ describe('ManualReviewToolService.maybeClearOtherReportsForUser', () => {
   );
 
   testWithQueue()(
+    'fires sweep when trigger action comes from a related item (e.g. associated account)',
+    async ({
+      org,
+      user,
+      queue,
+      mrtService,
+      addJob,
+      configureQueue,
+      pendingJobIds,
+    }) => {
+      await configureQueue({ disposition: 'AUTOMATIC_CLOSE' });
+
+      const actionedJob = await addJob({ creator: reportedUser });
+      await addJob({ creator: reportedUser });
+
+      // Simulate a related action (e.g. "Disable Account" on the user profile)
+      // that matches the trigger but targets a different item type/id.
+      const result = await mrtService.maybeClearOtherReportsForUser({
+        orgId: org.id,
+        actionedJob,
+        actionedQueueId: queue.id,
+        customActions: [
+          {
+            type: 'CUSTOM_ACTION',
+            actions: [{ id: TRIGGER_ACTION_ID }],
+            policies: [{ id: 'policy-1' }],
+            itemIds: ['related-user-item-id'],
+            itemTypeId: 'user-profile-type',
+          },
+        ],
+        reviewerId: user.id,
+        reviewerEmail,
+      });
+
+      expect(result?.jobsDisposed).toBe(1);
+      expect(new Set(await pendingJobIds())).toEqual(new Set([actionedJob.id]));
+    },
+  );
+
+  testWithQueue()(
     'is a no-op when the feature is disabled (null disposition)',
     async ({ org, user, queue, mrtService, addJob, configureQueue }) => {
       await configureQueue({ disposition: null, triggerActionIds: [] });


### PR DESCRIPTION
## Context & Requests for Reviewers

Sweep/fanout actions should also take into account related items they handle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved action processing to ensure related actions are properly handled during decision cleanup operations, enhancing the completeness of action workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->