### PR TITLE
Add EMAIL_ADDRESS scalar to @roostorg/coop-types (v2.4.0)

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -34,6 +34,11 @@ export const ScalarTypes = makeEnumLike([
   // schema field as an IP address so it can be surfaced as an identifier in
   // moderation flows (e.g., via schema-field role metadata).
   'IP_ADDRESS',
+  // Stored as a string at runtime. The dedicated scalar lets Coop tag a
+  // schema field as an email address so integrations (e.g., NCMEC) can
+  // pull it via schema-field role metadata. Format validation happens at
+  // the field-value level, not here.
+  'EMAIL_ADDRESS',
   // Polymorphic media: holds a URL plus the resolved kind (AUDIO/IMAGE/VIDEO),
   // detected from the URL extension at ingestion time. Lets an adopter declare
   // a single field (or container of fields) that mixes media kinds without
@@ -65,6 +70,7 @@ type ScalarTypeRuntimeTypeMapping = Satisfies<
     [ScalarTypes.RELATED_ITEM]: RelatedItem;
     [ScalarTypes.POLICY_ID]: string;
     [ScalarTypes.IP_ADDRESS]: string;
+    [ScalarTypes.EMAIL_ADDRESS]: string;
     [ScalarTypes.MEDIA]: {
       url: string;
       // The resolved kind, derived from the URL extension. `null` when the

--- a/types/package-lock.json
+++ b/types/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@roostorg/coop-types",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@roostorg/coop-types",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "ISC",
       "dependencies": {
         "date-fns": "^2.29.3",

--- a/types/package.json
+++ b/types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@roostorg/coop-types",
   "type": "module",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Shared TypeScript types for Coop: schema primitives, signal data maps, and integration contracts.",
   "module": "transpiled/index.js",
   "typings": "./transpiled/index.d.ts",


### PR DESCRIPTION
## Summary

Adds a dedicated `EMAIL_ADDRESS` entry to `ScalarTypes` and maps it to `string` in `ScalarTypeRuntimeTypeMapping`. Mirrors the `IP_ADDRESS` addition from #559.

## Why

Lets Coop tag a schema field as an email address so integrations (NCMEC today; potentially others later) can pull it via schema-field role metadata instead of accepting any `STRING`-typed field. Required before #840 can switch the `email` field role from `STRING` to `EMAIL_ADDRESS` (which is what reviewers flagged as the right shape there).

## Test plan

- [x] `npm run build` clean
- [x] `node --test transpiled/test_scripts/makeDateStringTest.test.js` passes (single existing test; the directory-mode invocation has a pre-existing issue unrelated to this PR)
- [ ] Reviewer: confirm the version bump (2.3.0 → 2.4.0) is the right semver; this is additive only

## Follow-up

After this merges and the publish workflow ships 2.4.0, #840 will be rebased to depend on `^2.4.0` and swap `STRING` → `EMAIL_ADDRESS` in the role mapping + migration CHECK constraint + client UI filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for email address scalar values, with string-based runtime handling and field-level validation.
* **Chores**
  * Updated the package version to **2.4.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->