### PR TITLE
Add PHONE_NUMBER scalar to @roostorg/coop-types (v2.5.0)

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -39,6 +39,11 @@ export const ScalarTypes = makeEnumLike([
   // pull it via schema-field role metadata. Format validation happens at
   // the field-value level, not here.
   'EMAIL_ADDRESS',
+  // Stored as a string at runtime. The dedicated scalar lets Coop tag a
+  // schema field as a phone number so integrations (e.g., NCMEC) can pull
+  // it via schema-field role metadata. Format normalization (E.164) and
+  // validation happen at the field-value level, not here.
+  'PHONE_NUMBER',
   // Polymorphic media: holds a URL plus the resolved kind (AUDIO/IMAGE/VIDEO),
   // detected from the URL extension at ingestion time. Lets an adopter declare
   // a single field (or container of fields) that mixes media kinds without
@@ -71,6 +76,7 @@ type ScalarTypeRuntimeTypeMapping = Satisfies<
     [ScalarTypes.POLICY_ID]: string;
     [ScalarTypes.IP_ADDRESS]: string;
     [ScalarTypes.EMAIL_ADDRESS]: string;
+    [ScalarTypes.PHONE_NUMBER]: string;
     [ScalarTypes.MEDIA]: {
       url: string;
       // The resolved kind, derived from the URL extension. `null` when the

--- a/types/package-lock.json
+++ b/types/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@roostorg/coop-types",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@roostorg/coop-types",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "ISC",
       "dependencies": {
         "date-fns": "^2.29.3",

--- a/types/package.json
+++ b/types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@roostorg/coop-types",
   "type": "module",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Shared TypeScript types for Coop: schema primitives, signal data maps, and integration contracts.",
   "module": "transpiled/index.js",
   "typings": "./transpiled/index.d.ts",


### PR DESCRIPTION
## Summary

Adds a dedicated `PHONE_NUMBER` entry to `ScalarTypes` and maps it to `string` in `ScalarTypeRuntimeTypeMapping`. Mirrors the `EMAIL_ADDRESS` addition from #841.

## Why

Lets Coop tag a schema field as a phone number so integrations (NCMEC reported user `phone[]` today, others later) can pull it via schema-field role metadata instead of accepting any `STRING`-typed field. Same two-tier pattern (field role = floor, additional-info webhook = ceiling) the audit in #843 settled on.

Format normalization (E.164) and validation belong at the field-value layer, not in this type. A subsequent server / client PR will add the `fieldTypeHandlers` entry, the `phone` field role on `UserSchemaFieldRoles`, the migration adding the `phone_field` column, and the admin UI control. Same shape as #842 followed #841.

Part of the audit in #843; first of the two PRs needed to close the phone P1 item.

## Test plan

- [x] `npm run build` clean
- [x] `node --test transpiled/test_scripts/makeDateStringTest.test.js` passes (single existing test; the directory-mode invocation has a pre-existing issue unrelated to this PR, same as #841)
- [ ] Reviewer: confirm the version bump (2.4.0 → 2.5.0) is the right semver; additive only

🤖 Generated with [Claude Code](https://claude.com/claude-code)