### PR TITLE
feat: 670 per reviewer skip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 **Full Changelog**: https://github.com/roostorg/coop/compare/1.0.2...main
 
+## Review Console
+
+- Added per-queue job sort modes for manual review: FIFO (default, unchanged), most-reported-first, and custom weighted — ordering is computed at enqueue via BullMQ job priority, so the locked dequeue path is unchanged (#718)
+- Added org-configurable job priority weights (Settings → Job Priorities) for weighted queues; changing weights or a queue's sort mode re-sorts already-queued jobs in a background sweep (#892)
+- Skip is now per-reviewer: a skipped job is hidden from that reviewer for 30 minutes while returning to the shared pool immediately; entering a drained or fully-skipped queue redirects to the queue list (#893)
+
 # Coop 1.0.2
 
 This release addresses reported security advisories, improves NCMEC CyberTipline reporting, and includes front-end quality-of-life improvements.

--- a/client/src/graphql/generated.ts
+++ b/client/src/graphql/generated.ts
@@ -15409,15 +15409,6 @@ export type GQLLogSkipMutation = {
   readonly logSkip: boolean;
 };
 
-export type GQLReleaseJobLockMutationVariables = Exact<{
-  input: GQLReleaseJobLockInput;
-}>;
-
-export type GQLReleaseJobLockMutation = {
-  readonly __typename: 'Mutation';
-  readonly releaseJobLock: boolean;
-};
-
 export type GQLJobFieldsFragment = {
   readonly __typename: 'ManualReviewJob';
   readonly id: string;
@@ -35024,54 +35015,6 @@ export type GQLLogSkipMutationOptions = Apollo.BaseMutationOptions<
   GQLLogSkipMutation,
   GQLLogSkipMutationVariables
 >;
-export const GQLReleaseJobLockDocument = gql`
-  mutation ReleaseJobLock($input: ReleaseJobLockInput!) {
-    releaseJobLock(input: $input)
-  }
-`;
-export type GQLReleaseJobLockMutationFn = Apollo.MutationFunction<
-  GQLReleaseJobLockMutation,
-  GQLReleaseJobLockMutationVariables
->;
-
-/**
- * __useGQLReleaseJobLockMutation__
- *
- * To run a mutation, you first call `useGQLReleaseJobLockMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useGQLReleaseJobLockMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [gqlReleaseJobLockMutation, { data, loading, error }] = useGQLReleaseJobLockMutation({
- *   variables: {
- *      input: // value for 'input'
- *   },
- * });
- */
-export function useGQLReleaseJobLockMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    GQLReleaseJobLockMutation,
-    GQLReleaseJobLockMutationVariables
-  >,
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<
-    GQLReleaseJobLockMutation,
-    GQLReleaseJobLockMutationVariables
-  >(GQLReleaseJobLockDocument, options);
-}
-export type GQLReleaseJobLockMutationHookResult = ReturnType<
-  typeof useGQLReleaseJobLockMutation
->;
-export type GQLReleaseJobLockMutationResult =
-  Apollo.MutationResult<GQLReleaseJobLockMutation>;
-export type GQLReleaseJobLockMutationOptions = Apollo.BaseMutationOptions<
-  GQLReleaseJobLockMutation,
-  GQLReleaseJobLockMutationVariables
->;
 export const GQLGetRelatedItemsDocument = gql`
   query getRelatedItems($itemIdentifiers: [ItemIdentifierInput!]!) {
     latestItemSubmissions(itemIdentifiers: $itemIdentifiers) {
@@ -45764,7 +45707,6 @@ export const namedOperations = {
     DequeueManualReviewJob: 'DequeueManualReviewJob',
     SubmitManualReviewDecision: 'SubmitManualReviewDecision',
     LogSkip: 'LogSkip',
-    ReleaseJobLock: 'ReleaseJobLock',
     AddJobComment: 'AddJobComment',
     DeleteJobComment: 'DeleteJobComment',
     DeleteRoutingRule: 'DeleteRoutingRule',

--- a/client/src/graphql/generated.ts
+++ b/client/src/graphql/generated.ts
@@ -15356,15 +15356,6 @@ export type GQLLogSkipMutation = {
   readonly logSkip: boolean;
 };
 
-export type GQLReleaseJobLockMutationVariables = Exact<{
-  input: GQLReleaseJobLockInput;
-}>;
-
-export type GQLReleaseJobLockMutation = {
-  readonly __typename: 'Mutation';
-  readonly releaseJobLock: boolean;
-};
-
 export type GQLJobFieldsFragment = {
   readonly __typename: 'ManualReviewJob';
   readonly id: string;
@@ -34938,54 +34929,6 @@ export type GQLLogSkipMutationOptions = Apollo.BaseMutationOptions<
   GQLLogSkipMutation,
   GQLLogSkipMutationVariables
 >;
-export const GQLReleaseJobLockDocument = gql`
-  mutation ReleaseJobLock($input: ReleaseJobLockInput!) {
-    releaseJobLock(input: $input)
-  }
-`;
-export type GQLReleaseJobLockMutationFn = Apollo.MutationFunction<
-  GQLReleaseJobLockMutation,
-  GQLReleaseJobLockMutationVariables
->;
-
-/**
- * __useGQLReleaseJobLockMutation__
- *
- * To run a mutation, you first call `useGQLReleaseJobLockMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useGQLReleaseJobLockMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [gqlReleaseJobLockMutation, { data, loading, error }] = useGQLReleaseJobLockMutation({
- *   variables: {
- *      input: // value for 'input'
- *   },
- * });
- */
-export function useGQLReleaseJobLockMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    GQLReleaseJobLockMutation,
-    GQLReleaseJobLockMutationVariables
-  >,
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<
-    GQLReleaseJobLockMutation,
-    GQLReleaseJobLockMutationVariables
-  >(GQLReleaseJobLockDocument, options);
-}
-export type GQLReleaseJobLockMutationHookResult = ReturnType<
-  typeof useGQLReleaseJobLockMutation
->;
-export type GQLReleaseJobLockMutationResult =
-  Apollo.MutationResult<GQLReleaseJobLockMutation>;
-export type GQLReleaseJobLockMutationOptions = Apollo.BaseMutationOptions<
-  GQLReleaseJobLockMutation,
-  GQLReleaseJobLockMutationVariables
->;
 export const GQLGetCommentsForJobDocument = gql`
   query GetCommentsForJob($jobId: ID!) {
     getCommentsForJob(jobId: $jobId) {
@@ -45522,7 +45465,6 @@ export const namedOperations = {
     DequeueManualReviewJob: 'DequeueManualReviewJob',
     SubmitManualReviewDecision: 'SubmitManualReviewDecision',
     LogSkip: 'LogSkip',
-    ReleaseJobLock: 'ReleaseJobLock',
     AddJobComment: 'AddJobComment',
     DeleteJobComment: 'DeleteJobComment',
     DeleteRoutingRule: 'DeleteRoutingRule',

--- a/client/src/webpages/dashboard/mrt/manual_review_job/ManualReviewJobReview.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/ManualReviewJobReview.tsx
@@ -39,7 +39,6 @@ import {
   useGQLDequeueManualReviewJobMutation,
   useGQLLogSkipMutation,
   useGQLManualReviewJobInfoQuery,
-  useGQLReleaseJobLockMutation,
   useGQLSubmitManualReviewDecisionMutation,
   type GQLActionParameter,
   type GQLThreadManualReviewJobPayload,
@@ -221,10 +220,6 @@ gql`
   mutation LogSkip($input: LogSkipInput!) {
     logSkip(input: $input)
   }
-
-  mutation ReleaseJobLock($input: ReleaseJobLockInput!) {
-    releaseJobLock(input: $input)
-  }
 `;
 
 enum BuiltInActionType {
@@ -342,17 +337,18 @@ function ManualReviewJobReviewImpl(props: {
 
   const actionStore = useContext(ManualReviewActionStore);
 
-  const setSelectedRelatedActions = (
-    actions: ManualReviewJobEnqueuedActionData[],
-  ) => {
-    actionStore?.setActions(
-      actions.map((it) => ({
-        itemId: it.target.identifier.itemId,
-        action: it.action,
-      })),
-    );
-    selectedRelatedActionsSetter(actions);
-  };
+  const setSelectedRelatedActions = useCallback(
+    (actions: ManualReviewJobEnqueuedActionData[]) => {
+      actionStore?.setActions(
+        actions.map((it) => ({
+          itemId: it.target.identifier.itemId,
+          action: it.action,
+        })),
+      );
+      selectedRelatedActionsSetter(actions);
+    },
+    [actionStore],
+  );
 
   const { queueId, jobId, lockToken } = useParams<{
     queueId?: string;
@@ -364,12 +360,12 @@ function ManualReviewJobReviewImpl(props: {
   const mrtParentComponentRef = useRef<HTMLDivElement>(null);
   const reportedUserRef = useRef<HTMLDivElement>(null);
 
-  const resetState = () => {
+  const resetState = useCallback(() => {
     setSelectedPrimaryActions([]);
     setSelectedPrimaryPolicies([]);
     setSelectedRelatedActions([]);
     setDecisionReason(undefined);
-  };
+  }, [setSelectedRelatedActions]);
 
   const {
     data,
@@ -389,9 +385,12 @@ function ManualReviewJobReviewImpl(props: {
     onCompleted: (data) => {
       // Here, we update the URL to include the queue ID, job ID, and lock
       // token. That way, users are able to send around the URL to others.
-      // In case we can't find the required job, we can just fail silently.
       const { dequeueManualReviewJob } = data;
       if (dequeueManualReviewJob == null) {
+        // No reviewable job: the queue is drained, or everything left is
+        // skipped by this reviewer. Send them back to the queue list instead
+        // of leaving them on a perpetual loading spinner.
+        navigate('/dashboard/manual_review/queues', { replace: true });
         return;
       }
 
@@ -739,10 +738,6 @@ function ManualReviewJobReviewImpl(props: {
     fetchPolicy: 'no-cache',
   });
 
-  const [releaseJobLock] = useGQLReleaseJobLockMutation({
-    fetchPolicy: 'no-cache',
-  });
-
   const advanceToNextJobAfterInvalidation = useCallback(async () => {
     setIsAdvancingToNextJob(true);
     try {
@@ -754,8 +749,7 @@ function ManualReviewJobReviewImpl(props: {
     } finally {
       setIsAdvancingToNextJob(false);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [getNextJob, navigate]);
+  }, [getNextJob, navigate, resetState]);
 
   // Runs after the invalidate mutation resolves. Refreshes the job view,
   // and if invalidation deleted the current job, advances to the next one.
@@ -783,20 +777,21 @@ function ManualReviewJobReviewImpl(props: {
   }, [jobId, queueId, refetchJobInfo, advanceToNextJobAfterInvalidation]);
 
   const skipToNextJob = async () => {
-    // First, release the lock on the current job and log the skip
+    // Skipping is one server-side operation: it logs the skip, hides the job
+    // from this reviewer for the skip window, and releases the lock so the
+    // job returns to the shared pool for everyone else.
     if (queueId && job?.id && lockToken) {
-      await Promise.all([
-        logSkip(),
-        releaseJobLock({
-          variables: {
-            input: {
-              queueId,
-              jobId: job.id,
-              lockToken,
-            },
-          },
-        }),
-      ]);
+      const result = await logSkip();
+      if (result.data?.logSkip !== true) {
+        // Nothing was released or hidden; stay on the current job so the
+        // reviewer can retry (or decide) instead of advancing past it.
+        setModalInfo({
+          visible: true,
+          modalBody: 'Failed to skip this job. Please try again.',
+          footer: [{ title: 'Ok', type: 'primary', onClick: hideModal }],
+        });
+        return;
+      }
     }
 
     // Reset state and try to get the next job
@@ -809,7 +804,11 @@ function ManualReviewJobReviewImpl(props: {
     }
   };
 
-  if (loading || jobDataLoading || (!closedJob && !lockToken)) {
+  // `loading && !data`: the job-info query reloads in place (e.g. when its
+  // jobIds variable changes while advancing, or on refetch after an
+  // invalidation). Once we have data, keep the current view up during those
+  // reloads instead of flashing the full-screen spinner.
+  if ((loading && !data) || jobDataLoading || (!closedJob && !lockToken)) {
     return (
       <div className="flex items-center justify-center w-full h-screen">
         <ComponentLoading />

--- a/client/src/webpages/dashboard/mrt/manual_review_job/ManualReviewJobReview.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/ManualReviewJobReview.tsx
@@ -39,7 +39,6 @@ import {
   useGQLDequeueManualReviewJobMutation,
   useGQLLogSkipMutation,
   useGQLManualReviewJobInfoQuery,
-  useGQLReleaseJobLockMutation,
   useGQLSubmitManualReviewDecisionMutation,
   type GQLActionParameter,
   type GQLThreadManualReviewJobPayload,
@@ -221,10 +220,6 @@ gql`
   mutation LogSkip($input: LogSkipInput!) {
     logSkip(input: $input)
   }
-
-  mutation ReleaseJobLock($input: ReleaseJobLockInput!) {
-    releaseJobLock(input: $input)
-  }
 `;
 
 enum BuiltInActionType {
@@ -342,17 +337,18 @@ function ManualReviewJobReviewImpl(props: {
 
   const actionStore = useContext(ManualReviewActionStore);
 
-  const setSelectedRelatedActions = (
-    actions: ManualReviewJobEnqueuedActionData[],
-  ) => {
-    actionStore?.setActions(
-      actions.map((it) => ({
-        itemId: it.target.identifier.itemId,
-        action: it.action,
-      })),
-    );
-    selectedRelatedActionsSetter(actions);
-  };
+  const setSelectedRelatedActions = useCallback(
+    (actions: ManualReviewJobEnqueuedActionData[]) => {
+      actionStore?.setActions(
+        actions.map((it) => ({
+          itemId: it.target.identifier.itemId,
+          action: it.action,
+        })),
+      );
+      selectedRelatedActionsSetter(actions);
+    },
+    [actionStore],
+  );
 
   const { queueId, jobId, lockToken } = useParams<{
     queueId?: string;
@@ -364,12 +360,12 @@ function ManualReviewJobReviewImpl(props: {
   const mrtParentComponentRef = useRef<HTMLDivElement>(null);
   const reportedUserRef = useRef<HTMLDivElement>(null);
 
-  const resetState = () => {
+  const resetState = useCallback(() => {
     setSelectedPrimaryActions([]);
     setSelectedPrimaryPolicies([]);
     setSelectedRelatedActions([]);
     setDecisionReason(undefined);
-  };
+  }, [setSelectedRelatedActions]);
 
   const {
     data,
@@ -389,9 +385,12 @@ function ManualReviewJobReviewImpl(props: {
     onCompleted: (data) => {
       // Here, we update the URL to include the queue ID, job ID, and lock
       // token. That way, users are able to send around the URL to others.
-      // In case we can't find the required job, we can just fail silently.
       const { dequeueManualReviewJob } = data;
       if (dequeueManualReviewJob == null) {
+        // No reviewable job: the queue is drained, or everything left is
+        // skipped by this reviewer. Send them back to the queue list instead
+        // of leaving them on a perpetual loading spinner.
+        navigate('/dashboard/manual_review/queues', { replace: true });
         return;
       }
 
@@ -739,10 +738,6 @@ function ManualReviewJobReviewImpl(props: {
     fetchPolicy: 'no-cache',
   });
 
-  const [releaseJobLock] = useGQLReleaseJobLockMutation({
-    fetchPolicy: 'no-cache',
-  });
-
   const advanceToNextJobAfterInvalidation = useCallback(async () => {
     setIsAdvancingToNextJob(true);
     try {
@@ -754,8 +749,7 @@ function ManualReviewJobReviewImpl(props: {
     } finally {
       setIsAdvancingToNextJob(false);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [getNextJob, navigate]);
+  }, [getNextJob, navigate, resetState]);
 
   // Runs after the invalidate mutation resolves. Refreshes the job view,
   // and if invalidation deleted the current job, advances to the next one.
@@ -783,25 +777,50 @@ function ManualReviewJobReviewImpl(props: {
   }, [jobId, queueId, refetchJobInfo, advanceToNextJobAfterInvalidation]);
 
   const skipToNextJob = async () => {
-    // First, release the lock on the current job and log the skip
+    // This is wired straight to a button's `onClick`, so nothing downstream
+    // catches a rejection: any error escaping here is an unhandled promise
+    // rejection and the reviewer gets no feedback at all. Both the skip and
+    // the follow-up dequeue therefore handle rejection explicitly.
+    const showSkipFailed = () =>
+      setModalInfo({
+        visible: true,
+        modalBody: 'Failed to skip this job. Please try again.',
+        footer: [{ title: 'Ok', type: 'primary', onClick: hideModal }],
+      });
+
+    // Skipping is one server-side operation: it logs the skip, hides the job
+    // from this reviewer for the skip window, and releases the lock so the
+    // job returns to the shared pool for everyone else.
     if (queueId && job?.id && lockToken) {
-      await Promise.all([
-        logSkip(),
-        releaseJobLock({
-          variables: {
-            input: {
-              queueId,
-              jobId: job.id,
-              lockToken,
-            },
-          },
-        }),
-      ]);
+      let skipped: boolean;
+      try {
+        const result = await logSkip();
+        skipped = result.data?.logSkip === true;
+      } catch {
+        // Network/GraphQL failure. Same reviewer-facing outcome as a falsy
+        // response: nothing was released or hidden.
+        skipped = false;
+      }
+      if (!skipped) {
+        // Stay on the current job so the reviewer can retry (or decide)
+        // instead of advancing past it.
+        showSkipFailed();
+        return;
+      }
     }
 
     // Reset state and try to get the next job
     resetState();
-    const result = await getNextJob();
+    let result;
+    try {
+      result = await getNextJob();
+    } catch {
+      // The skip already succeeded, so the job is gone from this reviewer's
+      // view; only the advance failed. Surface it rather than leaving the
+      // reviewer on a job they no longer hold.
+      showSkipFailed();
+      return;
+    }
 
     // If there's no next job, redirect to the queues page
     if (result.data?.dequeueManualReviewJob == null) {
@@ -809,7 +828,11 @@ function ManualReviewJobReviewImpl(props: {
     }
   };
 
-  if (loading || jobDataLoading || (!closedJob && !lockToken)) {
+  // `loading && !data`: the job-info query reloads in place (e.g. when its
+  // jobIds variable changes while advancing, or on refetch after an
+  // invalidation). Once we have data, keep the current view up during those
+  // reloads instead of flashing the full-screen spinner.
+  if ((loading && !data) || jobDataLoading || (!closedJob && !lockToken)) {
     return (
       <div className="flex items-center justify-center w-full h-screen">
         <ComponentLoading />

--- a/server/services/manualReviewToolService/manualReviewToolService.ts
+++ b/server/services/manualReviewToolService/manualReviewToolService.ts
@@ -1660,8 +1660,6 @@ export class ManualReviewToolService {
     return this.queueOps.updateHiddenActionsForQueue(opts);
   }
 
-  // Skipping is one server-side operation so the client can't end up with
-  // half a skip (e.g. lock released but skip not recorded).
   async logSkip(opts: {
     orgId: string;
     queueId: string;

--- a/server/services/manualReviewToolService/manualReviewToolService.ts
+++ b/server/services/manualReviewToolService/manualReviewToolService.ts
@@ -1660,6 +1660,8 @@ export class ManualReviewToolService {
     return this.queueOps.updateHiddenActionsForQueue(opts);
   }
 
+  // Skipping is one server-side operation so the client can't end up with
+  // half a skip (e.g. lock released but skip not recorded).
   async logSkip(opts: {
     orgId: string;
     queueId: string;
@@ -1667,6 +1669,22 @@ export class ManualReviewToolService {
     userId: string;
   }) {
     await this.skipOps.logSkip(opts);
+    // Hide the job from THIS reviewer for the skip window; the dequeue path
+    // reads this back and steps past it.
+    await this.queueOps.recordReviewerSkip({
+      orgId: opts.orgId,
+      queueId: opts.queueId,
+      reviewerId: opts.userId,
+      jobId: opts.jobId,
+    });
+    // Release the reviewer's lock (the lock token is the reviewer's userId)
+    // so the job returns to the shared pool immediately for everyone else.
+    await this.releaseJobLock({
+      orgId: opts.orgId,
+      queueId: opts.queueId,
+      jobId: opts.jobId,
+      lockToken: opts.userId,
+    });
   }
 
   async releaseJobLock(opts: {

--- a/server/services/manualReviewToolService/manualReviewToolService.ts
+++ b/server/services/manualReviewToolService/manualReviewToolService.ts
@@ -1661,6 +1661,14 @@ export class ManualReviewToolService {
     userId: string;
   }) {
     await this.skipOps.logSkip(opts);
+    // Hides the job from THIS reviewer for the skip window and releases their
+    // lock so it returns to the shared pool immediately for everyone else.
+    await this.queueOps.recordReviewerSkip({
+      orgId: opts.orgId,
+      queueId: opts.queueId,
+      reviewerId: opts.userId,
+      jobId: opts.jobId,
+    });
   }
 
   async releaseJobLock(opts: {

--- a/server/services/manualReviewToolService/modules/QueueOperations.reviewerSkips.test.ts
+++ b/server/services/manualReviewToolService/modules/QueueOperations.reviewerSkips.test.ts
@@ -1,0 +1,200 @@
+import { uid } from 'uid';
+
+import getBottle from '../../../iocContainer/index.js';
+import createMrtQueue from '../../../test/fixtureHelpers/createMrtQueue.js';
+import createOrg from '../../../test/fixtureHelpers/createOrg.js';
+import createUser from '../../../test/fixtureHelpers/createUser.js';
+import { makeTestWithFixture } from '../../../test/utils.js';
+import { instantiateOpaqueType } from '../../../utils/typescript-types.js';
+import {
+  makeSubmissionId,
+  type NormalizedItemData,
+} from '../../itemProcessingService/index.js';
+import { type ItemSubmissionWithTypeIdentifier } from '../../itemProcessingService/makeItemSubmissionWithTypeIdentifier.js';
+import { type ManualReviewJobPayload } from '../manualReviewToolService.js';
+
+describe('QueueOperations per-reviewer skips', () => {
+  const testWithQueue = () =>
+    makeTestWithFixture(async () => {
+      const container = (await getBottle()).container;
+
+      const { org, cleanup: orgCleanup } = await createOrg(
+        {
+          KyselyPg: container.KyselyPg,
+          ModerationConfigService: container.ModerationConfigService,
+          ApiKeyService: container.ApiKeyService,
+        },
+        uid(),
+      );
+
+      const { user, cleanup: userCleanup } = await createUser(
+        container.KyselyPg,
+        org.id,
+      );
+
+      const { queue, cleanup: queuesCleanup } = await createMrtQueue({
+        orgId: org.id,
+        mrtService: container.ManualReviewToolService,
+        userId: user.id,
+      });
+
+      return {
+        org,
+        queue,
+        user,
+        mrtService: container.ManualReviewToolService,
+        cleanup: async () => {
+          await queuesCleanup();
+          await userCleanup();
+          await orgCleanup();
+          await container.KyselyPg.destroy();
+          await container.KyselyPgReadReplica.destroy();
+        },
+      };
+    });
+
+  const makePayloadFor =
+    (itemTypeId: string) =>
+    (itemId: string): ManualReviewJobPayload => ({
+      kind: 'DEFAULT',
+      reportHistory: [],
+      reportedForReasons: [],
+      item: instantiateOpaqueType<ItemSubmissionWithTypeIdentifier>({
+        submissionId: makeSubmissionId(),
+        submissionTime: new Date(),
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        data: {} as NormalizedItemData,
+        itemTypeIdentifier: {
+          id: itemTypeId,
+          version: new Date().toISOString(),
+          schemaVariant: 'original',
+        },
+        creator: { id: uid(), typeId: uid() },
+        itemId,
+      }),
+      enqueueSourceInfo: { kind: 'REPORT' },
+    });
+
+  testWithQueue()(
+    'a skipped job is hidden from that reviewer but immediately available to others',
+    async ({ org, queue, mrtService }) => {
+      const queueOps = mrtService['queueOps'];
+      const payloadFor = makePayloadFor(uid());
+
+      const xJob = await queueOps.addJob({
+        orgId: org.id,
+        queueId: queue.id,
+        enqueueSourceInfo: { kind: 'REPORT' },
+        priority: 1000,
+        jobPayload: { policyIds: [], payload: payloadFor('item-X') },
+      });
+      await queueOps.addJob({
+        orgId: org.id,
+        queueId: queue.id,
+        enqueueSourceInfo: { kind: 'REPORT' },
+        priority: 2000,
+        jobPayload: { policyIds: [], payload: payloadFor('item-Y') },
+      });
+
+      await queueOps.recordReviewerSkip({
+        orgId: org.id,
+        queueId: queue.id,
+        reviewerId: 'reviewer-a',
+        jobId: xJob.id,
+      });
+
+      const aJob = await queueOps.dequeueNextJobWithLock({
+        orgId: org.id,
+        queueId: queue.id,
+        lockToken: 'reviewer-a',
+      });
+      expect(aJob?.job.payload.item.itemId).toBe('item-Y');
+
+      const bJob = await queueOps.dequeueNextJobWithLock({
+        orgId: org.id,
+        queueId: queue.id,
+        lockToken: 'reviewer-b',
+      });
+      expect(bJob?.job.payload.item.itemId).toBe('item-X');
+    },
+  );
+
+  testWithQueue()(
+    'a queue whose only jobs are skipped returns null instead of hanging',
+    async ({ org, queue, mrtService }) => {
+      const queueOps = mrtService['queueOps'];
+      const payloadFor = makePayloadFor(uid());
+
+      const onlyJob = await queueOps.addJob({
+        orgId: org.id,
+        queueId: queue.id,
+        enqueueSourceInfo: { kind: 'REPORT' },
+        priority: 1000,
+        jobPayload: { policyIds: [], payload: payloadFor('item-X') },
+      });
+      await queueOps.recordReviewerSkip({
+        orgId: org.id,
+        queueId: queue.id,
+        reviewerId: 'reviewer-a',
+        jobId: onlyJob.id,
+      });
+
+      const result = await queueOps.dequeueNextJobWithLock({
+        orgId: org.id,
+        queueId: queue.id,
+        lockToken: 'reviewer-a',
+      });
+      expect(result).toBeNull();
+    },
+  );
+
+  testWithQueue()(
+    'logSkip hides the job from the skipper and releases their lock in one call',
+    async ({ org, queue, user, mrtService }) => {
+      const queueOps = mrtService['queueOps'];
+      const payloadFor = makePayloadFor(uid());
+
+      await queueOps.addJob({
+        orgId: org.id,
+        queueId: queue.id,
+        enqueueSourceInfo: { kind: 'REPORT' },
+        priority: 1000,
+        jobPayload: { policyIds: [], payload: payloadFor('item-X') },
+      });
+      await queueOps.addJob({
+        orgId: org.id,
+        queueId: queue.id,
+        enqueueSourceInfo: { kind: 'REPORT' },
+        priority: 2000,
+        jobPayload: { policyIds: [], payload: payloadFor('item-Y') },
+      });
+
+      const first = await queueOps.dequeueNextJobWithLock({
+        orgId: org.id,
+        queueId: queue.id,
+        lockToken: user.id,
+      });
+      expect(first?.job.payload.item.itemId).toBe('item-X');
+      await mrtService.logSkip({
+        orgId: org.id,
+        queueId: queue.id,
+        jobId: first!.job.id,
+        userId: user.id,
+      });
+
+      const other = await queueOps.dequeueNextJobWithLock({
+        orgId: org.id,
+        queueId: queue.id,
+        lockToken: 'reviewer-b',
+      });
+      expect(other?.job.payload.item.itemId).toBe('item-X');
+
+      const next = await queueOps.dequeueNextJobWithLock({
+        orgId: org.id,
+        queueId: queue.id,
+        lockToken: user.id,
+      });
+      expect(next?.job.payload.item.itemId).toBe('item-Y');
+    },
+  );
+});

--- a/server/services/manualReviewToolService/modules/QueueOperations.reviewerSkips.test.ts
+++ b/server/services/manualReviewToolService/modules/QueueOperations.reviewerSkips.test.ts
@@ -1,0 +1,188 @@
+import { uid } from 'uid';
+
+import createMrtQueue from '../../../test/fixtureHelpers/createMrtQueue.js';
+import createOrg from '../../../test/fixtureHelpers/createOrg.js';
+import createUser from '../../../test/fixtureHelpers/createUser.js';
+import { makeTransactionalTestWithFixture } from '../../../test/harness/transactionalTest.js';
+import { instantiateOpaqueType } from '../../../utils/typescript-types.js';
+import {
+  makeSubmissionId,
+  type NormalizedItemData,
+} from '../../itemProcessingService/index.js';
+import { type ItemSubmissionWithTypeIdentifier } from '../../itemProcessingService/makeItemSubmissionWithTypeIdentifier.js';
+import { type ManualReviewJobPayload } from '../manualReviewToolService.js';
+
+describe('QueueOperations per-reviewer skips', () => {
+  // Runs inside a transaction that rolls back, so the fixtures need no manual
+  // teardown.
+  const testWithQueue = makeTransactionalTestWithFixture(async ({ deps }) => {
+    const { org } = await createOrg(
+      {
+        KyselyPg: deps.KyselyPg,
+        ModerationConfigService: deps.ModerationConfigService,
+        ApiKeyService: deps.ApiKeyService,
+      },
+      uid(),
+    );
+
+    const { user } = await createUser(deps.KyselyPg, org.id);
+
+    const { queue } = await createMrtQueue({
+      orgId: org.id,
+      mrtService: deps.ManualReviewToolService,
+      userId: user.id,
+    });
+
+    return {
+      org,
+      queue,
+      user,
+      mrtService: deps.ManualReviewToolService,
+    };
+  });
+
+  const makePayloadFor =
+    (itemTypeId: string) =>
+    (itemId: string): ManualReviewJobPayload => ({
+      kind: 'DEFAULT',
+      reportHistory: [],
+      reportedForReasons: [],
+      item: instantiateOpaqueType<ItemSubmissionWithTypeIdentifier>({
+        submissionId: makeSubmissionId(),
+        submissionTime: new Date(),
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        data: {} as NormalizedItemData,
+        itemTypeIdentifier: {
+          id: itemTypeId,
+          version: new Date().toISOString(),
+          schemaVariant: 'original',
+        },
+        creator: { id: uid(), typeId: uid() },
+        itemId,
+      }),
+      enqueueSourceInfo: { kind: 'REPORT' },
+    });
+
+  testWithQueue(
+    'a skipped job is hidden from that reviewer but immediately available to others',
+    async ({ org, queue, mrtService }) => {
+      const queueOps = mrtService['queueOps'];
+      const payloadFor = makePayloadFor(uid());
+
+      const xJob = await queueOps.addJob({
+        orgId: org.id,
+        queueId: queue.id,
+        enqueueSourceInfo: { kind: 'REPORT' },
+        priority: 1000,
+        jobPayload: { policyIds: [], payload: payloadFor('item-X') },
+      });
+      await queueOps.addJob({
+        orgId: org.id,
+        queueId: queue.id,
+        enqueueSourceInfo: { kind: 'REPORT' },
+        priority: 2000,
+        jobPayload: { policyIds: [], payload: payloadFor('item-Y') },
+      });
+
+      await queueOps.recordReviewerSkip({
+        orgId: org.id,
+        queueId: queue.id,
+        reviewerId: 'reviewer-a',
+        jobId: xJob.id,
+      });
+
+      const aJob = await queueOps.dequeueNextJobWithLock({
+        orgId: org.id,
+        queueId: queue.id,
+        lockToken: 'reviewer-a',
+      });
+      expect(aJob?.job.payload.item.itemId).toBe('item-Y');
+
+      const bJob = await queueOps.dequeueNextJobWithLock({
+        orgId: org.id,
+        queueId: queue.id,
+        lockToken: 'reviewer-b',
+      });
+      expect(bJob?.job.payload.item.itemId).toBe('item-X');
+    },
+  );
+
+  testWithQueue(
+    'a queue whose only jobs are skipped returns null instead of hanging',
+    async ({ org, queue, mrtService }) => {
+      const queueOps = mrtService['queueOps'];
+      const payloadFor = makePayloadFor(uid());
+
+      const onlyJob = await queueOps.addJob({
+        orgId: org.id,
+        queueId: queue.id,
+        enqueueSourceInfo: { kind: 'REPORT' },
+        priority: 1000,
+        jobPayload: { policyIds: [], payload: payloadFor('item-X') },
+      });
+      await queueOps.recordReviewerSkip({
+        orgId: org.id,
+        queueId: queue.id,
+        reviewerId: 'reviewer-a',
+        jobId: onlyJob.id,
+      });
+
+      const result = await queueOps.dequeueNextJobWithLock({
+        orgId: org.id,
+        queueId: queue.id,
+        lockToken: 'reviewer-a',
+      });
+      expect(result).toBeNull();
+    },
+  );
+
+  testWithQueue(
+    'logSkip hides the job from the skipper and releases their lock in one call',
+    async ({ org, queue, user, mrtService }) => {
+      const queueOps = mrtService['queueOps'];
+      const payloadFor = makePayloadFor(uid());
+
+      await queueOps.addJob({
+        orgId: org.id,
+        queueId: queue.id,
+        enqueueSourceInfo: { kind: 'REPORT' },
+        priority: 1000,
+        jobPayload: { policyIds: [], payload: payloadFor('item-X') },
+      });
+      await queueOps.addJob({
+        orgId: org.id,
+        queueId: queue.id,
+        enqueueSourceInfo: { kind: 'REPORT' },
+        priority: 2000,
+        jobPayload: { policyIds: [], payload: payloadFor('item-Y') },
+      });
+
+      const first = await queueOps.dequeueNextJobWithLock({
+        orgId: org.id,
+        queueId: queue.id,
+        lockToken: user.id,
+      });
+      expect(first?.job.payload.item.itemId).toBe('item-X');
+      await mrtService.logSkip({
+        orgId: org.id,
+        queueId: queue.id,
+        jobId: first!.job.id,
+        userId: user.id,
+      });
+
+      const other = await queueOps.dequeueNextJobWithLock({
+        orgId: org.id,
+        queueId: queue.id,
+        lockToken: 'reviewer-b',
+      });
+      expect(other?.job.payload.item.itemId).toBe('item-X');
+
+      const next = await queueOps.dequeueNextJobWithLock({
+        orgId: org.id,
+        queueId: queue.id,
+        lockToken: user.id,
+      });
+      expect(next?.job.payload.item.itemId).toBe('item-Y');
+    },
+  );
+});

--- a/server/services/manualReviewToolService/modules/QueueOperations.ts
+++ b/server/services/manualReviewToolService/modules/QueueOperations.ts
@@ -163,7 +163,7 @@ export default class QueueOperations {
     private readonly pgQuery: Kysely<ManualReviewToolServicePg>,
     private readonly pgQueryReadReplica: Kysely<ManualReviewToolServicePg>,
     private readonly moderationConfigService: Dependencies['ModerationConfigService'],
-    redis: RedisConnection,
+    private readonly redis: RedisConnection,
   ) {
     this.transactionWithRetry = makeKyselyTransactionWithRetry(this.pgQuery);
     // Reassingment here is a hack to work around TS syntax limitations
@@ -1253,7 +1253,9 @@ export default class QueueOperations {
 
     let hasDecision = true;
     while (hasDecision) {
-      const job = await worker.getNextJob(lockToken);
+      // block: false so a drained queue returns null immediately instead of
+      // long-polling and hanging the reviewer's request.
+      const job = await worker.getNextJob(lockToken, { block: false });
 
       if (!job) {
         return null;
@@ -1304,47 +1306,104 @@ export default class QueueOperations {
     await this.checkQueueExists(orgId, queueId);
     const worker = await this.getBullWorker({ orgId, queueId });
 
-    let hasDecision = true;
-    while (hasDecision) {
-      const job = await worker.getNextJob(lockToken);
+    // Jobs this reviewer skipped within the skip window (the lock token is
+    // the reviewer's userId). The scan steps past them by keeping them locked
+    // until it finishes, then releases them in `finally` so they return to
+    // the shared pool — a skip is per-reviewer, not global.
+    const reviewerSkips = await this.getActiveReviewerSkips({
+      orgId,
+      queueId,
+      reviewerId: lockToken,
+    });
+    const heldAside: Job<StoredManualReviewJob>[] = [];
 
-      if (!job) {
-        return null;
+    try {
+      while (true) {
+        const job = await worker.getNextJob(lockToken, { block: false });
+
+        if (!job) {
+          return null;
+        }
+        if (reviewerSkips.has(job.data.id)) {
+          heldAside.push(job);
+          continue;
+        }
+
+        const convertedJob = await this.legacyJobToJob(job, orgId);
+
+        // There is a race condition due to the locking mechanism where a job can
+        // be decided on but not dequeued, so we check here if the first job in the
+        // queue has a decision, and if so use the lock token to immediately
+        // remove it, then grab a new job and return to the caller. it is very
+        // unlikely that there are multiple jobs like this at the front of the
+        // queue, but not impossible.
+        const decision = await this.pgQueryReadReplica
+          .selectFrom('manual_review_tool.manual_review_decisions')
+          .select(['decision_components']) // not really necessary to return anything
+          .where('created_at', '>=', new Date('2023-10-01'))
+          .where('org_id', '=', orgId)
+          .where('id', '=', jobIdToGuid(convertedJob.data.id))
+          .executeTakeFirst();
+
+        if (decision !== undefined) {
+          await this.removeJob({
+            orgId,
+            queueId,
+            lockToken,
+            jobId: convertedJob.data.id,
+          }).catch(() => {});
+          // then continue while loop
+        } else {
+          // this is the most likely case, where there is a job
+          // and it has never been decided before
+          return { job: convertedJob.data, lockToken };
+        }
       }
-
-      const convertedJob = await this.legacyJobToJob(job, orgId);
-
-      // There is a race condition due to the locking mechanism where a job can
-      // be decided on but not dequeued, so we check here if the first job in the
-      // queue has a decision, and if so use the lock token to immediately
-      // remove it, then grab a new job and return to the caller. it is very
-      // unlikely that there are multiple jobs like this at the front of the
-      // queue, but not impossible.
-      const decision = await this.pgQueryReadReplica
-        .selectFrom('manual_review_tool.manual_review_decisions')
-        .select(['decision_components']) // not really necessary to return anything
-        .where('created_at', '>=', new Date('2023-10-01'))
-        .where('org_id', '=', orgId)
-        .where('id', '=', jobIdToGuid(convertedJob.data.id))
-        .executeTakeFirst();
-
-      hasDecision = decision !== undefined;
-
-      if (hasDecision) {
-        await this.removeJob({
+    } finally {
+      // Release the held-aside jobs so other reviewers can pick them up
+      // immediately. This reviewer stays excluded via the skip set.
+      for (const held of heldAside) {
+        await this.releaseJobLock({
           orgId,
           queueId,
+          jobId: held.data.id,
           lockToken,
-          jobId: convertedJob.data.id,
         }).catch(() => {});
-        // then continue while loop
-      } else {
-        // this is the most likely case, where there is a job
-        // and it has never been decided before
-        return { job: convertedJob.data, lockToken };
       }
     }
-    return null;
+  }
+
+  static readonly REVIEWER_SKIP_TTL_MS = 30 * 60 * 1000;
+
+  #reviewerSkipKey(orgId: string, queueId: string, reviewerId: string): string {
+    return `{${orgId}}:mrt-reviewer-skips:${queueId}:${reviewerId}`;
+  }
+
+  async recordReviewerSkip(opts: {
+    orgId: string;
+    queueId: string;
+    reviewerId: string;
+    jobId: string;
+  }): Promise<void> {
+    const { orgId, queueId, reviewerId, jobId } = opts;
+    const key = this.#reviewerSkipKey(orgId, queueId, reviewerId);
+    const expiresAt = Date.now() + QueueOperations.REVIEWER_SKIP_TTL_MS;
+    await this.redis.zadd(key, expiresAt, jobId);
+    // Backstop: the whole set disappears once everything in it has expired.
+    await this.redis.pexpire(key, QueueOperations.REVIEWER_SKIP_TTL_MS);
+  }
+
+  async getActiveReviewerSkips(opts: {
+    orgId: string;
+    queueId: string;
+    reviewerId: string;
+  }): Promise<Set<string>> {
+    const { orgId, queueId, reviewerId } = opts;
+    const key = this.#reviewerSkipKey(orgId, queueId, reviewerId);
+    // Drop expired entries, then read what's still active.
+    await this.redis.zremrangebyscore(key, 0, Date.now());
+    const ids = await this.redis.zrange(key, 0, -1);
+    return new Set(ids);
   }
 
   /**
@@ -1942,9 +2001,13 @@ export async function getBullWorker<JobData = unknown>(
   await worker.startStalledCheckTimer();
 
   // Cast worker to a version of its original type, but fixed to correctly
-  // indicate that getNextJob() can return undefined
+  // indicate that getNextJob() can return undefined and accepts a `block`
+  // option (false = return immediately instead of long-polling).
   return worker as unknown as Omit<Worker<JobData>, 'getNextJob'> & {
-    getNextJob: (lockToken: string) => Promise<Job<JobData> | undefined>;
+    getNextJob: (
+      lockToken: string,
+      opts?: { block?: boolean },
+    ) => Promise<Job<JobData> | undefined>;
   };
 }
 

--- a/server/services/manualReviewToolService/modules/QueueOperations.ts
+++ b/server/services/manualReviewToolService/modules/QueueOperations.ts
@@ -169,7 +169,7 @@ export default class QueueOperations {
     private readonly pgQuery: Kysely<ManualReviewToolServicePg>,
     private readonly pgQueryReadReplica: Kysely<ManualReviewToolServicePg>,
     private readonly moderationConfigService: Dependencies['ModerationConfigService'],
-    redis: RedisConnection,
+    private readonly redis: RedisConnection,
     private readonly tracer: Dependencies['Tracer'],
   ) {
     this.transactionWithRetry = makeKyselyTransactionWithRetry(this.pgQuery);
@@ -1346,7 +1346,9 @@ export default class QueueOperations {
 
     let hasDecision = true;
     while (hasDecision) {
-      const job = await worker.getNextJob(lockToken);
+      // block: false so a drained queue returns null immediately instead of
+      // long-polling and hanging the reviewer's request.
+      const job = await worker.getNextJob(lockToken, { block: false });
 
       if (!job) {
         return null;
@@ -1373,7 +1375,12 @@ export default class QueueOperations {
           queueId,
           lockToken,
           jobId: job.data.id,
-        }).catch(() => {});
+        }).catch((error: unknown) => {
+          // Non-fatal: the scan should still hand this reviewer a job. But it
+          // must not be silent — see the note on the same call in
+          // `dequeueNextJobWithLock`.
+          this.tracer.logActiveSpanFailedIfAny(error);
+        });
         // then continue while loop
       } else {
         // this is the most likely case, where there is a job
@@ -1397,47 +1404,139 @@ export default class QueueOperations {
     await this.checkQueueExists(orgId, queueId);
     const worker = await this.getBullWorker({ orgId, queueId });
 
-    let hasDecision = true;
-    while (hasDecision) {
-      const job = await worker.getNextJob(lockToken);
+    // Jobs this reviewer skipped within the skip window (the lock token is
+    // the reviewer's userId). The scan steps past them by keeping them locked
+    // until it finishes, then releases them in `finally` so they return to
+    // the shared pool — a skip is per-reviewer, not global.
+    const reviewerSkips = await this.getActiveReviewerSkips({
+      orgId,
+      queueId,
+      reviewerId: lockToken,
+    });
+    const heldAside: Job<StoredManualReviewJob>[] = [];
 
-      if (!job) {
-        return null;
+    try {
+      while (true) {
+        const job = await worker.getNextJob(lockToken, { block: false });
+
+        if (!job) {
+          return null;
+        }
+        if (reviewerSkips.has(job.data.id)) {
+          heldAside.push(job);
+          continue;
+        }
+
+        const convertedJob = await this.legacyJobToJob(job, orgId);
+
+        // There is a race condition due to the locking mechanism where a job can
+        // be decided on but not dequeued, so we check here if the first job in the
+        // queue has a decision, and if so use the lock token to immediately
+        // remove it, then grab a new job and return to the caller. it is very
+        // unlikely that there are multiple jobs like this at the front of the
+        // queue, but not impossible.
+        const decision = await this.pgQueryReadReplica
+          .selectFrom('manual_review_tool.manual_review_decisions')
+          .select(['decision_components']) // not really necessary to return anything
+          .where('created_at', '>=', new Date('2023-10-01'))
+          .where('org_id', '=', orgId)
+          .where('id', '=', jobIdToGuid(convertedJob.data.id))
+          .executeTakeFirst();
+
+        if (decision !== undefined) {
+          await this.removeJob({
+            orgId,
+            queueId,
+            lockToken,
+            jobId: convertedJob.data.id,
+          }).catch((error: unknown) => {
+            // Non-fatal, but not silent either. The common cause is another
+            // reviewer having re-locked the job, in which case they will
+            // retire it and doing nothing is correct. The case that matters is
+            // a Redis failure: the decided job then stays `active` until its
+            // lock expires, after which the stalled checker returns it to
+            // `wait` — forever. `maxStalledCount` does not bound this, because
+            // BullMQ only applies the deferred stall failure inside
+            // `processJob`, which never runs on these workers (`autorun:
+            // false`). So a stuck decided job recirculates indefinitely and
+            // this report is the only signal it happened.
+            this.tracer.logActiveSpanFailedIfAny(error);
+          });
+          // then continue while loop
+        } else {
+          // this is the most likely case, where there is a job
+          // and it has never been decided before
+          return { job: convertedJob.data, lockToken };
+        }
       }
