### PR TITLE
ncmec: wire HMA hashes into outgoing report's fileDetails.originalFileHash

### DIFF
--- a/server/services/ncmecService/buildSubmitReportParamsFromDecision.test.ts
+++ b/server/services/ncmecService/buildSubmitReportParamsFromDecision.test.ts
@@ -376,4 +376,88 @@ describe('buildSubmitReportParamsFromDecision', () => {
       expect(result.reportedUser).not.toHaveProperty('email');
     });
   });
+
+  describe('HMA hash extraction on media', () => {
+    it('attaches hashes from the matching image in item data', async () => {
+      const result = await buildSubmitReportParamsFromDecision(
+        makeInput({
+          reportedUserItemType: makeUserItemType({}),
+          reportedUserData: asNormalizedData({ display_name: 'Alice' }),
+          contentItemType: makeContentItemType({}),
+          contentData: asNormalizedData({
+            created_at: FIXED_NOW,
+            image: {
+              url: 'https://example.com/m1.png',
+              hashes: { md5: 'abc123', pdq: 'def456' },
+            },
+          }),
+        }),
+      );
+
+      expect(result.media[0]).toMatchObject({
+        url: 'https://example.com/m1.png',
+        hashes: { md5: 'abc123', pdq: 'def456' },
+      });
+    });
+
+    it('finds the matching image inside an ARRAY-of-IMAGE container', async () => {
+      const result = await buildSubmitReportParamsFromDecision(
+        makeInput({
+          reportedUserItemType: makeUserItemType({}),
+          reportedUserData: asNormalizedData({ display_name: 'Alice' }),
+          contentItemType: makeContentItemType({}),
+          contentData: asNormalizedData({
+            created_at: FIXED_NOW,
+            images: [
+              {
+                url: 'https://example.com/other.png',
+                hashes: { md5: 'wrong' },
+              },
+              {
+                url: 'https://example.com/m1.png',
+                hashes: { md5: 'right' },
+              },
+            ],
+          }),
+        }),
+      );
+
+      expect(result.media[0].hashes).toEqual({ md5: 'right' });
+    });
+
+    it('omits `hashes` when no image in the data matches the reported URL', async () => {
+      const result = await buildSubmitReportParamsFromDecision(
+        makeInput({
+          reportedUserItemType: makeUserItemType({}),
+          reportedUserData: asNormalizedData({ display_name: 'Alice' }),
+          contentItemType: makeContentItemType({}),
+          contentData: asNormalizedData({
+            created_at: FIXED_NOW,
+            image: {
+              url: 'https://example.com/different.png',
+              hashes: { md5: 'abc' },
+            },
+          }),
+        }),
+      );
+
+      expect(result.media[0]).not.toHaveProperty('hashes');
+    });
+
+    it('omits `hashes` when the matching image has no hashes attached', async () => {
+      const result = await buildSubmitReportParamsFromDecision(
+        makeInput({
+          reportedUserItemType: makeUserItemType({}),
+          reportedUserData: asNormalizedData({ display_name: 'Alice' }),
+          contentItemType: makeContentItemType({}),
+          contentData: asNormalizedData({
+            created_at: FIXED_NOW,
+            image: { url: 'https://example.com/m1.png' },
+          }),
+        }),
+      );
+
+      expect(result.media[0]).not.toHaveProperty('hashes');
+    });
+  });
 });

--- a/server/services/ncmecService/buildSubmitReportParamsFromDecision.ts
+++ b/server/services/ncmecService/buildSubmitReportParamsFromDecision.ts
@@ -168,6 +168,7 @@ export async function buildSubmitReportParamsFromDecision(
         'ipAddress',
         reportedItem.contentItem.data,
       );
+      const hashes = extractHashesForUrl(reportedItem.contentItem.data, it.url);
       return {
         id: it.id,
         typeId: it.typeId,
@@ -176,6 +177,7 @@ export async function buildSubmitReportParamsFromDecision(
         industryClassification: it.industryClassification,
         fileAnnotations: it.fileAnnotations,
         ...(mediaIp ? { ipAddress: mediaIp } : {}),
+        ...(hashes ? { hashes } : {}),
       };
     }),
   );
@@ -213,4 +215,49 @@ export async function buildSubmitReportParamsFromDecision(
       : {}),
     ...(jobId !== undefined ? { jobId } : {}),
   };
