### PR TITLE
Remove hard-coded NCMEC test-org allowlist

### DIFF
--- a/server/services/ncmecService/ncmecReporting.ts
+++ b/server/services/ncmecService/ncmecReporting.ts
@@ -1799,29 +1799,10 @@ export default class NcmecReporting {
         // failure, since we can't guarantee all traces with exceptions are
         // sampled in DD
         try {
-          // These are test accounts that we send to prospective users, and
-          // they should be able to click "Send to NCMEC" in the UI, but no
-          // NCMEC report should actually be created.
-          const testOrgs = ['4def6a77d6a', 'acc701627cb'];
-
           if (!(await this.hasNCMECReportingEnabled(reportParams.orgId))) {
             throw new Error(
               `NCMEC reports are not enabled for org ${reportParams.orgId}`,
             );
-          }
-
-          if (testOrgs.includes(reportParams.orgId)) {
-            if (reportParams.jobId !== undefined) {
-              await this.#recordSubmissionError({
-                jobId: reportParams.jobId,
-                userId: reportParams.reportedUser.id,
-                userTypeId: reportParams.reportedUser.typeId,
-                status: 'PERMANENT_ERROR',
-                error:
-                  'Org is on the NCMEC test allowlist; reports are suppressed.',
-              });
-            }
-            return 'UNSUPPORTED_ORG';
           }
 
           if (reportParams.media.length === 0) {


### PR DESCRIPTION
## Context & Requests for Reviewers

This removes some hard-coded test orgs that were a leftover from Coop's pre-ROOST days. These presumably no longer exist (and it's messy to hard-code stuff like this).

## Tests

None.

## (Optional) Rollout Plan

I can't think of anything here, unless a managed service provider happens to be using these org IDs but that seems deeply unlikely. These hard-coded IDs were there from the very first commit in this repo.

## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] ~~**If you changed anything user-facing** (i.e. user interface or APIs):~~
- [ ] ~~**If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**~~
- [ ] ~~**If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**~~
- [ ] ~~**If you added a new signal in `server/services/signalsService/signals/**`:**~~