### PR TITLE
[COOP-661] remove table constraint for NCMEC non-media submissions

### DIFF
--- a/db/src/scripts/api-server-pg/2026.06.30T03.50.47.allow_text_only_ncmec_reports.sql
+++ b/db/src/scripts/api-server-pg/2026.06.30T03.50.47.allow_text_only_ncmec_reports.sql
@@ -1,0 +1,30 @@
+-- The existing `reported_media_check_non_empty` CHECK on ncmec_reporting.ncmec_reports
+-- requires >= 1 media item, which blocks storing legitimate text-only reports
+-- even after the application-side media gates were removed (#661).
+--
+-- We want to replace it with a constraint that matches the new logic. A
+-- report must carry media OR messages (but there must be one). `array_length` of an
+-- empty/NULL array is NULL, so coalesce to 0 before comparing. The column stays
+-- `jsonb[] NOT NULL`, so rows still cannot be NULL.
+--
+-- Safe for existing data: every current row satisfied the old "media non-empty"
+-- constraint, so it satisfies "media OR messages non-empty".
+--
+-- Rollback caveat: reverting to the media-only constraint will FAIL once any
+-- text-only (empty reported_media) row exists. Reverting is only clean
+-- before such rows are written; afterward it requires removing/backfilling
+-- those rows, and deleting NCMEC report records has compliance implications.
+-- Treat this as effectively forward-only.
+
+BEGIN;
+
+ALTER TABLE ncmec_reporting.ncmec_reports
+  DROP CONSTRAINT IF EXISTS reported_media_check_non_empty;
+
+ALTER TABLE ncmec_reporting.ncmec_reports
+  ADD CONSTRAINT reported_media_or_messages_non_empty CHECK (
+    coalesce(array_length(reported_media, 1), 0) > 0
+    OR coalesce(array_length(reported_messages, 1), 0) > 0
+  );
+
+COMMIT;


### PR DESCRIPTION
## Context & Requests for Reviewers

PR 2 of X to fix #661 

See #866. This PR needs to go out alongside #866. This is the migration change to change the DB constraint to allow non-media submissions to NCMEC.

## Tests

Validated against the local DB by running the migration body inside a transaction and rolling it back

## (Optional) Rollout Plan

This PR needs to be the first or second PR to go out alongside #866 

## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] **If you changed anything user-facing** (i.e. user interface or APIs):
  Did you update the CHANGELOG.md and related docs?

- [ ] **If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**
  Did you update the corresponding history tables and their triggers?

- [ ] **If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?

- [ ] **If you added a new signal in `server/services/signalsService/signals/**`:**
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.
