### PR TITLE
ncmec: add `incidentDateTimeDescription` reviewer-input field

### DIFF
--- a/client/src/graphql/generated.ts
+++ b/client/src/graphql/generated.ts
@@ -4584,6 +4584,12 @@ export type GQLSubmitNcmecReportDecisionComponent =
 export type GQLSubmitNcmecReportInput = {
   readonly additionalInfo?: InputMaybe<Scalars['String']['input']>;
   readonly escalateToHighPriority?: InputMaybe<Scalars['String']['input']>;
+  /**
+   * Free-text description of what the `<incidentDateTime>` value represents
+   * (e.g. "user uploaded this image"). Surfaced on NCMEC analyst views next
+   * to the timestamp itself. Optional; max 3000 characters.
+   */
+  readonly incidentDateTimeDescription?: InputMaybe<Scalars['String']['input']>;
   readonly incidentType: GQLNcmecIncidentType;
   readonly reportedMedia: ReadonlyArray<GQLNcmecMediaInput>;
   readonly reportedMessages: ReadonlyArray<GQLNcmecThreadInput>;

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ncmec/NCMECReviewUser.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ncmec/NCMECReviewUser.tsx
@@ -368,8 +368,11 @@ export default function NCMECReviewUser(
   const [escalateToHighPriority, setEscalateToHighPriority] = useState('');
   const [escalateChecked, setEscalateChecked] = useState(false);
   const [additionalInfo, setAdditionalInfo] = useState('');
+  const [incidentDateTimeDescription, setIncidentDateTimeDescription] =
+    useState('');
   const trimmedEscalate = escalateToHighPriority.trim();
   const trimmedAdditionalInfo = additionalInfo.trim();
+  const trimmedIncidentDateTimeDescription = incidentDateTimeDescription.trim();
   const escalateMissingReason = escalateChecked && trimmedEscalate === '';
   const [sendReportModalVisible, setSendReportModalVisible] = useState(false);
   const [deselectAndIgnoreModalVisible, setDeselectAndIgnoreModalVisible] =
@@ -721,6 +724,12 @@ export default function NCMECReviewUser(
                 ...(trimmedAdditionalInfo !== ''
                   ? { additionalInfo: trimmedAdditionalInfo }
                   : {}),
+                ...(trimmedIncidentDateTimeDescription !== ''
+                  ? {
+                      incidentDateTimeDescription:
+                        trimmedIncidentDateTimeDescription,
+                    }
+                  : {}),
               },
             });
           },
