### PR TITLE
Scope zizmor workflow to only run when workflow files change

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -3,8 +3,10 @@ name: GitHub Actions security analysis
 on:
   push:
     branches: ['main']
+    paths: ['.github/workflows/**']
   pull_request:
     branches: ['**']
+    paths: ['.github/workflows/**']
 
 concurrency:
   group: zizmor-${{ github.ref }}


### PR DESCRIPTION
## Summary

- Add `paths: ['.github/workflows/**']` filter to the zizmor workflow so it only triggers when workflow files are actually modified, instead of on every PR.

## Context

The zizmor check currently runs on every PR regardless of what files changed. Since it only scans `.github/workflows/` YAML files, running it on PRs that don't touch workflows is unnecessary noise — especially when pre-existing findings cause it to fail and block unrelated PRs (e.g. #918).

## Testing

The change is a 2-line addition to the workflow trigger config. After this, zizmor will only run on PRs that modify files under `.github/workflows/`.