### PR TITLE
Disambiguate NCMEC test flag

### DIFF
--- a/server/iocContainer/index.ts
+++ b/server/iocContainer/index.ts
@@ -144,6 +144,7 @@ import {
 } from '../services/moderationConfigService/moderationConfigServiceQueries.js';
 import {
   buildSubmitReportParamsFromDecision,
+  isNcmecTestDeployment,
   makeNcmecService,
   type NcmecService,
 } from '../services/ncmecService/index.js';
@@ -1283,16 +1284,15 @@ export default async function getBottle() {
                       getItemTypeEventuallyConsistent:
                         container.getItemTypeEventuallyConsistent,
                     });
-                  // Submissions go to the NCMEC test endpoint
-                  // (exttest.cybertip.org) unless the deployment is explicitly
-                  // configured for production via NCMEC_ENV=production. Operators
-                  // are responsible for matching this to whether the credentials
-                  // configured in Settings → NCMEC are production or test
-                  // credentials issued by NCMEC.
-                  const isTest = process.env.NCMEC_ENV !== 'production';
+                  // Per-report test flag, persisted to `ncmec_reports.is_test`.
+                  // Endpoint selection (sandbox vs production) is driven by
+                  // NCMEC_ENV inside submitReport; this flag records whether
+                  // this specific report row is a test submission and gates
+                  // downstream action publishing.
+                  const isTestReport = isNcmecTestDeployment();
                   await container.NcmecService.submitReport(
                     reportParams,
-                    isTest,
+                    isTestReport,
                   );
                   const actionAndPolicy =
                     await container.NcmecService.getNCMECActionsToRunAndPolicies(
@@ -1307,7 +1307,7 @@ export default async function getBottle() {
                     actionAndPolicy != null &&
                     actionAndPolicy.actionsToRunIds != null &&
                     isNonEmptyArray(decisionActions) &&
-                    !isTest
+                    !isTestReport
                   ) {
                     await publishActions({
                       decisionActions,

--- a/server/services/ncmecService/index.ts
+++ b/server/services/ncmecService/index.ts
@@ -16,3 +16,4 @@ export {
   buildSubmitReportParamsFromDecision,
   LEGACY_FALLBACK_INCIDENT_TYPE,
 } from './buildSubmitReportParamsFromDecision.js';
+export { isNcmecTestDeployment } from './ncmecEnv.js';

--- a/server/services/ncmecService/ncmecEnv.test.ts
+++ b/server/services/ncmecService/ncmecEnv.test.ts
@@ -1,0 +1,33 @@
+import { isNcmecTestDeployment } from './ncmecEnv.js';
+
+describe('isNcmecTestDeployment', () => {
+  const original = process.env.NCMEC_ENV;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.NCMEC_ENV;
+    } else {
+      process.env.NCMEC_ENV = original;
+    }
+  });
+
+  it('returns true when NCMEC_ENV is unset', () => {
+    delete process.env.NCMEC_ENV;
+    expect(isNcmecTestDeployment()).toBe(true);
+  });
+
+  it('returns true when NCMEC_ENV is "test"', () => {
+    process.env.NCMEC_ENV = 'test';
+    expect(isNcmecTestDeployment()).toBe(true);
+  });
+
+  it('returns true when NCMEC_ENV is any non-production value', () => {
+    process.env.NCMEC_ENV = 'staging';
+    expect(isNcmecTestDeployment()).toBe(true);
+  });
+
+  it('returns false only when NCMEC_ENV is exactly "production"', () => {
+    process.env.NCMEC_ENV = 'production';
+    expect(isNcmecTestDeployment()).toBe(false);
+  });
+});

--- a/server/services/ncmecService/ncmecEnv.ts
+++ b/server/services/ncmecService/ncmecEnv.ts
@@ -1,0 +1,18 @@
+/**
+ * Whether this deployment submits NCMEC CyberTips to the sandbox endpoint
+ * (`exttest.cybertip.org`) rather than the production endpoint
+ * (`report.cybertip.org`).
+ *
+ * Driven solely by `NCMEC_ENV`: any value other than the literal `"production"`
+ * (including unset/empty) routes to the sandbox. This is a **deployment-wide**
+ * property — it does not vary per report. Contrast with the per-report
+ * `isTestReport` flag persisted on `ncmec_reports.is_test`, which records
+ * whether an individual report row is a test submission.
+ *
+ * Centralising this here means endpoint selection has a single source of
+ * truth; call sites no longer need to thread a sandbox boolean into
+ * `submitReport` for the endpoint to be chosen correctly.
+ */
+export function isNcmecTestDeployment(): boolean {
+  return process.env.NCMEC_ENV !== 'production';
+}

--- a/server/services/ncmecService/ncmecReporting.ts
+++ b/server/services/ncmecService/ncmecReporting.ts
@@ -37,6 +37,7 @@ import {
   ncmecDebugEnabled,
   ncmecDebugLog,
 } from './ncmecDebug.js';
+import { isNcmecTestDeployment } from './ncmecEnv.js';
 import { summarizeNcmecErrorForReviewer } from './ncmecReviewerErrors.js';
 
 export const NCMECEvent = makeEnumLike([
@@ -1765,7 +1766,11 @@ export default class NcmecReporting {
 
   async submitReport(
     reportParams: NCMECReportParams,
-    isTest: boolean,
+    /** Whether this individual report row is a test submission. Persisted to
+     * `ncmec_reports.is_test` and used to skip the existing-report dedup
+     * check, the prior-CT-report lookup, and data-preservation requests.
+     * Distinct from `isNcmecTestDeployment()` (env-driven endpoint selection). */
+    isTestReport: boolean,
   ): Promise<NcmecReportResult> {
     return this.tracer.addSpan(
       {
@@ -1791,7 +1796,8 @@ export default class NcmecReporting {
           jsonStringify(logSafeReportParams),
         );
         ncmecDebugLog('submitReport.start', {
-          isTest,
+          isTestReport,
+          sandbox: isNcmecTestDeployment(),
           ...logSafeReportParams,
         });
 
@@ -1860,7 +1866,7 @@ export default class NcmecReporting {
             throw new Error('Insufficient settings');
           }
 
-          if (isTest === false) {
+          if (isTestReport === false) {
             const hasExistingReport = await this.getUserHasExistingNcmeReport({
               orgId: reportParams.orgId,
               userId: reportParams.reportedUser.id,
@@ -1927,7 +1933,7 @@ export default class NcmecReporting {
 
           // Skip for test submissions: prod and exttest report IDs don't
           // cross-reference.
-          const priorCTReports = isTest
+          const priorCTReports = isTestReport
             ? []
             : await this.getPriorCTReportIds({
                 orgId: reportParams.orgId,
@@ -1971,7 +1977,6 @@ export default class NcmecReporting {
           const { reportId, xml } = await this.#submit(
             report,
             cybertipAuthenticationCredentials,
-            isTest,
           );
 
           const reportedMedia = await Promise.all(
@@ -2001,7 +2006,6 @@ export default class NcmecReporting {
                 media,
                 cybertipAuthenticationCredentials,
                 mergedMediaInfo,
-                isTest,
               );
             }),
           );
@@ -2014,7 +2018,6 @@ export default class NcmecReporting {
                       reportId,
                       cybertipAuthenticationCredentials,
                       additionalFile,
-                      isTest,
                     ),
                   ),
                 )
@@ -2025,14 +2028,9 @@ export default class NcmecReporting {
             reportId,
             reportParams.threads,
             cybertipAuthenticationCredentials,
-            isTest,
           );
 
-          await this.#finish(
-            reportId,
-            cybertipAuthenticationCredentials,
-            isTest,
-          );
+          await this.#finish(reportId, cybertipAuthenticationCredentials);
 
           await this.pgQuery
             .insertInto('ncmec_reporting.ncmec_reports')
@@ -2049,11 +2047,14 @@ export default class NcmecReporting {
               additional_files: additionalFiles,
               reported_messages: threadCsvs,
               incident_type: reportParams.incidentType,
-              is_test: isTest,
+              is_test: isTestReport,
             })
             .execute();
 
-          if (ncmecConfig?.ncmec_preservation_endpoint && isTest === false) {
+          if (
+            ncmecConfig?.ncmec_preservation_endpoint &&
+            isTestReport === false
+          ) {
             await this.#sendUserPreservationRequest({
               orgId: reportParams.orgId,
               user: {
@@ -2078,7 +2079,8 @@ export default class NcmecReporting {
             error: e,
             message: jsonStringify({
               reportParams: logSafeReportParams,
-              isTest,
+              isTestReport,
+              sandbox: isNcmecTestDeployment(),
             }),
           });
           span.recordException(e as Exception);
@@ -2104,7 +2106,6 @@ export default class NcmecReporting {
       additionalInfo?: string[] | undefined;
       fileName?: string;
     },
-    isTest: boolean,
   ): Promise<NcmecAdditionalFile> {
     const downloadWithRetries = withRetries(
       {
@@ -2140,7 +2141,6 @@ export default class NcmecReporting {
           }),
           route: '/upload',
           includeContentType: false, // remove ContentType header
-          isTest,
         });
       },
     );
@@ -2162,7 +2162,6 @@ export default class NcmecReporting {
         },
       },
       cybertipAuthenticationCredentials,
-      isTest,
     );
     return {
       ncmecFileId: fileId,
@@ -2174,13 +2173,15 @@ export default class NcmecReporting {
   async #submit(
     report: Report,
     cybertipAuthenticationCredentials: CyberTipAuth,
-    isTest: boolean,
   ) {
     const reportXML = js2xml(report, { compact: true });
 
-    ncmecDebugLog('submit.xml', { isTest, length: reportXML.length });
+    ncmecDebugLog('submit.xml', {
+      sandbox: isNcmecTestDeployment(),
+      length: reportXML.length,
+    });
     await ncmecDebugDump(
-      `${isTest ? 'TEST-' : 'PROD-'}${new Date()
+      `${isNcmecTestDeployment() ? 'TEST-' : 'PROD-'}${new Date()
         .toISOString()
         .replace(/[:.]/g, '-')}-submit.xml`,
       reportXML,
@@ -2190,7 +2191,6 @@ export default class NcmecReporting {
       cybertipAuthenticationCredentials,
       body: reportXML,
       route: '/submit',
-      isTest,
     });
 
     const responseJson = response.body as CyberTipSubmitResponse;
@@ -2211,7 +2211,6 @@ export default class NcmecReporting {
     media: Media,
     cybertipAuthenticationCredentials: CyberTipAuth,
     additionalInfo: MediaAdditionalInfo,
-    isTest: boolean,
   ) {
     // TODO: Handle when this fails because of Unidici's memory limit
     const downloadWithRetries = withRetries(
@@ -2245,7 +2244,6 @@ export default class NcmecReporting {
           }),
           route: '/upload',
           includeContentType: false,
-          isTest,
         });
       },
     );
@@ -2273,7 +2271,6 @@ export default class NcmecReporting {
     const xml = await this.#uploadFileDetails(
       fileDetailsObject,
       cybertipAuthenticationCredentials,
-      isTest,
     );
     return {
       ncmecFileId: fileId,
@@ -2286,17 +2283,16 @@ export default class NcmecReporting {
   async #uploadFileDetails(
     fileDetails: FileDetails,
     cybertipAuthenticationCredentials: CyberTipAuth,
-    isTest: boolean,
   ) {
     const fileDetailsXML = js2xml(fileDetails, { compact: true });
     ncmecDebugLog('fileinfo.xml', {
-      isTest,
+      sandbox: isNcmecTestDeployment(),
       reportId: fileDetails.fileDetails.reportId,
       fileId: fileDetails.fileDetails.fileId,
       length: fileDetailsXML.length,
     });
     await ncmecDebugDump(
-      `${isTest ? 'TEST-' : 'PROD-'}${new Date()
+      `${isNcmecTestDeployment() ? 'TEST-' : 'PROD-'}${new Date()
         .toISOString()
         .replace(/[:.]/g, '-')}-fileinfo-${fileDetails.fileDetails.fileId}.xml`,
       fileDetailsXML,
@@ -2305,7 +2301,6 @@ export default class NcmecReporting {
       cybertipAuthenticationCredentials,
       body: fileDetailsXML,
       route: '/fileinfo',
-      isTest,
     });
 
     const responseJson = response.body as CyberTipFileDetailsResponse;
@@ -2319,7 +2314,6 @@ export default class NcmecReporting {
     reportId: string,
     reportedMedia: readonly NCMECThreadReport[],
     cybertipAuthenticationCredentials: CyberTipAuth,
-    isTest: boolean,
   ) {
     const escapeCSVField = (field: string | undefined | null): string => {
       if (field == null) {
@@ -2377,7 +2371,6 @@ export default class NcmecReporting {
           body: requestBody,
           route: '/upload',
           includeContentType: false,
-          isTest,
         });
 
         if (!response.ok || response.body == null) {
@@ -2403,7 +2396,6 @@ export default class NcmecReporting {
             },
           },
           cybertipAuthenticationCredentials,
-          isTest,
         );
 
         return {
@@ -2418,9 +2410,11 @@ export default class NcmecReporting {
   async #finish(
     reportId: string,
     cybertipAuthenticationCredentials: CyberTipAuth,
-    isTest: boolean,
   ) {
-    ncmecDebugLog('finish.request', { reportId, isTest });
+    ncmecDebugLog('finish.request', {
+      reportId,
+      sandbox: isNcmecTestDeployment(),
+    });
     const requestBody = new FormData();
     requestBody.append('id', reportId);
 
@@ -2429,7 +2423,6 @@ export default class NcmecReporting {
       body: requestBody,
       route: '/finish',
       includeContentType: false,
-      isTest,
     });
 
     if (!response.ok) {
@@ -2488,14 +2481,12 @@ export default class NcmecReporting {
     cybertipAuthenticationCredentials: CyberTipAuth;
     body: string | FormData | FormDataLikeWithStreams;
     route: `/${string}`;
-    isTest: boolean;
     includeContentType?: boolean;
   }) {
     const {
       cybertipAuthenticationCredentials,
       body,
       route,
-      isTest,
       includeContentType = true,
     } = input;
     const username = cybertipAuthenticationCredentials.username;
@@ -2512,12 +2503,13 @@ export default class NcmecReporting {
         jitter: true,
       },
       async () => {
-        const url = isTest
+        const sandbox = isNcmecTestDeployment();
+        const url = sandbox
           ? `https://exttest.cybertip.org/ispws${route}`
           : `https://report.cybertip.org/ispws${route}`;
         ncmecDebugLog('cybertip.request', {
           route,
-          isTest,
+          sandbox,
           bodyKind: typeof body === 'string' ? 'xml' : 'formData',
           bodyLength: typeof body === 'string' ? body.length : undefined,
         });

--- a/server/services/ncmecService/ncmecService.ts
+++ b/server/services/ncmecService/ncmecService.ts
@@ -59,8 +59,14 @@ export class NcmecService {
     );
   }
 
-  async submitReport(reportParams: NCMECReportParams, isTest: boolean) {
-    return this.ncmecReporting.submitReport(reportParams, isTest);
+  async submitReport(
+    reportParams: NCMECReportParams,
+    /** Whether this individual report row is a test submission, persisted to
+     * `ncmec_reports.is_test`. Endpoint selection (sandbox vs production) is
+     * driven by `NCMEC_ENV` inside `NcmecReporting.submitReport`. */
+    isTestReport: boolean,
+  ) {
+    return this.ncmecReporting.submitReport(reportParams, isTestReport);
   }
 
   /** Org-scoped retry for a previously-failed NCMEC submission. See

--- a/server/services/ncmecService/retryNcmecSubmission.ts
+++ b/server/services/ncmecService/retryNcmecSubmission.ts
@@ -4,6 +4,7 @@ import {
   buildSubmitReportParamsFromDecision,
   LEGACY_FALLBACK_INCIDENT_TYPE,
 } from './buildSubmitReportParamsFromDecision.js';
+import { isNcmecTestDeployment } from './ncmecEnv.js';
 import type NcmecReporting from './ncmecReporting.js';
 
 /** Result of a retry attempt. Distinct cases let the GraphQL layer return a
@@ -104,11 +105,14 @@ export async function retryNcmecSubmission(
     return { kind: 'permanent_error', error };
   }
 
-  const isTest = process.env.NCMEC_ENV !== 'production';
+  const isTestReport = isNcmecTestDeployment();
   // submitReport owns `ncmec_reports_errors` writes via `jobId` so retries
   // always update retry_count/last_error. Don't double-write here.
   try {
-    const result = await deps.ncmecReporting.submitReport(reportParams, isTest);
+    const result = await deps.ncmecReporting.submitReport(
+      reportParams,
+      isTestReport,
+    );
     if (result === 'SUCCESS') {
       return { kind: 'success' };
     }

--- a/server/test/integ/ncmec-submission.integ.test.ts
+++ b/server/test/integ/ncmec-submission.integ.test.ts
@@ -197,13 +197,22 @@ describe('NCMEC submitReport (integration)', () => {
       const result = await ncmecReporting.submitReport(reportParams, false);
       expect(result).toBe('SUCCESS');
 
+      // Endpoint selection follows NCMEC_ENV (unset here → sandbox), NOT the
+      // per-report isTestReport flag. So even though isTestReport=false above,
+      // the requests must go to the test endpoint exttest.cybertip.org.
+      expect(
+        stub.calls
+          .filter((c) => c.url.includes('cybertip.org'))
+          .every((c) => c.url.startsWith('https://exttest.cybertip.org/')),
+      ).toBe(true);
+
       // protocol sequence — the full NCMEC submit flow
       const routes = stub.calls
         .filter((c) => c.url.includes('cybertip.org'))
         .map((c) => c.url.replace(/^.*\/ispws/, ''));
       expect(routes).toEqual(['/submit', '/upload', '/fileinfo', '/finish']);
 
-      // preservation fired (isTest=false + endpoint set)
+      // preservation fired (isTestReport=false + endpoint set)
       expect(stub.calls.some((c) => c.url === PRESERVATION_URL)).toBe(true);
 
       // outgoing /submit request shape — proves the field-role-resolved email,


### PR DESCRIPTION
## Context & Requests for Reviewers

<!-- Briefly describe the changes introduced in this pull request. Link GitHub Issue if available for context on your change. -->

## Tests

<!-- Describe how you tested your changes, including any manual steps or automated tests performed. -->
<!-- Provide screenshots if available -->

## (Optional) Rollout Plan

<!--
Are there any special things that have to be done before this can be deployed
to prod (e.g., other blocking PRs; manual load testing/validation that needs to
be done on staging; etc.)? If so, please note them here.
 -->

## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] **If you changed anything user-facing** (i.e. user interface or APIs):
  Did you update the CHANGELOG.md and related docs?

- [ ] **If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**
  Did you update the corresponding history tables and their triggers?

- [ ] **If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?

- [ ] **If you added a new signal in `server/services/signalsService/signals/**`:**
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.