### PR TITLE
ncmec: wire webhook fileDetails.hash into outgoing report's originalFileHash

### DIFF
--- a/server/services/ncmecService/ncmecReporting.test.ts
+++ b/server/services/ncmecService/ncmecReporting.test.ts
@@ -5,7 +5,6 @@ import {
   NCMECEvent,
   resolveReportedPersonEmail,
   summarizeCyberTipFailure,
-  toOriginalFileHashes,
 } from './ncmecReporting.js';
 
 describe('NCMEC reporting', () => {
@@ -351,36 +350,8 @@ describe('NCMEC reporting', () => {
     });
   });
 
-  describe('toOriginalFileHashes', () => {
-    it('uppercases the algorithm into the `hashType` attribute', () => {
-      expect(toOriginalFileHashes({ md5: 'abc', pdq: 'def' })).toEqual([
-        { _text: 'abc', _attributes: { hashType: 'MD5' } },
-        { _text: 'def', _attributes: { hashType: 'PDQ' } },
-      ]);
-    });
-
-    it('trims surrounding whitespace from hash values', () => {
-      expect(toOriginalFileHashes({ md5: '  abc  ' })).toEqual([
-        { _text: 'abc', _attributes: { hashType: 'MD5' } },
-      ]);
-    });
-
-    it('drops entries with empty or whitespace-only hash values', () => {
-      // NCMEC requires non-empty `hash` text and `hashType` attribute;
-      // an entry with whitespace would fail XSD validation on receipt.
-      expect(
-        toOriginalFileHashes({ md5: '', sha1: '   ', sha256: 'kept' }),
-      ).toEqual([{ _text: 'kept', _attributes: { hashType: 'SHA256' } }]);
-    });
-
-    it('returns undefined when no entries survive filtering', () => {
-      // Caller branches on undefined to omit the `originalFileHash` key
-      // entirely rather than serialise an empty array.
-      expect(toOriginalFileHashes(undefined)).toBeUndefined();
-      expect(toOriginalFileHashes({})).toBeUndefined();
-      expect(toOriginalFileHashes({ md5: '', sha1: '  ' })).toBeUndefined();
-    });
-  });
+  // toOriginalFileHashes tests moved to ./toOriginalFileHashes.test.ts
+  // (this file was over the 500-line max-lines limit after expansion).
 
   describe('summarizeCyberTipFailure', () => {
     const previousDebug = process.env.NCMEC_DEBUG;

--- a/server/services/ncmecService/ncmecReporting.ts
+++ b/server/services/ncmecService/ncmecReporting.ts
@@ -561,24 +561,38 @@ export function mergeFieldRoleIpIntoEvents(
   return events.length > 0 ? events : undefined;
 }
 
-/** Convert a map of HMA-style hashes (`{ md5: '...', pdq: '...' }`) into the
- * NCMEC `originalFileHash[]` shape. Trims blanks, uppercases the algorithm
- * name into the `hashType` attribute, drops empty entries. Returns undefined
- * when there are no usable hashes; callers should branch on that to omit the
- * key entirely rather than serialise an empty array. */
-export function toOriginalFileHashes(
-  hashes: Record<string, string> | undefined,
-): OriginalFileHash[] | undefined {
-  if (!hashes) return undefined;
+/** Build the NCMEC `originalFileHash[]` shape from both hash sources Coop
+ * has: HMA-computed hashes stored on the item data (keyed by algorithm),
+ * and any single `{ hash, hashType }` returned by the additional-info
+ * webhook for this media. Trims blanks, uppercases the algorithm name into
+ * the `hashType` attribute, drops empty entries, and dedupes on
+ * (`hashType`, hash value) so a webhook that returns the same algorithm as
+ * HMA doesn't produce duplicate entries. Returns undefined when no usable
+ * hashes survive filtering; callers should branch on that to omit the key
+ * entirely rather than serialise an empty array. */
+export function toOriginalFileHashes(opts: {
+  hmaHashes?: Record<string, string>;
+  webhookFileDetails?: { hash: string; hashType: string };
+}): OriginalFileHash[] | undefined {
   const result: OriginalFileHash[] = [];
-  for (const [algorithm, hash] of Object.entries(hashes)) {
+  const seen = new Set<string>();
+  const push = (algorithm: string, hash: string) => {
     const trimmedHash = typeof hash === 'string' ? hash.trim() : '';
     const trimmedAlgorithm = algorithm.trim();
-    if (trimmedHash === '' || trimmedAlgorithm === '') continue;
-    result.push({
-      _text: trimmedHash,
-      _attributes: { hashType: trimmedAlgorithm.toUpperCase() },
-    });
+    if (trimmedHash === '' || trimmedAlgorithm === '') return;
+    const hashType = trimmedAlgorithm.toUpperCase();
+    const key = `${hashType} ${trimmedHash}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    result.push({ _text: trimmedHash, _attributes: { hashType } });
+  };
+  if (opts.hmaHashes) {
+    for (const [algorithm, hash] of Object.entries(opts.hmaHashes)) {
+      push(algorithm, hash);
+    }
+  }
+  if (opts.webhookFileDetails) {
+    push(opts.webhookFileDetails.hashType, opts.webhookFileDetails.hash);
   }
   return result.length > 0 ? result : undefined;
 }
@@ -749,6 +763,15 @@ type MediaAdditionalInfo = {
   fileName?: string;
   /** When set, sent to NCMEC in file details (whether the content was publicly viewable). */
   publiclyAvailable?: boolean;
+  /** Optional single hash from the additional-info webhook response.
+   * Merged with HMA-sourced hashes (see `toOriginalFileHashes`); deduped
+   * on (`hashType` uppercase, trimmed hash value) so a webhook that
+   * returns the same algorithm as HMA doesn't produce duplicate entries
+   * in the outgoing `originalFileHash[]` list. */
+  fileDetails?: {
+    hash: string;
+    hashType: string;
+  };
 };
 
 type FileAdditionalInfo = {
@@ -1138,9 +1161,6 @@ export default class NcmecReporting {
         media: reportedMedia.map((media) => ({
           id: media.id,
           typeId: media.typeId,
-          fileDetails: {
-            ipCaptureEvent: [],
-          },
         })),
       };
     }
@@ -1994,7 +2014,10 @@ export default class NcmecReporting {
     const fileAnnotations = this.#fileAnnotationArrayToNCMECFileAnnotation(
       media.fileAnnotations,
     );
-    const originalFileHash = toOriginalFileHashes(media.hashes);
+    const originalFileHash = toOriginalFileHashes({
+      hmaHashes: media.hashes,
+      webhookFileDetails: additionalInfo.fileDetails,
+    });
     const xml = await this.#uploadFileDetails(
       {
         fileDetails: {

--- a/server/services/ncmecService/toOriginalFileHashes.test.ts
+++ b/server/services/ncmecService/toOriginalFileHashes.test.ts
@@ -1,0 +1,104 @@
+import { toOriginalFileHashes } from './ncmecReporting.js';
+
+describe('toOriginalFileHashes', () => {
+  it('uppercases the algorithm into the `hashType` attribute', () => {
+    expect(
+      toOriginalFileHashes({ hmaHashes: { md5: 'abc', pdq: 'def' } }),
+    ).toEqual([
+      { _text: 'abc', _attributes: { hashType: 'MD5' } },
+      { _text: 'def', _attributes: { hashType: 'PDQ' } },
+    ]);
+  });
+
+  it('trims surrounding whitespace from hash values', () => {
+    expect(toOriginalFileHashes({ hmaHashes: { md5: '  abc  ' } })).toEqual([
+      { _text: 'abc', _attributes: { hashType: 'MD5' } },
+    ]);
+  });
+
+  it('drops entries with empty or whitespace-only hash values', () => {
+    // NCMEC requires non-empty `hash` text and `hashType` attribute; an
+    // entry with whitespace would fail XSD validation on receipt.
+    expect(
+      toOriginalFileHashes({
+        hmaHashes: { md5: '', sha1: '   ', sha256: 'kept' },
+      }),
+    ).toEqual([{ _text: 'kept', _attributes: { hashType: 'SHA256' } }]);
+  });
+
+  it('returns undefined when no entries survive filtering', () => {
+    // Caller branches on undefined to omit the `originalFileHash` key
+    // entirely rather than serialise an empty array.
+    expect(toOriginalFileHashes({})).toBeUndefined();
+    expect(toOriginalFileHashes({ hmaHashes: {} })).toBeUndefined();
+    expect(
+      toOriginalFileHashes({ hmaHashes: { md5: '', sha1: '  ' } }),
+    ).toBeUndefined();
+  });
+
+  it('includes the webhook hash when only the webhook source has data', () => {
+    expect(
+      toOriginalFileHashes({
+        webhookFileDetails: { hash: 'webhook-abc', hashType: 'md5' },
+      }),
+    ).toEqual([{ _text: 'webhook-abc', _attributes: { hashType: 'MD5' } }]);
+  });
+
+  it('combines HMA and webhook hashes when both sources provide data', () => {
+    expect(
+      toOriginalFileHashes({
+        hmaHashes: { md5: 'hma-md5', pdq: 'hma-pdq' },
+        webhookFileDetails: { hash: 'webhook-sha1', hashType: 'sha1' },
+      }),
+    ).toEqual([
+      { _text: 'hma-md5', _attributes: { hashType: 'MD5' } },
+      { _text: 'hma-pdq', _attributes: { hashType: 'PDQ' } },
+      { _text: 'webhook-sha1', _attributes: { hashType: 'SHA1' } },
+    ]);
+  });
+
+  it('dedupes when HMA and webhook return the same (algorithm, hash) pair', () => {
+    // Common case: both sources independently compute MD5 of the same
+    // content. Single entry in the outgoing report instead of two.
+    expect(
+      toOriginalFileHashes({
+        hmaHashes: { md5: 'same-value' },
+        webhookFileDetails: { hash: 'same-value', hashType: 'md5' },
+      }),
+    ).toEqual([{ _text: 'same-value', _attributes: { hashType: 'MD5' } }]);
+  });
+
+  it('keeps both entries when HMA and webhook return the same algorithm but different hashes', () => {
+    // Real conflict (different MD5 values for the same content) is signal
+    // NCMEC investigators may care about; surface both rather than picking
+    // a winner.
+    expect(
+      toOriginalFileHashes({
+        hmaHashes: { md5: 'hma-md5' },
+        webhookFileDetails: { hash: 'webhook-md5', hashType: 'md5' },
+      }),
+    ).toEqual([
+      { _text: 'hma-md5', _attributes: { hashType: 'MD5' } },
+      { _text: 'webhook-md5', _attributes: { hashType: 'MD5' } },
+    ]);
+  });
+
+  it('drops a whitespace-only webhook hash', () => {
+    expect(
+      toOriginalFileHashes({
+        webhookFileDetails: { hash: '   ', hashType: 'md5' },
+      }),
+    ).toBeUndefined();
+  });
+
+  it('dedupe is case-insensitive on the algorithm name', () => {
+    // Webhook returns `MD5` uppercase; HMA returns `md5` lowercase. Same
+    // algorithm, should dedupe on identical hash value.
+    expect(
+      toOriginalFileHashes({
+        hmaHashes: { md5: 'shared' },
+        webhookFileDetails: { hash: 'shared', hashType: 'MD5' },
+      }),
+    ).toEqual([{ _text: 'shared', _attributes: { hashType: 'MD5' } }]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the follow-up gap explicitly noted in PR #844. NCMEC accepts multiple `originalFileHash[]` entries per file. #844 wired HMA-sourced hashes through but the additional-info webhook's single `{ hash, hashType }` per media was still being dropped.

**Stacked on #844** (which is stacked on #842). Base will auto-flip when #844 merges.

## What was dropped

Two reasons the webhook hash never made it into the outgoing report:

1. `MediaAdditionalInfo` (the internal type that `#upload` consumes) didn't declare `fileDetails`. The validation-schema-typed `NcmecAdditionalInfoResponse` has it (`ncmecReporting.ts:676-679`), but the data was erased at the boundary between webhook response and internal use.
2. `toOriginalFileHashes` took only the HMA map as input. No call path passed the webhook hash through.

## Changes

- Add `fileDetails?: { hash; hashType }` to `MediaAdditionalInfo` so the data carries through from webhook response to `#upload`.
- Refactor `toOriginalFileHashes` to take both sources via an opts object: `{ hmaHashes, webhookFileDetails }`. Hashes from both are combined and **deduped on `(hashType uppercase, trimmed hash value)`** so a webhook returning the same algorithm as HMA produces one entry in the outgoing report, not two. Different hashes for the same algorithm get kept separately (treated as a real conflict, not a duplicate).
- Update `#upload` call site to pass both sources.
- Remove dead `fileDetails: { ipCaptureEvent: [] }` from the no-webhook fallback (`ncmecReporting.ts:1161`). It never matched any consumed shape and nothing read it (`ipCaptureEvent` lives at the top level of `MediaAdditionalInfo`, not nested in `fileDetails`).

## Tests

6 new cases for `toOriginalFileHashes`:
- Webhook-only hash → included
- Both HMA + webhook → combined
- Same `(algorithm, hash)` from both → deduped to one entry
- Same algorithm but different hashes → both kept (real conflict, surface it)
- Whitespace-only webhook hash → dropped
- Case-insensitive dedup on algorithm name (webhook `MD5` vs HMA `md5`)

The `toOriginalFileHashes` test block moved to its own file (`toOriginalFileHashes.test.ts`) to keep `ncmecReporting.test.ts` under the 500-line `max-lines` limit. No behavior change from the move.

## AGENTS.md callouts

- No migration
- No `coop-types` bump
- No GraphQL surface change
- Pure backend; wires data we already receive into a slot we already build

## Test plan

- [x] `(cd server && npx jest services/ncmecService)` — 81 passed, 6 suites
- [x] Server `tsc --noEmit` clean for changed files (pre-existing EMAIL_ADDRESS-related errors from #842 stack unrelated)
- [ ] Reviewer: confirm the dedup precedence (HMA first, then webhook) is the right order. Currently HMA wins ordering for non-duplicate algorithms; for exact-dup `(algo, hash)` the order doesn't matter because only one is emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)