-
-      const convertedJob = await this.legacyJobToJob(job, orgId);
-
-      // There is a race condition due to the locking mechanism where a job can
-      // be decided on but not dequeued, so we check here if the first job in the
-      // queue has a decision, and if so use the lock token to immediately
-      // remove it, then grab a new job and return to the caller. it is very
-      // unlikely that there are multiple jobs like this at the front of the
-      // queue, but not impossible.
-      const decision = await this.pgQueryReadReplica
-        .selectFrom('manual_review_tool.manual_review_decisions')
-        .select(['decision_components']) // not really necessary to return anything
-        .where('created_at', '>=', new Date('2023-10-01'))
-        .where('org_id', '=', orgId)
-        .where('id', '=', jobIdToGuid(convertedJob.data.id))
-        .executeTakeFirst();
-
-      hasDecision = decision !== undefined;
-
-      if (hasDecision) {
-        await this.removeJob({
+    } finally {
+      // Release the held-aside jobs so other reviewers can pick them up
+      // immediately. This reviewer stays excluded via the skip set.
+      for (const held of heldAside) {
+        // No `.catch` here on purpose: `releaseJobLock` never rejects — it
+        // reports its own failures to the active span and returns. Chaining a
+        // handler here would be dead code. Releasing is best-effort anyway; a
+        // failure leaves the job locked until `lockDuration` expires, and
+        // throwing from a `finally` would replace whatever result or error the
+        // caller was about to receive.
+        await this.releaseJobLock({
           orgId,
           queueId,
+          jobId: held.data.id,
           lockToken,
-          jobId: convertedJob.data.id,
-        }).catch(() => {});
-        // then continue while loop
-      } else {
-        // this is the most likely case, where there is a job
-        // and it has never been decided before
-        return { job: convertedJob.data, lockToken };
+        });
       }
     }
