### PR TITLE
Disable max lines lint on tests files

### DIFF
--- a/server/.eslintrc.cjs
+++ b/server/.eslintrc.cjs
@@ -694,6 +694,7 @@ module.exports = {
           },
         ],
         'no-console': 'off',
+        'max-lines': 'off',
         // Allow `typeof import('...')` annotations; needed for E2E tests.
         '@typescript-eslint/consistent-type-imports': [
           'error',


### PR DESCRIPTION
## Context & Requests for Reviewers

As we are more tests to cover regressions and new features our tests files may become bigger than 500 lines which is acceptable. We can certainly split test files, but some are logical part of specific features. as such this is not really as needed for tests compared to normal feature files.