### PR TITLE
fix(mrt): scope queue mutations to the correct org

### DIFF
--- a/server/graphql/modules/manualReviewTool.ts
+++ b/server/graphql/modules/manualReviewTool.ts
@@ -2460,10 +2460,11 @@ const Mutation: GQLMutationResolvers = {
       throw forbiddenError('User does not have permission to edit MRT queues');
     }
 
-    await context.services.ManualReviewToolService.addAccessibleQueuesForUser(
-      params.input.userId,
-      params.input.queueIds,
-    );
+    await context.services.ManualReviewToolService.addAccessibleQueuesForUser({
+      orgId: user.orgId,
+      userId: params.input.userId,
+      queueIds: params.input.queueIds,
+    });
 
     // TODO: try/catch and return failure cases
     return gqlSuccessResult(
@@ -2481,8 +2482,11 @@ const Mutation: GQLMutationResolvers = {
     }
 
     await context.services.ManualReviewToolService.removeAccessibleQueuesForUser(
-      params.input.userId,
-      params.input.queueIds,
+      {
+        orgId: user.orgId,
+        userId: params.input.userId,
+        queueIds: params.input.queueIds,
+      },
     );
 
     // TODO: try/catch and return failure cases

--- a/server/services/manualReviewToolService/dbTypes.ts
+++ b/server/services/manualReviewToolService/dbTypes.ts
@@ -6,6 +6,7 @@ import {
 } from '../../storage/dataWarehouse/warehouseDateTypes.js';
 import { type JsonOf } from '../../utils/encoding.js';
 import { type ConditionSetWithResultAsLogged } from '../analyticsLoggers/ruleExecutionLoggingUtils.js';
+import { type CoreAppTablesPg } from '../coreAppTables.js';
 import { type NormalizedItemData } from '../itemProcessingService/toNormalizedItemDataOrErrors.js';
 import {
   type ConditionSet,
@@ -74,6 +75,9 @@ export type RoutingRuleExecutionsRow = {
 );
 
 export type ManualReviewToolServicePg = {
+  // Shared with CoreAppTablesPg so org-scoping checks can query the caller's
+  // users (see GHSA-mf74-gf5j-hxr9).
+  'public.users': CoreAppTablesPg['public.users'];
   'manual_review_tool.manual_review_queues': {
     id: string;
     name: string;

--- a/server/services/manualReviewToolService/dbTypes.ts
+++ b/server/services/manualReviewToolService/dbTypes.ts
@@ -75,8 +75,7 @@ export type RoutingRuleExecutionsRow = {
 );
 
 export type ManualReviewToolServicePg = {
-  // Shared with CoreAppTablesPg so org-scoping checks can query the caller's
-  // users (see GHSA-mf74-gf5j-hxr9).
+  // Shared with CoreAppTablesPg so org-scoping checks can query public.users.
   'public.users': CoreAppTablesPg['public.users'];
   'manual_review_tool.manual_review_queues': {
     id: string;

--- a/server/services/manualReviewToolService/manualReviewToolService.ts
+++ b/server/services/manualReviewToolService/manualReviewToolService.ts
@@ -838,18 +838,28 @@ export class ManualReviewToolService {
         });
   }
 
-  async addAccessibleQueuesForUser(
-    userId: string,
-    queueIds: readonly string[],
-  ) {
-    return this.queueOps.addAccessibleQueuesForUser([userId], queueIds);
+  async addAccessibleQueuesForUser(opts: {
+    orgId: string;
+    userId: string;
+    queueIds: readonly string[];
+  }) {
+    return this.queueOps.addAccessibleQueuesForUser({
+      orgId: opts.orgId,
+      userIds: [opts.userId],
+      queueIds: opts.queueIds,
+    });
   }
 
-  async removeAccessibleQueuesForUser(
-    userId: string,
-    queueIds: readonly string[],
-  ) {
-    return this.queueOps.removeAccessibleQueuesForUser(userId, queueIds);
+  async removeAccessibleQueuesForUser(opts: {
+    orgId: string;
+    userId: string;
+    queueIds: readonly string[];
+  }) {
+    return this.queueOps.removeAccessibleQueuesForUser({
+      orgId: opts.orgId,
+      userId: opts.userId,
+      queueIds: opts.queueIds,
+    });
   }
 
   /**

--- a/server/services/manualReviewToolService/modules/JobRouting.test.ts
+++ b/server/services/manualReviewToolService/modules/JobRouting.test.ts
@@ -5,6 +5,7 @@ import { uid } from 'uid';
 import getBottle from '../../../iocContainer/index.js';
 import createContentItemTypes from '../../../test/fixtureHelpers/createContentItemTypes.js';
 import createOrg from '../../../test/fixtureHelpers/createOrg.js';
+import createUser from '../../../test/fixtureHelpers/createUser.js';
 import { makeTestWithFixture } from '../../../test/utils.js';
 import { toCorrelationId } from '../../../utils/correlationIds.js';
 import { jsonStringify } from '../../../utils/encoding.js';
@@ -30,7 +31,11 @@ describe('JobRouting tests', () => {
       },
       uid(),
     );
-    const userId = uid();
+    const { user, cleanup: userCleanup } = await createUser(
+      container.KyselyPg,
+      org.id,
+    );
+    const userId = user.id;
     const { itemTypes, cleanup: itemTypesCleanup } =
       await createContentItemTypes({
         moderationConfigService: container.ModerationConfigService,
@@ -249,6 +254,7 @@ describe('JobRouting tests', () => {
           noPolicyQueue.id,
         );
         await itemTypesCleanup();
+        await userCleanup();
         await orgCleanup();
         await container.closeSharedResourcesForShutdown();
       },

--- a/server/services/manualReviewToolService/modules/QueueOperations.test.ts
+++ b/server/services/manualReviewToolService/modules/QueueOperations.test.ts
@@ -336,6 +336,13 @@ describe('QueueOperations', () => {
           queueIds: [attacker.queue.id],
         }),
       ).rejects.toBeDefined();
+
+      const viewers = await mrtService.getUsersWhoCanSeeQueue({
+        orgId: attacker.org.id,
+        queueId: attacker.queue.id,
+        userId: attacker.user.id,
+      });
+      expect(viewers.map((v) => v.userId)).toContain(attacker.user.id);
     },
   );
 

--- a/server/services/manualReviewToolService/modules/QueueOperations.test.ts
+++ b/server/services/manualReviewToolService/modules/QueueOperations.test.ts
@@ -7,6 +7,7 @@ import createContentItemTypes from '../../../test/fixtureHelpers/createContentIt
 import createMrtQueue from '../../../test/fixtureHelpers/createMrtQueue.js';
 import createOrg from '../../../test/fixtureHelpers/createOrg.js';
 import createUser from '../../../test/fixtureHelpers/createUser.js';
+import { makeTransactionalTestWithFixture } from '../../../test/harness/transactionalTest.js';
 import { makeTestWithFixture } from '../../../test/utils.js';
 import { UserPermission } from '../../userManagementService/index.js';
 import {
@@ -232,66 +233,36 @@ describe('QueueOperations', () => {
     },
   );
 
-  // Regression for GHSA-mf74-gf5j-hxr9: addAccessibleQueuesForUser /
-  // removeAccessibleQueuesForUser used to accept an arbitrary queueId /
-  // userId with no org-scoping, so an authenticated user in Org A could
-  // grant (or revoke) access to queues and users belonging to Org B.
-  //
-  // These fixtures build two independent orgs, each with a user and a
-  // queue, then assert that the caller's orgId gates both the queue and
-  // the user.
   const testWithTwoOrgs = () =>
-    makeTestWithFixture(async () => {
-      const container = (await getBottle()).container;
-
+    makeTransactionalTestWithFixture(async ({ deps }) => {
       const buildOrg = async () => {
-        const { org, cleanup: orgCleanup } = await createOrg(
+        const { org } = await createOrg(
           {
-            KyselyPg: container.KyselyPg,
-            ModerationConfigService: container.ModerationConfigService,
-            ApiKeyService: container.ApiKeyService,
+            KyselyPg: deps.KyselyPg,
+            ModerationConfigService: deps.ModerationConfigService,
+            ApiKeyService: deps.ApiKeyService,
           },
           uid(),
         );
-        const { user, cleanup: userCleanup } = await createUser(
-          container.KyselyPg,
-          org.id,
-        );
-        const { queue, cleanup: queueCleanup } = await createMrtQueue({
+        const { user } = await createUser(deps.KyselyPg, org.id);
+        const { queue } = await createMrtQueue({
           orgId: org.id,
-          mrtService: container.ManualReviewToolService,
+          mrtService: deps.ManualReviewToolService,
           userId: user.id,
         });
-        return { org, user, queue, orgCleanup, userCleanup, queueCleanup };
+        return { org, user, queue };
       };
 
-      const attacker = await buildOrg();
-      const victim = await buildOrg();
-
       return {
-        attacker,
-        victim,
-        mrtService: container.ManualReviewToolService,
-        kyselyPg: container.KyselyPg,
-        cleanup: async () => {
-          await attacker.queueCleanup();
-          await victim.queueCleanup();
-          await attacker.userCleanup();
-          await victim.userCleanup();
-          await attacker.orgCleanup();
-          await victim.orgCleanup();
-          await container.KyselyPg.destroy();
-          await container.KyselyPgReadReplica.destroy();
-        },
+        attacker: await buildOrg(),
+        victim: await buildOrg(),
+        mrtService: deps.ManualReviewToolService,
       };
     });
 
   testWithTwoOrgs()(
     'addAccessibleQueuesForUser must not grant access to a queue in a different org',
     async ({ attacker, victim, mrtService }) => {
-      // Attacker (Org A) passes the victim's queueId (Org B) to grant their
-      // own user access. This is a cross-org IDOR: the service must reject it
-      // and no access row should be written.
       await expect(
         mrtService.addAccessibleQueuesForUser({
           orgId: attacker.org.id,
@@ -312,8 +283,6 @@ describe('QueueOperations', () => {
   testWithTwoOrgs()(
     'addAccessibleQueuesForUser must not grant access for a user in a different org',
     async ({ attacker, victim, mrtService }) => {
-      // Attacker (Org A) passes a userId belonging to Org B against their own
-      // queue. The service must reject cross-user cross-org mutation.
       await expect(
         mrtService.addAccessibleQueuesForUser({
           orgId: attacker.org.id,
@@ -334,9 +303,6 @@ describe('QueueOperations', () => {
   testWithTwoOrgs()(
     'removeAccessibleQueuesForUser must not revoke access for a queue in a different org',
     async ({ attacker, victim, mrtService }) => {
-      // Seed legitimate access for the victim's user on the victim's queue,
-      // then have the attacker (Org A) pass the victim's queueId to revoke
-      // it. Must be rejected; the seeded access must survive.
       await mrtService.addAccessibleQueuesForUser({
         orgId: victim.org.id,
         userId: victim.user.id,
@@ -363,9 +329,6 @@ describe('QueueOperations', () => {
   testWithTwoOrgs()(
     'removeAccessibleQueuesForUser must not revoke access for a user in a different org',
     async ({ attacker, victim, mrtService }) => {
-      // Attacker (Org A) passes a userId belonging to Org B against their
-      // own queue. The service must reject the cross-user mutation -- this
-      // is the path that would otherwise delete a victim reviewer's access.
       await expect(
         mrtService.removeAccessibleQueuesForUser({
           orgId: attacker.org.id,
@@ -379,8 +342,6 @@ describe('QueueOperations', () => {
   testWithTwoOrgs()(
     'addAccessibleQueuesForUser grants access within the same org',
     async ({ attacker, mrtService }) => {
-      // Same-org happy path: the caller's own user gets access to the
-      // caller's own queue. Guards against over-rejecting.
       await expect(
         mrtService.addAccessibleQueuesForUser({
           orgId: attacker.org.id,

--- a/server/services/manualReviewToolService/modules/QueueOperations.test.ts
+++ b/server/services/manualReviewToolService/modules/QueueOperations.test.ts
@@ -231,4 +231,170 @@ describe('QueueOperations', () => {
       ).resolves.toBeUndefined();
     },
   );
+
+  // Regression for GHSA-mf74-gf5j-hxr9: addAccessibleQueuesForUser /
+  // removeAccessibleQueuesForUser used to accept an arbitrary queueId /
+  // userId with no org-scoping, so an authenticated user in Org A could
+  // grant (or revoke) access to queues and users belonging to Org B.
+  //
+  // These fixtures build two independent orgs, each with a user and a
+  // queue, then assert that the caller's orgId gates both the queue and
+  // the user.
+  const testWithTwoOrgs = () =>
+    makeTestWithFixture(async () => {
+      const container = (await getBottle()).container;
+
+      const buildOrg = async () => {
+        const { org, cleanup: orgCleanup } = await createOrg(
+          {
+            KyselyPg: container.KyselyPg,
+            ModerationConfigService: container.ModerationConfigService,
+            ApiKeyService: container.ApiKeyService,
+          },
+          uid(),
+        );
+        const { user, cleanup: userCleanup } = await createUser(
+          container.KyselyPg,
+          org.id,
+        );
+        const { queue, cleanup: queueCleanup } = await createMrtQueue({
+          orgId: org.id,
+          mrtService: container.ManualReviewToolService,
+          userId: user.id,
+        });
+        return { org, user, queue, orgCleanup, userCleanup, queueCleanup };
+      };
+
+      const attacker = await buildOrg();
+      const victim = await buildOrg();
+
+      return {
+        attacker,
+        victim,
+        mrtService: container.ManualReviewToolService,
+        kyselyPg: container.KyselyPg,
+        cleanup: async () => {
+          await attacker.queueCleanup();
+          await victim.queueCleanup();
+          await attacker.userCleanup();
+          await victim.userCleanup();
+          await attacker.orgCleanup();
+          await victim.orgCleanup();
+          await container.KyselyPg.destroy();
+          await container.KyselyPgReadReplica.destroy();
+        },
+      };
+    });
+
+  testWithTwoOrgs()(
+    'addAccessibleQueuesForUser must not grant access to a queue in a different org',
+    async ({ attacker, victim, mrtService }) => {
+      // Attacker (Org A) passes the victim's queueId (Org B) to grant their
+      // own user access. This is a cross-org IDOR: the service must reject it
+      // and no access row should be written.
+      await expect(
+        mrtService.addAccessibleQueuesForUser({
+          orgId: attacker.org.id,
+          userId: attacker.user.id,
+          queueIds: [victim.queue.id],
+        }),
+      ).rejects.toBeDefined();
+
+      const viewers = await mrtService.getUsersWhoCanSeeQueue({
+        orgId: victim.org.id,
+        queueId: victim.queue.id,
+        userId: attacker.user.id,
+      });
+      expect(viewers.map((v) => v.userId)).not.toContain(attacker.user.id);
+    },
+  );
+
+  testWithTwoOrgs()(
+    'addAccessibleQueuesForUser must not grant access for a user in a different org',
+    async ({ attacker, victim, mrtService }) => {
+      // Attacker (Org A) passes a userId belonging to Org B against their own
+      // queue. The service must reject cross-user cross-org mutation.
+      await expect(
+        mrtService.addAccessibleQueuesForUser({
+          orgId: attacker.org.id,
+          userId: victim.user.id,
+          queueIds: [attacker.queue.id],
+        }),
+      ).rejects.toBeDefined();
+
+      const viewers = await mrtService.getUsersWhoCanSeeQueue({
+        orgId: attacker.org.id,
+        queueId: attacker.queue.id,
+        userId: victim.user.id,
+      });
+      expect(viewers.map((v) => v.userId)).not.toContain(victim.user.id);
+    },
+  );
+
+  testWithTwoOrgs()(
+    'removeAccessibleQueuesForUser must not revoke access for a queue in a different org',
+    async ({ attacker, victim, mrtService }) => {
+      // Seed legitimate access for the victim's user on the victim's queue,
+      // then have the attacker (Org A) pass the victim's queueId to revoke
+      // it. Must be rejected; the seeded access must survive.
+      await mrtService.addAccessibleQueuesForUser({
+        orgId: victim.org.id,
+        userId: victim.user.id,
+        queueIds: [victim.queue.id],
+      });
+
+      await expect(
+        mrtService.removeAccessibleQueuesForUser({
+          orgId: attacker.org.id,
+          userId: attacker.user.id,
+          queueIds: [victim.queue.id],
+        }),
+      ).rejects.toBeDefined();
+
+      const viewers = await mrtService.getUsersWhoCanSeeQueue({
+        orgId: victim.org.id,
+        queueId: victim.queue.id,
+        userId: victim.user.id,
+      });
+      expect(viewers.map((v) => v.userId)).toContain(victim.user.id);
+    },
+  );
+
+  testWithTwoOrgs()(
+    'removeAccessibleQueuesForUser must not revoke access for a user in a different org',
+    async ({ attacker, victim, mrtService }) => {
+      // Attacker (Org A) passes a userId belonging to Org B against their
+      // own queue. The service must reject the cross-user mutation -- this
+      // is the path that would otherwise delete a victim reviewer's access.
+      await expect(
+        mrtService.removeAccessibleQueuesForUser({
+          orgId: attacker.org.id,
+          userId: victim.user.id,
+          queueIds: [attacker.queue.id],
+        }),
+      ).rejects.toBeDefined();
+    },
+  );
+
+  testWithTwoOrgs()(
+    'addAccessibleQueuesForUser grants access within the same org',
+    async ({ attacker, mrtService }) => {
+      // Same-org happy path: the caller's own user gets access to the
+      // caller's own queue. Guards against over-rejecting.
+      await expect(
+        mrtService.addAccessibleQueuesForUser({
+          orgId: attacker.org.id,
+          userId: attacker.user.id,
+          queueIds: [attacker.queue.id],
+        }),
+      ).resolves.toBeDefined();
+
+      const viewers = await mrtService.getUsersWhoCanSeeQueue({
+        orgId: attacker.org.id,
+        queueId: attacker.queue.id,
+        userId: attacker.user.id,
+      });
+      expect(viewers.map((v) => v.userId)).toContain(attacker.user.id);
+    },
+  );
 });

--- a/server/services/manualReviewToolService/modules/QueueOperations.test.ts
+++ b/server/services/manualReviewToolService/modules/QueueOperations.test.ts
@@ -365,4 +365,46 @@ describe('QueueOperations', () => {
       expect(viewers.map((v) => v.userId)).toContain(attacker.user.id);
     },
   );
+
+  testWithTwoOrgs()(
+    'createManualReviewQueue must not grant access to a user in a different org',
+    async ({ attacker, victim, mrtService }) => {
+      await expect(
+        mrtService.createManualReviewQueue({
+          name: 'attacker-queue',
+          description: null,
+          userIds: [victim.user.id],
+          hiddenActionIds: [],
+          isAppealsQueue: false,
+          invokedBy: {
+            userId: attacker.user.id,
+            permissions: [UserPermission.EDIT_MRT_QUEUES],
+            orgId: attacker.org.id,
+          },
+        }),
+      ).rejects.toMatchObject({ name: 'AccessibleQueueNotInOrgError' });
+    },
+  );
+
+  testWithTwoOrgs()(
+    'updateManualReviewQueue must not grant access to a user in a different org',
+    async ({ attacker, victim, mrtService }) => {
+      await expect(
+        mrtService.updateManualReviewQueue({
+          orgId: attacker.org.id,
+          queueId: attacker.queue.id,
+          userIds: [attacker.user.id, victim.user.id],
+          actionIdsToHide: [],
+          actionIdsToUnhide: [],
+        }),
+      ).rejects.toMatchObject({ name: 'AccessibleQueueNotInOrgError' });
+
+      const viewers = await mrtService.getUsersWhoCanSeeQueue({
+        orgId: attacker.org.id,
+        queueId: attacker.queue.id,
+        userId: attacker.user.id,
+      });
+      expect(viewers.map((v) => v.userId)).not.toContain(victim.user.id);
+    },
+  );
 });

--- a/server/services/manualReviewToolService/modules/QueueOperations.ts
+++ b/server/services/manualReviewToolService/modules/QueueOperations.ts
@@ -104,7 +104,8 @@ export type ManualReviewQueueErrorType = 'ManualReviewQueueNameExistsError';
 export type QueueOperationsErrorType =
   | 'DeleteAllJobsUnauthorizedError'
   | 'QueueDoesNotExistError'
-  | 'UnableToDeleteDefaultQueueError';
+  | 'UnableToDeleteDefaultQueueError'
+  | 'AccessibleQueueNotInOrgError';
 
 // Compound identifier for a queue. orgId is needed for security, but also
 // because queues are/will be actually sharded across redis instances for
@@ -655,10 +656,18 @@ export default class QueueOperations {
       .execute();
   }
 
-  async addAccessibleQueuesForUser(
-    userIds: string[],
-    queueIds: readonly string[],
-  ) {
+  async addAccessibleQueuesForUser(opts: {
+    orgId: string;
+    userIds: readonly string[];
+    queueIds: readonly string[];
+  }) {
+    const { orgId, userIds, queueIds } = opts;
+    await assertUsersAndQueuesInOrg(this.pgQuery, {
+      orgId,
+      userIds,
+      queueIds,
+    });
+
     return this.pgQuery
       .insertInto('manual_review_tool.users_and_accessible_queues')
       .values(
@@ -670,10 +679,18 @@ export default class QueueOperations {
       .execute();
   }
 
-  async removeAccessibleQueuesForUser(
-    userId: string,
-    queueIds: readonly string[],
-  ) {
+  async removeAccessibleQueuesForUser(opts: {
+    orgId: string;
+    userId: string;
+    queueIds: readonly string[];
+  }) {
+    const { orgId, userId, queueIds } = opts;
+    await assertUsersAndQueuesInOrg(this.pgQuery, {
+      orgId,
+      userIds: [userId],
+      queueIds,
+    });
+
     return this.pgQuery
       .deleteFrom('manual_review_tool.users_and_accessible_queues')
       .where('user_id', '=', userId)
@@ -1882,6 +1899,58 @@ const makeQueueDoesNotExistError = (data: ErrorInstanceData) => {
     ...data,
   });
 };
+
+/**
+ * Thrown when a caller tries to mutate another org's accessible-queue rows.
+ * Guards the cross-org IDOR fixed in GHSA-mf74-gf5j-hxr9: both the target
+ * queues and the target user must belong to the caller's org.
+ */
+const makeAccessibleQueueNotInOrgError = (data: ErrorInstanceData) =>
+  new CoopError({
+    status: 403,
+    type: [ErrorType.Unauthorized],
+    title: "Queue or user does not belong to the caller's organization",
+    name: 'AccessibleQueueNotInOrgError',
+    ...data,
+  });
+
+/**
+ * Defense-in-depth org-scoping for accessible-queue mutations
+ * (GHSA-mf74-gf5j-hxr9). Rejects before any write if a target queue or
+ * target user does not belong to the caller's org.
+ */
+async function assertUsersAndQueuesInOrg(
+  db: Kysely<ManualReviewToolServicePg>,
+  opts: {
+    orgId: string;
+    userIds: readonly string[];
+    queueIds: readonly string[];
+  },
+) {
+  const { orgId, userIds, queueIds } = opts;
+
+  // Every target queue must belong to the caller's org.
+  const inOrgQueues = await db
+    .selectFrom('manual_review_tool.manual_review_queues')
+    .select('id')
+    .where('org_id', '=', orgId)
+    .where('id', 'in', queueIds)
+    .execute();
+  if (inOrgQueues.length !== new Set(queueIds).size) {
+    throw makeAccessibleQueueNotInOrgError({ shouldErrorSpan: true });
+  }
+
+  // Every target user must belong to the caller's org.
+  const inOrgUsers = await db
+    .selectFrom('public.users')
+    .select('id')
+    .where('org_id', '=', orgId)
+    .where('id', 'in', userIds)
+    .execute();
+  if (inOrgUsers.length !== new Set(userIds).size) {
+    throw makeAccessibleQueueNotInOrgError({ shouldErrorSpan: true });
+  }
+}
 
 export const makeUnableToDeleteDefaultQueueError = (
   data: ErrorInstanceData,

--- a/server/services/manualReviewToolService/modules/QueueOperations.ts
+++ b/server/services/manualReviewToolService/modules/QueueOperations.ts
@@ -267,6 +267,11 @@ export default class QueueOperations {
       );
     }
 
+    // Defense-in-depth org-scoping: every user granted access to the new
+    // queue must belong to the caller's org. The queue itself is always
+    // created in the caller's org (orgId from the invoker).
+    await assertUsersInOrg(this.pgQuery, { orgId, userIds });
+
     try {
       return await this.transactionWithRetry(async (transaction) => {
         // In newer versions of kysely, this is greatly simplified with
@@ -358,6 +363,16 @@ export default class QueueOperations {
       clearReportsScope,
       clearReportsTriggerActionIds,
     } = input;
+
+    // Defense-in-depth org-scoping: the target queue and every user granted
+    // access must belong to the caller's org. Reject before any write so a
+    // cross-org queueId or userId can't mutate users_and_accessible_queues
+    // rows belonging to another org.
+    await assertUsersAndQueuesInOrg(this.pgQuery, {
+      orgId,
+      userIds,
+      queueIds: [queueId],
+    });
 
     return this.transactionWithRetry(async (transaction) => {
       const [updatedQueue, _, __] = await Promise.all([
@@ -1913,6 +1928,46 @@ const makeAccessibleQueueNotInOrgError = (data: ErrorInstanceData) =>
   });
 
 /**
+ * Rejects before any write if a target queue does not belong to the caller's
+ * org. Defense-in-depth org-scoping for accessible-queue mutations.
+ */
+async function assertQueuesInOrg(
+  db: Kysely<ManualReviewToolServicePg>,
+  opts: { orgId: string; queueIds: readonly string[] },
+) {
+  const { orgId, queueIds } = opts;
+  const inOrgQueues = await db
+    .selectFrom('manual_review_tool.manual_review_queues')
+    .select('id')
+    .where('org_id', '=', orgId)
+    .where('id', 'in', queueIds)
+    .execute();
+  if (inOrgQueues.length !== new Set(queueIds).size) {
+    throw makeAccessibleQueueNotInOrgError({ shouldErrorSpan: true });
+  }
+}
+
+/**
+ * Rejects before any write if a target user does not belong to the caller's
+ * org. Defense-in-depth org-scoping for accessible-queue mutations.
+ */
+async function assertUsersInOrg(
+  db: Kysely<ManualReviewToolServicePg>,
+  opts: { orgId: string; userIds: readonly string[] },
+) {
+  const { orgId, userIds } = opts;
+  const inOrgUsers = await db
+    .selectFrom('public.users')
+    .select('id')
+    .where('org_id', '=', orgId)
+    .where('id', 'in', userIds)
+    .execute();
+  if (inOrgUsers.length !== new Set(userIds).size) {
+    throw makeAccessibleQueueNotInOrgError({ shouldErrorSpan: true });
+  }
+}
+
+/**
  * Rejects before any write if a target queue or user does not belong to the
  * caller's org.
  */
@@ -1924,29 +1979,14 @@ async function assertUsersAndQueuesInOrg(
     queueIds: readonly string[];
   },
 ) {
-  const { orgId, userIds, queueIds } = opts;
-
-  // Every target queue must belong to the caller's org.
-  const inOrgQueues = await db
-    .selectFrom('manual_review_tool.manual_review_queues')
-    .select('id')
-    .where('org_id', '=', orgId)
-    .where('id', 'in', queueIds)
-    .execute();
-  if (inOrgQueues.length !== new Set(queueIds).size) {
-    throw makeAccessibleQueueNotInOrgError({ shouldErrorSpan: true });
-  }
-
-  // Every target user must belong to the caller's org.
-  const inOrgUsers = await db
-    .selectFrom('public.users')
-    .select('id')
-    .where('org_id', '=', orgId)
-    .where('id', 'in', userIds)
-    .execute();
-  if (inOrgUsers.length !== new Set(userIds).size) {
-    throw makeAccessibleQueueNotInOrgError({ shouldErrorSpan: true });
-  }
+  await assertQueuesInOrg(db, {
+    orgId: opts.orgId,
+    queueIds: opts.queueIds,
+  });
+  await assertUsersInOrg(db, {
+    orgId: opts.orgId,
+    userIds: opts.userIds,
+  });
 }
 
 export const makeUnableToDeleteDefaultQueueError = (

--- a/server/services/manualReviewToolService/modules/QueueOperations.ts
+++ b/server/services/manualReviewToolService/modules/QueueOperations.ts
@@ -1901,9 +1901,7 @@ const makeQueueDoesNotExistError = (data: ErrorInstanceData) => {
 };
 
 /**
- * Thrown when a caller tries to mutate another org's accessible-queue rows.
- * Guards the cross-org IDOR fixed in GHSA-mf74-gf5j-hxr9: both the target
- * queues and the target user must belong to the caller's org.
+ * Thrown when a target queue or user does not belong to the caller's org.
  */
 const makeAccessibleQueueNotInOrgError = (data: ErrorInstanceData) =>
   new CoopError({
@@ -1915,9 +1913,8 @@ const makeAccessibleQueueNotInOrgError = (data: ErrorInstanceData) =>
   });
 
 /**
- * Defense-in-depth org-scoping for accessible-queue mutations
- * (GHSA-mf74-gf5j-hxr9). Rejects before any write if a target queue or
- * target user does not belong to the caller's org.
+ * Rejects before any write if a target queue or user does not belong to the
+ * caller's org.
  */
 async function assertUsersAndQueuesInOrg(
   db: Kysely<ManualReviewToolServicePg>,


### PR DESCRIPTION
## Context & Requests for Reviewers

Fixes GHSA-mf74-gf5j-hxr9.

## Tests

I added regression tests for the issue(s) here (and used them to guide the implementation).

## Checklist

- [x] **If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**
  Did you update the corresponding history tables and their triggers?

- [x] **If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?

- [x] **If you added a new signal in `server/services/signalsService/signals/**`:**
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved queue access controls so changes stay within the correct organization.
  * Prevented granting or removing queue access across organization boundaries.
  * Added stricter validation when creating or updating manual review queues to avoid invalid access changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->