### PR TITLE
fix: Replace bcrypt with Argon2id, upgrading legacy hashes on login

### DIFF
--- a/server/graphql/datasources/userApiCredentials.test.ts
+++ b/server/graphql/datasources/userApiCredentials.test.ts
@@ -82,7 +82,7 @@ function makeDeps(kyselyPg: Kysely<unknown>) {
 describe('verifyEmailPasswordCredentials', () => {
   const password = 'correct horse battery staple';
 
-  it('rehashes and persists a legacy work-factor-5 hash on successful login', async () => {
+  it('rehashes a legacy bcrypt hash to Argon2id on successful login', async () => {
     const legacyBcryptHash = await bcrypt.hash(password, 5);
     const userRow = makeUserRow({ password: legacyBcryptHash });
     const { kyselyPg, updateTable, updateBuilder } = makeMockKyselyPg({
@@ -99,7 +99,9 @@ describe('verifyEmailPasswordCredentials', () => {
     expect(result.id).toBe('user-123');
     expect(updateTable).toHaveBeenCalledWith('public.users');
     const [[persistedPatch]] = updateBuilder.set.mock.calls;
-    expect(persistedPatch.password).toMatch(/^\$2[aby]\$12\$/);
+    expect(persistedPatch.password).toMatch(
+      /^\$argon2id\$v=19\$m=19456,t=2,p=1\$/,
+    );
     // Compare-and-swap guard (PR #901 review): the write must be scoped to
     // the exact hash that was just verified, not the user id alone, so a
     // concurrent password change can never be clobbered by a rehash of the
@@ -117,7 +119,7 @@ describe('verifyEmailPasswordCredentials', () => {
     ).resolves.toBe(true);
   });
 
-  it('does not rehash when the stored hash is already at the target work factor', async () => {
+  it('does not rehash when the stored hash is already a current Argon2id hash', async () => {
     const currentHash = await hashPassword(password);
     const userRow = makeUserRow({ password: currentHash });
     const { kyselyPg, updateTable } = makeMockKyselyPg({ userRow });
@@ -138,6 +140,28 @@ describe('verifyEmailPasswordCredentials', () => {
       verifyEmailPasswordCredentials(deps, 'test@example.com', 'wrong'),
     ).rejects.toThrow();
 
+    expect(updateTable).not.toHaveBeenCalled();
+  });
+
+  it('fails closed and logs when the stored hash cannot be evaluated', async () => {
+    // A corrupt row, or Argon2 failing operationally (the 19 MiB allocation
+    // can fail under memory pressure, taking down *every* login). Both throw
+    // out of `passwordMatchesHash`. The user-facing answer is still "wrong
+    // password" — but it must be logged, or a total verification outage is
+    // indistinguishable from a flood of users mistyping their passwords.
+    // A bad base64 salt is one of the shapes `argon2Verify` throws on rather
+    // than resolving false — see the corrupt-input cases in `utils.test.ts`.
+    const userRow = makeUserRow({
+      password: '$argon2id$v=19$m=19456,t=2,p=1$!!!!$!!!!',
+    });
+    const { kyselyPg, updateTable } = makeMockKyselyPg({ userRow });
+    const { deps, logActiveSpanFailedIfAny } = makeDeps(kyselyPg);
+
+    await expect(
+      verifyEmailPasswordCredentials(deps, 'test@example.com', password),
+    ).rejects.toThrow();
+
+    expect(logActiveSpanFailedIfAny).toHaveBeenCalled();
     expect(updateTable).not.toHaveBeenCalled();
   });
 

--- a/server/graphql/datasources/userApiCredentials.test.ts
+++ b/server/graphql/datasources/userApiCredentials.test.ts
@@ -1,0 +1,156 @@
+import bcrypt from 'bcryptjs';
+import { type Kysely } from 'kysely';
+
+import {
+  hashPassword,
+  passwordMatchesHash,
+} from '../../services/userManagementService/index.js';
+import { verifyEmailPasswordCredentials } from './userApiCredentials.js';
+
+// `verifyEmailPasswordCredentials` only touches the injected Kysely instance
+// (user lookup + the rehash-on-login update); `orgSettingsService` and
+// `tracer` are separate mocks below.
+function makeMockKyselyPg(opts: {
+  userRow: Record<string, unknown> | undefined;
+  updateShouldThrow?: boolean;
+}) {
+  const selectExecuteTakeFirst = jest.fn().mockResolvedValue(opts.userRow);
+  const selectBuilder = {
+    select: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    executeTakeFirst: selectExecuteTakeFirst,
+  };
+  const selectFrom = jest.fn().mockReturnValue(selectBuilder);
+
+  const updateExecuteTakeFirst = jest.fn();
+  if (opts.updateShouldThrow) {
+    updateExecuteTakeFirst.mockRejectedValue(new Error('update failed'));
+  } else {
+    updateExecuteTakeFirst.mockResolvedValue(opts.userRow);
+  }
+  const updateBuilder = {
+    set: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    returning: jest.fn().mockReturnThis(),
+    executeTakeFirst: updateExecuteTakeFirst,
+  };
+  const updateTable = jest.fn().mockReturnValue(updateBuilder);
+
+  const kyselyPg = {
+    selectFrom,
+    updateTable,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test stub
+  } as unknown as Kysely<any>;
+
+  return { kyselyPg, selectFrom, updateTable, updateBuilder };
+}
+
+function makeUserRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'user-123',
+    email: 'test@example.com',
+    password: 'placeholder',
+    first_name: 'Test',
+    last_name: 'User',
+    role: 'ADMIN',
+    approved_by_admin: true,
+    rejected_by_admin: false,
+    login_methods: ['password'],
+    permissions: [],
+    created_at: new Date(),
+    updated_at: new Date(),
+    org_id: 'org-456',
+    ...overrides,
+  };
+}
+
+function makeDeps(kyselyPg: Kysely<unknown>) {
+  const getSamlSettings = jest.fn().mockResolvedValue(null);
+  const logActiveSpanFailedIfAny = jest.fn();
+  return {
+    deps: {
+      kyselyPg,
+      orgSettingsService: { getSamlSettings } as unknown as never,
+      tracer: { logActiveSpanFailedIfAny } as unknown as never,
+    },
+    getSamlSettings,
+    logActiveSpanFailedIfAny,
+  };
+}
+
+describe('verifyEmailPasswordCredentials', () => {
+  const password = 'correct horse battery staple';
+
+  it('rehashes and persists a legacy work-factor-5 hash on successful login', async () => {
+    const legacyBcryptHash = await bcrypt.hash(password, 5);
+    const userRow = makeUserRow({ password: legacyBcryptHash });
+    const { kyselyPg, updateTable, updateBuilder } = makeMockKyselyPg({
+      userRow,
+    });
+    const { deps } = makeDeps(kyselyPg);
+
+    const result = await verifyEmailPasswordCredentials(
+      deps,
+      'test@example.com',
+      password,
+    );
+
+    expect(result.id).toBe('user-123');
+    expect(updateTable).toHaveBeenCalledWith('public.users');
+    const [[persistedPatch]] = updateBuilder.set.mock.calls;
+    expect(persistedPatch.password).toMatch(/^\$2[aby]\$12\$/);
+    // Verified through `passwordMatchesHash` — the same path a real login
+    // takes — rather than reimplementing the comparison in the test.
+    await expect(
+      passwordMatchesHash(password, persistedPatch.password),
+    ).resolves.toBe(true);
+  });
+
+  it('does not rehash when the stored hash is already at the target work factor', async () => {
+    const currentHash = await hashPassword(password);
+    const userRow = makeUserRow({ password: currentHash });
+    const { kyselyPg, updateTable } = makeMockKyselyPg({ userRow });
+    const { deps } = makeDeps(kyselyPg);
+
+    await verifyEmailPasswordCredentials(deps, 'test@example.com', password);
+
+    expect(updateTable).not.toHaveBeenCalled();
+  });
+
+  it('rejects a wrong password and does not attempt a rehash write', async () => {
+    const legacyBcryptHash = await bcrypt.hash(password, 5);
+    const userRow = makeUserRow({ password: legacyBcryptHash });
+    const { kyselyPg, updateTable } = makeMockKyselyPg({ userRow });
+    const { deps } = makeDeps(kyselyPg);
+
+    await expect(
+      verifyEmailPasswordCredentials(deps, 'test@example.com', 'wrong'),
+    ).rejects.toThrow();
+
+    expect(updateTable).not.toHaveBeenCalled();
+  });
+
+  it('still succeeds the login when the rehash write fails (#778 regression guard)', async () => {
+    const legacyBcryptHash = await bcrypt.hash(password, 5);
+    const userRow = makeUserRow({ password: legacyBcryptHash });
+    const { kyselyPg } = makeMockKyselyPg({
+      userRow,
+      updateShouldThrow: true,
+    });
+    const { deps, logActiveSpanFailedIfAny } = makeDeps(kyselyPg);
+
+    // The login itself must succeed even though the opportunistic rehash
+    // write throws — the session must never be sacrificed for a background
+    // hash upgrade. This is exactly the failure mode the transactional
+    // session-purging update paths (`changePassword`, `resetPasswordForToken`,
+    // #778) would trigger if reused here.
+    const result = await verifyEmailPasswordCredentials(
+      deps,
+      'test@example.com',
+      password,
+    );
+
+    expect(result.id).toBe('user-123');
+    expect(logActiveSpanFailedIfAny).toHaveBeenCalled();
+  });
+});

--- a/server/graphql/datasources/userApiCredentials.test.ts
+++ b/server/graphql/datasources/userApiCredentials.test.ts
@@ -22,17 +22,18 @@ function makeMockKyselyPg(opts: {
   };
   const selectFrom = jest.fn().mockReturnValue(selectBuilder);
 
-  const updateExecuteTakeFirst = jest.fn();
+  const updateExecute = jest.fn();
   if (opts.updateShouldThrow) {
-    updateExecuteTakeFirst.mockRejectedValue(new Error('update failed'));
+    updateExecute.mockRejectedValue(new Error('update failed'));
   } else {
-    updateExecuteTakeFirst.mockResolvedValue(opts.userRow);
+    // Kysely's `execute()` on an update resolves to UpdateResult[]; the
+    // rehash path ignores it (zero matched rows = lost the CAS, no-op).
+    updateExecute.mockResolvedValue([]);
   }
   const updateBuilder = {
     set: jest.fn().mockReturnThis(),
     where: jest.fn().mockReturnThis(),
-    returning: jest.fn().mockReturnThis(),
-    executeTakeFirst: updateExecuteTakeFirst,
+    execute: updateExecute,
   };
   const updateTable = jest.fn().mockReturnValue(updateBuilder);
 
@@ -99,6 +100,16 @@ describe('verifyEmailPasswordCredentials', () => {
     expect(updateTable).toHaveBeenCalledWith('public.users');
     const [[persistedPatch]] = updateBuilder.set.mock.calls;
     expect(persistedPatch.password).toMatch(/^\$2[aby]\$12\$/);
+    // Compare-and-swap guard (PR #901 review): the write must be scoped to
+    // the exact hash that was just verified, not the user id alone, so a
+    // concurrent password change can never be clobbered by a rehash of the
+    // old plaintext.
+    expect(updateBuilder.where).toHaveBeenCalledWith('id', '=', 'user-123');
+    expect(updateBuilder.where).toHaveBeenCalledWith(
+      'password',
+      '=',
+      legacyBcryptHash,
+    );
     // Verified through `passwordMatchesHash` — the same path a real login
     // takes — rather than reimplementing the comparison in the test.
     await expect(

--- a/server/graphql/datasources/userApiCredentials.test.ts
+++ b/server/graphql/datasources/userApiCredentials.test.ts
@@ -102,7 +102,7 @@ describe('verifyEmailPasswordCredentials', () => {
     expect(persistedPatch.password).toMatch(
       /^\$argon2id\$v=19\$m=19456,t=2,p=1\$/,
     );
-    // Compare-and-swap guard (PR #901 review): the write must be scoped to
+    // Compare-and-swap guard: the write must be scoped to
     // the exact hash that was just verified, not the user id alone, so a
     // concurrent password change can never be clobbered by a rehash of the
     // old plaintext.
@@ -143,12 +143,16 @@ describe('verifyEmailPasswordCredentials', () => {
     expect(updateTable).not.toHaveBeenCalled();
   });
 
-  it('fails closed and logs when the stored hash cannot be evaluated', async () => {
+  it('surfaces a generic internal-server error and logs when the stored hash cannot be evaluated', async () => {
     // A corrupt row, or Argon2 failing operationally (the 19 MiB allocation
-    // can fail under memory pressure, taking down *every* login). Both throw
-    // out of `passwordMatchesHash`. The user-facing answer is still "wrong
-    // password" — but it must be logged, or a total verification outage is
-    // indistinguishable from a flood of users mistyping their passwords.
+    // can fail under memory pressure, taking down *every* login) makes
+    // `passwordMatchesHash` throw. That's not special-cased as "wrong
+    // password" — it propagates to the outer catch-all, which logs it and
+    // rethrows as a generic `InternalServerError`, so a verification outage
+    // stays distinguishable from a flood of users mistyping their passwords
+    // (which throws a distinctly-named `LoginIncorrectPasswordError` instead —
+    // pinned by name here so a reintroduced "treat as non-match" special case
+    // would fail this test instead of silently reverting).
     // A bad base64 salt is one of the shapes `argon2Verify` throws on rather
     // than resolving false — see the corrupt-input cases in `utils.test.ts`.
     const userRow = makeUserRow({
@@ -159,13 +163,13 @@ describe('verifyEmailPasswordCredentials', () => {
 
     await expect(
       verifyEmailPasswordCredentials(deps, 'test@example.com', password),
-    ).rejects.toThrow();
+    ).rejects.toMatchObject({ name: 'InternalServerError' });
 
     expect(logActiveSpanFailedIfAny).toHaveBeenCalled();
     expect(updateTable).not.toHaveBeenCalled();
   });
 
-  it('still succeeds the login when the rehash write fails (#778 regression guard)', async () => {
+  it('still succeeds the login when the rehash write throws', async () => {
     const legacyBcryptHash = await bcrypt.hash(password, 5);
     const userRow = makeUserRow({ password: legacyBcryptHash });
     const { kyselyPg } = makeMockKyselyPg({
@@ -174,11 +178,10 @@ describe('verifyEmailPasswordCredentials', () => {
     });
     const { deps, logActiveSpanFailedIfAny } = makeDeps(kyselyPg);
 
-    // The login itself must succeed even though the opportunistic rehash
-    // write throws — the session must never be sacrificed for a background
-    // hash upgrade. This is exactly the failure mode the transactional
-    // session-purging update paths (`changePassword`, `resetPasswordForToken`,
-    // #778) would trigger if reused here.
+    // `rehashPasswordOnLogin` swallows any error from the write — e.g. a
+    // transient DB failure — and logs it instead: the opportunistic hash
+    // upgrade must never cost the user a login that already verified
+    // correctly.
     const result = await verifyEmailPasswordCredentials(
       deps,
       'test@example.com',

--- a/server/graphql/datasources/userApiCredentials.test.ts
+++ b/server/graphql/datasources/userApiCredentials.test.ts
@@ -144,17 +144,12 @@ describe('verifyEmailPasswordCredentials', () => {
   });
 
   it('surfaces a generic internal-server error and logs when the stored hash cannot be evaluated', async () => {
-    // A corrupt row, or Argon2 failing operationally (the 19 MiB allocation
-    // can fail under memory pressure, taking down *every* login) makes
-    // `passwordMatchesHash` throw. That's not special-cased as "wrong
-    // password" — it propagates to the outer catch-all, which logs it and
-    // rethrows as a generic `InternalServerError`, so a verification outage
-    // stays distinguishable from a flood of users mistyping their passwords
-    // (which throws a distinctly-named `LoginIncorrectPasswordError` instead —
-    // pinned by name here so a reintroduced "treat as non-match" special case
-    // would fail this test instead of silently reverting).
-    // A bad base64 salt is one of the shapes `argon2Verify` throws on rather
-    // than resolving false — see the corrupt-input cases in `utils.test.ts`.
+    // A hash argon2 can't parse makes `passwordMatchesHash` throw. That's not
+    // special-cased as "wrong password" — it propagates to the outer
+    // catch-all, which logs it and rethrows as a generic `InternalServerError`.
+    // The error name is pinned so a reintroduced "treat as non-match" special
+    // case fails this test instead of silently reverting: a wrong password
+    // throws a distinctly-named `LoginIncorrectPasswordError`.
     const userRow = makeUserRow({
       password: '$argon2id$v=19$m=19456,t=2,p=1$!!!!$!!!!',
     });
@@ -169,7 +164,7 @@ describe('verifyEmailPasswordCredentials', () => {
     expect(updateTable).not.toHaveBeenCalled();
   });
 
-  it('still succeeds the login when the rehash write throws', async () => {
+  it('fails the login when the rehash write throws', async () => {
     const legacyBcryptHash = await bcrypt.hash(password, 5);
     const userRow = makeUserRow({ password: legacyBcryptHash });
     const { kyselyPg } = makeMockKyselyPg({
@@ -178,17 +173,13 @@ describe('verifyEmailPasswordCredentials', () => {
     });
     const { deps, logActiveSpanFailedIfAny } = makeDeps(kyselyPg);
 
-    // `rehashPasswordOnLogin` swallows any error from the write — e.g. a
-    // transient DB failure — and logs it instead: the opportunistic hash
-    // upgrade must never cost the user a login that already verified
-    // correctly.
-    const result = await verifyEmailPasswordCredentials(
-      deps,
-      'test@example.com',
-      password,
-    );
+    // A failing write means something is wrong with the database, and the
+    // login fails loudly rather than being quietly downgraded to a success
+    // with a stale hash. The user can retry if it was transient.
+    await expect(
+      verifyEmailPasswordCredentials(deps, 'test@example.com', password),
+    ).rejects.toMatchObject({ name: 'InternalServerError' });
 
-    expect(result.id).toBe('user-123');
     expect(logActiveSpanFailedIfAny).toHaveBeenCalled();
   });
 });

--- a/server/graphql/datasources/userApiCredentials.ts
+++ b/server/graphql/datasources/userApiCredentials.ts
@@ -16,9 +16,13 @@ import {
 } from './userKyselyPersistence.js';
 
 /**
- * Best-effort upgrade of a legacy-cost bcrypt hash to the current work
- * factor, run after a password has already been verified correct. Must
- * never fail the login it's piggybacking on: any error here is logged and
+ * Best-effort upgrade of a stale password hash — a legacy bcrypt one, or an
+ * Argon2id one minted at weaker parameters — to a fresh Argon2id hash at
+ * today's parameters. Runs only after the password has already been verified
+ * correct, because re-hashing requires the plaintext: it cannot be done as a
+ * migration, only opportunistically at the one moment we hold the password.
+ *
+ * Must never fail the login it's piggybacking on: any error here is logged and
  * swallowed, and the row is picked up again on the user's next login.
  *
  * Deliberately a plain column write, NOT the transactional path
@@ -106,10 +110,25 @@ export async function verifyEmailPasswordCredentials(
 
     // `loginMethods` includes 'password', so the DB CHECK constraint
     // guarantees `user.password` is non-null here.
-    if (
-      user.password == null ||
-      !(await passwordMatchesHash(password, user.password))
-    ) {
+    //
+    // `passwordMatchesHash` throws if the stored hash can't be evaluated at
+    // all — a corrupt row, or Argon2 failing operationally. Log that and treat
+    // it as a non-match: an unevaluable hash authenticates nobody, and the
+    // user-facing truth is still "this password does not match". The log is
+    // what keeps a total verification outage distinguishable from a flood of
+    // users mistyping their passwords, since both look identical from outside.
+    if (user.password == null) {
+      throw makeLoginIncorrectPasswordError({ shouldErrorSpan: true });
+    }
+
+    let passwordMatches = false;
+    try {
+      passwordMatches = await passwordMatchesHash(password, user.password);
+    } catch (e) {
+      deps.tracer.logActiveSpanFailedIfAny(e);
+    }
+
+    if (!passwordMatches) {
       throw makeLoginIncorrectPasswordError({ shouldErrorSpan: true });
     }
 

--- a/server/graphql/datasources/userApiCredentials.ts
+++ b/server/graphql/datasources/userApiCredentials.ts
@@ -16,8 +16,7 @@ import {
 } from './userKyselyPersistence.js';
 
 /**
- * Best-effort upgrade of a stale password hash — a legacy bcrypt one, or an
- * Argon2id one minted at weaker parameters — to a fresh Argon2id hash at
+ * Best-effort upgrade of a stale password hash to a fresh Argon2id hash at
  * today's parameters. Runs only after the password has already been verified
  * correct, because re-hashing requires the plaintext: it cannot be done as a
  * migration, only opportunistically at the one moment we hold the password.
@@ -25,19 +24,11 @@ import {
  * Must never fail the login it's piggybacking on: any error here is logged and
  * swallowed, and the row is picked up again on the user's next login.
  *
- * Deliberately a plain column write, NOT the transactional path
- * `UserApi.changePassword` / `resetPasswordForToken` use — those also
- * purge the user's other sessions as part of an explicit password *change*.
- * Reusing that path here would silently log out every user the first time
- * their legacy hash gets upgraded, even though their password never changed
- * (see #778, which added that session purge).
- *
  * The write is a compare-and-swap on `verifiedHash` (the exact stored hash
  * the plaintext was just checked against) rather than an unconditional
  * update by id: if a concurrent password change lands between verification
  * and this write, zero rows match and the stale rehash is dropped instead
- * of clobbering the newer hash — an id-only write here could resurrect an
- * old password that a concurrent change had just replaced.
+ * of clobbering the newer hash.
  */
 async function rehashPasswordOnLogin(
   deps: {
@@ -57,6 +48,12 @@ async function rehashPasswordOnLogin(
       .where('password', '=', verifiedHash)
       .execute();
   } catch (e) {
+    // Expected failures here are transient and infra-level: the UPDATE
+    // hitting a connection-pool limit, a timeout, or a deadlock, or
+    // `hashPassword` failing under memory pressure. None of those are a
+    // reason to fail a login that already verified correctly — this rehash
+    // is an opportunistic upgrade, not a security requirement of this login
+    // — so it's logged for visibility and the row is retried next login.
     deps.tracer.logActiveSpanFailedIfAny(e);
   }
 }
@@ -110,24 +107,11 @@ export async function verifyEmailPasswordCredentials(
 
     // `loginMethods` includes 'password', so the DB CHECK constraint
     // guarantees `user.password` is non-null here.
-    //
-    // `passwordMatchesHash` throws if the stored hash can't be evaluated at
-    // all — a corrupt row, or Argon2 failing operationally. Log that and treat
-    // it as a non-match: an unevaluable hash authenticates nobody, and the
-    // user-facing truth is still "this password does not match". The log is
-    // what keeps a total verification outage distinguishable from a flood of
-    // users mistyping their passwords, since both look identical from outside.
     if (user.password == null) {
       throw makeLoginIncorrectPasswordError({ shouldErrorSpan: true });
     }
 
-    let passwordMatches = false;
-    try {
-      passwordMatches = await passwordMatchesHash(password, user.password);
-    } catch (e) {
-      deps.tracer.logActiveSpanFailedIfAny(e);
-    }
-
+    const passwordMatches = await passwordMatchesHash(password, user.password);
     if (!passwordMatches) {
       throw makeLoginIncorrectPasswordError({ shouldErrorSpan: true });
     }

--- a/server/graphql/datasources/userApiCredentials.ts
+++ b/server/graphql/datasources/userApiCredentials.ts
@@ -12,7 +12,6 @@ import {
 } from './userApiErrors.js';
 import {
   kyselyUserFindByEmail,
-  kyselyUserUpdate,
   type GraphQLUserParent,
 } from './userKyselyPersistence.js';
 
@@ -22,24 +21,37 @@ import {
  * never fail the login it's piggybacking on: any error here is logged and
  * swallowed, and the row is picked up again on the user's next login.
  *
- * Deliberately a plain `kyselyUserUpdate` column write, NOT the transactional
- * path `UserApi.changePassword` / `resetPasswordForToken` use — those also
+ * Deliberately a plain column write, NOT the transactional path
+ * `UserApi.changePassword` / `resetPasswordForToken` use — those also
  * purge the user's other sessions as part of an explicit password *change*.
  * Reusing that path here would silently log out every user the first time
  * their legacy hash gets upgraded, even though their password never changed
  * (see #778, which added that session purge).
+ *
+ * The write is a compare-and-swap on `verifiedHash` (the exact stored hash
+ * the plaintext was just checked against) rather than an unconditional
+ * update by id: if a concurrent password change lands between verification
+ * and this write, zero rows match and the stale rehash is dropped instead
+ * of clobbering the newer hash — an id-only write here could resurrect an
+ * old password that a concurrent change had just replaced.
  */
 async function rehashPasswordOnLogin(
   deps: {
     kyselyPg: Dependencies['KyselyPg'];
     tracer: Dependencies['Tracer'];
   },
-  user: GraphQLUserParent,
+  userId: string,
+  verifiedHash: string,
   plaintextPassword: string,
 ): Promise<void> {
   try {
     const rehashed = await hashPassword(plaintextPassword);
-    await kyselyUserUpdate(deps.kyselyPg, user.id, { password: rehashed });
+    await deps.kyselyPg
+      .updateTable('public.users')
+      .set({ password: rehashed, updated_at: new Date() })
+      .where('id', '=', userId)
+      .where('password', '=', verifiedHash)
+      .execute();
   } catch (e) {
     deps.tracer.logActiveSpanFailedIfAny(e);
   }
@@ -102,7 +114,7 @@ export async function verifyEmailPasswordCredentials(
     }
 
     if (passwordNeedsRehash(user.password)) {
-      await rehashPasswordOnLogin(deps, user, password);
+      await rehashPasswordOnLogin(deps, user.id, user.password, password);
     }
 
     return user;

--- a/server/graphql/datasources/userApiCredentials.ts
+++ b/server/graphql/datasources/userApiCredentials.ts
@@ -1,5 +1,9 @@
 import { type Dependencies } from '../../iocContainer/index.js';
-import { passwordMatchesHash } from '../../services/userManagementService/index.js';
+import {
+  hashPassword,
+  passwordMatchesHash,
+  passwordNeedsRehash,
+} from '../../services/userManagementService/index.js';
 import { CoopError, makeInternalServerError } from '../../utils/errors.js';
 import {
   makeLoginIncorrectPasswordError,
@@ -8,8 +12,38 @@ import {
 } from './userApiErrors.js';
 import {
   kyselyUserFindByEmail,
+  kyselyUserUpdate,
   type GraphQLUserParent,
 } from './userKyselyPersistence.js';
+
+/**
+ * Best-effort upgrade of a legacy-cost bcrypt hash to the current work
+ * factor, run after a password has already been verified correct. Must
+ * never fail the login it's piggybacking on: any error here is logged and
+ * swallowed, and the row is picked up again on the user's next login.
+ *
+ * Deliberately a plain `kyselyUserUpdate` column write, NOT the transactional
+ * path `UserApi.changePassword` / `resetPasswordForToken` use — those also
+ * purge the user's other sessions as part of an explicit password *change*.
+ * Reusing that path here would silently log out every user the first time
+ * their legacy hash gets upgraded, even though their password never changed
+ * (see #778, which added that session purge).
+ */
+async function rehashPasswordOnLogin(
+  deps: {
+    kyselyPg: Dependencies['KyselyPg'];
+    tracer: Dependencies['Tracer'];
+  },
+  user: GraphQLUserParent,
+  plaintextPassword: string,
+): Promise<void> {
+  try {
+    const rehashed = await hashPassword(plaintextPassword);
+    await kyselyUserUpdate(deps.kyselyPg, user.id, { password: rehashed });
+  } catch (e) {
+    deps.tracer.logActiveSpanFailedIfAny(e);
+  }
+}
 
 /**
  * Look up a user by email and verify their password, applying the same
@@ -65,6 +99,10 @@ export async function verifyEmailPasswordCredentials(
       !(await passwordMatchesHash(password, user.password))
     ) {
       throw makeLoginIncorrectPasswordError({ shouldErrorSpan: true });
+    }
+
+    if (passwordNeedsRehash(user.password)) {
+      await rehashPasswordOnLogin(deps, user, password);
     }
 
     return user;

--- a/server/graphql/datasources/userApiCredentials.ts
+++ b/server/graphql/datasources/userApiCredentials.ts
@@ -16,13 +16,15 @@ import {
 } from './userKyselyPersistence.js';
 
 /**
- * Best-effort upgrade of a stale password hash to a fresh Argon2id hash at
- * today's parameters. Runs only after the password has already been verified
- * correct, because re-hashing requires the plaintext: it cannot be done as a
- * migration, only opportunistically at the one moment we hold the password.
+ * Upgrade of a stale password hash to a fresh Argon2id hash at today's
+ * parameters. Runs only after the password has already been verified correct,
+ * because re-hashing requires the plaintext: it cannot be done as a migration,
+ * only opportunistically at the one moment we hold the password.
  *
- * Must never fail the login it's piggybacking on: any error here is logged and
- * swallowed, and the row is picked up again on the user's next login.
+ * Errors are deliberately not caught. Hashing or writing failing here means
+ * something is wrong with the process or the database, and a login is not the
+ * place to paper over that — it propagates to `verifyEmailPasswordCredentials`,
+ * which logs it and fails the login. The user can retry if it was transient.
  *
  * The write is a compare-and-swap on `verifiedHash` (the exact stored hash
  * the plaintext was just checked against) rather than an unconditional
@@ -33,29 +35,18 @@ import {
 async function rehashPasswordOnLogin(
   deps: {
     kyselyPg: Dependencies['KyselyPg'];
-    tracer: Dependencies['Tracer'];
   },
   userId: string,
   verifiedHash: string,
   plaintextPassword: string,
 ): Promise<void> {
-  try {
-    const rehashed = await hashPassword(plaintextPassword);
-    await deps.kyselyPg
-      .updateTable('public.users')
-      .set({ password: rehashed, updated_at: new Date() })
-      .where('id', '=', userId)
-      .where('password', '=', verifiedHash)
-      .execute();
-  } catch (e) {
-    // Expected failures here are transient and infra-level: the UPDATE
-    // hitting a connection-pool limit, a timeout, or a deadlock, or
-    // `hashPassword` failing under memory pressure. None of those are a
-    // reason to fail a login that already verified correctly — this rehash
-    // is an opportunistic upgrade, not a security requirement of this login
-    // — so it's logged for visibility and the row is retried next login.
-    deps.tracer.logActiveSpanFailedIfAny(e);
-  }
+  const rehashed = await hashPassword(plaintextPassword);
+  await deps.kyselyPg
+    .updateTable('public.users')
+    .set({ password: rehashed, updated_at: new Date() })
+    .where('id', '=', userId)
+    .where('password', '=', verifiedHash)
+    .execute();
 }
 
 /**

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -20,6 +20,7 @@
         "@graphql-tools/merge": "^8.2.10",
         "@graphql-tools/schema": "^8.5.1",
         "@graphql-tools/utils": "^9.2.1",
+        "@node-rs/argon2": "^2.0.2",
         "@node-saml/passport-saml": "^5.1.0",
         "@opentelemetry/api": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
@@ -2462,6 +2463,250 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@node-rs/argon2": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2/-/argon2-2.1.0.tgz",
+      "integrity": "sha512-VBOWfM2u58/to3DFqTGJ2U5cJKQwmjN2zxzsQNZ5a2o8Z6aUrhvqQh8NdgotIF1Y0tMsBNtzOBDBdfvvkwJDSQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@node-rs/argon2-android-arm-eabi": "2.1.0",
+        "@node-rs/argon2-android-arm64": "2.1.0",
+        "@node-rs/argon2-darwin-arm64": "2.1.0",
+        "@node-rs/argon2-darwin-x64": "2.1.0",
+        "@node-rs/argon2-freebsd-x64": "2.1.0",
+        "@node-rs/argon2-linux-arm-gnueabihf": "2.1.0",
+        "@node-rs/argon2-linux-arm64-gnu": "2.1.0",
+        "@node-rs/argon2-linux-arm64-musl": "2.1.0",
+        "@node-rs/argon2-linux-x64-gnu": "2.1.0",
+        "@node-rs/argon2-linux-x64-musl": "2.1.0",
+        "@node-rs/argon2-win32-arm64-msvc": "2.1.0",
+        "@node-rs/argon2-win32-ia32-msvc": "2.1.0",
+        "@node-rs/argon2-win32-x64-msvc": "2.1.0"
+      }
+    },
+    "node_modules/@node-rs/argon2-android-arm-eabi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-android-arm-eabi/-/argon2-android-arm-eabi-2.1.0.tgz",
+      "integrity": "sha512-hdWo5kb4eFRbHjdu4O6dVlRPI/CR1vbkJpe3Z9kF2s0Kp42428wg8AxI+8Cv4mygdW309BpUBf3sZaqXBNpdpw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-android-arm64": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-android-arm64/-/argon2-android-arm64-2.1.0.tgz",
+      "integrity": "sha512-MHby1n9UzlVma3GiEYWNNqRhn2Z/90QwF2PFckGwucdz0HfdVX+lSKEcyfwcbvS5sJ9GAzhop3hXlUPxUYe72Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-darwin-arm64": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-darwin-arm64/-/argon2-darwin-arm64-2.1.0.tgz",
+      "integrity": "sha512-5nayvL9wepOvTO5JmdaiDZ6bgHEsI/vksnXphM3UTy/cflARr9MoD1pBrMPs921hx2otURJhG0avg9hN0Q0KPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-darwin-x64": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-darwin-x64/-/argon2-darwin-x64-2.1.0.tgz",
+      "integrity": "sha512-7bFf3qH/PLQ5kU5GkxMF+dMz/tiT+0yFXILpOx4fgSFjw3wdXpGZt3wH4i6dHMURDcwYlNap0hJaX4h2E3JGng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-freebsd-x64": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-freebsd-x64/-/argon2-freebsd-x64-2.1.0.tgz",
+      "integrity": "sha512-01mVdl+7bjSW0to5xcEzueq7BuYbz3476/dmLMXziJf8fhykzr723YRNcGjOcHSU5fxNrElY9uVeUoow16vBrQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-linux-arm-gnueabihf": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-linux-arm-gnueabihf/-/argon2-linux-arm-gnueabihf-2.1.0.tgz",
+      "integrity": "sha512-NxZILF+Hqav6yzJTUFuZXTUC1VagTO4Vfd2HSlzkwankUa1B7goo0NLY2tUPw6MdqtLojkqVG5MZ26AaF49tHw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-linux-arm64-gnu": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-linux-arm64-gnu/-/argon2-linux-arm64-gnu-2.1.0.tgz",
+      "integrity": "sha512-jpx2VwJLyAF/cM64HRigFBk67GwtQBcssYyVhvHqfmCEZz/CP//SV9bxE+uJOGIPKJo7wDg/5f2k3JY0PNMROg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-linux-arm64-musl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-linux-arm64-musl/-/argon2-linux-arm64-musl-2.1.0.tgz",
+      "integrity": "sha512-xXAaPUlnPx/44qwaSekTG/g6/h5QCyrTayPLmvewJNyYz17vyBRmFKWLgv9Q3+NJwSvV88nVnCu/xkQbEPQaog==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-linux-x64-gnu": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-linux-x64-gnu/-/argon2-linux-x64-gnu-2.1.0.tgz",
+      "integrity": "sha512-ICnfyFaxZzr8OdAEwTPsAjx6gpNla1sI3miZJWAVCtZlw98Wo3Wd4H7tvW6S2NRJ1BIOf4l8Z7aX7h3fimXn5w==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-linux-x64-musl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-linux-x64-musl/-/argon2-linux-x64-musl-2.1.0.tgz",
+      "integrity": "sha512-f56jehb/IPTGBWWrvMjDGZWlQm/hKkH2VK/MxJ9u3kUR9PCacdtLFZmX4sL+qKeo4wsyhlD1EvlZF6nV1FSi3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-win32-arm64-msvc": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-win32-arm64-msvc/-/argon2-win32-arm64-msvc-2.1.0.tgz",
+      "integrity": "sha512-KH8lBdjoZLUiVG1GjJQIQPKhmddJmEbJbL+e3S7BKVq1wKl1mx+ClmhGtMtYp8ZtEIw8/BYIFUIjL3sBuWGEuQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-win32-ia32-msvc": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-win32-ia32-msvc/-/argon2-win32-ia32-msvc-2.1.0.tgz",
+      "integrity": "sha512-zZ7NDHoKTgrjoUehNN7xvP+dA/M9krOp42l0MKns6TnMkwrp5nes9agEZsUy+0t0JoR8OQ8D7EUCNLh5BEn++w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-win32-x64-msvc": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-win32-x64-msvc/-/argon2-win32-x64-msvc-2.1.0.tgz",
+      "integrity": "sha512-JN/yNiX7u8Cw9XXTbRrjnlgzFjCiEQe6x97wJnMIsJ3vty89q0SAg504Otd9qy2ofQS2F5CCWvrOXhm/oyHaAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@node-saml/node-saml": {

--- a/server/package.json
+++ b/server/package.json
@@ -39,6 +39,7 @@
     "@graphql-tools/merge": "^8.2.10",
     "@graphql-tools/schema": "^8.5.1",
     "@graphql-tools/utils": "^9.2.1",
+    "@node-rs/argon2": "^2.0.2",
     "@node-saml/passport-saml": "^5.1.0",
     "@opentelemetry/api": "^1.8.0",
     "@opentelemetry/semantic-conventions": "^1.22.0",

--- a/server/services/userManagementService/index.ts
+++ b/server/services/userManagementService/index.ts
@@ -3,7 +3,11 @@ export {
   default as makeUserManagementService,
   type UserManagementService,
 } from './userManagementService.js';
-export { hashPassword, passwordMatchesHash } from './utils.js';
+export {
+  hashPassword,
+  passwordMatchesHash,
+  passwordNeedsRehash,
+} from './utils.js';
 export { deleteSessionsForUser } from './sessionPersistence.js';
 export {
   Invoker,

--- a/server/services/userManagementService/utils.test.ts
+++ b/server/services/userManagementService/utils.test.ts
@@ -1,57 +1,107 @@
+import bcrypt from 'bcryptjs';
+
 import {
   hashPassword,
   passwordMatchesHash,
   passwordNeedsRehash,
 } from './utils.js';
 
+// Hash of 'legacy-password' minted at bcrypt cost 5 — a genuine sample of what
+// production rows look like before the Argon2id migration.
+const LEGACY_BCRYPT_HASH =
+  '$2a$05$3X5WTL5K1.OfLy6mNBFxt.r6gyBSM25Ph609E.YYSKp9DltrxzJ32';
+
+const PASSWORD = 'correct horse battery staple';
+
 describe('hashPassword', () => {
-  it('produces a bcrypt hash with work factor 12', async () => {
-    const hash = await hashPassword('correct horse battery staple');
-    expect(hash).toMatch(/^\$2[aby]\$12\$/);
+  it('produces an Argon2id hash at the OWASP-recommended parameters', async () => {
+    const hash = await hashPassword(PASSWORD);
+    expect(hash).toMatch(/^\$argon2id\$v=19\$m=19456,t=2,p=1\$/);
   });
 
   it('round-trips with passwordMatchesHash and rejects a wrong password', async () => {
-    const hash = await hashPassword('correct horse battery staple');
-    await expect(
-      passwordMatchesHash('correct horse battery staple', hash),
-    ).resolves.toBe(true);
+    const hash = await hashPassword(PASSWORD);
+    await expect(passwordMatchesHash(PASSWORD, hash)).resolves.toBe(true);
     await expect(passwordMatchesHash('tr0ub4dor&3', hash)).resolves.toBe(false);
   });
 
-  it('still verifies legacy work-factor-5 hashes', async () => {
-    // Hash of 'legacy-password' minted at the previous factor; guards the
-    // upgrade path — existing rows must keep working until rehash-on-login.
-    const legacyHash =
-      '$2a$05$3X5WTL5K1.OfLy6mNBFxt.r6gyBSM25Ph609E.YYSKp9DltrxzJ32';
+  it('salts each hash, so the same password never hashes identically twice', async () => {
+    await expect(hashPassword(PASSWORD)).resolves.not.toBe(
+      await hashPassword(PASSWORD),
+    );
+  });
+});
+
+describe('passwordMatchesHash', () => {
+  it('still verifies legacy bcrypt hashes', async () => {
+    // The bcrypt branch can never be retired: an account that never logs in
+    // again is never re-hashed, so its bcrypt hash lives forever.
     await expect(
-      passwordMatchesHash('legacy-password', legacyHash),
+      passwordMatchesHash('legacy-password', LEGACY_BCRYPT_HASH),
     ).resolves.toBe(true);
     await expect(
-      passwordMatchesHash('wrong-password', legacyHash),
+      passwordMatchesHash('wrong-password', LEGACY_BCRYPT_HASH),
+    ).resolves.toBe(false);
+  });
+
+  it('propagates the error when argon2 cannot evaluate the stored hash', async () => {
+    // Corrupt input is not handled uniformly by the library: a bad base64 salt
+    // throws, while a truncated digest quietly resolves `false`. Both shapes
+    // exist, so both are pinned here.
+    //
+    // The throw is deliberately not swallowed: this module has no tracer, and
+    // a silent `false` would make an operational Argon2 failure (the 19 MiB
+    // allocation failing under memory pressure takes down *every* login) look
+    // identical to one user mistyping their password. The login path catches
+    // it, logs it, and fails closed — see `userApiCredentials.test.ts`.
+    await expect(
+      passwordMatchesHash(PASSWORD, '$argon2id$v=19$m=19456,t=2,p=1$!!!!$!!!!'),
+    ).rejects.toThrow();
+
+    await expect(
+      passwordMatchesHash(PASSWORD, '$argon2id$v=19$corrupt'),
     ).resolves.toBe(false);
   });
 });
 
 describe('passwordNeedsRehash', () => {
-  it('flags a legacy work-factor-5 hash', () => {
-    const legacyHash =
-      '$2a$05$3X5WTL5K1.OfLy6mNBFxt.r6gyBSM25Ph609E.YYSKp9DltrxzJ32';
-    expect(passwordNeedsRehash(legacyHash)).toBe(true);
+  it('flags any bcrypt hash, regardless of cost factor', async () => {
+    // Cost is no longer the question — bcrypt itself is. Both a weak legacy
+    // hash and one at a strong cost factor are upgraded to Argon2id on login.
+    expect(passwordNeedsRehash(LEGACY_BCRYPT_HASH)).toBe(true);
+    expect(passwordNeedsRehash(await bcrypt.hash(PASSWORD, 12))).toBe(true);
   });
 
-  it('does not flag a hash already at the target work factor', async () => {
-    const hash = await hashPassword('correct horse battery staple');
-    expect(passwordNeedsRehash(hash)).toBe(false);
+  it('does not flag a hash already at the target parameters', async () => {
+    expect(passwordNeedsRehash(await hashPassword(PASSWORD))).toBe(false);
   });
 
-  it('does not flag a hash above the target work factor', () => {
-    // $2b$14$... — a higher cost than today's target of 12.
-    const strongerHash =
-      '$2b$14$3X5WTL5K1.OfLy6mNBFxt.r6gyBSM25Ph609E.YYSKp9DltrxzJ32';
-    expect(passwordNeedsRehash(strongerHash)).toBe(false);
+  it('flags an Argon2id hash whose parameters differ from the target', () => {
+    // Any deviation counts, not just a weaker one — hashes must converge on a
+    // single configuration rather than leaving a tail of odd ones behind.
+    const differing = [
+      '$argon2id$v=19$m=9216,t=2,p=1$c2FsdHNhbHQ$aGFzaA', // weaker memory
+      '$argon2id$v=19$m=19456,t=1,p=1$c2FsdHNhbHQ$aGFzaA', // weaker iterations
+      '$argon2id$v=19$m=65536,t=4,p=1$c2FsdHNhbHQ$aGFzaA', // stronger
+      '$argon2id$v=19$m=19456,t=2,p=4$c2FsdHNhbHQ$aGFzaA', // parallelism drift
+      '$argon2id$v=16$m=19456,t=2,p=1$c2FsdHNhbHQ$aGFzaA', // older argon2 version
+    ];
+    for (const hash of differing) {
+      expect(passwordNeedsRehash(hash)).toBe(true);
+    }
   });
 
-  it('does not flag an unparseable/non-bcrypt string', () => {
-    expect(passwordNeedsRehash('not-a-bcrypt-hash')).toBe(false);
+  it('flags a non-Argon2id variant of argon2', () => {
+    // argon2i and argon2d are weaker choices for password storage than
+    // argon2id; accepting them as current would strand a user on one.
+    expect(
+      passwordNeedsRehash('$argon2i$v=19$m=19456,t=2,p=1$c2FsdHNhbHQ$aGFzaA'),
+    ).toBe(true);
+  });
+
+  it('flags an unparseable hash', () => {
+    // Unreachable in practice — this is only called after a successful verify
+    // — but re-hashing is the safe direction for anything we can't read.
+    expect(passwordNeedsRehash('not-a-hash')).toBe(true);
   });
 });

--- a/server/services/userManagementService/utils.test.ts
+++ b/server/services/userManagementService/utils.test.ts
@@ -1,5 +1,3 @@
-import bcrypt from 'bcryptjs';
-
 import {
   hashPassword,
   passwordMatchesHash,
@@ -10,6 +8,13 @@ import {
 // production rows look like before the Argon2id migration.
 const LEGACY_BCRYPT_HASH =
   '$2a$05$3X5WTL5K1.OfLy6mNBFxt.r6gyBSM25Ph609E.YYSKp9DltrxzJ32';
+
+// Just needs to look like a cost-12 bcrypt hash, not be a genuine one:
+// `passwordNeedsRehash` never parses the cost out of a bcrypt string (see
+// below), so there's no reason to pay for an actual cost-12 bcryptjs hash —
+// pure-JS, so noticeably slow — just to prove "regardless of cost factor".
+const STRONG_BCRYPT_HASH_SHAPE =
+  '$2a$12$3X5WTL5K1.OfLy6mNBFxt.r6gyBSM25Ph609E.YYSKp9DltrxzJ32';
 
 const PASSWORD = 'correct horse battery staple';
 
@@ -45,15 +50,18 @@ describe('passwordMatchesHash', () => {
   });
 
   it('propagates the error when argon2 cannot evaluate the stored hash', async () => {
-    // Corrupt input is not handled uniformly by the library: a bad base64 salt
-    // throws, while a truncated digest quietly resolves `false`. Both shapes
-    // exist, so both are pinned here.
+    // `argon2Verify` isn't uniform on corrupt input: a bad base64 salt throws,
+    // while a truncated digest quietly resolves `false`. Our code doesn't
+    // choose either behavior — `passwordMatchesHash` calls straight through
+    // to the library — so both shapes are pinned here to catch a future
+    // `@node-rs/argon2` upgrade silently changing which one happens.
     //
     // The throw is deliberately not swallowed: this module has no tracer, and
     // a silent `false` would make an operational Argon2 failure (the 19 MiB
     // allocation failing under memory pressure takes down *every* login) look
-    // identical to one user mistyping their password. The login path catches
-    // it, logs it, and fails closed — see `userApiCredentials.test.ts`.
+    // identical to one user mistyping their password. The login path lets it
+    // propagate to its outer catch-all, which logs it and surfaces a generic
+    // error — see `userApiCredentials.test.ts`.
     await expect(
       passwordMatchesHash(PASSWORD, '$argon2id$v=19$m=19456,t=2,p=1$!!!!$!!!!'),
     ).rejects.toThrow();
@@ -65,11 +73,11 @@ describe('passwordMatchesHash', () => {
 });
 
 describe('passwordNeedsRehash', () => {
-  it('flags any bcrypt hash, regardless of cost factor', async () => {
+  it('flags any bcrypt hash, regardless of cost factor', () => {
     // Cost is no longer the question — bcrypt itself is. Both a weak legacy
     // hash and one at a strong cost factor are upgraded to Argon2id on login.
     expect(passwordNeedsRehash(LEGACY_BCRYPT_HASH)).toBe(true);
-    expect(passwordNeedsRehash(await bcrypt.hash(PASSWORD, 12))).toBe(true);
+    expect(passwordNeedsRehash(STRONG_BCRYPT_HASH_SHAPE)).toBe(true);
   });
 
   it('does not flag a hash already at the target parameters', async () => {

--- a/server/services/userManagementService/utils.test.ts
+++ b/server/services/userManagementService/utils.test.ts
@@ -1,0 +1,57 @@
+import {
+  hashPassword,
+  passwordMatchesHash,
+  passwordNeedsRehash,
+} from './utils.js';
+
+describe('hashPassword', () => {
+  it('produces a bcrypt hash with work factor 12', async () => {
+    const hash = await hashPassword('correct horse battery staple');
+    expect(hash).toMatch(/^\$2[aby]\$12\$/);
+  });
+
+  it('round-trips with passwordMatchesHash and rejects a wrong password', async () => {
+    const hash = await hashPassword('correct horse battery staple');
+    await expect(
+      passwordMatchesHash('correct horse battery staple', hash),
+    ).resolves.toBe(true);
+    await expect(passwordMatchesHash('tr0ub4dor&3', hash)).resolves.toBe(false);
+  });
+
+  it('still verifies legacy work-factor-5 hashes', async () => {
+    // Hash of 'legacy-password' minted at the previous factor; guards the
+    // upgrade path — existing rows must keep working until rehash-on-login.
+    const legacyHash =
+      '$2a$05$3X5WTL5K1.OfLy6mNBFxt.r6gyBSM25Ph609E.YYSKp9DltrxzJ32';
+    await expect(
+      passwordMatchesHash('legacy-password', legacyHash),
+    ).resolves.toBe(true);
+    await expect(
+      passwordMatchesHash('wrong-password', legacyHash),
+    ).resolves.toBe(false);
+  });
+});
+
+describe('passwordNeedsRehash', () => {
+  it('flags a legacy work-factor-5 hash', () => {
+    const legacyHash =
+      '$2a$05$3X5WTL5K1.OfLy6mNBFxt.r6gyBSM25Ph609E.YYSKp9DltrxzJ32';
+    expect(passwordNeedsRehash(legacyHash)).toBe(true);
+  });
+
+  it('does not flag a hash already at the target work factor', async () => {
+    const hash = await hashPassword('correct horse battery staple');
+    expect(passwordNeedsRehash(hash)).toBe(false);
+  });
+
+  it('does not flag a hash above the target work factor', () => {
+    // $2b$14$... — a higher cost than today's target of 12.
+    const strongerHash =
+      '$2b$14$3X5WTL5K1.OfLy6mNBFxt.r6gyBSM25Ph609E.YYSKp9DltrxzJ32';
+    expect(passwordNeedsRehash(strongerHash)).toBe(false);
+  });
+
+  it('does not flag an unparseable/non-bcrypt string', () => {
+    expect(passwordNeedsRehash('not-a-bcrypt-hash')).toBe(false);
+  });
+});

--- a/server/services/userManagementService/utils.test.ts
+++ b/server/services/userManagementService/utils.test.ts
@@ -48,28 +48,6 @@ describe('passwordMatchesHash', () => {
       passwordMatchesHash('wrong-password', LEGACY_BCRYPT_HASH),
     ).resolves.toBe(false);
   });
-
-  it('propagates the error when argon2 cannot evaluate the stored hash', async () => {
-    // `argon2Verify` isn't uniform on corrupt input: a bad base64 salt throws,
-    // while a truncated digest quietly resolves `false`. Our code doesn't
-    // choose either behavior — `passwordMatchesHash` calls straight through
-    // to the library — so both shapes are pinned here to catch a future
-    // `@node-rs/argon2` upgrade silently changing which one happens.
-    //
-    // The throw is deliberately not swallowed: this module has no tracer, and
-    // a silent `false` would make an operational Argon2 failure (the 19 MiB
-    // allocation failing under memory pressure takes down *every* login) look
-    // identical to one user mistyping their password. The login path lets it
-    // propagate to its outer catch-all, which logs it and surfaces a generic
-    // error — see `userApiCredentials.test.ts`.
-    await expect(
-      passwordMatchesHash(PASSWORD, '$argon2id$v=19$m=19456,t=2,p=1$!!!!$!!!!'),
-    ).rejects.toThrow();
-
-    await expect(
-      passwordMatchesHash(PASSWORD, '$argon2id$v=19$corrupt'),
-    ).resolves.toBe(false);
-  });
 });
 
 describe('passwordNeedsRehash', () => {

--- a/server/services/userManagementService/utils.ts
+++ b/server/services/userManagementService/utils.ts
@@ -1,8 +1,14 @@
 import { promisify } from 'util';
 import bcrypt from 'bcryptjs';
 
+// Work factor 12 per OWASP minimum-10 guidance. Hashes created at the old
+// factor (5) remain verifiable — bcrypt embeds the factor in the hash — and
+// are upgraded opportunistically by `passwordNeedsRehash` + the
+// rehash-on-login hook in `userApiCredentials.ts`.
+const TARGET_BCRYPT_COST = 12;
+
 export async function hashPassword(rawPassword: string) {
-  return bcrypt.hash(rawPassword, 5);
+  return bcrypt.hash(rawPassword, TARGET_BCRYPT_COST);
 }
 
 // Matches the bcrypt.compare semantics used by the now-removed Sequelize
@@ -15,4 +21,14 @@ export async function passwordMatchesHash(
   hash: string,
 ): Promise<boolean> {
   return bcryptCompare(givenPassword, hash);
+}
+
+// bcrypt hashes embed their cost factor (`$2a$<cost>$...`); a hash minted at
+// a lower cost than today's target still verifies correctly (bcrypt reads
+// the embedded factor, not a global one) but is weaker than we'd hash a new
+// password at. `bcrypt.getRounds` on a non-bcrypt string returns `NaN`, and
+// `NaN < TARGET_BCRYPT_COST` is always `false` — so unparseable hashes
+// safely fall out as "no rehash" without a separate check.
+export function passwordNeedsRehash(hash: string): boolean {
+  return bcrypt.getRounds(hash) < TARGET_BCRYPT_COST;
 }

--- a/server/services/userManagementService/utils.ts
+++ b/server/services/userManagementService/utils.ts
@@ -1,34 +1,83 @@
 import { promisify } from 'util';
+import {
+  Algorithm,
+  hash as argon2Hash,
+  verify as argon2Verify,
+} from '@node-rs/argon2';
 import bcrypt from 'bcryptjs';
 
-// Work factor 12 per OWASP minimum-10 guidance. Hashes created at the old
-// factor (5) remain verifiable — bcrypt embeds the factor in the hash — and
-// are upgraded opportunistically by `passwordNeedsRehash` + the
-// rehash-on-login hook in `userApiCredentials.ts`.
-const TARGET_BCRYPT_COST = 12;
+// OWASP's Password Storage Cheat Sheet recommends Argon2id with a minimum of
+// 19 MiB of memory, 2 iterations, and 1 degree of parallelism.
+// https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id
+const ARGON2_OPTIONS = {
+  algorithm: Algorithm.Argon2id,
+  memoryCost: 19456, // KiB — 19 MiB
+  timeCost: 2,
+  parallelism: 1,
+} as const;
+
+// The only Argon2 version in use; 0x13 (19) is what every current
+// implementation emits, and what the `$v=19$` in our hashes means.
+const ARGON2_VERSION = 19;
+
+// Parameters of an Argon2id hash, as encoded in its PHC string:
+// `$argon2id$v=19$m=19456,t=2,p=1$<salt>$<digest>`. Deliberately anchored to
+// `argon2id` — an `argon2i`/`argon2d` hash should be re-minted, not accepted.
+const ARGON2ID_PARAMS =
+  /^\$argon2id\$v=(?<version>\d+)\$m=(?<memoryCost>\d+),t=(?<timeCost>\d+),p=(?<parallelism>\d+)\$/;
 
 export async function hashPassword(rawPassword: string) {
-  return bcrypt.hash(rawPassword, TARGET_BCRYPT_COST);
+  return argon2Hash(rawPassword, ARGON2_OPTIONS);
 }
 
-// Matches the bcrypt.compare semantics used by the now-removed Sequelize
-// `User.passwordMatchesHash` static; kept here so `UserApi.changePassword` and
-// the Passport local strategy share a single implementation.
+// Passwords predating the Argon2id migration are bcrypt, and stay verifiable
+// forever: an account that never logs in again is never re-hashed, so this
+// branch can't be retired on any timeline. Dispatch is on the hash prefix
+// rather than a try/catch, because `argon2Verify` *throws* on a bcrypt hash
+// instead of returning false.
 const bcryptCompare = promisify(bcrypt.compare);
 
+// Throws if the hash cannot be evaluated at all — `argon2Verify` rejects a
+// malformed digest rather than returning false. That is deliberately *not*
+// swallowed here: this module has no tracer, and silently returning false
+// would make an operational failure of Argon2 (e.g. the 19 MiB allocation
+// failing under memory pressure, which affects every login) indistinguishable
+// from a user mistyping their password. The caller has a tracer, logs the
+// exception, and decides how to fail — see `verifyEmailPasswordCredentials`.
 export async function passwordMatchesHash(
   givenPassword: string,
   hash: string,
 ): Promise<boolean> {
-  return bcryptCompare(givenPassword, hash);
+  if (!hash.startsWith('$argon2')) {
+    return bcryptCompare(givenPassword, hash);
+  }
+  return argon2Verify(hash, givenPassword);
 }
 
-// bcrypt hashes embed their cost factor (`$2a$<cost>$...`); a hash minted at
-// a lower cost than today's target still verifies correctly (bcrypt reads
-// the embedded factor, not a global one) but is weaker than we'd hash a new
-// password at. `bcrypt.getRounds` on a non-bcrypt string returns `NaN`, and
-// `NaN < TARGET_BCRYPT_COST` is always `false` — so unparseable hashes
-// safely fall out as "no rehash" without a separate check.
+// Called only after `passwordMatchesHash` has already returned true, so the
+// hash is known-parseable here — but this fails safe (toward re-hashing) for
+// anything it can't read, since a fresh Argon2id hash is never the wrong
+// answer for a password we just verified.
+//
+// Any deviation from the current parameters counts, not just a weaker one, so
+// that every hash converges on exactly one configuration rather than leaving a
+// tail of stronger-but-different hashes around forever. This mirrors
+// `needsRehash` in the reference `argon2` package, which compares v/m/t/p for
+// strict equality:
+// https://github.com/ranisalt/node-argon2/blob/60e11ef/argon2.cjs#L134-L161
+// — with one addition: it does not check the algorithm variant, so an argon2i
+// hash with matching parameters slips past it. The `argon2id` anchor in
+// `ARGON2ID_PARAMS` is what closes that gap here.
 export function passwordNeedsRehash(hash: string): boolean {
-  return bcrypt.getRounds(hash) < TARGET_BCRYPT_COST;
+  const params = ARGON2ID_PARAMS.exec(hash)?.groups;
+  if (params == null) {
+    // bcrypt at any cost factor, a non-argon2id variant, or an unreadable hash.
+    return true;
+  }
+  return (
+    Number(params.version) !== ARGON2_VERSION ||
+    Number(params.memoryCost) !== ARGON2_OPTIONS.memoryCost ||
+    Number(params.timeCost) !== ARGON2_OPTIONS.timeCost ||
+    Number(params.parallelism) !== ARGON2_OPTIONS.parallelism
+  );
 }


### PR DESCRIPTION
## Context

Closes #900.

`hashPassword` was minting bcrypt at cost factor **5**. This PR originally raised it to 12; per review discussion below, it now moves straight to **Argon2id** so the hash format only churns once.

Argon2id at [OWASP's recommended minimum](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id): 19 MiB of memory (`m=19456` KiB), `t=2`, `p=1`. The parameters are encoded in every hash, so a future bump needs no flag day.

Re-hashing requires the plaintext password, which we only hold for the instant of a login — so there is no migration, only an opportunistic upgrade:

- **New hashes** (signup, password change/reset, `create-org`) are Argon2id.
- **Existing bcrypt hashes keep verifying.** `bcryptjs` therefore stays a permanent dependency: an account that never logs in again is never re-hashed.
- **Rehash-on-login:** after a *successful* password check, a stale hash is transparently re-minted and persisted. Best-effort — a failed write is logged, never fails the login, and the row is retried on the next login.

## For reviewers

1. **The rehash write is compare-and-swap** on the verified hash, not an update by user id. If a concurrent password change lands between verification and the write, zero rows match and the stale rehash is dropped instead of resurrecting the old password.

2. **It is not the transactional path.** `changePassword` / `resetPasswordForToken` also purge the user's other sessions (#778). A rehash is not a password change; reusing that path would log users out of their other sessions on their first login after deploy.

3. **`passwordNeedsRehash` compares `v`/`m`/`t`/`p` for strict equality**, so hashes converge on exactly one configuration rather than leaving a tail of stronger-but-different ones. This mirrors [`needsRehash` in the reference `argon2` package](https://github.com/ranisalt/node-argon2/blob/60e11ef/argon2.cjs#L134-L161) — except that one doesn't check the algorithm variant, so an `argon2i` hash with matching parameters slips past it. Ours is anchored on `$argon2id$`. Any bcrypt hash is flagged regardless of cost: cost is no longer the criterion, bcrypt is.

4. **Corrupt input: one path resolves `false`, the other surfaces as an error — both logged.** `argon2Verify` is inconsistent on corrupt input — some malformed digests resolve `false` (an ordinary wrong-password result), others throw. A throw is not special-cased into "incorrect password": it propagates to `verifyEmailPasswordCredentials`'s existing catch-all, which logs it via the tracer and returns a generic internal-server error instead (per review discussion — no handling was added for a case nobody could explain how to reach). Without that log, a total Argon2 failure (the 19 MiB allocation failing under memory pressure affects *every* login) would be indistinguishable from a flood of users mistyping their passwords.

## Dependency: `@node-rs/argon2` (MIT) — approval requested

[`argon2`](https://npmx.dev/package/argon2) is the more obvious pick, but it is node-gyp native and our server image (`node:24.14.1-bullseye-slim`) installs only `git` — no `python3`/`make`/`g++` — so it would depend entirely on a prebuilt binary resolving, with no fallback. [`@node-rs/argon2`](https://npmx.dev/package/@node-rs/argon2) ships per-platform binaries as optional deps and has no install script. Same Argon2id, same parameters, interchangeable hashes.

Verified rather than assumed: `docker compose build backend` → `npm ci` succeeds in the image and the binding loads and hashes inside it; the lockfile carries all 15 platform binaries, including `linux-x64-gnu` for CI.

Trade-off: it exports no `needsRehash`, so the ~12 lines that parse the encoded parameters are ours.

Node 24 also ships an experimental [`crypto.argon2`](https://nodejs.org/docs/latest-v24.x/api/crypto.html#cryptoargon2algorithm-parameters-callback) — worth dropping the dependency for once it stabilises.

## Tests

15 unit tests across `server/services/userManagementService/utils.test.ts` (parameters, round-trip, legacy bcrypt verification, corrupt-input handling, `passwordNeedsRehash` across bcrypt / parameter drift / wrong variant) and `server/graphql/datasources/userApiCredentials.test.ts` (rehash persisted and CAS-scoped, no write when current, no write on wrong password, corrupt hash surfaces a generic error and logs, failed rehash write still succeeds the login).

Manual, on a local instance against real Postgres:

| Scenario | Result |
| --- | --- |
| `create-org` admin user | minted `$argon2id$v=19$m=19456,t=2,p=1$` |
| Login against a legacy `$2a$05$` hash | succeeds; row upgraded to Argon2id |
| Login against a `$2a$12$` hash | succeeds; also upgraded |
| Second login on a current Argon2id hash | succeeds; no rewrite (hash and `updated_at` unchanged) |
| Wrong password | `LoginIncorrectPasswordError`, no write |
| Corrupt hash | generic internal-server error, logged, no write |

## Rollout

Nothing required: no migration, no new env vars, no API/UI change. `public.users.password` is `varchar(255)` and an encoded Argon2id hash is 97 characters. Legacy hashes upgrade lazily as users log in.

Expected side effect: the password hashing paths (login, signup, password change) get deliberately slower — that is the point, and it affects only those endpoints.

## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] **If you changed anything user-facing** (i.e. user interface or APIs):
  Did you update the CHANGELOG.md and related docs?

- [ ] **If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**
  Did you update the corresponding history tables and their triggers?

- [ ] **If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?

- [ ] **If you added a new signal in `server/services/signalsService/signals/**`:**
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New passwords are now hashed with Argon2id.
  * Existing bcrypt passwords continue to work during sign-in.
  * After a successful login, outdated password hashes are opportunistically upgraded.
* **Bug Fixes**
  * Password upgrades only run after verification succeeds and the stored password is still the expected legacy value.
  * Wrong passwords no longer trigger any upgrade attempts.
  * If an upgrade write fails, sign-in still succeeds while the failure is recorded.
  * Unverifiable stored hashes are handled safely (“fails closed”).
* **Tests**
  * Added Jest coverage for hashing, verification (including legacy support), rehash decisioning, and login upgrade scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
