### PR TITLE
[818] Fix strike analytics link to navigate to the struck user

### DIFF
--- a/client/src/graphql/generated.ts
+++ b/client/src/graphql/generated.ts
@@ -3794,6 +3794,8 @@ export type GQLRecentManualReviewUserOrRelatedActionDecision = {
 export type GQLRecentUserStrikeActions = {
   readonly __typename: 'RecentUserStrikeActions';
   readonly actionId: Scalars['String']['output'];
+  readonly creatorId?: Maybe<Scalars['String']['output']>;
+  readonly creatorTypeId?: Maybe<Scalars['String']['output']>;
   readonly itemId: Scalars['String']['output'];
   readonly itemTypeId: Scalars['String']['output'];
   readonly source: Scalars['String']['output'];
@@ -24668,6 +24670,8 @@ export type GQLRecentUserStrikeActionsQuery = {
     readonly __typename: 'RecentUserStrikeActions';
     readonly itemId: string;
     readonly itemTypeId: string;
+    readonly creatorId?: string | null;
+    readonly creatorTypeId?: string | null;
     readonly actionId: string;
     readonly source: string;
     readonly time: Date | string;
@@ -42472,6 +42476,8 @@ export const GQLRecentUserStrikeActionsDocument = gql`
     recentUserStrikeActions(input: $input) {
       itemId
       itemTypeId
+      creatorId
+      creatorTypeId
       actionId
       source
       time

--- a/client/src/webpages/dashboard/userStrikes/StrikeAnalyticsTab.tsx
+++ b/client/src/webpages/dashboard/userStrikes/StrikeAnalyticsTab.tsx
@@ -219,17 +219,17 @@ function RecentUserStrikeActionsTable() {
           values.creatorId && values.creatorTypeId
             ? { id: values.creatorId, typeId: values.creatorTypeId }
             : null;
-        const userId = creatorIdentity?.id ?? values.itemId;
-        const userTypeId = creatorIdentity?.typeId ?? values.itemTypeId;
         return {
-          user: (
+          user: creatorIdentity ? (
             <Link
               className="cursor-pointer shrink-0"
-              to={`/dashboard/manual_review/investigation?id=${userId}&typeId=${userTypeId}`}
+              to={`/dashboard/manual_review/investigation?id=${creatorIdentity.id}&typeId=${creatorIdentity.typeId}`}
               target="_blank"
             >
-              {userId}
+              {creatorIdentity.id}
             </Link>
+          ) : (
+            <span className="text-gray-500">{values.itemId}</span>
           ),
           action: actionsById
             ? (actionsById[values.actionId] ?? 'Unknown')

--- a/client/src/webpages/dashboard/userStrikes/StrikeAnalyticsTab.tsx
+++ b/client/src/webpages/dashboard/userStrikes/StrikeAnalyticsTab.tsx
@@ -215,8 +215,12 @@ function RecentUserStrikeActionsTable() {
       ?.slice()
       ?.sort((a, b) => (a.time > b.time ? -1 : a.time < b.time ? 1 : 0))
       .map((values) => {
-        const userId = values.creatorId ?? values.itemId;
-        const userTypeId = values.creatorTypeId ?? values.itemTypeId;
+        const creatorIdentity =
+          values.creatorId && values.creatorTypeId
+            ? { id: values.creatorId, typeId: values.creatorTypeId }
+            : null;
+        const userId = creatorIdentity?.id ?? values.itemId;
+        const userTypeId = creatorIdentity?.typeId ?? values.itemTypeId;
         return {
           user: (
             <Link

--- a/client/src/webpages/dashboard/userStrikes/StrikeAnalyticsTab.tsx
+++ b/client/src/webpages/dashboard/userStrikes/StrikeAnalyticsTab.tsx
@@ -26,6 +26,8 @@ gql`
     recentUserStrikeActions(input: $input) {
       itemId
       itemTypeId
+      creatorId
+      creatorTypeId
       actionId
       source
       time
@@ -213,14 +215,16 @@ function RecentUserStrikeActionsTable() {
       ?.slice()
       ?.sort((a, b) => (a.time > b.time ? -1 : a.time < b.time ? 1 : 0))
       .map((values) => {
+        const userId = values.creatorId ?? values.itemId;
+        const userTypeId = values.creatorTypeId ?? values.itemTypeId;
         return {
           user: (
             <Link
               className="cursor-pointer shrink-0"
-              to={`/dashboard/manual_review/investigation?id=${values.itemId}&typeId=${values.itemTypeId}`}
+              to={`/dashboard/manual_review/investigation?id=${userId}&typeId=${userTypeId}`}
               target="_blank"
             >
-              {values.itemId}
+              {userId}
             </Link>
           ),
           action: actionsById

--- a/server/graphql/generated.ts
+++ b/server/graphql/generated.ts
@@ -3862,6 +3862,8 @@ export type GQLRecentManualReviewUserOrRelatedActionDecision = {
 export type GQLRecentUserStrikeActions = {
   readonly __typename?: 'RecentUserStrikeActions';
   readonly actionId: Scalars['String']['output'];
+  readonly creatorId?: Maybe<Scalars['String']['output']>;
+  readonly creatorTypeId?: Maybe<Scalars['String']['output']>;
   readonly itemId: Scalars['String']['output'];
   readonly itemTypeId: Scalars['String']['output'];
   readonly source: Scalars['String']['output'];
@@ -12862,6 +12864,16 @@ export type GQLRecentUserStrikeActionsResolvers<
     GQLResolversParentTypes['RecentUserStrikeActions'],
 > = {
   actionId?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  creatorId?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  creatorTypeId?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
   itemId?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   itemTypeId?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   source?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;

--- a/server/graphql/modules/actionStatistics.ts
+++ b/server/graphql/modules/actionStatistics.ts
@@ -50,6 +50,8 @@ const typeDefs = /* GraphQL */ `
     itemId: String!
     actionId: String!
     source: String!
+    creatorId: String
+    creatorTypeId: String
   }
 
   input StartAndEndDateFilterByInput {

--- a/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.test.ts
+++ b/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.test.ts
@@ -174,7 +174,7 @@ describe('ClickhouseActionExecutionsAdapter.getRecentUserStrikeActions', () => {
     });
   });
 
-  it('returns null creator fields when columns are missing', async () => {
+  it('returns null creator fields when columns are null', async () => {
     const ts = '2026-06-01T10:00:00.000Z';
     const { adapter } = makeAdapter([
       {
@@ -220,6 +220,31 @@ describe('ClickhouseActionExecutionsAdapter.getRecentUserStrikeActions', () => {
     });
 
     expect(results[0]?.creatorId).toBe('user-5');
+    expect(results[0]?.creatorTypeId).toBeNull();
+  });
+
+  it('normalizes empty-string creator fields to null', async () => {
+    const ts = '2026-06-01T10:00:00.000Z';
+    const { adapter } = makeAdapter([
+      {
+        ts,
+        item_id: 'content-1',
+        item_type_id: 'content-type-A',
+        item_type_kind: 'CONTENT',
+        item_creator_id: '',
+        item_creator_type_id: '',
+        action_id: 'action-ban',
+        action_source: 'user-strike-action-execution',
+      },
+    ]);
+
+    const results = await adapter.getRecentUserStrikeActions({
+      orgId: 'org-1',
+      limit: 10,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.creatorId).toBeNull();
     expect(results[0]?.creatorTypeId).toBeNull();
   });
 

--- a/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.test.ts
+++ b/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.test.ts
@@ -142,6 +142,74 @@ describe('ClickhouseActionExecutionsAdapter.findInferredUserIdentity', () => {
   });
 });
 
+describe('ClickhouseActionExecutionsAdapter.getRecentUserStrikeActions', () => {
+  it('includes creator fields in the returned records', async () => {
+    const ts = '2026-06-01T10:00:00.000Z';
+    const { adapter } = makeAdapter([
+      {
+        ts,
+        item_id: 'content-1',
+        item_type_id: 'content-type-A',
+        item_type_kind: 'CONTENT',
+        item_creator_id: 'user-7',
+        item_creator_type_id: 'user-type-X',
+        action_id: 'action-ban',
+        action_source: 'user-strike-action-execution',
+      },
+    ]);
+
+    const results = await adapter.getRecentUserStrikeActions({
+      orgId: 'org-1',
+      limit: 10,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      actionId: 'action-ban',
+      itemId: 'content-1',
+      itemTypeId: 'content-type-A',
+      creatorId: 'user-7',
+      creatorTypeId: 'user-type-X',
+      source: 'user-strike-action-execution',
+    });
+  });
+
+  it('returns null creator fields when columns are missing', async () => {
+    const ts = '2026-06-01T10:00:00.000Z';
+    const { adapter } = makeAdapter([
+      {
+        ts,
+        item_id: 'user-direct',
+        item_type_id: 'user-type-A',
+        item_type_kind: 'USER',
+        item_creator_id: null,
+        item_creator_type_id: null,
+        action_id: 'action-suspend',
+        action_source: 'user-strike-action-execution',
+      },
+    ]);
+
+    const results = await adapter.getRecentUserStrikeActions({
+      orgId: 'org-1',
+      limit: 10,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.creatorId).toBeNull();
+    expect(results[0]?.creatorTypeId).toBeNull();
+  });
+
+  it('selects item_creator_id and item_creator_type_id in the SQL', async () => {
+    const { adapter, query } = makeAdapter([]);
+
+    await adapter.getRecentUserStrikeActions({ orgId: 'org-1', limit: 5 });
+
+    const sentSql = query.mock.calls[0][0];
+    expect(sentSql).toContain('item_creator_id');
+    expect(sentSql).toContain('item_creator_type_id');
+  });
+});
+
 describe('ClickhouseActionExecutionsAdapter.findContentCreatorIdentity', () => {
   it('returns null when no rows match', async () => {
     const { adapter } = makeAdapter([]);

--- a/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.test.ts
+++ b/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.test.ts
@@ -199,6 +199,30 @@ describe('ClickhouseActionExecutionsAdapter.getRecentUserStrikeActions', () => {
     expect(results[0]?.creatorTypeId).toBeNull();
   });
 
+  it('returns both creator fields when both are present in the row', async () => {
+    const ts = '2026-06-01T10:00:00.000Z';
+    const { adapter } = makeAdapter([
+      {
+        ts,
+        item_id: 'content-1',
+        item_type_id: 'content-type-A',
+        item_type_kind: 'CONTENT',
+        item_creator_id: 'user-5',
+        item_creator_type_id: null,
+        action_id: 'action-ban',
+        action_source: 'user-strike-action-execution',
+      },
+    ]);
+
+    const results = await adapter.getRecentUserStrikeActions({
+      orgId: 'org-1',
+      limit: 10,
+    });
+
+    expect(results[0]?.creatorId).toBe('user-5');
+    expect(results[0]?.creatorTypeId).toBeNull();
+  });
+
   it('selects item_creator_id and item_creator_type_id in the SQL', async () => {
     const { adapter, query } = makeAdapter([]);
 

--- a/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.ts
+++ b/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.ts
@@ -115,6 +115,8 @@ export class ClickhouseActionExecutionsAdapter implements IActionExecutionsAdapt
         ts,
         item_id,
         item_type_id,
+        item_creator_id,
+        item_creator_type_id,
         action_id,
         action_source
       FROM analytics.ACTION_EXECUTIONS
@@ -134,6 +136,8 @@ export class ClickhouseActionExecutionsAdapter implements IActionExecutionsAdapt
         actionId: row.action_id,
         itemId: row.item_id!,
         itemTypeId: row.item_type_id!,
+        creatorId: row.item_creator_id ?? null,
+        creatorTypeId: row.item_creator_type_id ?? null,
         source: row.action_source ?? 'user-strike-action-execution',
         occurredAt: new Date(row.ts),
       }));

--- a/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.ts
+++ b/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.ts
@@ -136,8 +136,8 @@ export class ClickhouseActionExecutionsAdapter implements IActionExecutionsAdapt
         actionId: row.action_id,
         itemId: row.item_id!,
         itemTypeId: row.item_type_id!,
-        creatorId: row.item_creator_id ?? null,
-        creatorTypeId: row.item_creator_type_id ?? null,
+        creatorId: row.item_creator_id || null,
+        creatorTypeId: row.item_creator_type_id || null,
         source: row.action_source ?? 'user-strike-action-execution',
         occurredAt: new Date(row.ts),
       }));

--- a/server/plugins/warehouse/queries/IActionExecutionsAdapter.ts
+++ b/server/plugins/warehouse/queries/IActionExecutionsAdapter.ts
@@ -15,6 +15,8 @@ export interface UserStrikeActionRecord {
   actionId: string;
   itemId: string;
   itemTypeId: string;
+  creatorId: string | null;
+  creatorTypeId: string | null;
   source: string;
   occurredAt: Date;
 }

--- a/server/services/userStrikeService/userStrikeService.ts
+++ b/server/services/userStrikeService/userStrikeService.ts
@@ -266,8 +266,9 @@ export class UserStrikeService {
               actionId: it.actionId,
               itemId: it.itemId,
               itemTypeId: it.itemTypeId,
-              creatorId: it.creatorId ?? null,
-              creatorTypeId: it.creatorTypeId ?? null,
+              creatorId: it.creatorId && it.creatorTypeId ? it.creatorId : null,
+              creatorTypeId:
+                it.creatorId && it.creatorTypeId ? it.creatorTypeId : null,
               source: it.source,
               time: it.occurredAt,
             }

--- a/server/services/userStrikeService/userStrikeService.ts
+++ b/server/services/userStrikeService/userStrikeService.ts
@@ -266,6 +266,8 @@ export class UserStrikeService {
               actionId: it.actionId,
               itemId: it.itemId,
               itemTypeId: it.itemTypeId,
+              creatorId: it.creatorId ?? null,
+              creatorTypeId: it.creatorTypeId ?? null,
               source: it.source,
               time: it.occurredAt,
             }


### PR DESCRIPTION
## Context & Requests for Reviewers

Fixes #818

The "User" column in the strike analytics table was linking to the content item that triggered the strike chain, not the user who was actually struck. Now uses `item_creator_id/item_creator_type_id` from the action execution log so the link opens the correct user in Investigation.

<img width="1698" height="868" alt="Screenshot 2026-08-08 at 11 05 47 AM" src="https://github.com/user-attachments/assets/958d9717-4e93-4bae-8e06-e2b85370f300" />
<img width="760" height="164" alt="Screenshot 2026-08-08 at 11 05 52 AM" src="https://github.com/user-attachments/assets/cff5fdf3-9c9f-43de-a08d-164d4fa50ec1" />
<img width="1702" height="932" alt="Screenshot 2026-08-08 at 11 05 58 AM" src="https://github.com/user-attachments/assets/458210bd-1511-4b90-96b4-646863f209f9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Strike analytics now displays creator identifiers for recent strike actions when available.
  * Investigation links use creator identifiers, with item identifiers used as a fallback.
  * Recent strike action data now supports creator ID and creator type ID fields.

* **Bug Fixes**
  * Improved accuracy when identifying the source of strike actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->