### PR TITLE
ncmec: fix fileDetails.ipCaptureEvent XSD ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 
 - Added `email` as a supported schema field role for user items, ensuring inclusion and validation for NCMEC reports (#840, #842)
 - `EMAIL_ADDRESS` added as a first-class scalar in `@roostorg/coop-types` (v2.4.0) (#841)
-- Auto-populate user report history, original filename, and file relevance for NCMEC reports (#855)
+- Auto-populate `originalFileName` (from the media URL) and `fileRelevance` (defaults to `Reported`) for NCMEC reports (#855). The same PR also wires `priorCTReports` end-to-end, but the field does not populate in production yet because an earlier duplicate-submission check stops the report before the lookup runs; resolving that check is tracked as a follow-up.
+- Fixed `fileDetails.ipCaptureEvent` XSD element ordering: `ipCaptureEvent` was emitted after `industryClassification`, which NCMEC's validator rejected (`cvc-complex-type.2.4.a`). Affected any adopter who had the IP-address schema field role configured on a Content item type. Latent since the `/fileinfo` submission path was first written; activated by #641 (#856).
 
 ## Review Console
 

--- a/server/services/ncmecService/ncmecReporting.builders.test.ts
+++ b/server/services/ncmecService/ncmecReporting.builders.test.ts
@@ -137,9 +137,9 @@ describe('buildFileDetailsObject', () => {
       'publiclyAvailable',
       'fileRelevance',
       'fileAnnotations',
+      'ipCaptureEvent',
       'industryClassification',
       'originalFileHash',
-      'ipCaptureEvent',
       'additionalInfo',
     ]);
   });

--- a/server/services/ncmecService/ncmecReporting.ts
+++ b/server/services/ncmecService/ncmecReporting.ts
@@ -132,9 +132,9 @@ type FileDetails = {
     publiclyAvailable?: boolean;
     fileRelevance?: 'Reported' | 'Supplemental Reported';
     fileAnnotations?: FileAnnotations;
+    ipCaptureEvent?: IPNCMECEvent[];
     industryClassification?: NCMECIndustryClassificationType;
     originalFileHash?: OriginalFileHash[];
-    ipCaptureEvent?: IPNCMECEvent[];
     deviceId?: DeviceId[];
     details?: Detail[];
     additionalInfo?: string[];
@@ -843,8 +843,8 @@ export type BuildFileDetailsObjectInput = {
     'publiclyAvailable' | 'ipCaptureEvent' | 'additionalInfo'
   >;
   /** Combined HMA + webhook hashes as built by `toOriginalFileHashes`.
-   * Rendered in the `<originalFileHash>` element(s) between
-   * `industryClassification` and `ipCaptureEvent` per the XSD. */
+   * Rendered in the `<originalFileHash>` element(s) after
+   * `industryClassification` per the XSD. */
   originalFileHash?: readonly OriginalFileHash[];
 };
 
@@ -912,10 +912,6 @@ export function buildFileDetailsObject(
         : {}),
       fileRelevance,
       ...(fileAnnotations ? { fileAnnotations } : {}),
-      industryClassification: media.industryClassification,
-      ...(originalFileHash && originalFileHash.length > 0
-        ? { originalFileHash: [...originalFileHash] }
-        : {}),
       ...(additionalInfo.ipCaptureEvent &&
       additionalInfo.ipCaptureEvent.length > 0
         ? {
@@ -927,6 +923,10 @@ export function buildFileDetailsObject(
               ...(it.port ? { port: it.port } : {}),
             })),
           }
+        : {}),
+      industryClassification: media.industryClassification,
+      ...(originalFileHash && originalFileHash.length > 0
+        ? { originalFileHash: [...originalFileHash] }
         : {}),
       ...(additionalInfo.additionalInfo
         ? { additionalInfo: additionalInfo.additionalInfo }


### PR DESCRIPTION
## Context & Requests for Reviewers

Closes #856.

NCMEC's validator rejects `fileDetails` submissions whenever `ipCaptureEvent` appears after `industryClassification`, with `cvc-complex-type.2.4.a: Invalid content was found starting with element 'ipCaptureEvent'. One of '{deviceId, details, additionalInfo}' is expected.` That's the post-`industryClassification` element set the schema allows; `ipCaptureEvent` is not in it, so it has to be emitted before `industryClassification`.

The bug has been latent since the `/fileinfo` submission path was first written. It activated when #641 wired the `ipAddress` schema field role for Content item types, which made the wrong-positioned element actually appear in submissions. Any adopter who has configured the IP-address field role on a Content type AND submits reports including media with an associated IP would see NCMEC return HTTP 400 on the `/fileinfo` step (after `/submit` and `/upload` succeed, so the report ID is already issued but the submission is unrecoverable without retry).

### What changes

- `FileDetails` TS type: `ipCaptureEvent` moved before `industryClassification` (and before `originalFileHash`, which still appears immediately after `industryClassification` per the comment in `BuildFileDetailsObjectInput`).
- `buildFileDetailsObject` return literal: same reorder, matches the TS type so `js2xml` emits children in the correct sequence.
- `ncmecReporting.builders.test.ts`: the XSD-insertion-order assertion was anchoring the *wrong* order (the same order the validator rejects). Updated to the corrected order so future regressions of this class fail in CI rather than against `exttest.cybertip.org`.
- `BuildFileDetailsObjectInput.originalFileHash` docblock: updated the stale reference that said "between `industryClassification` and `ipCaptureEvent`" to reflect the new ordering.
- `CHANGELOG.md`:
  - New entry under NCMEC for this fix.
  - Rewrote the existing #855 entry to be honest that `priorCTReports` does not populate in production yet (an earlier duplicate-submission check guarantees the new lookup always returns empty). Resolving the duplicate-submission check is tracked as a follow-up issue.

### AGENTS.md callouts

- **Touches NCMEC submission code**, flagged as a sensitive area in `coop/AGENTS.md`. Change is mechanical (key reorder in two object literals) and the existing XSD-insertion-order test was already designed to anchor this class of bug; updating it here is the regression guard.
- No GraphQL `generated.ts` changes.
- No DB migration.
- No dependency changes.
- No client-side changes.
- Lockfiles not touched.

### Tests

- `npm run test:prepush -- services/ncmecService/ncmecReporting.builders.test.ts services/ncmecService/buildSubmitReportObject.test.ts services/ncmecService/ncmecReporting.test.ts` — 70/70 pass locally.
- The updated XSD-insertion-order assertion now anchors the corrected order; reverting either the TS type reorder or the builder literal reorder breaks the test, so the regression guard is in place.
- End-to-end verification against `exttest.cybertip.org` for the failing scenario in #856 has not been re-run in this PR; the same scenario that originally triggered the rejection should be re-run after merge to confirm the validator now accepts the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed NCMEC report field ordering so submissions validate correctly.
  * Adjusted report details to better align with required schema expectations.

* **Documentation**
  * Updated the changelog with clearer notes about auto-filled report fields and reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->