+}
+
+/** Walk an item's data looking for an image-shaped value (`{ url, hashes }`)
+ * whose `url` matches the target. Returns the `hashes` map (typically
+ * populated by HMA at item-submission time, e.g. `{ md5: '...', pdq: '...' }`)
+ * or undefined when no match is found.
+ *
+ * Recurses into arrays and plain objects so ARRAY-of-IMAGE and MAP-of-IMAGE
+ * containers are covered, not just scalar IMAGE fields. Returns on the first
+ * match — duplicate URLs across fields would only ever yield the same hashes
+ * since HMA is deterministic per URL. */
+export function extractHashesForUrl(
+  data: NormalizedItemData,
+  url: string,
+): Record<string, string> | undefined {
+  const visit = (value: unknown): Record<string, string> | undefined => {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        const found = visit(item);
+        if (found) return found;
+      }
+      return undefined;
+    }
+    if (typeof value !== 'object' || value === null) return undefined;
+    const obj = value as Record<string, unknown>;
+    if (
+      typeof obj.url === 'string' &&
+      obj.url === url &&
+      typeof obj.hashes === 'object' &&
+      obj.hashes !== null
+    ) {
+      const hashes = obj.hashes as Record<string, unknown>;
+      const stringHashes: Record<string, string> = {};
+      for (const [k, v] of Object.entries(hashes)) {
+        if (typeof v === 'string') stringHashes[k] = v;
+      }
+      return Object.keys(stringHashes).length > 0 ? stringHashes : undefined;
+    }
+    for (const inner of Object.values(obj)) {
+      const found = visit(inner);
+      if (found) return found;
+    }
+    return undefined;
+  };
+  return visit(data);
 }

--- a/server/services/ncmecService/ncmecReporting.test.ts
+++ b/server/services/ncmecService/ncmecReporting.test.ts
@@ -5,6 +5,7 @@ import {
   NCMECEvent,
   resolveReportedPersonEmail,
   summarizeCyberTipFailure,
+  toOriginalFileHashes,
 } from './ncmecReporting.js';
 
 describe('NCMEC reporting', () => {
@@ -347,6 +348,37 @@ describe('NCMEC reporting', () => {
       expect(
         resolveReportedPersonEmail(undefined, '  role@example.com  '),
       ).toEqual([{ _text: 'role@example.com' }]);
+    });
+  });
+
+  describe('toOriginalFileHashes', () => {
+    it('uppercases the algorithm into the `hashType` attribute', () => {
+      expect(toOriginalFileHashes({ md5: 'abc', pdq: 'def' })).toEqual([
+        { _text: 'abc', _attributes: { hashType: 'MD5' } },
+        { _text: 'def', _attributes: { hashType: 'PDQ' } },
+      ]);
+    });
+
+    it('trims surrounding whitespace from hash values', () => {
+      expect(toOriginalFileHashes({ md5: '  abc  ' })).toEqual([
+        { _text: 'abc', _attributes: { hashType: 'MD5' } },
+      ]);
+    });
+
+    it('drops entries with empty or whitespace-only hash values', () => {
+      // NCMEC requires non-empty `hash` text and `hashType` attribute;
+      // an entry with whitespace would fail XSD validation on receipt.
+      expect(
+        toOriginalFileHashes({ md5: '', sha1: '   ', sha256: 'kept' }),
+      ).toEqual([{ _text: 'kept', _attributes: { hashType: 'SHA256' } }]);
+    });
+
+    it('returns undefined when no entries survive filtering', () => {
+      // Caller branches on undefined to omit the `originalFileHash` key
+      // entirely rather than serialise an empty array.
+      expect(toOriginalFileHashes(undefined)).toBeUndefined();
+      expect(toOriginalFileHashes({})).toBeUndefined();
+      expect(toOriginalFileHashes({ md5: '', sha1: '  ' })).toBeUndefined();
     });
   });
 

--- a/server/services/ncmecService/ncmecReporting.ts
+++ b/server/services/ncmecService/ncmecReporting.ts
@@ -133,10 +133,18 @@ type FileDetails = {
     fileRelevance?: 'Reported' | 'Supplemental Reported';
     fileAnnotations?: FileAnnotations;
     industryClassification?: NCMECIndustryClassificationType;
+    originalFileHash?: OriginalFileHash[];
     ipCaptureEvent?: IPNCMECEvent[];
     deviceId?: DeviceId[];
     details?: Detail[];
     additionalInfo?: string[];
+  };
+};
+
+type OriginalFileHash = {
+  _text: string;
+  _attributes: {
+    hashType: string;
   };
 };
 
@@ -174,6 +182,12 @@ type Media = {
    * `Upload` event. */
   ipAddress?: string;
   deviceId?: DeviceNCMECEvent[];
+  /** Hashes computed for this URL (typically by HMA at item submission
+   * time). Keyed by hash algorithm name (e.g. `md5`, `pdq`); the value is
+   * the hex-encoded hash. Forwarded to NCMEC as `originalFileHash`
+   * entries with the algorithm name uppercased into the `hashType`
+   * attribute. */
+  hashes?: Record<string, string>;
 };
 
 type NCMECUserParams = {
@@ -545,6 +559,28 @@ export function mergeFieldRoleIpIntoEvents(
       : []),
   ];
   return events.length > 0 ? events : undefined;
