### PR TITLE
[915] Fix Podman compose setup by resolving backend from resolv.conf

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -22,6 +22,8 @@ RUN NODE_OPTIONS="--max-old-space-size=5250" VITE_OTEL_EXPORTER_OTLP_TRACES_ENDP
 
 FROM nginx:1.29.1-bookworm AS serve
 COPY --from=build /app/build /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+ENV NGINX_ENTRYPOINT_LOCAL_RESOLVERS=1
+ENV NGINX_ENVSUBST_FILTER=NGINX_
+COPY nginx.conf /etc/nginx/templates/default.conf.template
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -3,7 +3,8 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    resolver 127.0.0.11 valid=30s;
+    # Populated at container start from /etc/resolv.conf.
+    resolver ${NGINX_LOCAL_RESOLVERS} valid=30s ipv6=off;
     set $backend "http://server:8080";
 
     location ^~ /api/ {


### PR DESCRIPTION
## Context & Requests for Reviewers

Fixes #915.

The client nginx config hardcoded Docker’s embedded DNS (`127.0.0.11`) for runtime resolution of the `server` backend. That works on Docker, but Podman uses the network gateway as its nameserver, so nginx fails to resolve `server` and `/api/` requests return 502.

Use the official nginx image’s built-in local resolver support: read nameservers from `/etc/resolv.conf` at container start and render them into the config via `NGINX_ENTRYPOINT_LOCAL_RESOLVERS` and a template.

## Test plan
- [x] **Podman before fix:** hardcoded `127.0.0.11` + real `coop-server` → `GET /api/v1/ready` returns **502**; nginx logs `send() failed (111: Connection refused) while resolving, resolver: 127.0.0.11:53`
- [x] **Podman after fix:** dynamic resolver matches Podman nameserver (e.g. `10.89.x.1`) + real `coop-server` → `GET /api/v1/ready` returns **200 Healthy** through nginx
- [x] **Docker regression:** fixed client image + real `coop-server` on `coop_default` → `GET /api/v1/ready` returns **200 Healthy** through nginx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container startup configuration for dynamic Nginx resolver settings.
  * Added support for configuring local DNS resolvers through environment variables.
  * Disabled IPv6 resolver lookups and added a 30-second DNS validity period.
  * Restricted environment-variable substitution to approved Nginx-prefixed settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->