### PR TITLE
Fix "Something Went Wrong" when opening MRT jobs with an unparseable Created At

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## Review Console
 
 - Fixed a "Job submission failed" error that prevented reviewers from clearing jobs whose item had an unparseable `Created At` value; the decision now records instead of failing (#913)
-- Fixed a "Something Went Wrong" page when opening a job or queue whose `Created At` value was unparseable; the affected date now shows `Unknown` instead of blanking the view (#913)
+- Fixed a "Something Went Wrong" page when opening a job or queue whose `Created At` value was unparseable; the affected date now shows `Unknown` instead of blanking the view (#916)
 
 # Coop 1.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Review Console
 
 - Fixed a "Job submission failed" error that prevented reviewers from clearing jobs whose item had an unparseable `Created At` value; the decision now records instead of failing (#913)
+- Fixed a "Something Went Wrong" page when opening a job or queue whose `Created At` value was unparseable; the affected date now shows `Unknown` instead of blanking the view (#913)
 
 # Coop 1.0.2
 

--- a/client/src/utils/time.test.ts
+++ b/client/src/utils/time.test.ts
@@ -1,0 +1,42 @@
+import { safeFormat, safeFormatDistanceToNow } from './time';
+
+describe('Time utils tests', () => {
+  describe('safeFormat', () => {
+    it('formats a valid date', () => {
+      expect(safeFormat('2026-07-15T13:06:00Z', 'yyyy-MM-dd')).toBe(
+        '2026-07-15',
+      );
+    });
+
+    it('formats the epoch instead of treating it as empty', () => {
+      expect(safeFormat(new Date(0), 'yyyy')).not.toBe('Unknown');
+    });
+
+    it('returns the fallback for an unparseable string without throwing', () => {
+      expect(safeFormat('not a date', 'yyyy-MM-dd')).toBe('Unknown');
+    });
+
+    it('returns the fallback for null and undefined', () => {
+      expect(safeFormat(null, 'yyyy-MM-dd')).toBe('Unknown');
+      expect(safeFormat(undefined, 'yyyy-MM-dd')).toBe('Unknown');
+    });
+
+    it('honors a custom fallback', () => {
+      expect(safeFormat('not a date', 'yyyy-MM-dd', '-')).toBe('-');
+    });
+  });
+
+  describe('safeFormatDistanceToNow', () => {
+    it('returns a relative string for a valid date', () => {
+      expect(safeFormatDistanceToNow(new Date())).toContain('ago');
+    });
+
+    it('returns the fallback for an unparseable string without throwing', () => {
+      expect(safeFormatDistanceToNow('not a date')).toBe('Unknown');
+    });
+
+    it('returns the fallback for null', () => {
+      expect(safeFormatDistanceToNow(null)).toBe('Unknown');
+    });
+  });
+});

--- a/client/src/utils/time.test.ts
+++ b/client/src/utils/time.test.ts
@@ -1,4 +1,10 @@
-import { safeFormat, safeFormatDistanceToNow } from './time';
+import {
+  parseDatetimeToMonthDayYearDateStringInCurrentTimeZone,
+  parseDatetimeToReadableStringInCurrentTimeZone,
+  parseDatetimeToReadableStringInUTC,
+  safeFormat,
+  safeFormatDistanceToNow,
+} from './time';
 
 describe('Time utils tests', () => {
   describe('safeFormat', () => {
@@ -37,6 +43,64 @@ describe('Time utils tests', () => {
 
     it('returns the fallback for null', () => {
       expect(safeFormatDistanceToNow(null)).toBe('Unknown');
+    });
+  });
+
+  describe('parseDatetimeToReadableStringInUTC', () => {
+    it('formats a valid date', () => {
+      expect(
+        parseDatetimeToReadableStringInUTC('2026-07-15T13:06:00Z'),
+      ).toMatch(/07\/15\/26/);
+    });
+
+    it('returns fallback for an unparseable string', () => {
+      expect(parseDatetimeToReadableStringInUTC('not a date')).toBe('Unknown');
+    });
+
+    it('returns fallback for null', () => {
+      expect(parseDatetimeToReadableStringInUTC(null)).toBe('Unknown');
+    });
+  });
+
+  describe('parseDatetimeToReadableStringInCurrentTimeZone', () => {
+    it('formats a valid date', () => {
+      expect(
+        parseDatetimeToReadableStringInCurrentTimeZone('2026-07-15T13:06:00Z'),
+      ).toMatch(/07\/15\/26/);
+    });
+
+    it('returns fallback for an unparseable string', () => {
+      expect(parseDatetimeToReadableStringInCurrentTimeZone('not a date')).toBe(
+        'Unknown',
+      );
+    });
+
+    it('returns fallback for null', () => {
+      expect(parseDatetimeToReadableStringInCurrentTimeZone(null)).toBe(
+        'Unknown',
+      );
+    });
+  });
+
+  describe('parseDatetimeToMonthDayYearDateStringInCurrentTimeZone', () => {
+    it('formats a valid date', () => {
+      expect(
+        parseDatetimeToMonthDayYearDateStringInCurrentTimeZone(
+          '2026-07-15T13:06:00Z',
+        ),
+      ).toMatch(/Jul 15, 2026/);
+    });
+
+    it('returns fallback for an unparseable string', () => {
+      expect(
+        parseDatetimeToMonthDayYearDateStringInCurrentTimeZone('not a date'),
+      ).toBe('Unknown');
+    });
+
+    it('returns fallback for null', () => {
+      expect(parseDatetimeToMonthDayYearDateStringInCurrentTimeZone(null)).toBe(
+        'Unknown',
+      );
     });
   });
 });

--- a/client/src/utils/time.ts
+++ b/client/src/utils/time.ts
@@ -68,9 +68,12 @@ export function safeFormatDistanceToNow(
 }
 
 export function parseDatetimeToReadableStringInUTC(
-  date: string | DateString | Date,
+  date: MaybeDate,
+  fallback = 'Unknown',
 ): string {
+  if (date == null) return fallback;
   const d = toDate(date);
+  if (!isValid(d)) return fallback;
   return new Intl.DateTimeFormat('en-US', {
     timeZone: 'UTC',
     month: '2-digit',
@@ -86,15 +89,21 @@ export function parseDatetimeToReadableStringInUTC(
 }
 
 export function parseDatetimeToReadableStringInCurrentTimeZone(
-  date: string | DateString | Date,
+  date: MaybeDate,
+  fallback = 'Unknown',
 ): string {
-  return format(toDate(date), 'MM/dd/yy hh:mm:ss a');
+  if (date == null) return fallback;
+  const d = toDate(date);
+  return isValid(d) ? format(d, 'MM/dd/yy hh:mm:ss a') : fallback;
 }
 
 export function parseDatetimeToMonthDayYearDateStringInCurrentTimeZone(
-  date: string | DateString | Date,
+  date: MaybeDate,
+  fallback = 'Unknown',
 ): string {
-  return format(toDate(date), 'MMM d, yyyy');
+  if (date == null) return fallback;
+  const d = toDate(date);
+  return isValid(d) ? format(d, 'MMM d, yyyy') : fallback;
 }
 
 export function startOfHourUTC(date: Date): Date {

--- a/client/src/utils/time.ts
+++ b/client/src/utils/time.ts
@@ -1,5 +1,12 @@
 import { DateString } from '@roostorg/coop-types';
-import { addDays, addHours, format, isBefore } from 'date-fns';
+import {
+  addDays,
+  addHours,
+  format,
+  formatDistanceToNow,
+  isBefore,
+  isValid,
+} from 'date-fns';
 
 export enum LookbackLength {
   CUSTOM = 'Custom',
@@ -30,6 +37,34 @@ export function formatDate(date = new Date()): string {
 
 function toDate(date: string | DateString | Date): Date {
   return date instanceof Date ? date : new Date(date);
+}
+
+type MaybeDate = string | DateString | Date | null | undefined;
+
+/**
+ * date-fns `format` throws on an invalid date; this returns `fallback` instead.
+ */
+export function safeFormat(
+  date: MaybeDate,
+  formatStr: string,
+  fallback = 'Unknown',
+): string {
+  if (date == null) return fallback;
+  const d = toDate(date);
+  return isValid(d) ? format(d, formatStr) : fallback;
+}
+
+/**
+ * date-fns `formatDistanceToNow` throws on an invalid date; this returns
+ * `fallback` instead.
+ */
+export function safeFormatDistanceToNow(
+  date: MaybeDate,
+  fallback = 'Unknown',
+): string {
+  if (date == null) return fallback;
+  const d = toDate(date);
+  return isValid(d) ? formatDistanceToNow(d, { addSuffix: true }) : fallback;
 }
 
 export function parseDatetimeToReadableStringInUTC(

--- a/client/src/webpages/dashboard/mrt/ManualReviewQueueJobsPreview.tsx
+++ b/client/src/webpages/dashboard/mrt/ManualReviewQueueJobsPreview.tsx
@@ -1,5 +1,5 @@
+import { safeFormat } from '@/utils/time';
 import { gql } from '@apollo/client';
-import { format } from 'date-fns';
 import { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { Row } from 'react-table';
@@ -198,7 +198,7 @@ export default function ManualReviewQueueJobsPreview() {
             </div>
           ),
           createdAt: (
-            <div>{format(new Date(values.createdAt), 'MM/dd/yy hh:mm a')}</div>
+            <div>{safeFormat(values.createdAt, 'MM/dd/yy hh:mm a')}</div>
           ),
           jobId: values.jobId,
           values,

--- a/client/src/webpages/dashboard/mrt/manual_review_job/ReportInfoComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/ReportInfoComponent.tsx
@@ -13,7 +13,7 @@ import { userHasPermissions } from '@/routing/permissions';
 import { filterNullOrUndefined } from '@/utils/collections';
 import { getFieldValueForRole } from '@/utils/itemUtils';
 import { selectPreferredUserItem } from '@/utils/manualReviewTool';
-import { format } from 'date-fns';
+import { safeFormat } from '@/utils/time';
 import { ExternalLink } from 'lucide-react';
 import { useCallback } from 'react';
 import { Link } from 'react-router-dom';
@@ -153,7 +153,7 @@ export default function ReportInfoComponent(props: {
                   {isAppeal ? 'Appeal ' : 'Report '}Received
                 </th>
                 <td className="py-1 align-top text-start text-slate-500">
-                  {format(new Date(createdAt as string), 'MM/dd/yy hh:mm a')}
+                  {safeFormat(createdAt, 'MM/dd/yy hh:mm a')}
                 </td>
               </tr>
               <tr>

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobCommentSection.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ManualReviewJobCommentSection.tsx
@@ -1,3 +1,4 @@
+import { safeFormatDistanceToNow } from '@/utils/time';
 import {
   CommentOutlined,
   DeleteOutlined,
@@ -7,7 +8,6 @@ import {
 } from '@ant-design/icons';
 import { gql } from '@apollo/client';
 import { Button, Input } from 'antd';
-import { formatDistanceToNow } from 'date-fns';
 import { useEffect, useRef, useState } from 'react';
 
 import ComponentLoading from '../../../../../components/common/ComponentLoading';
@@ -99,9 +99,7 @@ function ManualReviewJobComment(props: {
               isBeingDeleted ? 'text-gray-300' : 'text-gray-500'
             }`}
           >
-            {formatDistanceToNow(new Date(comment.createdAt as string), {
-              addSuffix: true,
-            })}
+            {safeFormatDistanceToNow(comment.createdAt)}
           </div>
         </div>
         <div


### PR DESCRIPTION
## Context & Requests for Reviewers

Client-side counterpart to #913. That PR fixed the server decision-log path so a bad `createdAt` records as `null` instead of failing submission. The React client still rendered the same value through unguarded `date-fns` calls, which throw `RangeError: Invalid time value` on an invalid date and unmount the view into the "Something Went Wrong" error boundary.

This adds `safeFormat` / `safeFormatDistanceToNow` helpers in `client/src/utils/time.ts` that fall back to `Unknown` for invalid dates (epoch 0 stays valid), and uses them on the three MRT render sites:

- `ReportInfoComponent.tsx` (report/appeal received time on the job detail view)
- `ManualReviewJobCommentSection.tsx` (comment timestamps)
- `ManualReviewQueueJobsPreview.tsx` (Created At column in the queue job list)

Note: per `client/AGENTS.md` this touches the MRT area; no GraphQL schema or `generated.ts` changes are involved.

## Tests

- New `client/src/utils/time.test.ts` covering valid dates, epoch, unparseable strings, null/undefined, and custom fallback (regression test for the throw).
- `npx vitest run src/utils/time.test.ts` passes; lint and `tsc --noEmit` clean on changed files.

## (Optional) Rollout Plan

None. Client-only rendering change.

## Checklist

- [x] **If you changed anything user-facing** (i.e. user interface or APIs): Did you update the CHANGELOG.md and related docs?

🤖 Generated with [Claude Code](https://claude.com/claude-code)