@@ -847,6 +856,26 @@ export default function NCMECReviewUser(
           />
           <span className="text-xs text-slate-500">
             {additionalInfo.length}/3000 characters
+          </span>
+        </div>
+        <div className="flex flex-col gap-2">
+          <label
+            htmlFor="ncmecIncidentDateTimeDescription"
+            className="text-base font-bold"
+          >
+            Incident date/time description (optional)
+          </label>
+          <textarea
+            id="ncmecIncidentDateTimeDescription"
+            maxLength={3000}
+            value={incidentDateTimeDescription}
+            onChange={(e) => setIncidentDateTimeDescription(e.target.value)}
+            placeholder="Describe what kind of date/time this is, like 'user uploaded this image' or 'message sent by user'."
+            className="min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+            rows={3}
+          />
+          <span className="text-xs text-slate-500">
+            {incidentDateTimeDescription.length}/3000 characters
           </span>
         </div>
       </div>

--- a/server/graphql/generated.ts
+++ b/server/graphql/generated.ts
@@ -4652,6 +4652,12 @@ export type GQLSubmitNcmecReportDecisionComponent =
 export type GQLSubmitNcmecReportInput = {
   readonly additionalInfo?: InputMaybe<Scalars['String']['input']>;
   readonly escalateToHighPriority?: InputMaybe<Scalars['String']['input']>;
+  /**
+   * Free-text description of what the `<incidentDateTime>` value represents
+   * (e.g. "user uploaded this image"). Surfaced on NCMEC analyst views next
+   * to the timestamp itself. Optional; max 3000 characters.
+   */
+  readonly incidentDateTimeDescription?: InputMaybe<Scalars['String']['input']>;
   readonly incidentType: GQLNcmecIncidentType;
   readonly reportedMedia: ReadonlyArray<GQLNcmecMediaInput>;
   readonly reportedMessages: ReadonlyArray<GQLNcmecThreadInput>;

--- a/server/graphql/modules/manualReviewTool.ts
+++ b/server/graphql/modules/manualReviewTool.ts
@@ -255,6 +255,12 @@ const typeDefs = /* GraphQL */ `
     incidentType: NCMECIncidentType!
     escalateToHighPriority: String
     additionalInfo: String
+    """
+    Free-text description of what the \`<incidentDateTime>\` value represents
+    (e.g. "user uploaded this image"). Surfaced on NCMEC analyst views next
+    to the timestamp itself. Optional; max 3000 characters.
+    """
+    incidentDateTimeDescription: String
   }
 
   enum AppealDecision {
@@ -2287,6 +2293,8 @@ const Mutation: GQLMutationResolvers = {
                 escalateToHighPriority:
                   decision.escalateToHighPriority ?? undefined,
                 additionalInfo: decision.additionalInfo ?? undefined,
+                incidentDateTimeDescription:
+                  decision.incidentDateTimeDescription ?? undefined,
               };
 
             default:

--- a/server/services/manualReviewToolService/modules/JobDecisioning.ts
+++ b/server/services/manualReviewToolService/modules/JobDecisioning.ts
@@ -102,6 +102,9 @@ export type ManualReviewDecisionComponent =
       incidentType: string;
       escalateToHighPriority?: string;
       additionalInfo?: string;
+      /** Free-text description of `<incidentDateTime>` (NCMEC XSD field).
+       * Reviewer-entered at decision time; max 3000 chars when supplied. */
+      incidentDateTimeDescription?: string;
     }
   | {
       type: 'TRANSFORM_JOB_AND_RECREATE_IN_QUEUE';

--- a/server/services/ncmecService/buildSubmitReportObject.test.ts
+++ b/server/services/ncmecService/buildSubmitReportObject.test.ts
@@ -1,0 +1,360 @@
+import {
+  buildSubmitReportObject,
+  NCMECEvent,
+  type BuildSubmitReportObjectInput,
+} from './ncmecReporting.js';
+
+const INCIDENT_DATE_TIME = '2026-05-27T18:00:00.000Z';
+
+/** Minimal valid inputs for `buildSubmitReportObject`. Tests override only
+ * the field(s) under test, so each case is self-explanatory. */
+function makeBuildReportInput(
+  overrides: {
+    reportParams?: Partial<BuildSubmitReportObjectInput['reportParams']> & {
+      reportedUser?: Partial<
+        BuildSubmitReportObjectInput['reportParams']['reportedUser']
+      >;
+    };
+    userAdditionalInfo?: BuildSubmitReportObjectInput['userAdditionalInfo'];
+    orgSettings?: Partial<BuildSubmitReportObjectInput['orgSettings']>;
+    clampedIncidentDateTime?: string;
+  } = {},
+): BuildSubmitReportObjectInput {
+  const { reportParams: paramOverrides, ...rest } = overrides;
+  const { reportedUser: userOverrides, ...reportParamOverrides } =
+    paramOverrides ?? {};
+  return {
+    reportParams: {
+      orgId: 'org-1',
+      reviewerId: 'reviewer-1',
+      reportedUser: {
+        id: 'user-1',
+        typeId: 'user-type-1',
+        ...userOverrides,
+      },
+      media: [],
+      threads: [],
+      incidentType:
+        'Child Pornography (possession, manufacture, and distribution)',
+      ...reportParamOverrides,
+    },
+    userAdditionalInfo: rest.userAdditionalInfo ?? {},
+    orgSettings: {
+      companyTemplate: 'AcmeESP',
+      legalURL: 'https://acme.example/legal',
+      reportingPersonEmail: 'reporter@acme.example',
+      ...rest.orgSettings,
+    },
+    clampedIncidentDateTime: rest.clampedIncidentDateTime ?? INCIDENT_DATE_TIME,
+  };
+}
+
+describe('buildSubmitReportObject', () => {
+  it('builds the minimum valid envelope (no webhook, no field-roles, no contact person)', () => {
+    const result = buildSubmitReportObject(makeBuildReportInput());
+    expect(result).toEqual({
+      report: {
+        incidentSummary: {
+          incidentType:
+            'Child Pornography (possession, manufacture, and distribution)',
+          incidentDateTime: INCIDENT_DATE_TIME,
+        },
+        reporter: {
+          reportingPerson: { email: [{ _text: 'reporter@acme.example' }] },
+          companyTemplate: 'AcmeESP',
+          legalURL: 'https://acme.example/legal',
+        },
+        personOrUserReported: {
+          espIdentifier: 'user-1',
+          espService: 'AcmeESP',
+          screenName: undefined,
+        },
+      },
+    });
+  });
+
+  it('preserves XSD insertion order under a kitchen-sink scenario', () => {
+    // NCMEC rejects out-of-order children with responseCode=4100 (the
+    // exact bug #477 fixed). Anchoring key order here lets a unit test
+    // catch the regression instead of waiting for exttest to reject it.
+    const result = buildSubmitReportObject(
+      makeBuildReportInput({
+        reportParams: {
+          escalateToHighPriority: 'reason',
+          additionalInfo: 'top-level note',
+          reportedUser: {
+            id: 'user-1',
+            typeId: 'user-type-1',
+            displayName: 'alice',
+            ipAddress: '203.0.113.7',
+            email: 'alice@example.com',
+          },
+        },
+        orgSettings: {
+          defaultInternetDetailType: 'WEB_PAGE',
+          moreInfoUrl: 'https://acme.example/profile/user-1',
+          termsOfService: 'Acme ToS',
+          contactPersonEmail: 'contact@acme.example',
+          contactPersonFirstName: 'Casey',
+          contactPersonLastName: 'Adopter',
+          contactPersonPhone: '+15551112222',
+        },
+        userAdditionalInfo: {
+          screenName: 'alice123',
+          ipCaptureEvent: [
+            {
+              ipAddress: '198.51.100.4',
+              eventName: NCMECEvent.Login,
+              dateTime: INCIDENT_DATE_TIME,
+            },
+          ],
+        },
+      }),
+    );
+    expect(Object.keys(result.report)).toEqual([
+      'incidentSummary',
+      'internetDetails',
+      'reporter',
+      'personOrUserReported',
+      'additionalInfo',
+    ]);
+    expect(Object.keys(result.report.incidentSummary)).toEqual([
+      'incidentType',
+      'escalateToHighPriority',
+      'incidentDateTime',
+    ]);
+    expect(Object.keys(result.report.reporter)).toEqual([
+      'reportingPerson',
+      'contactPerson',
+      'companyTemplate',
+      'termsOfService',
+      'legalURL',
+    ]);
+    expect(Object.keys(result.report.personOrUserReported!)).toEqual([
+      'personOrUserReportedPerson',
+      'espIdentifier',
+      'espService',
+      'screenName',
+      'displayName',
+      'ipCaptureEvent',
+    ]);
+  });
+
+  describe('input validation', () => {
+    it('throws when escalateToHighPriority is empty after trim', () => {
+      expect(() =>
+        buildSubmitReportObject(
+          makeBuildReportInput({
+            reportParams: { escalateToHighPriority: '   ' },
+          }),
+        ),
+      ).toThrow(/escalateToHighPriority must be non-blank/);
+    });
+
+    it('throws when escalateToHighPriority exceeds 3000 characters', () => {
+      expect(() =>
+        buildSubmitReportObject(
+          makeBuildReportInput({
+            reportParams: { escalateToHighPriority: 'x'.repeat(3001) },
+          }),
+        ),
+      ).toThrow(/at most 3000 characters/);
+    });
+
+    it('throws when additionalInfo is empty after trim', () => {
+      expect(() =>
+        buildSubmitReportObject(
+          makeBuildReportInput({
+            reportParams: { additionalInfo: '   ' },
+          }),
+        ),
+      ).toThrow(/additionalInfo must be non-blank/);
+    });
+
+    it('throws when additionalInfo exceeds 3000 characters', () => {
+      expect(() =>
+        buildSubmitReportObject(
+          makeBuildReportInput({
+            reportParams: { additionalInfo: 'x'.repeat(3001) },
+          }),
+        ),
+      ).toThrow(/at most 3000 characters/);
+    });
+  });
+
+  describe('reportedPersonEmail resolution', () => {
+    it('uses field-role email when webhook returned none', () => {
+      const result = buildSubmitReportObject(
+        makeBuildReportInput({
+          reportParams: {
+            reportedUser: {
+              id: 'user-1',
+              typeId: 'user-type-1',
+              email: 'role@example.com',
+            },
+          },
+        }),
+      );
+      expect(
+        result.report.personOrUserReported?.personOrUserReportedPerson?.email,
+      ).toEqual([{ _text: 'role@example.com' }]);
+    });
+
+    it('prefers webhook email (carries NCMEC attributes) over field-role email', () => {
+      // The webhook payload may attach `verified` / `type` attributes that
+      // the field-role bare string cannot carry. Always prefer webhook
+      // when both are present.
+      const result = buildSubmitReportObject(
+        makeBuildReportInput({
+          reportParams: {
+            reportedUser: {
+              id: 'user-1',
+              typeId: 'user-type-1',
+              email: 'role@example.com',
+            },
+          },
+          userAdditionalInfo: {
+            email: [
+              {
+                _text: 'webhook@example.com',
+                _attributes: { verified: true, type: 'Home' },
+              },
+            ],
+          },
+        }),
+      );
+      expect(
+        result.report.personOrUserReported?.personOrUserReportedPerson?.email,
+      ).toEqual([
+        {
+          _text: 'webhook@example.com',
+          _attributes: { verified: true, type: 'Home' },
+        },
+      ]);
+    });
+
+    it('omits personOrUserReportedPerson when neither source has an email', () => {
+      const result = buildSubmitReportObject(makeBuildReportInput());
+      expect(result.report.personOrUserReported).not.toHaveProperty(
+        'personOrUserReportedPerson',
+      );
+    });
+  });
+
+  describe('ipCaptureEvent merging', () => {
+    it('synthesises an Unknown event from the field-role IP when no webhook events exist', () => {
+      const result = buildSubmitReportObject(
+        makeBuildReportInput({
+          reportParams: {
+            reportedUser: {
+              id: 'user-1',
+              typeId: 'user-type-1',
+              ipAddress: '203.0.113.7',
+            },
+          },
+        }),
+      );
+      expect(result.report.personOrUserReported?.ipCaptureEvent).toEqual([
+        {
+          ipAddress: '203.0.113.7',
+          eventName: 'Unknown',
+          dateTime: INCIDENT_DATE_TIME,
+        },
+      ]);
+    });
+
+    it('keeps webhook events and only appends the field-role IP when distinct', () => {
+      const result = buildSubmitReportObject(
+        makeBuildReportInput({
+          reportParams: {
+            reportedUser: {
+              id: 'user-1',
+              typeId: 'user-type-1',
+              ipAddress: '203.0.113.7',
+            },
+          },
+          userAdditionalInfo: {
+            ipCaptureEvent: [
+              {
+                ipAddress: '198.51.100.4',
+                eventName: NCMECEvent.Login,
+                dateTime: INCIDENT_DATE_TIME,
+              },
+            ],
+          },
+        }),
+      );
+      const events = result.report.personOrUserReported?.ipCaptureEvent ?? [];
+      expect(events).toHaveLength(2);
+      expect(events[0]).toMatchObject({ ipAddress: '198.51.100.4' });
+      expect(events[1]).toMatchObject({
+        ipAddress: '203.0.113.7',
+        eventName: 'Unknown',
+      });
+    });
+  });
+
+  describe('contactPerson assembly', () => {
+    it('omits contactPerson entirely when no contact fields are set', () => {
+      const result = buildSubmitReportObject(makeBuildReportInput());
+      expect(result.report.reporter).not.toHaveProperty('contactPerson');
+    });
+
+    it('includes only the subset of contact fields the org has filled in', () => {
+      const result = buildSubmitReportObject(
+        makeBuildReportInput({
+          orgSettings: { contactPersonEmail: 'contact@acme.example' },
+        }),
+      );
+      expect(result.report.reporter.contactPerson).toEqual({
+        email: [{ _text: 'contact@acme.example' }],
+      });
+    });
+
+    it('trims whitespace from each contact field', () => {
+      const result = buildSubmitReportObject(
+        makeBuildReportInput({
+          orgSettings: {
+            contactPersonFirstName: '  Casey  ',
+            contactPersonLastName: ' Adopter ',
+            contactPersonPhone: ' +1555 ',
+            contactPersonEmail: ' contact@acme.example ',
+          },
+        }),
+      );
+      expect(result.report.reporter.contactPerson).toEqual({
+        firstName: 'Casey',
+        lastName: 'Adopter',
+        phone: { _text: '+1555' },
+        email: [{ _text: 'contact@acme.example' }],
+      });
+    });
+  });
+
+  describe('termsOfService', () => {
+    it('omits when blank', () => {
+      const result = buildSubmitReportObject(
+        makeBuildReportInput({ orgSettings: { termsOfService: '   ' } }),
+      );
+      expect(result.report.reporter).not.toHaveProperty('termsOfService');
+    });
+
+    it('omits when over 3000 characters (NCMEC ceiling)', () => {
+      const result = buildSubmitReportObject(
+        makeBuildReportInput({
+          orgSettings: { termsOfService: 'x'.repeat(3001) },
+        }),
+      );
+      expect(result.report.reporter).not.toHaveProperty('termsOfService');
+    });
+
+    it('passes through and trims an in-bounds value', () => {
+      const result = buildSubmitReportObject(
+        makeBuildReportInput({
+          orgSettings: { termsOfService: '  Acme ToS  ' },
+        }),
+      );
+      expect(result.report.reporter.termsOfService).toBe('Acme ToS');
+    });
+  });
+});

--- a/server/services/ncmecService/buildSubmitReportObject.test.ts
+++ b/server/services/ncmecService/buildSubmitReportObject.test.ts
@@ -180,6 +180,70 @@ describe('buildSubmitReportObject', () => {
         ),
       ).toThrow(/at most 3000 characters/);
     });
+
+    it('throws when incidentDateTimeDescription is empty after trim', () => {
+      expect(() =>
+        buildSubmitReportObject(
+          makeBuildReportInput({
+            reportParams: { incidentDateTimeDescription: '   ' },
+          }),
+        ),
+      ).toThrow(/incidentDateTimeDescription must be non-blank/);
+    });
+
+    it('throws when incidentDateTimeDescription exceeds 3000 characters', () => {
+      expect(() =>
+        buildSubmitReportObject(
+          makeBuildReportInput({
+            reportParams: {
+              incidentDateTimeDescription: 'x'.repeat(3001),
+            },
+          }),
+        ),
+      ).toThrow(/at most 3000 characters/);
+    });
+  });
+
+  describe('incidentDateTimeDescription', () => {
+    it('populates the element inside incidentSummary, after incidentDateTime', () => {
+      const result = buildSubmitReportObject(
+        makeBuildReportInput({
+          reportParams: {
+            incidentDateTimeDescription: 'user uploaded this image',
+          },
+        }),
+      );
+      expect(result.report.incidentSummary).toMatchObject({
+        incidentDateTimeDescription: 'user uploaded this image',
+      });
+      // XSD requires the description to follow incidentDateTime; anchoring
+      // key order here matches the comment on the `Report` type.
+      expect(Object.keys(result.report.incidentSummary)).toEqual([
+        'incidentType',
+        'incidentDateTime',
+        'incidentDateTimeDescription',
+      ]);
+    });
+
+    it('trims surrounding whitespace before emitting', () => {
+      const result = buildSubmitReportObject(
+        makeBuildReportInput({
+          reportParams: {
+            incidentDateTimeDescription: '  message sent by user  ',
+          },
+        }),
+      );
+      expect(result.report.incidentSummary.incidentDateTimeDescription).toBe(
+        'message sent by user',
+      );
+    });
+
+    it('omits the element when not supplied', () => {
+      const result = buildSubmitReportObject(makeBuildReportInput());
+      expect(result.report.incidentSummary).not.toHaveProperty(
+        'incidentDateTimeDescription',
+      );
+    });
   });
 
   describe('reportedPersonEmail resolution', () => {

--- a/server/services/ncmecService/buildSubmitReportParamsFromDecision.test.ts
+++ b/server/services/ncmecService/buildSubmitReportParamsFromDecision.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable max-lines -- shared fixture helpers (`makeUserItemType`,
+   `makeContentItemType`, `makeInput`) used by every describe block. */
 import { ScalarTypes, type DateString, type Field } from '@roostorg/coop-types';
 
 import { type NormalizedItemData } from '../itemProcessingService/index.js';
@@ -458,6 +460,48 @@ describe('buildSubmitReportParamsFromDecision', () => {
       );
 
       expect(result.media[0]).not.toHaveProperty('hashes');
+    });
+  });
+
+  describe('incidentDateTimeDescription propagation', () => {
+    it('forwards a non-blank value from the decision component, trimmed', async () => {
+      const input = makeInput({
+        reportedUserItemType: makeUserItemType({}),
+        reportedUserData: asNormalizedData({ display_name: 'Alice' }),
+        contentItemType: makeContentItemType({}),
+        contentData: asNormalizedData({ created_at: FIXED_NOW }),
+      });
+      const result = await buildSubmitReportParamsFromDecision({
+        ...input,
+        decisionComponent: {
+          ...input.decisionComponent,
+          incidentDateTimeDescription: '  user uploaded this image  ',
+        },
+      });
+      expect(result.incidentDateTimeDescription).toBe(
+        'user uploaded this image',
+      );
+    });
+
+    it('omits the field when the decision component left it unset or blank', async () => {
+      const input = makeInput({
+        reportedUserItemType: makeUserItemType({}),
+        reportedUserData: asNormalizedData({ display_name: 'Alice' }),
+        contentItemType: makeContentItemType({}),
+        contentData: asNormalizedData({ created_at: FIXED_NOW }),
+      });
+
+      const unset = await buildSubmitReportParamsFromDecision(input);
+      expect(unset).not.toHaveProperty('incidentDateTimeDescription');
+
+      const blank = await buildSubmitReportParamsFromDecision({
+        ...input,
+        decisionComponent: {
+          ...input.decisionComponent,
+          incidentDateTimeDescription: '   ',
+        },
+      });
+      expect(blank).not.toHaveProperty('incidentDateTimeDescription');
     });
   });
 });

--- a/server/services/ncmecService/buildSubmitReportParamsFromDecision.ts
+++ b/server/services/ncmecService/buildSubmitReportParamsFromDecision.ts
@@ -63,6 +63,7 @@ export interface BuildSubmitReportParamsInput {
     incidentType?: string;
     escalateToHighPriority?: string;
     additionalInfo?: string;
+    incidentDateTimeDescription?: string;
   };
   /** Optional fallback used when `decisionComponent.incidentType` is empty
    * (legacy DB rows). Callers that don't want a fallback should omit this. */
@@ -212,6 +213,13 @@ export async function buildSubmitReportParamsFromDecision(
     ...(decisionComponent.additionalInfo != null &&
     decisionComponent.additionalInfo.trim() !== ''
       ? { additionalInfo: decisionComponent.additionalInfo.trim() }
+      : {}),
+    ...(decisionComponent.incidentDateTimeDescription != null &&
+    decisionComponent.incidentDateTimeDescription.trim() !== ''
+      ? {
+          incidentDateTimeDescription:
+            decisionComponent.incidentDateTimeDescription.trim(),
+        }
       : {}),
     ...(jobId !== undefined ? { jobId } : {}),
   };

--- a/server/services/ncmecService/ncmecReporting.builders.test.ts
+++ b/server/services/ncmecService/ncmecReporting.builders.test.ts
@@ -86,9 +86,7 @@ describe('buildFileDetailsObject', () => {
         ],
         additionalInfo: ['from webhook'],
       },
-      originalFileHash: [
-        { _text: 'abc123', _attributes: { hashType: 'MD5' } },
-      ],
+      originalFileHash: [{ _text: 'abc123', _attributes: { hashType: 'MD5' } }],
     });
     expect(Object.keys(result.fileDetails)).toEqual([
       'reportId',

--- a/server/services/ncmecService/ncmecReporting.builders.test.ts
+++ b/server/services/ncmecService/ncmecReporting.builders.test.ts
@@ -1,0 +1,180 @@
+import {
+  buildFileDetailsObject,
+  fileAnnotationArrayToNCMECFileAnnotation,
+  NCMECEvent,
+  NCMECFileAnnotation,
+} from './ncmecReporting.js';
+
+const INCIDENT_DATE_TIME = '2026-05-27T18:00:00.000Z';
+
+describe('fileAnnotationArrayToNCMECFileAnnotation', () => {
+  it('returns undefined for empty or missing input', () => {
+    expect(fileAnnotationArrayToNCMECFileAnnotation(undefined)).toBeUndefined();
+    expect(fileAnnotationArrayToNCMECFileAnnotation([])).toBeUndefined();
+  });
+
+  it('maps each annotation enum value to the XSD child element name', () => {
+    // The XSD names each annotation as a self-closing child element; js2xml
+    // emits one element per key, so the resulting `Record` keys are the
+    // ground truth for what NCMEC sees.
+    expect(
+      fileAnnotationArrayToNCMECFileAnnotation([
+        NCMECFileAnnotation.GENERATIVE_AI,
+        NCMECFileAnnotation.INFANT,
+        NCMECFileAnnotation.ANIME_DRAWING_VIRTUAL_HENTAI,
+      ]),
+    ).toEqual({
+      generativeAi: undefined,
+      infant: undefined,
+      animeDrawingVirtualHentai: undefined,
+    });
+  });
+
+  it('dedupes repeated annotations into a single key', () => {
+    const result = fileAnnotationArrayToNCMECFileAnnotation([
+      NCMECFileAnnotation.VIRAL,
+      NCMECFileAnnotation.VIRAL,
+    ]);
+    expect(result).toEqual({ viral: undefined });
+  });
+});
+
+describe('buildFileDetailsObject', () => {
+  const baseInput = {
+    reportId: 1234,
+    fileId: 'ncmec-file-1',
+    media: {
+      industryClassification: 'A1' as const,
+      fileAnnotations: undefined,
+    },
+    additionalInfo: {},
+  };
+
+  it('builds the minimum fileDetails envelope with viewed-by-esp flags on', () => {
+    // NCMEC defaults: coop has reviewed both the file and any EXIF metadata
+    // before submitting, so these flags are always true.
+    expect(buildFileDetailsObject(baseInput)).toEqual({
+      fileDetails: {
+        reportId: 1234,
+        fileId: 'ncmec-file-1',
+        fileViewedByEsp: true,
+        exifViewedByEsp: true,
+        industryClassification: 'A1',
+      },
+    });
+  });
+
+  it('preserves XSD insertion order (Appendix C)', () => {
+    // js2xml emits children in insertion order; NCMEC rejects out-of-order
+    // submissions with responseCode=4100. Anchoring the key order here
+    // catches a regression that integration tests would only catch when
+    // exttest rejects the report.
+    const result = buildFileDetailsObject({
+      ...baseInput,
+      media: {
+        industryClassification: 'A1' as const,
+        fileAnnotations: [NCMECFileAnnotation.GENERATIVE_AI],
+      },
+      additionalInfo: {
+        publiclyAvailable: true,
+        ipCaptureEvent: [
+          {
+            ipAddress: '203.0.113.1',
+            eventName: NCMECEvent.Upload,
+            dateTime: INCIDENT_DATE_TIME,
+          },
+        ],
+        additionalInfo: ['from webhook'],
+      },
+      originalFileHash: [
+        { _text: 'abc123', _attributes: { hashType: 'MD5' } },
+      ],
+    });
+    expect(Object.keys(result.fileDetails)).toEqual([
+      'reportId',
+      'fileId',
+      'fileViewedByEsp',
+      'exifViewedByEsp',
+      'publiclyAvailable',
+      'fileAnnotations',
+      'industryClassification',
+      'originalFileHash',
+      'ipCaptureEvent',
+      'additionalInfo',
+    ]);
+  });
+
+  it('emits originalFileHash when supplied, omits when empty or unset', () => {
+    const withHash = buildFileDetailsObject({
+      ...baseInput,
+      originalFileHash: [
+        { _text: 'abc123', _attributes: { hashType: 'MD5' } },
+        { _text: 'def456', _attributes: { hashType: 'SHA1' } },
+      ],
+    });
+    expect(withHash.fileDetails.originalFileHash).toEqual([
+      { _text: 'abc123', _attributes: { hashType: 'MD5' } },
+      { _text: 'def456', _attributes: { hashType: 'SHA1' } },
+    ]);
+    const empty = buildFileDetailsObject({
+      ...baseInput,
+      originalFileHash: [],
+    });
+    expect(empty.fileDetails).not.toHaveProperty('originalFileHash');
+    expect(buildFileDetailsObject(baseInput).fileDetails).not.toHaveProperty(
+      'originalFileHash',
+    );
+  });
+
+  it('emits publiclyAvailable when set to true or false, omits when undefined', () => {
+    const truthy = buildFileDetailsObject({
+      ...baseInput,
+      additionalInfo: { publiclyAvailable: true },
+    });
+    const falsy = buildFileDetailsObject({
+      ...baseInput,
+      additionalInfo: { publiclyAvailable: false },
+    });
+    expect(truthy.fileDetails.publiclyAvailable).toBe(true);
+    expect(falsy.fileDetails.publiclyAvailable).toBe(false);
+    expect(baseInput.additionalInfo).not.toHaveProperty('publiclyAvailable');
+    expect(buildFileDetailsObject(baseInput).fileDetails).not.toHaveProperty(
+      'publiclyAvailable',
+    );
+  });
+
+  it('omits ipCaptureEvent when array is empty', () => {
+    const result = buildFileDetailsObject({
+      ...baseInput,
+      additionalInfo: { ipCaptureEvent: [] },
+    });
+    expect(result.fileDetails).not.toHaveProperty('ipCaptureEvent');
+  });
+
+  it('omits optional ipCaptureEvent fields (possibleProxy, port) when falsy', () => {
+    // NCMEC accepts a bare ipAddress + eventName + dateTime; sending
+    // `possibleProxy: false` or `port: 0` would be technically valid but
+    // adds noise. Only emit when explicitly truthy.
+    const result = buildFileDetailsObject({
+      ...baseInput,
+      additionalInfo: {
+        ipCaptureEvent: [
+          {
+            ipAddress: '203.0.113.1',
+            eventName: NCMECEvent.Upload,
+            dateTime: INCIDENT_DATE_TIME,
+            possibleProxy: false,
+            port: 0,
+          },
+        ],
+      },
+    });
+    expect(result.fileDetails.ipCaptureEvent).toEqual([
+      {
+        ipAddress: '203.0.113.1',
+        eventName: 'Upload',
+        dateTime: INCIDENT_DATE_TIME,
+      },
+    ]);
+  });
+});

--- a/server/services/ncmecService/ncmecReporting.ts
+++ b/server/services/ncmecService/ncmecReporting.ts
@@ -611,6 +611,277 @@ export function resolveReportedPersonEmail(
   return undefined;
 }
 
+/** Maps a list of `NCMECFileAnnotationType` enum values to the
+ * `FileAnnotations` element shape expected by the NCMEC `<fileDetails>` XSD
+ * (each annotation becomes an empty self-closing child element).
+ *
+ * Lives at module scope so the `buildFileDetailsObject` helper and the
+ * dry-run dump script can both build file-details XML without instantiating
+ * `NcmecReportingService`. */
+export function fileAnnotationArrayToNCMECFileAnnotation(
+  fileAnnotations?: readonly NCMECFileAnnotationType[],
+): FileAnnotations | undefined {
+  if (!fileAnnotations || fileAnnotations.length === 0) {
+    return undefined;
+  }
+  // Iterating through a table avoids one branch per annotation, which
+  // previously pushed cyclomatic complexity over the configured ESLint limit
+  // and made the function hard to extend when new annotation types are added.
+  const annotationFieldByType: Record<
+    NCMECFileAnnotationType,
+    keyof FileAnnotations
+  > = {
+    [NCMECFileAnnotation.ANIME_DRAWING_VIRTUAL_HENTAI]:
+      'animeDrawingVirtualHentai',
+    [NCMECFileAnnotation.POTENTIAL_MEME]: 'potentialMeme',
+    [NCMECFileAnnotation.VIRAL]: 'viral',
+    [NCMECFileAnnotation.POSSIBLE_SELF_PRODUCTION]: 'possibleSelfProduction',
+    [NCMECFileAnnotation.PHYSICAL_HARM]: 'physicalHarm',
+    [NCMECFileAnnotation.VIOLENCE_GORE]: 'violenceGore',
+    [NCMECFileAnnotation.BESTIALITY]: 'bestiality',
+    [NCMECFileAnnotation.LIVE_STREAMING]: 'liveStreaming',
+    [NCMECFileAnnotation.INFANT]: 'infant',
+    [NCMECFileAnnotation.GENERATIVE_AI]: 'generativeAi',
+  };
+  const result: FileAnnotations = {};
+  for (const annotation of fileAnnotations) {
+    const field = annotationFieldByType[annotation];
+    result[field] = undefined;
+  }
+  return result;
+}
+
+export type BuildSubmitReportObjectInput = {
+  reportParams: NCMECReportParams;
+  /** Reported user's webhook-derived additional info, from the
+   * `ncmec_additional_info_endpoint` webhook (or defaulted to empty when no
+   * endpoint is configured). */
+  userAdditionalInfo: {
+    email?: Email[];
+    screenName?: string;
+    ipCaptureEvent?: IPNCMECEvent[];
+  };
+  /** Slice of `ncmec_reporting.ncmec_org_settings` needed to build the
+   * report envelope. `companyTemplate`, `legalURL` and `reportingPersonEmail`
+   * are required (the caller validated them). */
+  orgSettings: {
+    companyTemplate: string;
+    legalURL: string;
+    defaultInternetDetailType?: string | null;
+    termsOfService?: string | null;
+    contactPersonEmail?: string | null;
+    contactPersonFirstName?: string | null;
+    contactPersonLastName?: string | null;
+    contactPersonPhone?: string | null;
+    /** From `ncmec_org_settings.contact_email`. */
+    reportingPersonEmail: string;
+    /** Optional URL used to populate `webPageIncident.url` when the org's
+     * `defaultInternetDetailType` is WEB_PAGE. */
+    moreInfoUrl?: string | null;
+  };
+  /** Latest media `createdAt`, already clamped to the past. */
+  clampedIncidentDateTime: string;
+};
+
+/** Build the `Report` envelope NCMEC's `/submit` endpoint expects. Pure: no
+ * DB or HTTP. The caller is responsible for resolving org settings and
+ * webhook-sourced additional info; this function only assembles them in the
+ * XSD-mandated order. Used by `submitReport` and by audit/dump tooling. */
+ 
+// further decomposition would obscure the XSD-mandated insertion order (see
+// the `Report` type comment) that NCMEC validates against.
+export function buildSubmitReportObject(
+  input: BuildSubmitReportObjectInput,
+): Report {
+  const {
+    reportParams,
+    userAdditionalInfo,
+    orgSettings,
+    clampedIncidentDateTime,
+  } = input;
+  const emailStringToNCMECEmail = (email: string) => ({ _text: email });
+
+  const incidentType =
+    NCMECIncidentType[reportParams.incidentType as NCMECIncidentType];
+
+  const escalateToHighPriority =
+    reportParams.escalateToHighPriority != null
+      ? reportParams.escalateToHighPriority.trim()
+      : undefined;
+  if (
+    escalateToHighPriority !== undefined &&
+    (escalateToHighPriority === '' || escalateToHighPriority.length > 3000)
+  ) {
+    throw new Error(
+      'escalateToHighPriority must be non-blank when supplied and at most 3000 characters',
+    );
+  }
+
+  const reportAdditionalInfo =
+    reportParams.additionalInfo != null
+      ? reportParams.additionalInfo.trim()
+      : undefined;
+  if (
+    reportAdditionalInfo !== undefined &&
+    (reportAdditionalInfo === '' || reportAdditionalInfo.length > 3000)
+  ) {
+    throw new Error(
+      'additionalInfo must be non-blank when supplied and at most 3000 characters',
+    );
+  }
+
+  const internetDetails = buildInternetDetailsFromOrgSetting(
+    orgSettings.defaultInternetDetailType,
+    orgSettings.moreInfoUrl,
+  );
+
+  const contactPersonEmail = orgSettings.contactPersonEmail?.trim();
+  const contactPersonFirstName = orgSettings.contactPersonFirstName?.trim();
+  const contactPersonLastName = orgSettings.contactPersonLastName?.trim();
+  const contactPersonPhone = orgSettings.contactPersonPhone?.trim();
+  const contactPerson =
+    contactPersonEmail ||
+    contactPersonFirstName ||
+    contactPersonLastName ||
+    contactPersonPhone
+      ? {
+          ...(contactPersonFirstName
+            ? { firstName: contactPersonFirstName }
+            : {}),
+          ...(contactPersonLastName ? { lastName: contactPersonLastName } : {}),
+          ...(contactPersonPhone
+            ? { phone: { _text: contactPersonPhone } }
+            : {}),
+          ...(contactPersonEmail
+            ? { email: [emailStringToNCMECEmail(contactPersonEmail)] }
+            : {}),
+        }
+      : undefined;
+
+  const termsOfService =
+    orgSettings.termsOfService != null &&
+    orgSettings.termsOfService.trim() !== '' &&
+    orgSettings.termsOfService.length <= 3000
+      ? orgSettings.termsOfService.trim()
+      : undefined;
+
+  const reportedPersonEmail = resolveReportedPersonEmail(
+    userAdditionalInfo.email,
+    reportParams.reportedUser.email,
+  );
+  const personOrUserReportedPerson = reportedPersonEmail
+    ? { email: reportedPersonEmail }
+    : undefined;
+
+  // The role IP is a bare string, not a login/upload signal, so `Unknown` is
+  // the safest event-name claim.
+  const reportedUserIpCaptureEvents = mergeFieldRoleIpIntoEvents(
+    userAdditionalInfo.ipCaptureEvent,
+    reportParams.reportedUser.ipCaptureEvent,
+    reportParams.reportedUser.ipAddress,
+    {
+      eventName: NCMECEvent.Unknown,
+      dateTime: clampedIncidentDateTime,
+    },
+  );
+
+  return {
+    report: {
+      incidentSummary: {
+        incidentType,
+        ...(escalateToHighPriority ? { escalateToHighPriority } : {}),
+        incidentDateTime: clampedIncidentDateTime,
+      },
+      ...(internetDetails ? { internetDetails } : {}),
+      reporter: {
+        reportingPerson: {
+          email: [emailStringToNCMECEmail(orgSettings.reportingPersonEmail)],
+        },
+        ...(contactPerson ? { contactPerson } : {}),
+        companyTemplate: orgSettings.companyTemplate,
+        ...(termsOfService ? { termsOfService } : {}),
+        legalURL: orgSettings.legalURL,
+      },
+      personOrUserReported: {
+        ...(personOrUserReportedPerson ? { personOrUserReportedPerson } : {}),
+        espIdentifier: reportParams.reportedUser.id,
+        espService: orgSettings.companyTemplate,
+        screenName: userAdditionalInfo.screenName,
+        ...(reportParams.reportedUser.displayName
+          ? { displayName: [reportParams.reportedUser.displayName] }
+          : {}),
+        ...(reportedUserIpCaptureEvents &&
+        reportedUserIpCaptureEvents.length > 0
+          ? { ipCaptureEvent: reportedUserIpCaptureEvents }
+          : {}),
+      },
+      ...(reportAdditionalInfo !== undefined
+        ? { additionalInfo: reportAdditionalInfo }
+        : {}),
+    },
+  };
+}
+
+export type BuildFileDetailsObjectInput = {
+  reportId: number;
+  fileId: string;
+  media: Pick<Media, 'industryClassification'> & {
+    fileAnnotations?: readonly NCMECFileAnnotationType[];
+  };
+  additionalInfo: Pick<
+    MediaAdditionalInfo,
+    'publiclyAvailable' | 'ipCaptureEvent' | 'additionalInfo'
+  >;
+  /** Combined HMA + webhook hashes as built by `toOriginalFileHashes`.
+   * Rendered in the `<originalFileHash>` element(s) between
+   * `industryClassification` and `ipCaptureEvent` per the XSD. */
+  originalFileHash?: readonly OriginalFileHash[];
+};
+
+/** Pure builder for the `FileDetails` envelope NCMEC's `/fileinfo`
+ * endpoint expects. Used by `submitReport`'s `#upload` step and by
+ * dry-run tooling that needs to serialize per-media XML without
+ * performing the upload. No DB or HTTP calls. */
+export function buildFileDetailsObject(
+  input: BuildFileDetailsObjectInput,
+): FileDetails {
+  const { reportId, fileId, media, additionalInfo, originalFileHash } = input;
+  const fileAnnotations = fileAnnotationArrayToNCMECFileAnnotation(
+    media.fileAnnotations,
+  );
+  return {
+    fileDetails: {
+      reportId,
+      fileId,
+      fileViewedByEsp: true,
+      exifViewedByEsp: true,
+      ...(additionalInfo.publiclyAvailable !== undefined
+        ? { publiclyAvailable: additionalInfo.publiclyAvailable }
+        : {}),
+      ...(fileAnnotations ? { fileAnnotations } : {}),
+      industryClassification: media.industryClassification,
+      ...(originalFileHash && originalFileHash.length > 0
+        ? { originalFileHash: [...originalFileHash] }
+        : {}),
+      ...(additionalInfo.ipCaptureEvent &&
+      additionalInfo.ipCaptureEvent.length > 0
+        ? {
+            ipCaptureEvent: additionalInfo.ipCaptureEvent.map((it) => ({
+              ipAddress: it.ipAddress,
+              eventName: it.eventName,
+              dateTime: it.dateTime,
+              ...(it.possibleProxy ? { possibleProxy: it.possibleProxy } : {}),
+              ...(it.port ? { port: it.port } : {}),
+            })),
+          }
+        : {}),
+      ...(additionalInfo.additionalInfo
+        ? { additionalInfo: additionalInfo.additionalInfo }
+        : {}),
+    },
+  };
+}
+
 export function buildInternetDetailsFromOrgSetting(
   defaultInternetDetailType: string | null | undefined,
   moreInfoUrl: string | null | undefined,
@@ -1570,44 +1841,7 @@ export default class NcmecReporting {
               it.id === reportParams.reportedUser.id &&
               it.typeId === reportParams.reportedUser.typeId,
           )!;
-          const emailStringToNCMECEmail = (email: string) => ({ _text: email });
           const ncmecConfig = await this.getNCMECConfig(reportParams.orgId);
-
-          // Use the incident type from the report params
-          const incidentType =
-            NCMECIncidentType[reportParams.incidentType as NCMECIncidentType];
-
-          const escalateToHighPriority =
-            reportParams.escalateToHighPriority != null
-              ? reportParams.escalateToHighPriority.trim()
-              : undefined;
-          if (
-            escalateToHighPriority !== undefined &&
-            (escalateToHighPriority === '' ||
-              escalateToHighPriority.length > 3000)
-          ) {
-            throw new Error(
-              'escalateToHighPriority must be non-blank when supplied and at most 3000 characters',
-            );
-          }
-
-          const reportAdditionalInfo =
-            reportParams.additionalInfo != null
-              ? reportParams.additionalInfo.trim()
-              : undefined;
-          if (
-            reportAdditionalInfo !== undefined &&
-            (reportAdditionalInfo === '' || reportAdditionalInfo.length > 3000)
-          ) {
-            throw new Error(
-              'additionalInfo must be non-blank when supplied and at most 3000 characters',
-            );
-          }
-
-          const internetDetails = buildInternetDetailsFromOrgSetting(
-            queryResponse.defaultInternetDetailType,
-            ncmecConfig?.more_info_url,
-          );
 
           const reportingPersonEmail = ncmecConfig?.contact_email?.trim();
           if (!reportingPersonEmail) {
@@ -1616,99 +1850,24 @@ export default class NcmecReporting {
             );
           }
 
-          const contactPersonEmail = queryResponse.contactPersonEmail?.trim();
-          const contactPersonFirstName =
-            queryResponse.contactPersonFirstName?.trim();
-          const contactPersonLastName =
-            queryResponse.contactPersonLastName?.trim();
-          const contactPersonPhone = queryResponse.contactPersonPhone?.trim();
-          const contactPerson =
-            contactPersonEmail ||
-            contactPersonFirstName ||
-            contactPersonLastName ||
-            contactPersonPhone
-              ? {
-                  ...(contactPersonFirstName
-                    ? { firstName: contactPersonFirstName }
-                    : {}),
-                  ...(contactPersonLastName
-                    ? { lastName: contactPersonLastName }
-                    : {}),
-                  ...(contactPersonPhone
-                    ? { phone: { _text: contactPersonPhone } }
-                    : {}),
-                  ...(contactPersonEmail
-                    ? { email: [emailStringToNCMECEmail(contactPersonEmail)] }
-                    : {}),
-                }
-              : undefined;
-
-          const termsOfService =
-            queryResponse.termsOfService != null &&
-            queryResponse.termsOfService.trim() !== '' &&
-            queryResponse.termsOfService.length <= 3000
-              ? queryResponse.termsOfService.trim()
-              : undefined;
-
-          const reportedPersonEmail = resolveReportedPersonEmail(
-            userAdditionalInfo.email,
-            reportParams.reportedUser.email,
-          );
-          const personOrUserReportedPerson = reportedPersonEmail
-            ? { email: reportedPersonEmail }
-            : undefined;
-
-          // The role IP is a bare string, not a login/upload signal, so
-          // `Unknown` is the safest event-name claim.
-          const reportedUserIpCaptureEvents = mergeFieldRoleIpIntoEvents(
-            userAdditionalInfo.ipCaptureEvent,
-            reportParams.reportedUser.ipCaptureEvent,
-            reportParams.reportedUser.ipAddress,
-            {
-              eventName: NCMECEvent.Unknown,
-              dateTime: clampedIncidentDateTime,
+          const report = buildSubmitReportObject({
+            reportParams,
+            userAdditionalInfo,
+            orgSettings: {
+              companyTemplate: queryResponse.companyTemplate,
+              legalURL: queryResponse.legalURL,
+              defaultInternetDetailType:
+                queryResponse.defaultInternetDetailType,
+              termsOfService: queryResponse.termsOfService,
+              contactPersonEmail: queryResponse.contactPersonEmail,
+              contactPersonFirstName: queryResponse.contactPersonFirstName,
+              contactPersonLastName: queryResponse.contactPersonLastName,
+              contactPersonPhone: queryResponse.contactPersonPhone,
+              reportingPersonEmail,
+              moreInfoUrl: ncmecConfig?.more_info_url,
             },
-          );
-
-          const report: Report = {
-            report: {
-              incidentSummary: {
-                incidentType,
-                ...(escalateToHighPriority ? { escalateToHighPriority } : {}),
-                incidentDateTime: clampedIncidentDateTime,
-              },
-              ...(internetDetails ? { internetDetails } : {}),
-              reporter: {
-                reportingPerson: {
-                  email: [emailStringToNCMECEmail(reportingPersonEmail)],
-                },
-                ...(contactPerson ? { contactPerson } : {}),
-                companyTemplate: queryResponse.companyTemplate,
-                ...(termsOfService ? { termsOfService } : {}),
-                legalURL: queryResponse.legalURL,
-              },
-              personOrUserReported: {
-                ...(personOrUserReportedPerson
-                  ? { personOrUserReportedPerson }
-                  : {}),
-                espIdentifier: reportParams.reportedUser.id,
-                espService: queryResponse.companyTemplate,
-                screenName: userAdditionalInfo.screenName,
-                ...(reportParams.reportedUser.displayName
-                  ? {
-                      displayName: [reportParams.reportedUser.displayName],
-                    }
-                  : {}),
-                ...(reportedUserIpCaptureEvents &&
-                reportedUserIpCaptureEvents.length > 0
-                  ? { ipCaptureEvent: reportedUserIpCaptureEvents }
-                  : {}),
-              },
-              ...(reportAdditionalInfo !== undefined
-                ? { additionalInfo: reportAdditionalInfo }
-                : {}),
-            },
-          };
+            clampedIncidentDateTime,
+          });
 
           // For the five actions here
           // 1. #submit
@@ -2011,47 +2170,19 @@ export default class NcmecReporting {
       throw new Error('NCMEC file upload failed.');
     }
     const fileId = responseJson.reportResponse.fileId._text;
-    const fileAnnotations = this.#fileAnnotationArrayToNCMECFileAnnotation(
-      media.fileAnnotations,
-    );
     const originalFileHash = toOriginalFileHashes({
       hmaHashes: media.hashes,
       webhookFileDetails: additionalInfo.fileDetails,
     });
+    const fileDetailsObject = buildFileDetailsObject({
+      reportId: parseInt(reportId),
+      fileId,
+      media,
+      additionalInfo,
+      ...(originalFileHash ? { originalFileHash } : {}),
+    });
     const xml = await this.#uploadFileDetails(
-      {
-        fileDetails: {
-          reportId: parseInt(reportId),
-          fileId,
-          fileViewedByEsp: true,
-          exifViewedByEsp: true,
-          ...(additionalInfo.publiclyAvailable !== undefined
-            ? { publiclyAvailable: additionalInfo.publiclyAvailable }
-            : {}),
-          ...(fileAnnotations ? { fileAnnotations } : {}),
-          industryClassification: media.industryClassification,
-          ...(originalFileHash && originalFileHash.length > 0
-            ? { originalFileHash }
-            : {}),
-          ...(additionalInfo.ipCaptureEvent &&
-          additionalInfo.ipCaptureEvent.length > 0
-            ? {
-                ipCaptureEvent: additionalInfo.ipCaptureEvent.map((it) => ({
-                  ipAddress: it.ipAddress,
-                  eventName: it.eventName,
-                  dateTime: it.dateTime,
-                  ...(it.possibleProxy
-                    ? { possibleProxy: it.possibleProxy }
-                    : {}),
-                  ...(it.port ? { port: it.port } : {}),
-                })),
-              }
-            : {}),
-          ...(additionalInfo.additionalInfo
-            ? { additionalInfo: additionalInfo.additionalInfo }
-            : {}),
-        },
-      },
+      fileDetailsObject,
       cybertipAuthenticationCredentials,
       isTest,
     );
@@ -2061,42 +2192,6 @@ export default class NcmecReporting {
       typeId: media.typeId,
       xml,
     };
-  }
-
-  #fileAnnotationArrayToNCMECFileAnnotation(
-    fileAnnotations?: readonly NCMECFileAnnotationType[],
-  ): FileAnnotations | undefined {
-    if (!fileAnnotations || fileAnnotations.length === 0) {
-      return undefined;
-    }
-    // Map each NCMEC annotation enum value to the corresponding XML field
-    // name. Iterating through the table avoids one logical branch per
-    // annotation, which previously pushed cyclomatic complexity over the
-    // configured ESLint limit and made the function hard to extend when new
-    // annotation types are added.
-    const annotationFieldByType: Record<
-      NCMECFileAnnotationType,
-      keyof FileAnnotations
-    > = {
-      [NCMECFileAnnotation.ANIME_DRAWING_VIRTUAL_HENTAI]:
-        'animeDrawingVirtualHentai',
-      [NCMECFileAnnotation.POTENTIAL_MEME]: 'potentialMeme',
-      [NCMECFileAnnotation.VIRAL]: 'viral',
-      [NCMECFileAnnotation.POSSIBLE_SELF_PRODUCTION]: 'possibleSelfProduction',
-      [NCMECFileAnnotation.PHYSICAL_HARM]: 'physicalHarm',
-      [NCMECFileAnnotation.VIOLENCE_GORE]: 'violenceGore',
-      [NCMECFileAnnotation.BESTIALITY]: 'bestiality',
-      [NCMECFileAnnotation.LIVE_STREAMING]: 'liveStreaming',
-      [NCMECFileAnnotation.INFANT]: 'infant',
-      [NCMECFileAnnotation.GENERATIVE_AI]: 'generativeAi',
-    };
-
-    const result: FileAnnotations = {};
-    for (const annotation of fileAnnotations) {
-      const field = annotationFieldByType[annotation];
-      result[field] = undefined;
-    }
-    return result;
   }
 
   async #uploadFileDetails(

