### PR TITLE
add NCMEC field + integration tests

### DIFF
--- a/server/services/ncmecService/fieldCoverage.test.ts
+++ b/server/services/ncmecService/fieldCoverage.test.ts
@@ -257,9 +257,67 @@ describe('NCMEC field coverage', () => {
     }
   });
 
-  it('renders all three scenarios to non-empty XML', () => {
+  it('renders all three scenarios to well-formed XML with scenario-specific markers', () => {
+    // The presence table checks the object tree; this is the only test that
+    // exercises the js2xml serialization path, so assert meaningful structural
+    // and field markers per scenario rather than just non-empty output.
+    const markers: Record<
+      ScenarioKey,
+      { present: string[]; absent: string[] }
+    > = {
+      // min: only org-setting-backed required fields — no user data, no
+      // escalation, no top-level additionalInfo. personOrUserReported is
+      // always emitted (espIdentifier/espService) but carries no IP event,
+      // display name, or prior reports.
+      min: {
+        present: [
+          '<report>',
+          '<incidentSummary>',
+          '<incidentType>',
+          '<incidentDateTime>',
+          '<reporter>',
+          '<personOrUserReported>',
+          '<espIdentifier>',
+        ],
+        absent: [
+          '<ipCaptureEvent>',
+          '<displayName>',
+          '<additionalInfo>',
+          '<escalateToHighPriority>',
+        ],
+      },
+      // field-roles: user data via roles populates personOrUserReported + IP
+      // event, but still no escalation or top-level additionalInfo.
+      'field-roles': {
+        present: [
+          '<personOrUserReported>',
+          '<espIdentifier>',
+          '<ipCaptureEvent>',
+          'jane@example.com',
+        ],
+        absent: ['<additionalInfo>', '<escalateToHighPriority>'],
+      },
+      // max: everything wired — escalation, additionalInfo, priorCTReports,
+      // and contactPerson all present.
+      max: {
+        present: [
+          '<escalateToHighPriority>',
+          '<additionalInfo>',
+          '<priorCTReports>',
+          '<contactPerson>',
+        ],
+        absent: [],
+      },
+    };
     for (const key of ['min', 'field-roles', 'max'] as ScenarioKey[]) {
-      expect(renderXml(scenarios[key]).length).toBeGreaterThan(0);
+      const xml = renderXml(scenarios[key]);
+      expect(xml.length).toBeGreaterThan(0);
+      for (const marker of markers[key].present) {
+        expect(xml).toContain(marker);
+      }
+      for (const marker of markers[key].absent) {
+        expect(xml).not.toContain(marker);
+      }
     }
   });
 
@@ -303,25 +361,6 @@ describe('NCMEC field coverage', () => {
         'estimatedLocation',
         'allEmailsReported',
         'associatedAccount',
-        'additionalInfo',
-      ],
-      fileDetails: [
-        'reportId',
-        'fileId',
-        'fileName',
-        'originalFileName',
-        'uploadedToEspTimestamp',
-        'locationOfFile',
-        'fileViewedByEsp',
-        'exifViewedByEsp',
-        'publiclyAvailable',
-        'fileRelevance',
-        'fileAnnotations',
-        'industryClassification',
-        'originalFileHash',
-        'ipCaptureEvent',
-        'deviceId',
-        'details',
         'additionalInfo',
       ],
       ipCaptureEvent: [

--- a/server/services/ncmecService/fieldCoverage.test.ts
+++ b/server/services/ncmecService/fieldCoverage.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Field-coverage regression net for the NCMEC CyberTip report builder.
+ *
+ * The builder emits different XML fields depending on how much data the
+ * adopter has about the reported user. We lock that behaviour by rendering
+ * the report under three configurations and asserting, per field, which ones
+ * populate it:
+ *
+ * - `min`         — bare minimum: no user data, no webhook, no reviewer
+ *                   escalation. Only the org-setting-backed fields NCMEC
+ *                   strictly requires appear.
+ * - `field-roles`  — the adopter maps their user data to coop's schema field
+ *                   roles (email, IP, display name, profile icon). Fields
+ *                   read off the user via roles now populate; webhook and
+ *                   reviewer-decision fields stay absent.
+ * - `max`         — everything wired: field roles + the additional-info
+ *                   webhook + a reviewer escalation + top-level notes.
+ */
+import { js2xml } from 'xml-js';
+
+import {
+  buildSubmitReportObject,
+  NCMECEvent,
+  type BuildSubmitReportObjectInput,
+} from './ncmecReporting.js';
+
+const INCIDENT_DATE_TIME = '2026-06-30T18:00:00.000Z';
+
+/** Minimal valid inputs for `buildSubmitReportObject`. Tests override only
+ * the field(s) under test, so each case is self-explanatory. */
+function makeBuildReportInput(
+  overrides: {
+    reportParams?: Partial<BuildSubmitReportObjectInput['reportParams']> & {
+      reportedUser?: Partial<
+        BuildSubmitReportObjectInput['reportParams']['reportedUser']
+      >;
+    };
+    userAdditionalInfo?: BuildSubmitReportObjectInput['userAdditionalInfo'];
+    orgSettings?: Partial<BuildSubmitReportObjectInput['orgSettings']>;
+    clampedIncidentDateTime?: string;
+    priorCTReports?: readonly number[];
+  } = {},
+): BuildSubmitReportObjectInput {
+  const { reportParams: paramOverrides, ...rest } = overrides;
+  const { reportedUser: userOverrides, ...reportParamOverrides } =
+    paramOverrides ?? {};
+  return {
+    reportParams: {
+      orgId: 'org-1',
+      reviewerId: 'reviewer-1',
+      reportedUser: {
+        id: 'user-1',
+        typeId: 'user-type-1',
+        ...userOverrides,
+      },
+      media: [],
+      threads: [],
+      incidentType:
+        'Child Pornography (possession, manufacture, and distribution)',
+      ...reportParamOverrides,
+    },
+    userAdditionalInfo: rest.userAdditionalInfo ?? {},
+    orgSettings: {
+      companyTemplate: 'AcmeESP',
+      legalURL: 'https://acme.example/legal',
+      reportingPersonEmail: 'reporter@acme.example',
+      ...rest.orgSettings,
+    },
+    clampedIncidentDateTime: rest.clampedIncidentDateTime ?? INCIDENT_DATE_TIME,
+    ...(rest.priorCTReports !== undefined
+      ? { priorCTReports: rest.priorCTReports }
+      : {}),
+  };
+}
+
+// Use `any` here to avoid a ts-node crash when many path functions are typed
+// against the deeply-nested Report union.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type AnyReport = any;
+
+function renderXml(report: ReturnType<typeof buildSubmitReportObject>): string {
+  return js2xml(report, { compact: true });
+}
+
+type ScenarioExpectations = {
+  min: boolean;
+  'field-roles': boolean;
+  max: boolean;
+};
+
+const presenceTable: Array<{
+  field: string;
+  path: (r: AnyReport) => unknown;
+  expected: ScenarioExpectations;
+}> = [
+  // Required by the XSD — present in every configuration (backed by org
+  // settings, not user data).
+  {
+    field: 'incidentSummary.incidentType',
+    path: (r) => r.report.incidentSummary.incidentType,
+    expected: { min: true, 'field-roles': true, max: true },
+  },
+  {
+    field: 'incidentSummary.incidentDateTime',
+    path: (r) => r.report.incidentSummary.incidentDateTime,
+    expected: { min: true, 'field-roles': true, max: true },
+  },
+  {
+    field: 'reporter.reportingPerson.email',
+    path: (r) => r.report.reporter.reportingPerson.email,
+    expected: { min: true, 'field-roles': true, max: true },
+  },
+  {
+    field: 'reporter.companyTemplate',
+    path: (r) => r.report.reporter.companyTemplate,
+    expected: { min: true, 'field-roles': true, max: true },
+  },
+  {
+    field: 'reporter.legalURL',
+    path: (r) => r.report.reporter.legalURL,
+    expected: { min: true, 'field-roles': true, max: true },
+  },
+  // These fields are read off the reported user's data via schema field roles.
+  // In `min` no user data is provided, so they're absent; with roles mapped
+  // they populate.
+  {
+    field: 'personOrUserReportedPerson.email',
+    path: (r) =>
+      r.report.personOrUserReported?.personOrUserReportedPerson?.email,
+    expected: { min: false, 'field-roles': true, max: true },
+  },
+  {
+    field: 'personOrUserReported.displayName',
+    path: (r) => r.report.personOrUserReported?.displayName,
+    expected: { min: false, 'field-roles': true, max: true },
+  },
+  {
+    field: 'personOrUserReported.ipCaptureEvent',
+    path: (r) => r.report.personOrUserReported?.ipCaptureEvent,
+    expected: { min: false, 'field-roles': true, max: true },
+  },
+  // These fields come from reviewer decisions or the additional-info webhook,
+  // neither of which the `min` or `field-roles` scenarios provide.
+  {
+    field: 'incidentSummary.escalateToHighPriority',
+    path: (r) => r.report.incidentSummary.escalateToHighPriority,
+    expected: { min: false, 'field-roles': false, max: true },
+  },
+  {
+    field: 'report.additionalInfo',
+    path: (r) => r.report.additionalInfo,
+    expected: { min: false, 'field-roles': false, max: true },
+  },
+  {
+    field: 'personOrUserReported.priorCTReports',
+    path: (r) => r.report.personOrUserReported?.priorCTReports,
+    expected: { min: false, 'field-roles': false, max: true },
+  },
+  {
+    field: 'reporter.contactPerson',
+    path: (r) => r.report.reporter.contactPerson,
+    expected: { min: false, 'field-roles': false, max: true },
+  },
+  {
+    field: 'reporter.termsOfService',
+    path: (r) => r.report.reporter.termsOfService,
+    expected: { min: false, 'field-roles': false, max: true },
+  },
+  {
+    field: 'internetDetails.webPageIncident',
+    path: (r) => r.report.internetDetails?.[0]?.webPageIncident,
+    expected: { min: false, 'field-roles': false, max: true },
+  },
+];
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+describe('NCMEC field coverage', () => {
+  // One rendered report per configuration (see the file header for what each
+  // represents). The presence table below asserts which fields each one emits.
+  const scenarios = {
+    min: buildSubmitReportObject(makeBuildReportInput()),
+    'field-roles': buildSubmitReportObject(
+      makeBuildReportInput({
+        reportParams: {
+          reportedUser: {
+            id: 'user-1',
+            typeId: 'user-type-1',
+            displayName: 'Jane Doe',
+            profilePicture: 'https://cdn.example/jane.png',
+            ipAddress: '203.0.113.7',
+            email: 'jane@example.com',
+          },
+        },
+      }),
+    ),
+    max: buildSubmitReportObject(
+      makeBuildReportInput({
+        reportParams: {
+          reportedUser: {
+            id: 'user-1',
+            typeId: 'user-type-1',
+            displayName: 'Jane Doe',
+            profilePicture: 'https://cdn.example/jane.png',
+            ipAddress: '203.0.113.7',
+            email: 'jane@example.com',
+          },
+          escalateToHighPriority: 'immediate risk',
+          additionalInfo: 'top-level note',
+        },
+        userAdditionalInfo: {
+          screenName: 'jane123',
+          email: [
+            {
+              _text: 'jane@example.com',
+              _attributes: { type: 'Home', verified: true },
+            },
+          ],
+          ipCaptureEvent: [
+            {
+              eventName: NCMECEvent.Login,
+              dateTime: INCIDENT_DATE_TIME,
+              ipAddress: '203.0.113.7',
+              possibleProxy: true,
+              port: 443,
+            },
+          ],
+        },
+        orgSettings: {
+          companyTemplate: 'AcmeESP',
+          legalURL: 'https://acme.example/legal',
+          reportingPersonEmail: 'reporter@acme.example',
+          contactPersonEmail: 'contact@acme.example',
+          contactPersonFirstName: 'Cmp',
+          contactPersonLastName: 'Last',
+          contactPersonPhone: '+15555550100',
+          termsOfService: 'do not be evil',
+          defaultInternetDetailType: 'WEB_PAGE',
+          moreInfoUrl: 'https://acme.example/info',
+        },
+        priorCTReports: [123, 456],
+      }),
+    ),
+  };
+
+  type ScenarioKey = keyof typeof scenarios;
+
+  const has = (path: (r: AnyReport) => unknown, key: ScenarioKey): boolean =>
+    path(scenarios[key]) !== undefined;
+
+  describe('presence table', () => {
+    for (const row of presenceTable) {
+      it(`emits ${row.field} per scenario expectations`, () => {
+        for (const key of ['min', 'field-roles', 'max'] as ScenarioKey[]) {
+          expect(has(row.path, key)).toBe(row.expected[key]);
+        }
+      });
+    }
+  });
+
+  it('renders all three scenarios to non-empty XML', () => {
+    for (const key of ['min', 'field-roles', 'max'] as ScenarioKey[]) {
+      expect(renderXml(scenarios[key]).length).toBeGreaterThan(0);
+    }
+  });
+
+  // xml-js emits child elements in object-key insertion order, and NCMEC's
+  // XSD requires a specific sequence — out-of-order children are rejected.
+  // These locks fail if the builder ever emits keys in the wrong order.
+  describe('XSD ordering locks', () => {
+    const orderOf = (emitted: string[], xsdSequence: string[]): string[] => {
+      const idx = new Map(xsdSequence.map((k, i) => [k, i] as const));
+      return emitted
+        .filter((k) => idx.has(k))
+        .sort((a, b) => idx.get(a)! - idx.get(b)!);
+    };
+
+    const XSD = {
+      incidentSummary: [
+        'incidentType',
+        'platform',
+        'escalateToHighPriority',
+        'reportAnnotations',
+        'incidentDateTime',
+        'incidentDateTimeDescription',
+      ],
+      personOrUserReported: [
+        'personOrUserReportedPerson',
+        'vehicleDescription',
+        'espIdentifier',
+        'espService',
+        'compromisedAccount',
+        'screenName',
+        'displayName',
+        'profileUrl',
+        'profileBio',
+        'ipCaptureEvent',
+        'deviceId',
+        'thirdPartyUserReported',
+        'priorCTReports',
+        'groupIdentifier',
+        'accountTemporarilyDisabled',
+        'accountPermanentlyDisabled',
+        'estimatedLocation',
+        'allEmailsReported',
+        'associatedAccount',
+        'additionalInfo',
+      ],
+      fileDetails: [
+        'reportId',
+        'fileId',
+        'fileName',
+        'originalFileName',
+        'uploadedToEspTimestamp',
+        'locationOfFile',
+        'fileViewedByEsp',
+        'exifViewedByEsp',
+        'publiclyAvailable',
+        'fileRelevance',
+        'fileAnnotations',
+        'industryClassification',
+        'originalFileHash',
+        'ipCaptureEvent',
+        'deviceId',
+        'details',
+        'additionalInfo',
+      ],
+      ipCaptureEvent: [
+        'ipAddress',
+        'eventName',
+        'dateTime',
+        'possibleProxy',
+        'port',
+      ],
+    };
+
+    it('incidentSummary children follow XSD sequence', () => {
+      const max = scenarios.max as AnyReport;
+      const emitted = Object.keys(max.report.incidentSummary);
+      expect(orderOf(emitted, XSD.incidentSummary)).toEqual(
+        emitted.filter((k) => XSD.incidentSummary.includes(k)),
+      );
+    });
+
+    it('personOrUserReported children follow XSD sequence', () => {
+      const max = scenarios.max as AnyReport;
+      const emitted = Object.keys(max.report.personOrUserReported);
+      expect(orderOf(emitted, XSD.personOrUserReported)).toEqual(
+        emitted.filter((k) => XSD.personOrUserReported.includes(k)),
+      );
+    });
+
+    it('ipCaptureEvent children follow XSD sequence', () => {
+      const max = scenarios.max as AnyReport;
+      const evs = max.report.personOrUserReported.ipCaptureEvent;
+      for (const ev of evs) {
+        const emitted = Object.keys(ev);
+        expect(orderOf(emitted, XSD.ipCaptureEvent)).toEqual(emitted);
+      }
+    });
+  });
+});

--- a/server/services/ncmecService/index.ts
+++ b/server/services/ncmecService/index.ts
@@ -3,7 +3,13 @@ export {
   default as makeNcmecService,
 } from './ncmecService.js';
 
-export { NCMECIncidentType } from './ncmecReporting.js';
+export {
+  NCMECIncidentType,
+  NCMECFileAnnotation,
+  NCMECIndustryClassification,
+  type NCMECReportParams,
+  default as NcmecReporting,
+} from './ncmecReporting.js';
 export { summarizeNcmecErrorForReviewer } from './ncmecReviewerErrors.js';
 export { filterDecisionsToFailedSubmissions } from './ncmecSubmissionFilters.js';
 export {

--- a/server/services/ncmecService/ncmecReporting.builders.test.ts
+++ b/server/services/ncmecService/ncmecReporting.builders.test.ts
@@ -137,9 +137,9 @@ describe('buildFileDetailsObject', () => {
       'publiclyAvailable',
       'fileRelevance',
       'fileAnnotations',
-      'ipCaptureEvent',
       'industryClassification',
       'originalFileHash',
+      'ipCaptureEvent',
       'additionalInfo',
     ]);
   });

--- a/server/services/ncmecService/ncmecReporting.test.ts
+++ b/server/services/ncmecService/ncmecReporting.test.ts
@@ -306,6 +306,34 @@ describe('NCMEC reporting', () => {
       expect(webhook).toHaveLength(1);
       expect(params).toHaveLength(1);
     });
+
+    it('canonicalises webhook/param event key order to the XSD sequence', () => {
+      // A webhook returning ipCaptureEvent with keys in non-XSD order must be
+      // rebuilt as { ipAddress, eventName, dateTime, possibleProxy?, port? }
+      // before serialisation, or xml-js emits out-of-order children and NCMEC
+      // rejects the report with responseCode=4100.
+      const nonCanonicalWebhook = {
+        eventName: NCMECEvent.Login,
+        dateTime: '2026-01-01T00:00:00.000Z',
+        ipAddress: '192.0.2.1',
+        port: 443,
+        possibleProxy: true,
+      };
+      const result = mergeFieldRoleIpIntoEvents(
+        [nonCanonicalWebhook],
+        undefined,
+        undefined,
+        synth,
+      );
+      expect(result).toEqual([nonCanonicalWebhook]);
+      expect(Object.keys(result![0])).toEqual([
+        'ipAddress',
+        'eventName',
+        'dateTime',
+        'possibleProxy',
+        'port',
+      ]);
+    });
   });
 
   describe('resolveReportedPersonEmail', () => {

--- a/server/services/ncmecService/ncmecReporting.ts
+++ b/server/services/ncmecService/ncmecReporting.ts
@@ -132,9 +132,9 @@ type FileDetails = {
     publiclyAvailable?: boolean;
     fileRelevance?: 'Reported' | 'Supplemental Reported';
     fileAnnotations?: FileAnnotations;
-    ipCaptureEvent?: IPNCMECEvent[];
     industryClassification?: NCMECIndustryClassificationType;
     originalFileHash?: OriginalFileHash[];
+    ipCaptureEvent?: IPNCMECEvent[];
     deviceId?: DeviceId[];
     details?: Detail[];
     additionalInfo?: string[];
@@ -931,6 +931,10 @@ export function buildFileDetailsObject(
         : {}),
       fileRelevance,
       ...(fileAnnotations ? { fileAnnotations } : {}),
+      industryClassification: media.industryClassification,
+      ...(originalFileHash && originalFileHash.length > 0
+        ? { originalFileHash: [...originalFileHash] }
+        : {}),
       ...(additionalInfo.ipCaptureEvent &&
       additionalInfo.ipCaptureEvent.length > 0
         ? {
@@ -942,10 +946,6 @@ export function buildFileDetailsObject(
               ...(it.port ? { port: it.port } : {}),
             })),
           }
-        : {}),
-      industryClassification: media.industryClassification,
-      ...(originalFileHash && originalFileHash.length > 0
-        ? { originalFileHash: [...originalFileHash] }
         : {}),
       ...(additionalInfo.additionalInfo
         ? { additionalInfo: additionalInfo.additionalInfo }

--- a/server/services/ncmecService/ncmecReporting.ts
+++ b/server/services/ncmecService/ncmecReporting.ts
@@ -525,6 +525,25 @@ export function clampIncidentDateTimeToPast(
   };
 }
 
+/** Rebuild an ipCaptureEvent object with keys in NCMEC XSD `xs:sequence`
+ * order (ipAddress, eventName, dateTime, possibleProxy, port) so xml-js
+ * serialises the children in the order NCMEC's validator requires. Webhook
+ * and caller-supplied events arrive in arbitrary key order; without this,
+ * a non-canonical webhook event produces out-of-order XML and NCMEC rejects
+ * the report with responseCode=4100. Absent keys
+ * are omitted so optional fields stay optional. */
+function canonicaliseIpEvent(event: IPNCMECEvent): IPNCMECEvent {
+  const out: IPNCMECEvent = {
+    ipAddress: event.ipAddress,
+    eventName: event.eventName,
+    dateTime: event.dateTime,
+  };
+  if (event.possibleProxy !== undefined)
+    out.possibleProxy = event.possibleProxy;
+  if (event.port !== undefined) out.port = event.port;
+  return out;
+}
+
 /** Build the `ipCaptureEvent` array for an NCMEC person or media block:
  * webhook events + caller-supplied events + role-IP-synthesised event, in
  * that order. Returns `undefined` when all sources are empty. */
@@ -546,8 +565,8 @@ export function mergeFieldRoleIpIntoEvents(
   const trimmedRoleIp =
     typeof roleIpAddress === 'string' ? roleIpAddress.trim() : '';
   const events: IPNCMECEvent[] = [
-    ...(webhookEvents ?? []),
-    ...paramEventsArray,
+    ...(webhookEvents ?? []).map(canonicaliseIpEvent),
+    ...paramEventsArray.map(canonicaliseIpEvent),
     ...(trimmedRoleIp !== ''
       ? [
           {

--- a/server/services/networkingService/index.ts
+++ b/server/services/networkingService/index.ts
@@ -34,7 +34,7 @@ type ResponseBodyMappings = {
   discard: undefined;
 };
 
-type HandleResponseBody = keyof ResponseBodyMappings;
+export type HandleResponseBody = keyof ResponseBodyMappings;
 
 // A symbol that we can stick on FormDataLikeWithStreams objects to
 // unambiguously identify those objects as FormDataLikeWithStreams.

--- a/server/test/integ/ncmec-submission.integ.test.ts
+++ b/server/test/integ/ncmec-submission.integ.test.ts
@@ -1,0 +1,244 @@
+import 'dotenv/config';
+
+import { uid } from 'uid';
+import { Headers } from 'undici';
+
+import {
+  NCMECFileAnnotation,
+  NCMECIncidentType,
+  NCMECIndustryClassification,
+  NcmecReporting,
+  type NCMECReportParams,
+} from '../../services/ncmecService/index.js';
+import {
+  type CoopResponse,
+  type FetchHTTP,
+} from '../../services/networkingService/index.js';
+import createOrg from '../fixtureHelpers/createOrg.js';
+import { makeTransactionalTestWithFixture } from '../harness/transactionalTest.js';
+
+const MEDIA_URL = 'https://cdn.example/sample.jpg';
+const PRESERVATION_URL = 'https://preserve.example/req';
+
+/** Records every outgoing fetchHTTP call and returns canned CyberTip
+ * responses. */
+function makeStubFetchHTTP(
+  reportId: string,
+  fileId: string,
+): {
+  fetchHTTP: FetchHTTP;
+  calls: Array<{
+    url: string;
+    method: string;
+    body: unknown;
+    headers?: Record<string, string | ReadonlyArray<string>>;
+  }>;
+} {
+  const calls: Array<{
+    url: string;
+    method: string;
+    body: unknown;
+    headers?: Record<string, string | ReadonlyArray<string>>;
+  }> = [];
+  const ok = <T>(body: T): CoopResponse<never> =>
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- CoopResponse<never> types body as `never`, but the stub must return a real canned body through that slot.
+    ({
+      status: 200,
+      ok: true,
+      headers: new Headers(),
+      body,
+    }) as CoopResponse<never>;
+  const fetchHTTP = (async (query: never) => {
+    const q = query as {
+      url: string;
+      method: string;
+      body: unknown;
+      headers?: Record<string, string | ReadonlyArray<string>>;
+      handleResponseBody: string;
+    };
+    // eslint-disable-next-line functional/immutable-data -- request recorder mutates by design
+    calls.push({
+      url: q.url,
+      method: q.method,
+      body: q.body,
+      headers: q.headers,
+    });
+
+    // media download for #upload
+    if (q.method === 'get') {
+      const stream = new ReadableStream({
+        start(ctr) {
+          ctr.enqueue(new TextEncoder().encode('fake-media-bytes'));
+          ctr.close();
+        },
+      });
+      return ok(stream) as never;
+    }
+    // NCMEC CyberTip protocol — every XML endpoint returns responseCode=0.
+    // /submit, /upload, /fileinfo use `reportResponse`; /finish uses
+    // `reportDoneResponse`.
+    if (
+      q.url.endsWith('/ispws/submit') ||
+      q.url.endsWith('/ispws/upload') ||
+      q.url.endsWith('/ispws/fileinfo')
+    ) {
+      const isSubmit = q.url.endsWith('/ispws/submit');
+      const isUpload = q.url.endsWith('/ispws/upload');
+      return ok({
+        reportResponse: {
+          responseCode: { _text: '0' },
+          ...(isSubmit ? { reportId: { _text: reportId } } : {}),
+          ...(isUpload ? { fileId: { _text: fileId } } : {}),
+        },
+      }) as never;
+    }
+    if (q.url.endsWith('/ispws/finish')) {
+      return ok({
+        reportDoneResponse: {
+          responseCode: { _text: '0' },
+          reportId: { _text: reportId },
+          files: [{ fileId: { _text: fileId } }],
+        },
+      }) as never;
+    }
+    if (q.url === PRESERVATION_URL) {
+      return ok(undefined) as never;
+    }
+    throw new Error(`stub fetchHTTP: unexpected request ${q.method} ${q.url}`);
+  }) as unknown as FetchHTTP;
+  return { fetchHTTP, calls };
+}
+
+describe('NCMEC submitReport (integration)', () => {
+  const testWithFixture = makeTransactionalTestWithFixture(async ({ deps }) => {
+    const orgId = uid();
+    const reportId = uid();
+    const fileId = 'f1';
+
+    const orgFixture = await createOrg(
+      {
+        KyselyPg: deps.KyselyPg,
+        ModerationConfigService: deps.ModerationConfigService,
+        ApiKeyService: deps.ApiKeyService,
+      },
+      orgId,
+    );
+
+    await deps.NcmecService.updateNcmecOrgSettings({
+      orgId,
+      username: 'espuser',
+      password: 'esppass',
+      contactEmail: 'reporter@example.com',
+      moreInfoUrl: null,
+      companyTemplate: 'AcmeESP',
+      legalUrl: 'https://acme.example/legal',
+      ncmecPreservationEndpoint: PRESERVATION_URL,
+      ncmecAdditionalInfoEndpoint: null,
+      defaultNcmecQueueId: null,
+      defaultInternetDetailType: 'WEB_PAGE',
+      termsOfService: null,
+      contactPersonEmail: null,
+      contactPersonFirstName: null,
+      contactPersonLastName: null,
+      contactPersonPhone: null,
+      mediaReviewRequirement: 'ALL',
+      minMediaToReview: null,
+    });
+
+    const stub = makeStubFetchHTTP(reportId, fileId);
+    const ncmecReporting = new NcmecReporting(
+      deps.KyselyPg,
+      deps.KyselyPgReadReplica,
+      stub.fetchHTTP,
+      deps.SigningKeyPairService,
+      deps.ModerationConfigService,
+      deps.getItemTypeEventuallyConsistent,
+      deps.Tracer,
+    );
+
+    return {
+      orgId,
+      reportId,
+      stub,
+      ncmecReporting,
+      userItemTypeId: orgFixture.defaultUserItemType.id,
+    };
+  });
+
+  testWithFixture(
+    'submitReport returns SUCCESS, persists a row, and runs submit→upload→fileinfo→finish',
+    async ({ deps, ncmecReporting, orgId, reportId, stub, userItemTypeId }) => {
+      const reportedUserId = uid();
+
+      const reportParams: NCMECReportParams = {
+        orgId,
+        reviewerId: 'reviewer-1',
+        reportedUser: {
+          id: reportedUserId,
+          typeId: userItemTypeId,
+          displayName: 'Jane Doe',
+          profilePicture: 'https://cdn.example/jane.png',
+          ipAddress: '203.0.113.7',
+          email: 'jane@example.com',
+        },
+        media: [
+          {
+            id: 'media-1',
+            typeId: userItemTypeId,
+            url: MEDIA_URL,
+            createdAt: '2026-06-30T12:00:00.000Z',
+            industryClassification: NCMECIndustryClassification.A1,
+            fileAnnotations: [NCMECFileAnnotation.GENERATIVE_AI],
+            hashes: {
+              md5: 'd41d8cd98f00b204e9800998ecf8427e',
+              pdq: 'pdqhash',
+            },
+          },
+        ],
+        threads: [],
+        incidentType:
+          NCMECIncidentType[
+            'Child Pornography (possession, manufacture, and distribution)'
+          ],
+        jobId: 'job-1',
+      };
+
+      const result = await ncmecReporting.submitReport(reportParams, false);
+      expect(result).toBe('SUCCESS');
+
+      // protocol sequence — the full NCMEC submit flow
+      const routes = stub.calls
+        .filter((c) => c.url.includes('cybertip.org'))
+        .map((c) => c.url.replace(/^.*\/ispws/, ''));
+      expect(routes).toEqual(['/submit', '/upload', '/fileinfo', '/finish']);
+
+      // preservation fired (isTest=false + endpoint set)
+      expect(stub.calls.some((c) => c.url === PRESERVATION_URL)).toBe(true);
+
+      // outgoing /submit request shape — proves the field-role-resolved email,
+      // the incidentType, and the espIdentifier made it into the XML, and that
+      // #sendCyberTipRequest set a Basic Authorization header.
+      const submitCall = stub.calls.find(
+        (c) => c.url.endsWith('/ispws/submit') && typeof c.body === 'string',
+      );
+      expect(submitCall).toBeDefined();
+      const submitXml = String(submitCall!.body);
+      expect(submitXml).toContain('<incidentType>');
+      expect(submitXml).toContain('jane@example.com');
+      expect(submitCall!.headers?.Authorization).toMatch(/^Basic /);
+
+      // persisted row
+      const row = await deps.KyselyPg.selectFrom(
+        'ncmec_reporting.ncmec_reports',
+      )
+        .select(['report_id', 'is_test', 'report_xml'])
+        .where('org_id', '=', orgId)
+        .where('report_id', '=', reportId)
+        .executeTakeFirst();
+      expect(row).toBeDefined();
+      expect(row?.is_test).toBe(false);
+      expect(String(row?.report_xml)).toContain('jane@example.com');
+    },
+    60_000,
+  );
+});

--- a/server/test/integ/ncmec-submission.integ.test.ts
+++ b/server/test/integ/ncmec-submission.integ.test.ts
@@ -11,14 +11,24 @@ import {
   type NCMECReportParams,
 } from '../../services/ncmecService/index.js';
 import {
+  type CoopRequestQuery,
   type CoopResponse,
   type FetchHTTP,
+  type HandleResponseBody,
 } from '../../services/networkingService/index.js';
 import createOrg from '../fixtureHelpers/createOrg.js';
 import { makeTransactionalTestWithFixture } from '../harness/transactionalTest.js';
 
 const MEDIA_URL = 'https://cdn.example/sample.jpg';
 const PRESERVATION_URL = 'https://preserve.example/req';
+
+/** Shape of one recorded outgoing fetchHTTP call. */
+type RecordedCall = {
+  url: string;
+  method: string;
+  body: unknown;
+  headers?: Record<string, string | ReadonlyArray<string>>;
+};
 
 /** Records every outgoing fetchHTTP call and returns canned CyberTip
  * responses. */
@@ -27,85 +37,66 @@ function makeStubFetchHTTP(
   fileId: string,
 ): {
   fetchHTTP: FetchHTTP;
-  calls: Array<{
-    url: string;
-    method: string;
-    body: unknown;
-    headers?: Record<string, string | ReadonlyArray<string>>;
-  }>;
+  calls: RecordedCall[];
 } {
-  const calls: Array<{
-    url: string;
-    method: string;
-    body: unknown;
-    headers?: Record<string, string | ReadonlyArray<string>>;
-  }> = [];
-  const ok = <T>(body: T): CoopResponse<never> =>
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- CoopResponse<never> types body as `never`, but the stub must return a real canned body through that slot.
+  const calls: RecordedCall[] = [];
+  const ok = <T extends HandleResponseBody>(body: unknown): CoopResponse<T> =>
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the stub returns a canned body through a slot typed by the caller's T.
     ({
       status: 200,
       ok: true,
       headers: new Headers(),
       body,
-    }) as CoopResponse<never>;
-  const fetchHTTP = (async (query: never) => {
-    const q = query as {
-      url: string;
-      method: string;
-      body: unknown;
-      headers?: Record<string, string | ReadonlyArray<string>>;
-      handleResponseBody: string;
-    };
+    }) as CoopResponse<T>;
+  const fetchHTTP: FetchHTTP = async <T extends HandleResponseBody>(
+    query: CoopRequestQuery<T>,
+  ): Promise<CoopResponse<T>> => {
+    const { url, method, body, headers } = query;
     // eslint-disable-next-line functional/immutable-data -- request recorder mutates by design
-    calls.push({
-      url: q.url,
-      method: q.method,
-      body: q.body,
-      headers: q.headers,
-    });
+    calls.push({ url, method, body, headers });
 
     // media download for #upload
-    if (q.method === 'get') {
+    if (method === 'get') {
       const stream = new ReadableStream({
         start(ctr) {
           ctr.enqueue(new TextEncoder().encode('fake-media-bytes'));
           ctr.close();
         },
       });
-      return ok(stream) as never;
+      return ok<T>(stream);
     }
     // NCMEC CyberTip protocol — every XML endpoint returns responseCode=0.
     // /submit, /upload, /fileinfo use `reportResponse`; /finish uses
     // `reportDoneResponse`.
     if (
-      q.url.endsWith('/ispws/submit') ||
-      q.url.endsWith('/ispws/upload') ||
-      q.url.endsWith('/ispws/fileinfo')
+      url.endsWith('/ispws/submit') ||
+      url.endsWith('/ispws/upload') ||
+      url.endsWith('/ispws/fileinfo')
     ) {
-      const isSubmit = q.url.endsWith('/ispws/submit');
-      const isUpload = q.url.endsWith('/ispws/upload');
-      return ok({
+      const isSubmit = url.endsWith('/ispws/submit');
+      const isUpload = url.endsWith('/ispws/upload');
+      return ok<T>({
         reportResponse: {
           responseCode: { _text: '0' },
           ...(isSubmit ? { reportId: { _text: reportId } } : {}),
           ...(isUpload ? { fileId: { _text: fileId } } : {}),
         },
-      }) as never;
+      });
     }
-    if (q.url.endsWith('/ispws/finish')) {
-      return ok({
+    if (url.endsWith('/ispws/finish')) {
+      return ok<T>({
         reportDoneResponse: {
           responseCode: { _text: '0' },
           reportId: { _text: reportId },
           files: [{ fileId: { _text: fileId } }],
         },
-      }) as never;
+      });
     }
-    if (q.url === PRESERVATION_URL) {
-      return ok(undefined) as never;
+    if (url === PRESERVATION_URL) {
+      return ok<T>(undefined);
     }
-    throw new Error(`stub fetchHTTP: unexpected request ${q.method} ${q.url}`);
-  }) as unknown as FetchHTTP;
+    throw new Error(`stub fetchHTTP: unexpected request ${method} ${url}`);
+  };
   return { fetchHTTP, calls };
 }
 
@@ -221,11 +212,15 @@ describe('NCMEC submitReport (integration)', () => {
       const submitCall = stub.calls.find(
         (c) => c.url.endsWith('/ispws/submit') && typeof c.body === 'string',
       );
-      expect(submitCall).toBeDefined();
-      const submitXml = String(submitCall!.body);
+      if (!submitCall) {
+        throw new Error(
+          'expected a /ispws/submit request with a string body, but none was recorded',
+        );
+      }
+      const submitXml = String(submitCall.body);
       expect(submitXml).toContain('<incidentType>');
       expect(submitXml).toContain('jane@example.com');
-      expect(submitCall!.headers?.Authorization).toMatch(/^Basic /);
+      expect(submitCall.headers?.Authorization).toMatch(/^Basic /);
 
       // persisted row
       const row = await deps.KyselyPg.selectFrom(


### PR DESCRIPTION
This adds some more NCMEC tests: an integration test for the full flow, and unit tests to ensure that our generated XML matches what NCMEC expects. As part of writing this I uncovered a potential bug -- we didn't always generate elements in the right order in `ipCaptureEvent` elements. That's fixed here too.

Fixes https://github.com/roostorg/coop/issues/858 by adding an integration test that submits to a mocked NCMEC endpoint.

Also addresses https://github.com/roostorg/coop/issues/851, not by actually writing the XML anywhere, but by writing unit tests that are equivalent to doing that and validating the XSD. We don't want to commit NCMEC's XSD to this repo since it's technically not public (even though all the info contained in it *is* public via their docs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NCMEC report XML generation to strictly follow required field ordering, reducing submission rejections.
  * Fixed IP capture event assembly so optional fields and values are included consistently and preserve expected data in the final submission.
* **Tests**
  * Added regression and integration tests to lock down XML output structure and end-to-end submission flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->