### PR TITLE
client: truncate queue ID column in ManualReviewQueuesDashboard (closes #662)

### DIFF
--- a/client/src/webpages/dashboard/mrt/ManualReviewQueuesDashboard.tsx
+++ b/client/src/webpages/dashboard/mrt/ManualReviewQueuesDashboard.tsx
@@ -745,7 +745,12 @@ export default function ManualReviewQueuesDashboard() {
                 />
               </div>
             ),
-            id: <CopyTextComponent value={values.id} />,
+            id: (
+              <CopyTextComponent
+                value={values.id}
+                displayValue={`${values.id.slice(0, 8)}…`}
+              />
+            ),
             name: (
               <div className="ContentTypesDashboard-type-name">
                 {values.name}


### PR DESCRIPTION
## Summary

Closes #662. The ID column in the Manual Review Queues dashboard displayed the full UUID with \`whitespace-nowrap\`, overflowing the column and pushing adjacent columns (queue name, oldest-task age) out of view. Reviewers had to horizontally scroll to read them.

Fix: truncate the displayed value to the first 8 characters with an ellipsis. Full UUID stays on the clipboard via \`CopyTextComponent\`'s existing \`displayValue\` prop.


## Test plan

- [x] \`(cd client && npx tsc --noEmit)\` clean for the changed file
- [x] Lint clean for the changed file (pre-existing icon-import warnings unrelated)
- [ ] Reviewer: spot-check that copy-to-clipboard still yields the full UUID

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated queue IDs in the dashboard table to display a shorter, truncated version for easier scanning.
  * Copying still uses the full queue ID, so users can quickly view a cleaner table without losing the original value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->