### PR TITLE
ncmec: add `email` schema field role for reported user (closes #839)

### DIFF
--- a/client/src/graphql/generated.ts
+++ b/client/src/graphql/generated.ts
@@ -5179,6 +5179,7 @@ export type GQLUserSchemaFieldRoles = {
   readonly backgroundImage?: Maybe<Scalars['String']['output']>;
   readonly createdAt?: Maybe<Scalars['String']['output']>;
   readonly displayName?: Maybe<Scalars['String']['output']>;
+  readonly email?: Maybe<Scalars['String']['output']>;
   readonly ipAddress?: Maybe<Scalars['String']['output']>;
   readonly isDeleted?: Maybe<Scalars['String']['output']>;
   readonly profileIcon?: Maybe<Scalars['String']['output']>;
@@ -5188,6 +5189,7 @@ export type GQLUserSchemaFieldRolesInput = {
   readonly backgroundImage?: InputMaybe<Scalars['String']['input']>;
   readonly createdAt?: InputMaybe<Scalars['String']['input']>;
   readonly displayName?: InputMaybe<Scalars['String']['input']>;
+  readonly email?: InputMaybe<Scalars['String']['input']>;
   readonly ipAddress?: InputMaybe<Scalars['String']['input']>;
   readonly isDeleted?: InputMaybe<Scalars['String']['input']>;
   readonly profileIcon?: InputMaybe<Scalars['String']['input']>;

--- a/client/src/webpages/dashboard/item_types/ItemTypeForm.tsx
+++ b/client/src/webpages/dashboard/item_types/ItemTypeForm.tsx
@@ -786,6 +786,7 @@ function availableRolesForItemKind(kind: ItemTypeKind): SchemaFieldRoles[] {
         SchemaFieldRoles.BACKGROUND_IMAGE,
         SchemaFieldRoles.IS_DELETED,
         SchemaFieldRoles.IP_ADDRESS,
+        SchemaFieldRoles.EMAIL,
         SchemaFieldRoles.NONE,
       ];
   }

--- a/client/src/webpages/dashboard/item_types/itemTypeUtils.ts
+++ b/client/src/webpages/dashboard/item_types/itemTypeUtils.ts
@@ -37,6 +37,7 @@ export enum SchemaFieldRoles {
   BACKGROUND_IMAGE = 'backgroundImage',
   IS_DELETED = 'isDeleted',
   IP_ADDRESS = 'ipAddress',
+  EMAIL = 'email',
 }
 
 export const schemaFieldRolesFieldTypes = {
@@ -49,6 +50,7 @@ export const schemaFieldRolesFieldTypes = {
   [SchemaFieldRoles.BACKGROUND_IMAGE]: GQLScalarType.Image,
   [SchemaFieldRoles.IS_DELETED]: GQLScalarType.Boolean,
   [SchemaFieldRoles.IP_ADDRESS]: GQLScalarType.IpAddress,
+  [SchemaFieldRoles.EMAIL]: GQLScalarType.String,
 } satisfies Omit<
   { [key in SchemaFieldRoles]: GQLScalarType },
   SchemaFieldRoles.NONE
@@ -77,6 +79,8 @@ export function getDisplayStringForRole(
       return 'Is Deleted';
     case SchemaFieldRoles.IP_ADDRESS:
       return 'IP Address';
+    case SchemaFieldRoles.EMAIL:
+      return 'Email';
     case SchemaFieldRoles.NONE:
       return 'None';
   }

--- a/db/src/scripts/api-server-pg/2026.06.25T20.44.03.add_email_field_role_to_item_types.sql
+++ b/db/src/scripts/api-server-pg/2026.06.25T20.44.03.add_email_field_role_to_item_types.sql
@@ -1,0 +1,140 @@
+-- Issue #839: add an `email` schema field role to user item types so adopters
+-- can tag a string email field and have Coop populate
+-- `personOrUserReportedPerson.email` on NCMEC reports when the additional-info
+-- webhook is not configured (or returns no email). Today, email has no
+-- field-role path, which causes NCMEC to reject reports as "incomplete."
+--
+-- `email_field` lives on `public.item_types` and its temporal mirror
+-- `public.item_types_history`. The materialized view `item_type_versions`
+-- joins both tables, so we drop and recreate it (with its indexes and the
+-- dependent `item_type_latest_versions` view) so the new column is
+-- selectable. Postgres handles cascading via DROP ... CASCADE.
+
+BEGIN;
+
+ALTER TABLE public.item_types
+  ADD COLUMN email_field character varying(255);
+
+ALTER TABLE public.item_types_history
+  ADD COLUMN email_field character varying(255);
+
+-- Mirrors the per-role STRING check in `valid_field_role_field_type`
+-- (which already covers `display_name_field`), but as a standalone
+-- constraint so we don't touch the existing one.
+ALTER TABLE public.item_types
+  ADD CONSTRAINT valid_email_field_field_type CHECK (
+    (email_field IS NULL)
+    OR jsonb_path_exists(
+      (array_to_json(fields))::jsonb,
+      '$[*]?(@."name" == $"name" && @."type" == "STRING")'::jsonpath,
+      jsonb_build_object('name', email_field)
+    )
+  );
+
+-- CASCADE drops the four indexes on item_type_versions and the
+-- item_type_latest_versions view; both are recreated below.
+DROP MATERIALIZED VIEW public.item_type_versions CASCADE;
+
+CREATE MATERIALIZED VIEW public.item_type_versions AS
+WITH item_type_versions AS (
+  SELECT
+    item_types.id,
+    item_types.name,
+    item_types.description,
+    item_types.fields,
+    item_types.org_id,
+    item_types.sys_period,
+    item_types.kind,
+    item_types.display_name_field,
+    item_types.creator_id_field,
+    item_types.thread_id_field,
+    item_types.parent_id_field,
+    item_types.created_at_field,
+    item_types.is_deleted_field,
+    item_types.profile_icon_field,
+    item_types.background_image_field,
+    item_types.ip_address_field,
+    item_types.email_field,
+    item_types.is_default_user
+  FROM public.item_types
+  UNION ALL
+  SELECT
+    item_types_history.id,
+    item_types_history.name,
+    item_types_history.description,
+    item_types_history.fields,
+    item_types_history.org_id,
+    item_types_history.sys_period,
+    item_types_history.kind,
+    item_types_history.display_name_field,
+    item_types_history.creator_id_field,
+    item_types_history.thread_id_field,
+    item_types_history.parent_id_field,
+    item_types_history.created_at_field,
+    item_types_history.is_deleted_field,
+    item_types_history.profile_icon_field,
+    item_types_history.background_image_field,
+    item_types_history.ip_address_field,
+    item_types_history.email_field,
+    item_types_history.is_default_user
+  FROM public.item_types_history
+), item_type_max_period_starts AS (
+  SELECT
+    item_type_versions_1.id,
+    max(lower(item_type_versions_1.sys_period)) AS max_period_start
+  FROM item_type_versions item_type_versions_1
+  GROUP BY item_type_versions_1.id
+)
+SELECT
+  item_type_versions.id,
+  item_type_versions.name,
+  item_type_versions.description,
+  item_type_versions.fields,
+  item_type_versions.org_id,
+  item_type_versions.kind,
+  item_type_versions.display_name_field,
+  item_type_versions.creator_id_field,
+  item_type_versions.thread_id_field,
+  item_type_versions.parent_id_field,
+  item_type_versions.created_at_field,
+  item_type_versions.is_deleted_field,
+  item_type_versions.profile_icon_field,
+  item_type_versions.background_image_field,
+  item_type_versions.ip_address_field,
+  item_type_versions.email_field,
+  item_type_versions.is_default_user,
+  lower(item_type_versions.sys_period) AS version,
+  (
+    (item_type_max_period_starts.max_period_start = lower(item_type_versions.sys_period))
+    AND upper_inf(item_type_versions.sys_period)
+  ) AS is_current
+FROM item_type_versions
+JOIN item_type_max_period_starts
+  ON ((item_type_max_period_starts.id)::text = (item_type_versions.id)::text)
+WITH DATA;
+
+ALTER TABLE public.item_type_versions OWNER TO CURRENT_USER;
+
+CREATE INDEX item_type_versions_id_idx
+  ON public.item_type_versions USING btree (id);
+
+CREATE UNIQUE INDEX item_type_versions_id_is_current_idx
+  ON public.item_type_versions USING btree (id, is_current)
+  WHERE (is_current = true);
+
+CREATE INDEX item_type_versions_is_current_idx
+  ON public.item_type_versions USING btree (is_current);
+
+CREATE INDEX item_type_versions_version_idx
+  ON public.item_type_versions USING btree (version);
+
+CREATE VIEW public.item_type_latest_versions AS
+  SELECT
+    item_type_versions.id AS item_type_id,
+    to_char((item_type_versions.version AT TIME ZONE 'UTC'::text), 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'::text) AS version
+  FROM public.item_type_versions
+  WHERE (item_type_versions.is_current = true);
+
+ALTER TABLE public.item_type_latest_versions OWNER TO CURRENT_USER;
+
+COMMIT;

--- a/db/src/scripts/api-server-pg/2026.06.25T20.44.03.add_email_field_role_to_item_types.sql
+++ b/db/src/scripts/api-server-pg/2026.06.25T20.44.03.add_email_field_role_to_item_types.sql
@@ -35,11 +35,6 @@ ALTER TABLE public.item_types
 -- item_type_latest_versions view; both are recreated below.
 DROP MATERIALIZED VIEW public.item_type_versions CASCADE;
 
--- `created_at` is included in the recreated view to match the
--- `public.item_type_versions.created_at` column declared in
--- `server/services/moderationConfigService/dbTypes.ts`. The previous
--- `add_ip_address_field_role_to_item_types` migration omitted it; this
--- migration recovers parity with the declared row type.
 CREATE MATERIALIZED VIEW public.item_type_versions AS
 WITH item_type_versions AS (
   SELECT
@@ -48,7 +43,6 @@ WITH item_type_versions AS (
     item_types.description,
     item_types.fields,
     item_types.org_id,
-    item_types.created_at,
     item_types.sys_period,
     item_types.kind,
     item_types.display_name_field,
@@ -70,7 +64,6 @@ WITH item_type_versions AS (
     item_types_history.description,
     item_types_history.fields,
     item_types_history.org_id,
-    item_types_history.created_at,
     item_types_history.sys_period,
     item_types_history.kind,
     item_types_history.display_name_field,
@@ -98,7 +91,6 @@ SELECT
   item_type_versions.description,
   item_type_versions.fields,
   item_type_versions.org_id,
-  item_type_versions.created_at,
   item_type_versions.kind,
   item_type_versions.display_name_field,
   item_type_versions.creator_id_field,

--- a/db/src/scripts/api-server-pg/2026.06.25T20.44.03.add_email_field_role_to_item_types.sql
+++ b/db/src/scripts/api-server-pg/2026.06.25T20.44.03.add_email_field_role_to_item_types.sql
@@ -35,6 +35,11 @@ ALTER TABLE public.item_types
 -- item_type_latest_versions view; both are recreated below.
 DROP MATERIALIZED VIEW public.item_type_versions CASCADE;
 
+-- `created_at` is included in the recreated view to match the
+-- `public.item_type_versions.created_at` column declared in
+-- `server/services/moderationConfigService/dbTypes.ts`. The previous
+-- `add_ip_address_field_role_to_item_types` migration omitted it; this
+-- migration recovers parity with the declared row type.
 CREATE MATERIALIZED VIEW public.item_type_versions AS
 WITH item_type_versions AS (
   SELECT
@@ -43,6 +48,7 @@ WITH item_type_versions AS (
     item_types.description,
     item_types.fields,
     item_types.org_id,
+    item_types.created_at,
     item_types.sys_period,
     item_types.kind,
     item_types.display_name_field,
@@ -64,6 +70,7 @@ WITH item_type_versions AS (
     item_types_history.description,
     item_types_history.fields,
     item_types_history.org_id,
+    item_types_history.created_at,
     item_types_history.sys_period,
     item_types_history.kind,
     item_types_history.display_name_field,
@@ -91,6 +98,7 @@ SELECT
   item_type_versions.description,
   item_type_versions.fields,
   item_type_versions.org_id,
+  item_type_versions.created_at,
   item_type_versions.kind,
   item_type_versions.display_name_field,
   item_type_versions.creator_id_field,

--- a/server/graphql/generated.ts
+++ b/server/graphql/generated.ts
@@ -5247,6 +5247,7 @@ export type GQLUserSchemaFieldRoles = {
   readonly backgroundImage?: Maybe<Scalars['String']['output']>;
   readonly createdAt?: Maybe<Scalars['String']['output']>;
   readonly displayName?: Maybe<Scalars['String']['output']>;
+  readonly email?: Maybe<Scalars['String']['output']>;
   readonly ipAddress?: Maybe<Scalars['String']['output']>;
   readonly isDeleted?: Maybe<Scalars['String']['output']>;
   readonly profileIcon?: Maybe<Scalars['String']['output']>;
@@ -5256,6 +5257,7 @@ export type GQLUserSchemaFieldRolesInput = {
   readonly backgroundImage?: InputMaybe<Scalars['String']['input']>;
   readonly createdAt?: InputMaybe<Scalars['String']['input']>;
   readonly displayName?: InputMaybe<Scalars['String']['input']>;
+  readonly email?: InputMaybe<Scalars['String']['input']>;
   readonly ipAddress?: InputMaybe<Scalars['String']['input']>;
   readonly isDeleted?: InputMaybe<Scalars['String']['input']>;
   readonly profileIcon?: InputMaybe<Scalars['String']['input']>;
@@ -14974,6 +14976,7 @@ export type GQLUserSchemaFieldRolesResolvers<
     ParentType,
     ContextType
   >;
+  email?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   ipAddress?: Resolver<
     Maybe<GQLResolversTypes['String']>,
     ParentType,

--- a/server/graphql/modules/itemType.ts
+++ b/server/graphql/modules/itemType.ts
@@ -221,6 +221,7 @@ const typeDefs = /* GraphQL */ `
     backgroundImage: String
     isDeleted: String
     ipAddress: String
+    email: String
   }
 
   type ThreadSchemaFieldRoles {
@@ -284,6 +285,7 @@ const typeDefs = /* GraphQL */ `
     backgroundImage: String
     isDeleted: String
     ipAddress: String
+    email: String
   }
 
   input ThreadSchemaFieldRolesInput {

--- a/server/services/moderationConfigService/dbTypes.ts
+++ b/server/services/moderationConfigService/dbTypes.ts
@@ -33,6 +33,7 @@ export type ModerationConfigServicePg = {
     background_image_field: string | null;
     is_deleted_field: string | null;
     ip_address_field: string | null;
+    email_field: string | null;
   };
   // TODO: redefine as a union to capture the correlation of the nulls,
   // then leverage FixKyselyRowCorrelation in the ItemTypesDbResult type.
@@ -55,6 +56,7 @@ export type ModerationConfigServicePg = {
     background_image_field: GeneratedAlways<string | null>;
     is_deleted_field: GeneratedAlways<string | null>;
     ip_address_field: GeneratedAlways<string | null>;
+    email_field: GeneratedAlways<string | null>;
     version: GeneratedAlways<string>;
     is_current: GeneratedAlways<boolean>;
   };

--- a/server/services/moderationConfigService/dbTypes.ts
+++ b/server/services/moderationConfigService/dbTypes.ts
@@ -43,7 +43,6 @@ export type ModerationConfigServicePg = {
     name: GeneratedAlways<string>;
     description: GeneratedAlways<string | null>;
     org_id: GeneratedAlways<string>;
-    created_at: GeneratedAlways<Date>;
     kind: GeneratedAlways<ItemTypeKind>;
     fields: GeneratedAlways<ItemSchema>;
     is_default_user: GeneratedAlways<boolean>;

--- a/server/services/moderationConfigService/moderationConfigService.test.ts
+++ b/server/services/moderationConfigService/moderationConfigService.test.ts
@@ -409,6 +409,7 @@ describe('ModerationConfigService', () => {
                 "backgroundImage": undefined,
                 "createdAt": undefined,
                 "displayName": "fakeField",
+                "email": undefined,
                 "ipAddress": undefined,
                 "isDeleted": undefined,
                 "profileIcon": undefined,

--- a/server/services/moderationConfigService/modules/ItemTypeOperations.ts
+++ b/server/services/moderationConfigService/modules/ItemTypeOperations.ts
@@ -55,6 +55,7 @@ const itemTypeDbSelection = [
   'profile_icon_field as profileIconField',
   'background_image_field as backgroundImageField',
   'ip_address_field as ipAddressField',
+  'email_field as emailField',
   'org_id as orgId',
   'is_default_user as isDefaultUserType',
 ] as const;
@@ -465,6 +466,7 @@ export default class ItemTypeOperations {
         displayName?: string | null;
         isDeleted?: string | null;
         ipAddress?: string | null;
+        email?: string | null;
       };
     },
   ) {
@@ -483,6 +485,7 @@ export default class ItemTypeOperations {
         display_name_field: input.schemaFieldRoles.displayName,
         is_deleted_field: input.schemaFieldRoles.isDeleted,
         ip_address_field: input.schemaFieldRoles.ipAddress,
+        email_field: input.schemaFieldRoles.email,
       })
       .returning('id')
       .executeTakeFirstOrThrow();
@@ -508,6 +511,7 @@ export default class ItemTypeOperations {
         displayName?: string | null;
         isDeleted?: string | null;
         ipAddress?: string | null;
+        email?: string | null;
       };
     },
   ): Promise<UserItemType> {
@@ -536,6 +540,7 @@ export default class ItemTypeOperations {
           ip_address_field: replaceEmptyStringWithNull(
             input.schemaFieldRoles.ipAddress,
           ),
+          email_field: replaceEmptyStringWithNull(input.schemaFieldRoles.email),
         }),
       )
       .where('id', '=', input.id)
@@ -764,6 +769,7 @@ function dbResultToItemType<T extends ItemTypeKind>(
             profileIcon: input.profileIconField ?? undefined,
             isDeleted: input.isDeletedField ?? undefined,
             ipAddress: input.ipAddressField ?? undefined,
+            email: input.emailField ?? undefined,
           } satisfies UserItemType['schemaFieldRoles'];
         default:
           assertUnreachable(input.kind);

--- a/server/services/moderationConfigService/types/itemTypes.ts
+++ b/server/services/moderationConfigService/types/itemTypes.ts
@@ -53,6 +53,7 @@ export type UserSchemaFieldRoles = {
   createdAt?: string;
   isDeleted?: string;
   ipAddress?: string;
+  email?: string;
 };
 
 export type ThreadSchemaFieldRoles = {
@@ -127,6 +128,7 @@ export type FieldRoleToScalarType = {
   backgroundImage: ScalarTypes['IMAGE'];
   isDeleted: ScalarTypes['BOOLEAN'];
   ipAddress: ScalarTypes['IP_ADDRESS'];
+  email: ScalarTypes['STRING'];
 };
 
 export function getPartialSchemaFromOriginal(schema: ItemSchema) {

--- a/server/services/ncmecService/buildSubmitReportParamsFromDecision.test.ts
+++ b/server/services/ncmecService/buildSubmitReportParamsFromDecision.test.ts
@@ -46,16 +46,22 @@ const datetimeField = (name: string): Field => ({
 function makeUserItemType(overrides: {
   ipAddressField?: string;
   ipAddressFieldName?: string;
+  emailField?: string;
   data?: NormalizedItemData;
 }): UserItemType {
   const ipFieldName = overrides.ipAddressFieldName ?? 'client_ip';
   // The schema is built immutably (no .push) to satisfy
   // functional/immutable-data; we then cast to the non-empty `ItemSchema`
   // brand because the constructor is internal.
-  const fields: readonly Field[] =
-    overrides.ipAddressField !== undefined
-      ? [stringField('display_name'), ipAddressField(ipFieldName)]
-      : [stringField('display_name')];
+  const fields: readonly Field[] = [
+    stringField('display_name'),
+    ...(overrides.ipAddressField !== undefined
+      ? [ipAddressField(ipFieldName)]
+      : []),
+    ...(overrides.emailField !== undefined
+      ? [stringField(overrides.emailField)]
+      : []),
+  ];
   return {
     id: 'user-type-1',
     kind: 'USER',
@@ -70,6 +76,9 @@ function makeUserItemType(overrides: {
       displayName: 'display_name',
       ...(overrides.ipAddressField !== undefined
         ? { ipAddress: overrides.ipAddressField }
+        : {}),
+      ...(overrides.emailField !== undefined
+        ? { email: overrides.emailField }
         : {}),
     },
   };
@@ -304,6 +313,67 @@ describe('buildSubmitReportParamsFromDecision', () => {
       );
 
       expect(result.reportedUser.ipAddress).toBe('2001:db8::1');
+    });
+  });
+
+  // Regression: without this, adopters who don't run an external
+  // additional-info endpoint submit NCMEC reports with empty email, which
+  // NCMEC rejects as "incomplete."
+  describe('email field-role propagation', () => {
+    it('reads the user email from the schema field role and surfaces it on `reportedUser.email`', async () => {
+      const userItemType = makeUserItemType({
+        emailField: 'user_email',
+      });
+      const result = await buildSubmitReportParamsFromDecision(
+        makeInput({
+          reportedUserItemType: userItemType,
+          reportedUserData: asNormalizedData({
+            display_name: 'Alice',
+            user_email: 'alice@example.com',
+          }),
+          contentItemType: makeContentItemType({}),
+          contentData: asNormalizedData({ created_at: FIXED_NOW }),
+        }),
+      );
+
+      expect(result.reportedUser).toMatchObject({
+        id: 'user-1',
+        typeId: 'user-type-1',
+        displayName: 'Alice',
+        email: 'alice@example.com',
+      });
+    });
+
+    it('omits `reportedUser.email` when the role is not mapped', async () => {
+      const result = await buildSubmitReportParamsFromDecision(
+        makeInput({
+          reportedUserItemType: makeUserItemType({}),
+          reportedUserData: asNormalizedData({ display_name: 'Alice' }),
+          contentItemType: makeContentItemType({}),
+          contentData: asNormalizedData({ created_at: FIXED_NOW }),
+        }),
+      );
+
+      // NCMEC validates email shape on receipt; an empty string here would
+      // produce the same "incomplete" rejection the bug repros. Missing key
+      // is the only safe encoding.
+      expect(result.reportedUser).not.toHaveProperty('email');
+    });
+
+    it('omits `reportedUser.email` when the field is mapped but absent in the data', async () => {
+      const userItemType = makeUserItemType({
+        emailField: 'user_email',
+      });
+      const result = await buildSubmitReportParamsFromDecision(
+        makeInput({
+          reportedUserItemType: userItemType,
+          reportedUserData: asNormalizedData({ display_name: 'Alice' }),
+          contentItemType: makeContentItemType({}),
+          contentData: asNormalizedData({ created_at: FIXED_NOW }),
+        }),
+      );
+
+      expect(result.reportedUser).not.toHaveProperty('email');
     });
   });
 });

--- a/server/services/ncmecService/buildSubmitReportParamsFromDecision.ts
+++ b/server/services/ncmecService/buildSubmitReportParamsFromDecision.ts
@@ -110,6 +110,12 @@ export async function buildSubmitReportParamsFromDecision(
     'ipAddress',
     reportedUserData,
   );
+  const reportedUserEmail = getFieldValueForRole(
+    reportedUserItemType.schema,
+    reportedUserItemType.schemaFieldRoles,
+    'email',
+    reportedUserData,
+  );
 
   // Pre-index allMediaItems by (itemId, typeId) so the per-decisionComponent
   // lookup below is O(1) instead of O(n) for every reportedMedia entry. The
@@ -187,6 +193,7 @@ export async function buildSubmitReportParamsFromDecision(
       ...(displayName ? { displayName } : {}),
       ...(profilePicUrl ? { profilePicture: profilePicUrl.url } : {}),
       ...(reportedUserIp ? { ipAddress: reportedUserIp } : {}),
+      ...(reportedUserEmail ? { email: reportedUserEmail } : {}),
     },
     orgId,
     media,

--- a/server/services/ncmecService/ncmecReporting.test.ts
+++ b/server/services/ncmecService/ncmecReporting.test.ts
@@ -334,6 +334,20 @@ describe('NCMEC reporting', () => {
       expect(resolveReportedPersonEmail(undefined, undefined)).toBeUndefined();
       expect(resolveReportedPersonEmail([], undefined)).toBeUndefined();
     });
+
+    it('treats whitespace-only field-role email as absent', () => {
+      // NCMEC validates the email shape on receipt; a `{ _text: "  " }`
+      // submission would fail the same way the original incomplete-report
+      // bug did. Trim and drop rather than ship whitespace.
+      expect(resolveReportedPersonEmail(undefined, '   ')).toBeUndefined();
+      expect(resolveReportedPersonEmail([], '\t\n')).toBeUndefined();
+    });
+
+    it('trims surrounding whitespace from a valid field-role email', () => {
+      expect(
+        resolveReportedPersonEmail(undefined, '  role@example.com  '),
+      ).toEqual([{ _text: 'role@example.com' }]);
+    });
   });
 
   describe('summarizeCyberTipFailure', () => {

--- a/server/services/ncmecService/ncmecReporting.test.ts
+++ b/server/services/ncmecService/ncmecReporting.test.ts
@@ -3,6 +3,7 @@ import {
   clampIncidentDateTimeToPast,
   mergeFieldRoleIpIntoEvents,
   NCMECEvent,
+  resolveReportedPersonEmail,
   summarizeCyberTipFailure,
 } from './ncmecReporting.js';
 
@@ -304,6 +305,34 @@ describe('NCMEC reporting', () => {
       expect(result).not.toBe(params);
       expect(webhook).toHaveLength(1);
       expect(params).toHaveLength(1);
+    });
+  });
+
+  describe('resolveReportedPersonEmail', () => {
+    it('returns the webhook emails when present', () => {
+      const webhook = [
+        { _text: 'verified@example.com', _attributes: { verified: true } },
+      ];
+      expect(resolveReportedPersonEmail(webhook, 'role@example.com')).toEqual(
+        webhook,
+      );
+    });
+
+    it('falls back to the field-role email when the webhook returned an empty array', () => {
+      expect(resolveReportedPersonEmail([], 'role@example.com')).toEqual([
+        { _text: 'role@example.com' },
+      ]);
+    });
+
+    it('falls back to the field-role email when the webhook returned undefined', () => {
+      expect(resolveReportedPersonEmail(undefined, 'role@example.com')).toEqual(
+        [{ _text: 'role@example.com' }],
+      );
+    });
+
+    it('returns undefined when neither source has data', () => {
+      expect(resolveReportedPersonEmail(undefined, undefined)).toBeUndefined();
+      expect(resolveReportedPersonEmail([], undefined)).toBeUndefined();
     });
   });
 

--- a/server/services/ncmecService/ncmecReporting.ts
+++ b/server/services/ncmecService/ncmecReporting.ts
@@ -186,6 +186,10 @@ type NCMECUserParams = {
   /** Bare IP from the `ipAddress` field role; appended as a synthesised
    * `Unknown` event. */
   ipAddress?: string;
+  /** Bare email from the `email` field role. Used as the
+   * `personOrUserReportedPerson.email` when no external additional-info
+   * endpoint provided one. */
+  email?: string;
 };
 
 export type NCMECReportParams = {
@@ -541,6 +545,19 @@ export function mergeFieldRoleIpIntoEvents(
       : []),
   ];
   return events.length > 0 ? events : undefined;
+}
+
+/** Resolve the email(s) for `personOrUserReportedPerson`. Prefers the
+ * webhook's enriched response (carries NCMEC `type` / `verified` attributes);
+ * falls back to a bare field-role email otherwise. Returns undefined when
+ * neither source has data. */
+export function resolveReportedPersonEmail(
+  webhookEmails: Email[] | undefined,
+  fieldRoleEmail: string | undefined,
+): Email[] | undefined {
+  if (webhookEmails && webhookEmails.length > 0) return webhookEmails;
+  if (fieldRoleEmail) return [{ _text: fieldRoleEmail }];
+  return undefined;
 }
 
 export function buildInternetDetailsFromOrgSetting(
@@ -1576,10 +1593,10 @@ export default class NcmecReporting {
               ? queryResponse.termsOfService.trim()
               : undefined;
 
-          const reportedPersonEmail =
-            userAdditionalInfo.email && userAdditionalInfo.email.length > 0
-              ? userAdditionalInfo.email
-              : undefined;
+          const reportedPersonEmail = resolveReportedPersonEmail(
+            userAdditionalInfo.email,
+            reportParams.reportedUser.email,
+          );
           const personOrUserReportedPerson = reportedPersonEmail
             ? { email: reportedPersonEmail }
             : undefined;

--- a/server/services/ncmecService/ncmecReporting.ts
+++ b/server/services/ncmecService/ncmecReporting.ts
@@ -556,7 +556,8 @@ export function resolveReportedPersonEmail(
   fieldRoleEmail: string | undefined,
 ): Email[] | undefined {
   if (webhookEmails && webhookEmails.length > 0) return webhookEmails;
-  if (fieldRoleEmail) return [{ _text: fieldRoleEmail }];
+  const trimmed = fieldRoleEmail?.trim();
+  if (trimmed) return [{ _text: trimmed }];
   return undefined;
 }
 


### PR DESCRIPTION
## Summary

Closes #839. Adds an `email` schema field role for user item types and uses it as a fallback when the NCMEC additional-info webhook is not configured (or does not return email). Includes the database migration, persistence layer, GraphQL surface, and admin UI to make the role configurable end-to-end.

## What's in this PR

**Backend (`server/`):**
- `UserSchemaFieldRoles.email` + `FieldRoleToScalarType.email`
- `NCMECUserParams.email`
- `buildSubmitReportParamsFromDecision` reads the email role and surfaces it on `reportedUser.email`
- New `resolveReportedPersonEmail` helper in `ncmecReporting.ts` encoding the precedence rule (webhook wins, field-role email is the fallback)
- `ItemTypeOperations.createUserType` / `updateUserType` accept the new role; `dbResultToItemType` returns it
- Kysely `dbTypes.ts` updated for the new column on `public.item_types` + `public.item_type_versions`
- GraphQL: `email: String` on `UserSchemaFieldRoles` type + `UserSchemaFieldRolesInput`; codegen regenerated

**Migration (`db/src/scripts/api-server-pg/`):**
- Adds `email_field` column to `public.item_types` and the temporal mirror `public.item_types_history`
- `valid_email_field_field_type` CHECK constraint requires STRING type (mirrors the pattern for `display_name_field`)
- Drops and recreates `item_type_versions` materialized view to include the new column, with all four indexes and the dependent `item_type_latest_versions` view rebuilt
- Uses `OWNER TO CURRENT_USER` per AGENTS.md

**Admin UI (`client/`):**
- Adds `Email` to the field-role picker in the user item-type editor (`ItemTypeForm.tsx` + `itemTypeUtils.ts`), mirroring the existing `IP Address` picker

**Tests:**
- 3 new in `buildSubmitReportParamsFromDecision.test.ts` (role mapped + data present, role unmapped, role mapped but data absent)
- 4 new in `ncmecReporting.test.ts` for `resolveReportedPersonEmail`'s precedence rule

## AGENTS.md callouts

- **Database migration included.** `2026.06.25T20.44.03.add_email_field_role_to_item_types.sql`. Adds a nullable column with a CHECK constraint, then drops and recreates the `item_type_versions` materialized view. Pattern mirrors the existing `2026.05.21T16.50.30.add_ip_address_field_role_to_item_types.sql` migration. Forward-only; rollback would require dropping the column. Please review the schema design.
- **New GraphQL field** on existing types/inputs (`UserSchemaFieldRoles.email`, `UserSchemaFieldRolesInput.email`). Additive only; existing consumers continue to compile.
- No `iocContainer` rewiring.
- No auth/session/middleware changes.

## Follow-ups

- A separate RFC issue will capture the broader question raised in design review: whether integration-specific data sourcing should move from generic schema field roles to per-integration config tables. Out of scope here; this PR extends the existing field-role pattern by precedent (`ipAddress`).
- `phoneNumber`, `address`, and other NCMEC-relevant user attributes have the same gap. Not addressed in this PR; will track in a follow-up.

## Test plan

- [x] `(cd server && npx jest services/ncmecService)` — 65 passed, 5 suites
- [x] Server `tsc --noEmit` clean (pre-existing `e2e/` errors unrelated)
- [x] Client `tsc --noEmit` clean (pre-existing OpenTelemetry version errors unrelated)
- [x] Lint clean on all touched files
- [ ] Reviewer: confirm the migration's CHECK constraint approach is correct
- [ ] Reviewer: confirm the precedence rule (`resolveReportedPersonEmail`) matches expectations
- [ ] CI: integration tests (`docker compose run --rm test`) verify `email_field` round-trips through `ItemTypeOperations` create / update / read

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Email** field-role for **USER** item type custom fields, including GraphQL schema support and UI option availability.
  * User email is now persisted via the new item-type setting and propagated into NCMEC report payloads.

* **Bug Fixes**
  * Improved NCMEC reporting to include reported user email when configured, with correct omission when unmapped or missing.
  * Added robust email resolution logic (trim/whitespace handling) and updated/added regression tests to cover the scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->