--- a/server/services/ncmecService/ncmecReporting.ts
+++ b/server/services/ncmecService/ncmecReporting.ts
@@ -687,7 +687,7 @@ export type BuildSubmitReportObjectInput = {
  * DB or HTTP. The caller is responsible for resolving org settings and
  * webhook-sourced additional info; this function only assembles them in the
  * XSD-mandated order. Used by `submitReport` and by audit/dump tooling. */
- 
+
 // further decomposition would obscure the XSD-mandated insertion order (see
 // the `Report` type comment) that NCMEC validates against.
 export function buildSubmitReportObject(

--- a/server/services/ncmecService/ncmecReporting.ts
+++ b/server/services/ncmecService/ncmecReporting.ts
@@ -217,6 +217,10 @@ export type NCMECReportParams = {
   escalateToHighPriority?: string;
   /** Optional free-text notes; if present must be non-blank and max 3000 chars. */
   additionalInfo?: string;
+  /** Optional free-text describing what `incidentDateTime` represents (e.g.
+   * "user uploaded this image"). If present, must be non-blank and max 3000
+   * chars. Surfaced on NCMEC analyst views next to the timestamp. */
+  incidentDateTimeDescription?: string;
   /** MRT decision id; when set, failures are recorded to `ncmec_reports_errors`. */
   jobId?: string;
 };
@@ -730,6 +734,20 @@ export function buildSubmitReportObject(
     );
   }
 
+  const incidentDateTimeDescription =
+    reportParams.incidentDateTimeDescription != null
+      ? reportParams.incidentDateTimeDescription.trim()
+      : undefined;
+  if (
+    incidentDateTimeDescription !== undefined &&
+    (incidentDateTimeDescription === '' ||
+      incidentDateTimeDescription.length > 3000)
+  ) {
+    throw new Error(
+      'incidentDateTimeDescription must be non-blank when supplied and at most 3000 characters',
+    );
+  }
+
   const internetDetails = buildInternetDetailsFromOrgSetting(
     orgSettings.defaultInternetDetailType,
     orgSettings.moreInfoUrl,
@@ -791,6 +809,7 @@ export function buildSubmitReportObject(
         incidentType,
         ...(escalateToHighPriority ? { escalateToHighPriority } : {}),
         incidentDateTime: clampedIncidentDateTime,
+        ...(incidentDateTimeDescription ? { incidentDateTimeDescription } : {}),
       },
       ...(internetDetails ? { internetDetails } : {}),
       reporter: {


### PR DESCRIPTION
## Context & Requests for Reviewers

Wires the NCMEC XSD `<incidentDateTimeDescription>` element end-to-end as an optional reviewer-input field. NCMEC analysts see this free-text description next to `<incidentDateTime>` in their review UI, explaining what the timestamp represents (e.g. "user uploaded this image", "message sent by user").

Closes one row in the field-coverage audit on #843. First in a series of small PRs systematically closing the code-gaps surfaced by that audit; this is the simplest path because it requires no migration, no webhook contract change, and no new field role.

### What changes

**Server**
- GraphQL SDL: `SubmitNcmecReportInput.incidentDateTimeDescription: String` with docstring; null→undefined normalization in the SUBMIT_NCMEC_REPORT resolver.
- Decision component type (`JobDecisioning.ts`): `SUBMIT_NCMEC_REPORT` shape extended.
- `buildSubmitReportParamsFromDecision`: trim + forward into `NCMECReportParams`.
- `buildSubmitReportObject`: validates (non-blank, ≤3000 chars per NCMEC's spec) and populates inside `incidentSummary` after `incidentDateTime` per XSD insertion order.
- GraphQL codegen regenerated.

**Client**
- `NCMECReviewUser` modal: new optional textarea, parallel to the existing `additionalInfo` field. 3000-char limit, character counter, placeholder text guiding reviewers ("describe what kind of date/time this is, like 'user uploaded this image' or 'message sent by user'").

**Storage**
- No migration. `decision_components` is a JSONB array; the new optional string serializes through without schema changes.

### AGENTS.md callouts

- **Touches NCMEC submission code**, flagged as a sensitive area. New direct unit tests on both the field-assembly path (`buildSubmitReportObject.test.ts`) and the decision-component propagation path (`buildSubmitReportParamsFromDecision.test.ts`).
- GraphQL `generated.ts` regenerated, not hand-edited.
- No DB migration.
- No dependency change.
- Lockfiles not touched.

## Tests

- `npm run test:prepush -- services/ncmecService/buildSubmitReportObject.test.ts services/ncmecService/buildSubmitReportParamsFromDecision.test.ts services/ncmecService/ncmecReporting.builders.test.ts services/ncmecService/ncmecReporting.test.ts` — all 78 tests pass locally.
- New `buildSubmitReportObject` cases: validation throws (empty after trim, >3000 chars), XSD insertion order (description follows incidentDateTime), trim semantics, omission when not supplied.
- New `buildSubmitReportParamsFromDecision` cases: trim from decision component, omit when blank or unset.

> [!NOTE]
> Stacked on #853 (`ncmec/test-report`), which is itself stacked on #842. The dependency chain is: #842 (EMAIL_ADDRESS handler, unblocks the test runner) → #853 (refactor + unit-test infrastructure) → this PR. Marked draft until both prerequisites land; rebasing onto main after that clears the base.

## (Optional) Rollout Plan

None. Additive only. Existing reports continue to work; the new field is omitted unless a reviewer types into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)