### PR TITLE
fix(mrt): collapse long text fields with Read more (#870)

### DIFF
--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobContentView.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobContentView.tsx
@@ -131,7 +131,7 @@ export default function ManualReviewJobContentView(props: {
   );
 
   return (
-    <div className="flex flex-col overflow-x-scroll">
+    <div className="flex flex-col">
       <div className="flex flex-row items-start py-4 space-x-4">
         {/* Split the data into two columns: non-media fields and media fields*/}
         <div className="max-w-full min-w-[50%] grow">

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobFieldsComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobFieldsComponent.tsx
@@ -14,7 +14,7 @@ import ReactAudioPlayer from 'react-audio-player';
 import { Link } from 'react-router-dom';
 
 import ComponentLoading from '../../../../../components/common/ComponentLoading';
-import CollapsibleText from './components/CollapsibleText';
+import CollapsibleText from '@/webpages/dashboard/mrt/manual_review_job/v2/components/CollapsibleText';
 
 import {
   GQLContentItem,

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobFieldsComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobFieldsComponent.tsx
@@ -14,6 +14,7 @@ import ReactAudioPlayer from 'react-audio-player';
 import { Link } from 'react-router-dom';
 
 import ComponentLoading from '../../../../../components/common/ComponentLoading';
+import CollapsibleText from './components/CollapsibleText';
 
 import {
   GQLContentItem,
@@ -190,12 +191,23 @@ function TableRowComponent(props: {
         </div>
       );
     }
+    case 'STRING': {
+      return (
+        <div className="flex flex-col whitespace-normal align-top text-start">
+          {label ? (
+            <div className="pr-3 font-bold text-slate-500 whitespace-nowrap">
+              {label}
+            </div>
+          ) : null}
+          <CollapsibleText text={String(value)} />
+        </div>
+      );
+    }
     case 'BOOLEAN':
     case 'GEOHASH':
     case 'ID':
     case 'NUMBER':
     case 'POLICY_ID':
-    case 'STRING':
     case 'EMAIL_ADDRESS': {
       // EMAIL_ADDRESS renders as plain text for now; a follow-up could make
       // it a mailto/pivot link the way IP_ADDRESS pivots on the IP.

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobFieldsComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobFieldsComponent.tsx
@@ -540,7 +540,7 @@ function FieldComponent(props: {
     case 'EMAIL_ADDRESS':
     case 'DATETIME':
       return (
-        <div className="py-0" key={data.name}>
+        <div className="py-0 min-w-0" key={data.name}>
           {!hideLabels ? (
             <div className="pb-px align-top text-start whitespace-nowrap">
               <ContentFieldLabelComponent data={data} />

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobFieldsComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobFieldsComponent.tsx
@@ -658,7 +658,7 @@ function ContainerComponent(props: {
         type: data.container!.valueScalarType,
       };
       return (
-        <div key={i} className="align-top text-start whitespace-nowrap">
+        <div key={i} className="align-top text-start min-w-0">
           {/*Talk to ethan about how to avoid casting here*/}
           <TableRowComponent
             data={itemData as TableRowComponentData}
@@ -701,14 +701,14 @@ function ContainerComponent(props: {
         </div>
       ) : null}
       <div
-        className={` ${
+        className={`${
           data.container!.valueScalarType === 'IMAGE' ||
           data.container!.valueScalarType === 'VIDEO' ||
           data.container!.valueScalarType === 'AUDIO' ||
           data.container!.valueScalarType === 'MEDIA'
-            ? ''
-            : 'flex-col'
-        } flex overflow-x-scroll border-slate-200 rounded p-1.5 ${
+            ? 'flex overflow-x-scroll'
+            : 'flex flex-col'
+        } border-slate-200 rounded p-1.5 ${
           transparentBackground ? '' : 'bg-slate-100'
         } ${expanded ? 'max-h-96 overflow-y-auto' : 'overflow-y-hidden'}`}
       >

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/components/CollapsibleText.test.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/components/CollapsibleText.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import '@testing-library/jest-dom/extend-expect';
+
+import CollapsibleText from './CollapsibleText';
+
+describe('CollapsibleText', () => {
+  it('renders short text in full without a Read more button', () => {
+    render(<CollapsibleText text="hello world" />);
+    expect(screen.getByText('hello world')).toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('collapses text exceeding maxGraphemes and shows Read more', () => {
+    const longText = 'a'.repeat(2001);
+    render(<CollapsibleText text={longText} />);
+    // The clamped preview still contains the start of the text.
+    expect(screen.getByText(longText)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /read more/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('expands to full text and toggles to Read less on click', () => {
+    const longText = 'a'.repeat(2001);
+    render(<CollapsibleText text={longText} />);
+    const moreButton = screen.getByRole('button', { name: /read more/i });
+    fireEvent.click(moreButton);
+    expect(
+      screen.getByRole('button', { name: /read less/i }),
+    ).toBeInTheDocument();
+    // Full text is now rendered (not clamped).
+    expect(screen.getByText(longText)).toBeInTheDocument();
+  });
+
+  it('collapses again on Read less click', () => {
+    const longText = 'a'.repeat(2001);
+    render(<CollapsibleText text={longText} />);
+    fireEvent.click(screen.getByRole('button', { name: /read more/i }));
+    fireEvent.click(screen.getByRole('button', { name: /read less/i }));
+    expect(
+      screen.getByRole('button', { name: /read more/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('counts graphemes, not UTF-16 code units (emoji with skin tone)', () => {
+    // 👨🏿 is a single grapheme but multiple UTF-16 code units / code points.
+    // 2001 such graphemes should trigger the collapse.
+    const grapheme = '👨🏿';
+    const longText = grapheme.repeat(2001);
+    render(<CollapsibleText text={longText} />);
+    expect(
+      screen.getByRole('button', { name: /read more/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('respects custom maxGraphemes and maxLines thresholds', () => {
+    // 11 chars, under default maxGraphemes (2000) but over custom maxGraphemes (10).
+    render(
+      <CollapsibleText text="12345678901" maxGraphemes={10} maxLines={2} />,
+    );
+    expect(
+      screen.getByRole('button', { name: /read more/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('does not collapse text at exactly maxGraphemes', () => {
+    render(<CollapsibleText text={'a'.repeat(2000)} />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/components/CollapsibleText.test.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/components/CollapsibleText.test.tsx
@@ -65,16 +65,39 @@ describe('CollapsibleText', () => {
 
   it('respects custom maxGraphemes and maxLines thresholds', () => {
     // 11 chars, under default maxGraphemes (2000) but over custom maxGraphemes (10).
-    render(
+    const { container } = render(
       <CollapsibleText text="12345678901" maxGraphemes={10} maxLines={2} />,
     );
     expect(
       screen.getByRole('button', { name: /read more/i }),
     ).toBeInTheDocument();
+    // The maxLines prop drives the visual clamp: assert it lands on the clamped
+    // div's WebkitLineClamp style (jsdom has no layout, so this is the verifiable
+    // surface for the line-count constraint).
+    const clampedDiv = container.querySelector(
+      'div[style*="-webkit-box"]',
+    ) as HTMLElement;
+    expect(clampedDiv.style.webkitLineClamp).toBe('2');
   });
 
   it('does not collapse text at exactly maxGraphemes', () => {
     render(<CollapsibleText text={'a'.repeat(2000)} />);
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('resets to collapsed when the text prop changes', () => {
+    // Simulates navigating between review jobs that reuse the same field name
+    // (React reuses the CollapsibleText instance). Expanding one long value,
+    //then rendering a different long value, must restore the collapsed state.
+    const { rerender } = render(<CollapsibleText text={'a'.repeat(2001)} />);
+    fireEvent.click(screen.getByRole('button', { name: /read more/i }));
+    expect(
+      screen.getByRole('button', { name: /read less/i }),
+    ).toBeInTheDocument();
+
+    rerender(<CollapsibleText text={'b'.repeat(2001)} />);
+    expect(
+      screen.getByRole('button', { name: /read more/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/components/CollapsibleText.test.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/components/CollapsibleText.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import '@testing-library/jest-dom/extend-expect';
 
-import CollapsibleText from './CollapsibleText';
+import CollapsibleText from '@/webpages/dashboard/mrt/manual_review_job/v2/components/CollapsibleText';
 
 describe('CollapsibleText', () => {
   it('renders short text in full without a Read more button', () => {
@@ -63,21 +63,32 @@ describe('CollapsibleText', () => {
     ).toBeInTheDocument();
   });
 
-  it('respects custom maxGraphemes and maxLines thresholds', () => {
+  it('respects a custom maxGraphemes threshold', () => {
     // 11 chars, under default maxGraphemes (2000) but over custom maxGraphemes (10).
-    const { container } = render(
-      <CollapsibleText text="12345678901" maxGraphemes={10} maxLines={2} />,
-    );
+    render(<CollapsibleText text="12345678901" maxGraphemes={10} />);
     expect(
       screen.getByRole('button', { name: /read more/i }),
     ).toBeInTheDocument();
-    // The maxLines prop drives the visual clamp: assert it lands on the clamped
-    // div's WebkitLineClamp style (jsdom has no layout, so this is the verifiable
-    // surface for the line-count constraint).
+  });
+
+  it('respects a custom maxLines threshold for wrapping text', () => {
+    const wrappingText = 'wrap '.repeat(20).trim();
+    const { container, rerender } = render(
+      <div style={{ width: 80 }}>
+        <CollapsibleText text={wrappingText} maxGraphemes={10} maxLines={2} />
+      </div>,
+    );
     const clampedDiv = container.querySelector(
       'div[style*="-webkit-box"]',
     ) as HTMLElement;
     expect(clampedDiv.style.webkitLineClamp).toBe('2');
+
+    rerender(
+      <div style={{ width: 80 }}>
+        <CollapsibleText text={wrappingText} maxGraphemes={10} maxLines={3} />
+      </div>,
+    );
+    expect(clampedDiv.style.webkitLineClamp).toBe('3');
   });
 
   it('does not collapse text at exactly maxGraphemes', () => {

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/components/CollapsibleText.test.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/components/CollapsibleText.test.tsx
@@ -15,7 +15,7 @@ describe('CollapsibleText', () => {
   it('collapses text exceeding maxGraphemes and shows Read more', () => {
     const longText = 'a'.repeat(2001);
     render(<CollapsibleText text={longText} />);
-    // The clamped preview still contains the start of the text.
+    // The full text is in the DOM (CSS line-clamp hides overflow visually, not in the DOM).
     expect(screen.getByText(longText)).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: /read more/i }),
@@ -45,11 +45,19 @@ describe('CollapsibleText', () => {
   });
 
   it('counts graphemes, not UTF-16 code units (emoji with skin tone)', () => {
-    // 👨🏿 is a single grapheme but multiple UTF-16 code units / code points.
-    // 2001 such graphemes should trigger the collapse.
+    // 👨🏿 is a single grapheme but 4 UTF-16 code units. A naive `.length`
+    // check would collapse at 501 such graphemes (length 2004 > 2000), but
+    // a correct grapheme count (501) stays under the threshold → no collapse.
     const grapheme = '👨🏿';
-    const longText = grapheme.repeat(2001);
-    render(<CollapsibleText text={longText} />);
+    const underThresholdByGrapheme = grapheme.repeat(501);
+    expect(underThresholdByGrapheme.length).toBeGreaterThan(2000);
+    render(<CollapsibleText text={underThresholdByGrapheme} />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+
+    // 2001 graphemes (8016 UTF-16 code units) does exceed the grapheme
+    // threshold → collapses.
+    const overThresholdByGrapheme = grapheme.repeat(2001);
+    render(<CollapsibleText text={overThresholdByGrapheme} />);
     expect(
       screen.getByRole('button', { name: /read more/i }),
     ).toBeInTheDocument();

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/components/CollapsibleText.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/components/CollapsibleText.tsx
@@ -1,0 +1,73 @@
+import { memo, useMemo, useState } from 'react';
+
+type CollapsibleTextProps = {
+  text: string;
+  maxLines?: number;
+  maxGraphemes?: number;
+};
+
+/** Count graphemes using Intl.Segmenter (handles all scripts correctly). */
+function countGraphemes(text: string): number {
+  const segmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+  let count = 0;
+  for (const _ of segmenter.segment(text)) {
+    count += 1;
+  }
+  return count;
+}
+
+/**
+ * Renders text with wrapping. When the text exceeds `maxGraphemes`, it is
+ * collapsed to `maxLines` visible lines with a "Read more" / "Read less"
+ * toggle. Short text renders in full with no toggle.
+ *
+ * Memoized: props are primitives (string, number), so React.memo's shallow
+ * comparison prevents re-renders (and re-segmentation) when a parent re-renders
+ * but the text hasn't changed — important for thread histories with many copies
+ * of the same message.
+ */
+function CollapsibleTextImpl({
+  text,
+  maxLines = 12,
+  maxGraphemes = 2000,
+}: CollapsibleTextProps) {
+  const isCollapsible = useMemo(
+    () => countGraphemes(text) > maxGraphemes,
+    [text, maxGraphemes],
+  );
+  const [expanded, setExpanded] = useState(false);
+
+  if (!isCollapsible) {
+    return (
+      <div className="whitespace-normal break-words text-start">{text}</div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col text-start">
+      <div
+        className="whitespace-normal break-words overflow-hidden"
+        // Inline style rather than Tailwind's line-clamp-N so the line count
+        // is fully dynamic (Tailwind's JIT won't generate line-clamp-${maxLines}
+        // from a template literal). This is exactly what line-clamp compiles to.
+        style={{
+          display: '-webkit-box',
+          WebkitBoxOrient: 'vertical',
+          WebkitLineClamp: expanded ? 'none' : maxLines,
+        }}
+      >
+        {text}
+      </div>
+      <button
+        type="button"
+        className="self-start pt-1 font-semibold text-blue-500 cursor-pointer"
+        onClick={() => setExpanded((e) => !e)}
+      >
+        {expanded ? 'Read less' : 'Read more'}
+      </button>
+    </div>
+  );
+}
+
+const CollapsibleText = memo(CollapsibleTextImpl);
+export default CollapsibleText;

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/components/CollapsibleText.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/components/CollapsibleText.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useState } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 
 type CollapsibleTextProps = {
   text: string;
@@ -6,14 +6,22 @@ type CollapsibleTextProps = {
   maxGraphemes?: number;
 };
 
-/** Count graphemes using Intl.Segmenter (handles all scripts correctly). */
-function countGraphemes(text: string): number {
+/**
+ * Count graphemes using Intl.Segmenter (handles all scripts correctly),
+ * stopping early once the count is known to exceed `threshold`. This avoids
+ * segmenting an entire pathological paste (e.g. a 1MB string) when we only
+ * need to know whether it crosses the collapse threshold.
+ */
+function exceedsGraphemeThreshold(text: string, threshold: number): boolean {
   const segmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
   let count = 0;
   for (const _ of segmenter.segment(text)) {
     count += 1;
+    if (count > threshold) {
+      return true;
+    }
   }
-  return count;
+  return false;
 }
 
 /**
@@ -32,10 +40,18 @@ function CollapsibleTextImpl({
   maxGraphemes = 2000,
 }: CollapsibleTextProps) {
   const isCollapsible = useMemo(
-    () => countGraphemes(text) > maxGraphemes,
+    () => exceedsGraphemeThreshold(text, maxGraphemes),
     [text, maxGraphemes],
   );
   const [expanded, setExpanded] = useState(false);
+
+  // When the text prop changes (e.g. navigating between review jobs that reuse
+  // the same field name → React reuses this component instance), reset to the
+  // collapsed state so newly loaded long content doesn't inherit the previous
+  // job's expanded view.
+  useEffect(() => {
+    setExpanded(false);
+  }, [text]);
 
   if (!isCollapsible) {
     return (


### PR DESCRIPTION
Fix #870.

This is a suggested UI, but feedback is very welcome!

I am slightly unsure about this -- if any users are regularly reviewing long blocks of text, then this actually introduces an extra click which could influence average handling time. I thought that 2000 graphemes seemed like a reasonable cutoff before we show the "Read more" button but I'm not sure about this!

# Long text (collapsed)
<img width="2928" height="1760" alt="Screenshot 2026-07-13 at 14-20-53 Review Job" src="https://github.com/user-attachments/assets/b7559aa8-03d5-4548-8ae0-fd17abcda61d" />

# Long text (expanded)
<img width="2928" height="1760" alt="Screenshot 2026-07-13 at 14-21-07 Review Job" src="https://github.com/user-attachments/assets/4a1f0bfa-df9a-4689-86ed-cb197bba5214" />

# Shorter text (below the limit)
<img width="2928" height="1760" alt="Screenshot 2026-07-13 at 14-08-22 Review Job" src="https://github.com/user-attachments/assets/edd60c04-4353-41e1-a8fe-ec227f8827f2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Long text values in manual review fields can now be expanded and collapsed with “Read more” and “Read less” controls.
  * Text limits correctly account for emojis and other multi-character symbols.
  * Media fields retain horizontal scrolling, while other content uses improved responsive layouts.

* **Bug Fixes**
  * Updated text state resets correctly when displayed content changes.
  * Improved handling of narrow layouts to prevent content overflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->