### PR TITLE
ci(client): run frontend tests in CI

### DIFF
--- a/.github/workflows/apply_pr_checks.yaml
+++ b/.github/workflows/apply_pr_checks.yaml
@@ -277,6 +277,9 @@ jobs:
       - name: Lint client
         run: docker compose run --rm --quiet-pull client npm run lint
 
+      - name: Test client
+        run: docker compose run --rm --quiet-pull client npm run test:prepush
+
       - name: Build client
         run: docker compose run --rm --quiet-pull client npm run build
 

--- a/client/src/components/Sidebar.test.tsx
+++ b/client/src/components/Sidebar.test.tsx
@@ -82,10 +82,8 @@ function renderSidebar(
   return { ...result, setSelectedMenuItem, logout };
 }
 
-function getSettingsLink() {
-  return screen
-    .getAllByRole('link')
-    .find((el) => el.getAttribute('href') === '/dashboard/settings');
+function getSettingsButton() {
+  return screen.queryByRole('button', { name: 'Settings' });
 }
 
 describe('Sidebar', () => {
@@ -93,7 +91,7 @@ describe('Sidebar', () => {
     renderSidebar();
     expect(screen.getByText('Overview')).toBeInTheDocument();
     expect(screen.getByText('Review Console')).toBeInTheDocument();
-    expect(getSettingsLink()).toBeDefined();
+    expect(getSettingsButton()).toBeInTheDocument();
   });
 
   it('shows settings sub-items when on a settings page', () => {
@@ -112,20 +110,21 @@ describe('Sidebar', () => {
 
   it('highlights gear icon on settings pages but not elsewhere', () => {
     const { unmount } = renderSidebar('/dashboard/settings', 'Settings');
-    expect(getSettingsLink()!.className).toContain('text-primary');
+    expect(getSettingsButton()).toHaveClass('text-primary');
     unmount();
 
     renderSidebar('/dashboard/overview', 'Overview');
-    expect(getSettingsLink()!.className).not.toContain('text-primary');
+    expect(getSettingsButton()).not.toHaveClass('text-primary');
   });
 
-  it('sets selectedMenuItem to Settings when gear icon is clicked', () => {
-    const { setSelectedMenuItem } = renderSidebar(
-      '/dashboard/overview',
-      'Overview',
-    );
-    fireEvent.click(getSettingsLink()!);
-    expect(setSelectedMenuItem).toHaveBeenCalledWith('Settings');
+  it('expands settings sub-items when gear icon is clicked', () => {
+    renderSidebar('/dashboard/overview', 'Overview');
+    const settingsButton = getSettingsButton();
+    expect(settingsButton).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(settingsButton!);
+
+    expect(settingsButton).toHaveAttribute('aria-expanded', 'true');
   });
 
   describe('path-based menu selection', () => {
@@ -142,7 +141,7 @@ describe('Sidebar', () => {
 
   it('hides gear icon when user lacks ManageOrg permission', () => {
     renderSidebar('/dashboard/overview', 'Overview', { permissions: [] });
-    expect(getSettingsLink()).toBeUndefined();
+    expect(getSettingsButton()).not.toBeInTheDocument();
   });
 
   it('hides sub-items when user lacks permissions', () => {

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -352,6 +352,8 @@ export default function Sidebar(props: SidebarProps) {
                 <TooltipTrigger asChild>
                   <div
                     role="button"
+                    aria-label="Settings"
+                    aria-expanded={isSettingsMenuVisible}
                     tabIndex={0}
                     onClick={() => setIsSettingsMenuExpanded((prev) => !prev)}
                     onKeyDown={(e) => {

--- a/client/src/coop-ui/Calendar.test.tsx
+++ b/client/src/coop-ui/Calendar.test.tsx
@@ -15,6 +15,7 @@ describe('Calendar Component', () => {
     renderCalendar({
       mode: 'single',
       selected: selectedDate,
+      defaultMonth: selectedDate,
     });
 
     const selectedDay = screen.getByText('15');
@@ -26,6 +27,7 @@ describe('Calendar Component', () => {
     renderCalendar({
       mode: 'multiple',
       selected: selectedDates,
+      defaultMonth: selectedDates[0],
     });
 
     selectedDates.forEach((date) => {

--- a/client/src/webpages/dashboard/mrt/manual_review_job/MergedReportsComponent.test.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/MergedReportsComponent.test.tsx
@@ -90,7 +90,7 @@ describe('MergedReportsComponent invalidation actions', () => {
     // Expand the table; collapsed by default.
     screen.getByRole('button', { name: /show/i }).click();
     const buttons = screen.getAllByRole('button', {
-      name: /invalidate reports/i,
+      name: /invalidate all reports/i,
     });
     expect(buttons).toHaveLength(2);
   });
@@ -99,7 +99,7 @@ describe('MergedReportsComponent invalidation actions', () => {
     renderMerged(false);
     screen.getByRole('button', { name: /show/i }).click();
     expect(
-      screen.queryByRole('button', { name: /invalidate reports/i }),
+      screen.queryByRole('button', { name: /invalidate all reports/i }),
     ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
This builds on top of https://github.com/roostorg/coop/pull/550.

This PR updates CI so that we run our frontend/client tests, and it fixes a few pre-existing test failures. Now we'll have even greater confidence in our CI!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Settings control in the sidebar so it is announced more clearly and reflects whether the menu is open.
  * Updated settings interaction behavior and visibility handling for users with and without permissions.
  * Refined calendar defaults so the correct month is shown when selecting dates.
  * Adjusted report invalidation labels for clearer actions.

* **Chores**
  * Added an extra frontend test step to the pull request checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->