-    return null;
+  }
+
+  static readonly REVIEWER_SKIP_TTL_MS = 30 * 60 * 1000;
+
+  #reviewerSkipKey(orgId: string, queueId: string, reviewerId: string): string {
+    return `{${orgId}}:mrt-reviewer-skips:${queueId}:${reviewerId}`;
+  }
+
+  /**
+   * Hides a job from one reviewer for the skip window and hands it straight
+   * back to everyone else.
+   *
+   * Releasing the lock is part of skipping, not a separate step callers have to
+   * remember — there is no case for recording a skip while still holding the
+   * job. `releaseJobLock` is a no-op when no lock is held, so this is safe even
+   * when the caller never took one.
+   */
+  async recordReviewerSkip(opts: {
+    orgId: string;
+    queueId: string;
+    reviewerId: string;
+    jobId: string;
+  }): Promise<void> {
+    const { orgId, queueId, reviewerId, jobId } = opts;
+    const key = this.#reviewerSkipKey(orgId, queueId, reviewerId);
+    const expiresAt = Date.now() + QueueOperations.REVIEWER_SKIP_TTL_MS;
+    await this.redis.zadd(key, expiresAt, jobId);
+    // Backstop: the whole set disappears once everything in it has expired.
+    await this.redis.pexpire(key, QueueOperations.REVIEWER_SKIP_TTL_MS);
+
+    // The lock token is the reviewer's own id.
+    await this.releaseJobLock({
+      orgId,
+      queueId,
+      jobId: instantiateOpaqueType<JobId>(jobId),
+      lockToken: reviewerId,
+    });
+  }
+
+  async getActiveReviewerSkips(opts: {
+    orgId: string;
+    queueId: string;
+    reviewerId: string;
+  }): Promise<Set<string>> {
+    const { orgId, queueId, reviewerId } = opts;
+    const key = this.#reviewerSkipKey(orgId, queueId, reviewerId);
+    // Drop expired entries, then read what's still active.
+    await this.redis.zremrangebyscore(key, 0, Date.now());
+    const ids = await this.redis.zrange(key, 0, -1);
+    return new Set(ids);
   }
 
   /**
@@ -1714,9 +1813,14 @@ export default class QueueOperations {
       // The token parameter ensures only the holder of the lock can release it
       await job.moveToDelayed(Date.now(), lockToken);
     } catch (error: unknown) {
-      // If the lock has already expired or the job is in a different state,
-      // we can safely ignore the error as the job is already released
-      // or will be handled by the stalled job checker
+      // Non-fatal: if the lock has already expired or the job moved state, the
+      // job is effectively released already (or the stalled checker will get
+      // it), and callers — including the `releaseJobLock` mutation and the
+      // held-aside loop in `dequeueNextJobWithLock` — treat releasing as
+      // best-effort cleanup that must not fail the operation around it.
+      // Reported rather than swallowed: a persistent failure here keeps a job
+      // locked for the full `lockDuration`, which is invisible otherwise.
+      this.tracer.logActiveSpanFailedIfAny(error);
     }
   }
 
@@ -2037,9 +2141,13 @@ export async function getBullWorker<JobData = unknown>(
   await worker.startStalledCheckTimer();
 
   // Cast worker to a version of its original type, but fixed to correctly
-  // indicate that getNextJob() can return undefined
+  // indicate that getNextJob() can return undefined and accepts a `block`
+  // option (false = return immediately instead of long-polling).
   return worker as unknown as Omit<Worker<JobData>, 'getNextJob'> & {
-    getNextJob: (lockToken: string) => Promise<Job<JobData> | undefined>;
+    getNextJob: (
+      lockToken: string,
+      opts?: { block?: boolean },
+    ) => Promise<Job<JobData> | undefined>;
   };
 }
 


### PR DESCRIPTION
## Context & Requests for Reviewers

Part 3 of 3 for #670. Previously, skipping a job just released the lock. The job came right back to the same reviewer, and skip was two separate client calls (`logSkip` + `releaseJobLock`) that could partially fail.

- **Skip is now one server-side operation**: `logSkip` atomically logs the skip, records the job in a per-reviewer Redis skip set (sorted set scored by expiry, with a TTL backstop), and releases the lock. The client's separate `ReleaseJobLock` call is removed.
- **Dequeue steps past skipped jobs for that reviewer only**: the scan holds skipped jobs aside under the reviewer's lock token and releases them in a `finally`, so they return to the shared pool immediately for everyone else.
- `getNextJob` now uses `block: false`, so a drained queue returns null immediately instead of long-polling and hanging the reviewer's request.
- UI: skip failures show a retry modal instead of failing silently; when no reviewable job remains (drained, or everything left is skipped by this reviewer), the reviewer is redirected to the queue list instead of a perpetual spinner.

Review focus: the held-aside-then-release pattern in `dequeueNextJobWithLock`, particularly lock-token semantics (the token is the reviewer's userId) and what happens if the release in `finally` partially fails.

## Tests

- `QueueOperations.reviewerSkips.test.ts` — skip set recording/expiry, dequeue filtering per reviewer, held-aside jobs released for other reviewers.

## Checklist

- [ ] **If you changed anything user-facing** (i.e. user interface or APIs):
    Did you update the CHANGELOG.md and related docs?