### PR TITLE
fix: Support non-standard scylla ports in DB Migrator

### DIFF
--- a/db/src/configs/scylla.ts
+++ b/db/src/configs/scylla.ts
@@ -24,6 +24,9 @@ const driverOpts = {
     consistency: scyllaTypes.consistencies.localQuorum,
   },
   keyspace: process.env.SCYLLA_KEYSPACE!,
+  protocolOptions: !!process.env.SCYLLA_PORT ? {
+    port: Number(process.env.SCYLLA_PORT),
+  } : undefined,
 };
 
 const scyllaEnvironmentDependentOptions = {

--- a/db/src/configs/scylla.ts
+++ b/db/src/configs/scylla.ts
@@ -24,7 +24,7 @@ const driverOpts = {
     consistency: scyllaTypes.consistencies.localQuorum,
   },
   keyspace: process.env.SCYLLA_KEYSPACE!,
-  protocolOptions:  {
+  protocolOptions: {
     port: parseInt(process.env.SCYLLA_PORT ?? '9042'),
   },
 };

--- a/db/src/configs/scylla.ts
+++ b/db/src/configs/scylla.ts
@@ -24,9 +24,9 @@ const driverOpts = {
     consistency: scyllaTypes.consistencies.localQuorum,
   },
   keyspace: process.env.SCYLLA_KEYSPACE!,
-  protocolOptions: !!process.env.SCYLLA_PORT ? {
-    port: Number(process.env.SCYLLA_PORT),
-  } : undefined,
+  protocolOptions:  {
+    port: parseInt(process.env.SCYLLA_PORT ?? '9042'),
+  },
 };
 
 const scyllaEnvironmentDependentOptions = {


### PR DESCRIPTION
## Context & Requests for Reviewers
The iocContainer for Coop supports a "SCYLLA_PORT" env var, but the DB migrator does not.  This makes it harder for adopters to run migrations against Scylla

## Tests
I've run `npm run build` and `npm run typecheck`.  I've also used it to connect to our dev and prod instances and run migrations.

## (Optional) Rollout Plan
Changes should be backwards compatible.

## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] **If you changed anything user-facing** (i.e. user interface or APIs):
  Did you update the CHANGELOG.md and related docs?

- [ ] **If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**
  Did you update the corresponding history tables and their triggers?

- [ ] **If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?

- [ ] **If you added a new signal in `server/services/signalsService/signals/**`:**
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection configuration to use a custom port when provided through the environment, helping Scylla-based setups connect correctly.
  * If no port is set, the app now continues using the default connection settings unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->