### PR TITLE
Fix RetryFailedNcmecDecisionsJob to honor NCMEC_ENV

### DIFF
--- a/server/workers_jobs/RetryFailedNcmecDecisionsJob.test.ts
+++ b/server/workers_jobs/RetryFailedNcmecDecisionsJob.test.ts
@@ -2,14 +2,10 @@ import { v1 as uuidv1 } from 'uuid';
 
 import {
   makeSubmissionId,
+  type ItemSubmissionWithTypeIdentifier,
   type NormalizedItemData,
 } from '../services/itemProcessingService/index.js';
-import { type ItemSubmissionWithTypeIdentifier } from '../services/itemProcessingService/makeItemSubmissionWithTypeIdentifier.js';
-import {
-  type ManualReviewToolService,
-  type NcmecContentItemSubmission,
-  type ReportHistory,
-} from '../services/manualReviewToolService/manualReviewToolService.js';
+import { type ManualReviewToolService } from '../services/manualReviewToolService/index.js';
 import { instantiateOpaqueType } from '../utils/typescript-types.js';
 import makeRetryFailedNcmecDecisionsJob from './RetryFailedNcmecDecisionsJob.js';
 
@@ -41,12 +37,14 @@ function makeNcmecDecisionRow(orgId: string): NcmecDecisionRow {
       },
     ],
     job_payload: {
+      id: uuidv1(),
+      orgId,
       createdAt: new Date(),
       policyIds: [],
       payload: {
         kind: 'NCMEC',
-        reportHistory: [] as ReportHistory,
-        allMediaItems: [] as NcmecContentItemSubmission[],
+        reportHistory: [],
+        allMediaItems: [],
         item: instantiateOpaqueType<ItemSubmissionWithTypeIdentifier>({
           submissionId: makeSubmissionId(),
           submissionTime: new Date(),
@@ -65,8 +63,10 @@ function makeNcmecDecisionRow(orgId: string): NcmecDecisionRow {
         }),
         enqueueSourceInfo: { kind: 'REPORT' },
       },
-    },
-  } as NcmecDecisionRow;
+      // The full `ManualReviewJob` union has many fields the retry job never
+      // reads; cast through `unknown` to avoid mirroring the entire type.
+    } as unknown as NcmecDecisionRow['job_payload'],
+  } as unknown as NcmecDecisionRow;
 }
 
 /** The USER item type returned by `getItemTypeEventuallyConsistent`. Only the

--- a/server/workers_jobs/RetryFailedNcmecDecisionsJob.test.ts
+++ b/server/workers_jobs/RetryFailedNcmecDecisionsJob.test.ts
@@ -1,0 +1,277 @@
+import { v1 as uuidv1 } from 'uuid';
+
+import {
+  makeSubmissionId,
+  type NormalizedItemData,
+} from '../services/itemProcessingService/index.js';
+import { type ItemSubmissionWithTypeIdentifier } from '../services/itemProcessingService/makeItemSubmissionWithTypeIdentifier.js';
+import {
+  type ManualReviewToolService,
+  type NcmecContentItemSubmission,
+  type ReportHistory,
+} from '../services/manualReviewToolService/manualReviewToolService.js';
+import { instantiateOpaqueType } from '../utils/typescript-types.js';
+import makeRetryFailedNcmecDecisionsJob from './RetryFailedNcmecDecisionsJob.js';
+
+/**
+ * Minimal shape of a row returned by
+ * `ManualReviewToolService.getNcmecDecisions`. Only the fields read by
+ * `processDecisionRetry` are populated; everything else is omitted and the
+ * cast satisfies TypeScript at the injection boundary.
+ */
+type NcmecDecisionRow = Awaited<
+  ReturnType<ManualReviewToolService['getNcmecDecisions']>
+>[number];
+
+function makeNcmecDecisionRow(orgId: string): NcmecDecisionRow {
+  const userItemTypeId = uuidv1();
+  const itemId = uuidv1();
+  return {
+    org_id: orgId,
+    id: uuidv1(),
+    queue_id: uuidv1(),
+    reviewer_id: 'reviewer-1',
+    decision_components: [
+      {
+        type: 'SUBMIT_NCMEC_REPORT',
+        reportedMedia: [],
+        reportedMessages: [],
+        incidentType:
+          'Child Pornography (possession, manufacture, and distribution)',
+      },
+    ],
+    job_payload: {
+      createdAt: new Date(),
+      policyIds: [],
+      payload: {
+        kind: 'NCMEC',
+        reportHistory: [] as ReportHistory,
+        allMediaItems: [] as NcmecContentItemSubmission[],
+        item: instantiateOpaqueType<ItemSubmissionWithTypeIdentifier>({
+          submissionId: makeSubmissionId(),
+          submissionTime: new Date(),
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          data: {} as NormalizedItemData,
+          itemTypeIdentifier: {
+            id: userItemTypeId,
+            version: new Date().toISOString(),
+            schemaVariant: 'original',
+          },
+          creator: {
+            id: itemId,
+            typeId: userItemTypeId,
+          },
+          itemId,
+        }),
+        enqueueSourceInfo: { kind: 'REPORT' },
+      },
+    },
+  } as NcmecDecisionRow;
+}
+
+/** The USER item type returned by `getItemTypeEventuallyConsistent`. Only the
+ * fields read by the retry job / buildSubmitReportParamsFromDecision are set. */
+function makeUserItemType(id: string) {
+  return {
+    id,
+    kind: 'USER' as const,
+    name: 'Test User Type',
+    description: null,
+    version: new Date().toISOString(),
+    schemaVariant: 'original' as const,
+    orgId: 'org-1',
+    isDefaultUserType: false,
+    schema: [
+      {
+        name: 'displayName',
+        type: 'TEXT',
+        optional: true,
+      },
+    ],
+    schemaFieldRoles: {},
+  };
+}
+
+/** Builds the 7 dependencies injected into the retry job. Each test overrides
+ * only what it needs via `overrides`. Methods that should never be called in a
+ * given test throw, so unexpected calls surface as failures. */
+function makeDeps(
+  overrides: Partial<{
+    submitReport: jest.Mock;
+    publishActions: jest.Mock;
+    getNCMECActionsToRunAndPolicies: jest.Mock;
+    decisions: NcmecDecisionRow[];
+  }> = {},
+) {
+  const ncmecService = {
+    submitReport: overrides.submitReport ?? jest.fn(async () => 'SUCCESS'),
+    getUsersWithNcmecDecision: jest.fn(async () => []),
+    getNcmecErrorsForJobIds: jest.fn(async () => []),
+    insertOrUpdateNcmecReportError: jest.fn(async () => undefined),
+    getNCMECActionsToRunAndPolicies:
+      overrides.getNCMECActionsToRunAndPolicies ??
+      jest.fn(async () => undefined),
+  };
+  const manualReviewToolService = {
+    getNcmecDecisions: jest.fn(async () => overrides.decisions ?? []),
+  };
+  const getItemTypeEventuallyConsistent = jest.fn(async () =>
+    makeUserItemType('user-type-1'),
+  );
+  const actionPublisher = {
+    publishActions: overrides.publishActions ?? jest.fn(async () => []),
+  };
+  const moderationConfigService = {
+    getActions: jest.fn(async () => []),
+    getPolicies: jest.fn(async () => []),
+  };
+  const userManagementService = {
+    getUsersForOrg: jest.fn(async () => []),
+  };
+  return {
+    ncmecService,
+    manualReviewToolService,
+    getItemTypeEventuallyConsistent,
+    actionPublisher,
+    moderationConfigService,
+    userManagementService,
+  };
+}
+
+describe('RetryFailedNcmecDecisionsJob', () => {
+  const ORG_ID = 'org-1';
+
+  /** Snapshot of NCMEC_ENV across the suite so each test can mutate it
+   * freely and we restore the original value in afterEach. */
+  let originalNcmecEnv: string | undefined;
+
+  beforeEach(() => {
+    originalNcmecEnv = process.env.NCMEC_ENV;
+  });
+  afterEach(() => {
+    if (originalNcmecEnv === undefined) {
+      delete process.env.NCMEC_ENV;
+    } else {
+      process.env.NCMEC_ENV = originalNcmecEnv;
+    }
+  });
+
+  it('passes isTest=true to submitReport when NCMEC_ENV is unset', async () => {
+    delete process.env.NCMEC_ENV;
+    const deps = makeDeps({
+      decisions: [makeNcmecDecisionRow(ORG_ID)],
+    });
+    const job = makeRetryFailedNcmecDecisionsJob(
+      jest.fn() as never, // closeSharedResourcesForShutdown (unused by run)
+      deps.manualReviewToolService as never,
+      deps.ncmecService as never,
+      deps.getItemTypeEventuallyConsistent as never,
+      deps.actionPublisher as never,
+      deps.moderationConfigService as never,
+      deps.userManagementService as never,
+    );
+
+    await job.run();
+
+    expect(deps.ncmecService.submitReport).toHaveBeenCalledTimes(1);
+    const [, isTest] = deps.ncmecService.submitReport.mock.calls[0];
+    expect(isTest).toBe(true);
+  });
+
+  it('passes isTest=true to submitReport when NCMEC_ENV is "test"', async () => {
+    process.env.NCMEC_ENV = 'test';
+    const deps = makeDeps({
+      decisions: [makeNcmecDecisionRow(ORG_ID)],
+    });
+    const job = makeRetryFailedNcmecDecisionsJob(
+      jest.fn() as never,
+      deps.manualReviewToolService as never,
+      deps.ncmecService as never,
+      deps.getItemTypeEventuallyConsistent as never,
+      deps.actionPublisher as never,
+      deps.moderationConfigService as never,
+      deps.userManagementService as never,
+    );
+
+    await job.run();
+
+    expect(deps.ncmecService.submitReport).toHaveBeenCalledTimes(1);
+    const [, isTest] = deps.ncmecService.submitReport.mock.calls[0];
+    expect(isTest).toBe(true);
+  });
+
+  it('passes isTest=false to submitReport when NCMEC_ENV=production', async () => {
+    process.env.NCMEC_ENV = 'production';
+    const deps = makeDeps({
+      decisions: [makeNcmecDecisionRow(ORG_ID)],
+    });
+    const job = makeRetryFailedNcmecDecisionsJob(
+      jest.fn() as never,
+      deps.manualReviewToolService as never,
+      deps.ncmecService as never,
+      deps.getItemTypeEventuallyConsistent as never,
+      deps.actionPublisher as never,
+      deps.moderationConfigService as never,
+      deps.userManagementService as never,
+    );
+
+    await job.run();
+
+    expect(deps.ncmecService.submitReport).toHaveBeenCalledTimes(1);
+    const [, isTest] = deps.ncmecService.submitReport.mock.calls[0];
+    expect(isTest).toBe(false);
+  });
+
+  it('does not publish actions when NCMEC_ENV is unset (isTest=true)', async () => {
+    delete process.env.NCMEC_ENV;
+    const deps = makeDeps({
+      decisions: [makeNcmecDecisionRow(ORG_ID)],
+      // Simulate an org that has actions configured to run on NCMEC report
+      // creation. In production mode these would publish; in test mode they
+      // must be suppressed.
+      getNCMECActionsToRunAndPolicies: jest.fn(async () => ({
+        actionsToRunIds: ['action-1'],
+        policyIds: ['policy-1'],
+      })),
+    });
+    const job = makeRetryFailedNcmecDecisionsJob(
+      jest.fn() as never,
+      deps.manualReviewToolService as never,
+      deps.ncmecService as never,
+      deps.getItemTypeEventuallyConsistent as never,
+      deps.actionPublisher as never,
+      deps.moderationConfigService as never,
+      deps.userManagementService as never,
+    );
+
+    await job.run();
+
+    expect(deps.ncmecService.submitReport).toHaveBeenCalledTimes(1);
+    expect(deps.actionPublisher.publishActions).not.toHaveBeenCalled();
+  });
+
+  it('publishes actions when NCMEC_ENV=production (isTest=false)', async () => {
+    process.env.NCMEC_ENV = 'production';
+    const deps = makeDeps({
+      decisions: [makeNcmecDecisionRow(ORG_ID)],
+      getNCMECActionsToRunAndPolicies: jest.fn(async () => ({
+        actionsToRunIds: ['action-1'],
+        policyIds: ['policy-1'],
+      })),
+    });
+    const job = makeRetryFailedNcmecDecisionsJob(
+      jest.fn() as never,
+      deps.manualReviewToolService as never,
+      deps.ncmecService as never,
+      deps.getItemTypeEventuallyConsistent as never,
+      deps.actionPublisher as never,
+      deps.moderationConfigService as never,
+      deps.userManagementService as never,
+    );
+
+    await job.run();
+
+    expect(deps.ncmecService.submitReport).toHaveBeenCalledTimes(1);
+    expect(deps.actionPublisher.publishActions).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/workers_jobs/RetryFailedNcmecDecisionsJob.ts
+++ b/server/workers_jobs/RetryFailedNcmecDecisionsJob.ts
@@ -118,12 +118,6 @@ export default inject(
           getItemTypeEventuallyConsistent,
         });
         submitReportInvoked = true;
-        // Submissions go to the NCMEC test endpoint
-        // (exttest.cybertip.org) unless the deployment is explicitly
-        // configured for production via NCMEC_ENV=production. Operators
-        // are responsible for matching this to whether the credentials
-        // configured in Settings → NCMEC are production or test credentials
-        // issued by NCMEC.
         const isTest = process.env.NCMEC_ENV !== 'production';
         const reportResult = await ncmecService.submitReport(
           reportParams,

--- a/server/workers_jobs/RetryFailedNcmecDecisionsJob.ts
+++ b/server/workers_jobs/RetryFailedNcmecDecisionsJob.ts
@@ -118,9 +118,16 @@ export default inject(
           getItemTypeEventuallyConsistent,
         });
         submitReportInvoked = true;
+        // Submissions go to the NCMEC test endpoint
+        // (exttest.cybertip.org) unless the deployment is explicitly
+        // configured for production via NCMEC_ENV=production. Operators
+        // are responsible for matching this to whether the credentials
+        // configured in Settings → NCMEC are production or test credentials
+        // issued by NCMEC.
+        const isTest = process.env.NCMEC_ENV !== 'production';
         const reportResult = await ncmecService.submitReport(
           reportParams,
-          false,
+          isTest,
         );
         if (
           reportResult === 'UNSUPPORTED_ORG' ||
@@ -133,7 +140,8 @@ export default inject(
           await ncmecService.getNCMECActionsToRunAndPolicies(orgId);
         if (
           actionAndPolicy != null &&
-          actionAndPolicy.actionsToRunIds != null
+          actionAndPolicy.actionsToRunIds != null &&
+          !isTest
         ) {
           const actions = await moderationConfigService.getActions({
             orgId,


### PR DESCRIPTION
## Context & Requests for Reviewers

We have a job, `RetryFailedNcmecDecisionsJob`, that does what it says on the tin -- it looks up failed NCMEC submissions and retries them. But the logic is flawed, in two ways:

- It uses `getNcmecDecisions` to find NCMEC decisions, but does not exclude `is_test=true` decisions made, so this query can include test decisions intended to go to the NCMEC test endpoint
- It always submits reports to the production NCMEC endpoint regardless of the `NCMEC_ENV` environment variable.

This PR fixes this potential bug by having the job respect the current value of `NCMEC_ENV`.

Closes #927 .

## Tests

See tests in the PR.

## (Optional) Rollout Plan

N/A.

## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] ~~**If you changed anything user-facing** (i.e. user interface or APIs):~~
- [ ] ~~**If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**~~
- [ ] ~~**If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**~~
- [ ] ~~**If you added a new signal in `server/services/signalsService/signals/**`:**~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * NCMEC report retries now correctly distinguish between test and production environments.
  * Moderation actions and policies are no longer published during test-mode retries.
* **Tests**
  * Added coverage for environment-specific report submission and action publishing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->