+}
+
+/** Convert a map of HMA-style hashes (`{ md5: '...', pdq: '...' }`) into the
+ * NCMEC `originalFileHash[]` shape. Trims blanks, uppercases the algorithm
+ * name into the `hashType` attribute, drops empty entries. Returns undefined
+ * when there are no usable hashes; callers should branch on that to omit the
+ * key entirely rather than serialise an empty array. */
+export function toOriginalFileHashes(
+  hashes: Record<string, string> | undefined,
+): OriginalFileHash[] | undefined {
+  if (!hashes) return undefined;
+  const result: OriginalFileHash[] = [];
+  for (const [algorithm, hash] of Object.entries(hashes)) {
+    const trimmedHash = typeof hash === 'string' ? hash.trim() : '';
+    const trimmedAlgorithm = algorithm.trim();
+    if (trimmedHash === '' || trimmedAlgorithm === '') continue;
+    result.push({
+      _text: trimmedHash,
+      _attributes: { hashType: trimmedAlgorithm.toUpperCase() },
+    });
+  }
+  return result.length > 0 ? result : undefined;
 }
 
 /** Resolve the email(s) for `personOrUserReportedPerson`. Prefers the
@@ -1958,6 +1994,7 @@ export default class NcmecReporting {
     const fileAnnotations = this.#fileAnnotationArrayToNCMECFileAnnotation(
       media.fileAnnotations,
     );
+    const originalFileHash = toOriginalFileHashes(media.hashes);
     const xml = await this.#uploadFileDetails(
       {
         fileDetails: {
@@ -1970,6 +2007,9 @@ export default class NcmecReporting {
             : {}),
           ...(fileAnnotations ? { fileAnnotations } : {}),
           industryClassification: media.industryClassification,
+          ...(originalFileHash && originalFileHash.length > 0
+            ? { originalFileHash }
+            : {}),
           ...(additionalInfo.ipCaptureEvent &&
           additionalInfo.ipCaptureEvent.length > 0
             ? {


### PR DESCRIPTION
## Summary

First P1 from the audit in #843. NCMEC's CyberTipline accepts an `originalFileHash[]` element with a `hashType` attribute per entry. HMA already computes per-image hashes at item-submission time (`HMAHashBankService.hashContentFromUrl`, stored on the image object alongside `url`), but the NCMEC report builder discarded them. This wires them through.

**Stacked on #842** because the same node_modules already has `@roostorg/coop-types@2.4.0`. Base will auto-flip to main when #842 merges.

## What's in this PR

**Types (`server/services/ncmecService/ncmecReporting.ts`):**
- New `OriginalFileHash` type (`{ _text: hash; _attributes: { hashType } }`)
- `originalFileHash?: OriginalFileHash[]` added to `FileDetails` (positioned after `industryClassification`, before `ipCaptureEvent`, in line with NCMEC XSD's forensic-fields grouping)
- `hashes?: Record<string, string>` added to internal `Media` type so the report assembly can pass them through to `#upload`

**Assembly (`buildSubmitReportParamsFromDecision.ts`):**
- New `extractHashesForUrl` helper walks the item data (scalar, array, and map containers) looking for an image-shaped value (`{ url, hashes }`) whose `url` matches the reported media's URL, returns the `hashes` map
- Each `media` entry now carries through `hashes` when present

**Submit (`ncmecReporting.ts:#upload`):**
- New `toOriginalFileHashes` exported helper converts the HMA map into NCMEC's `originalFileHash[]` shape: trims, drops empties, uppercases the algorithm name into the `hashType` attribute
- `#upload` includes the resulting array in `fileDetails` when non-empty

**Tests:**
- 4 new in `buildSubmitReportParamsFromDecision.test.ts`: scalar IMAGE case, ARRAY-of-IMAGE container traversal, URL-mismatch omission, missing-hashes omission
- 4 new in `ncmecReporting.test.ts` for `toOriginalFileHashes`: uppercasing, trimming, empty-value drops, undefined-on-empty

## What's NOT in this PR (deliberate)

- The webhook's `additionalInfo.media[].fileDetails.hash` (singular) is still not wired into the outgoing report. That's a separate gap noted in the audit; this PR focuses on HMA-sourced hashes which are the higher-leverage source since HMA runs for every adopter with image fields, webhook-sourced hashes only fire when an adopter has stood up the additional-info webhook
- No filtering of which algorithms NCMEC accepts; whatever HMA produces (MD5, SHA1, SHA256, PDQ, etc.) is forwarded as-is with the algorithm name uppercased. If NCMEC rejects unknown `hashType` values, we'd add a whitelist as a follow-up

## AGENTS.md callouts

- No migration
- No `coop-types` bump
- Pure backend plumbing wiring data we already have

## Test plan

- [x] `(cd server && npx jest services/ncmecService)` — 75 passed, 5 suites
- [x] Server `tsc --noEmit` clean (pre-existing `e2e/` errors unrelated)
- [ ] Reviewer: confirm the XSD ordering (`originalFileHash` between `industryClassification` and `ipCaptureEvent`) matches the actual NCMEC sequence
- [ ] Reviewer: confirm the algorithm-name uppercasing (e.g. `md5` → `MD5`, `pdq` → `PDQ`) matches what NCMEC's `hashType` attribute expects
- [ ] CI: integration tests verify the hash round-trips from HMA through to NCMEC

🤖 Generated with [Claude Code](https://claude.com/claude-code)