### PR TITLE
Fix investigation result table filters

### DIFF
--- a/client/src/webpages/dashboard/investigation/ItemInvestigationRuleResults.test.tsx
+++ b/client/src/webpages/dashboard/investigation/ItemInvestigationRuleResults.test.tsx
@@ -1,0 +1,196 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useGQLInvestigationItemsQuery,
+  type GQLRuleEnvironment,
+} from '../../../graphql/generated';
+import ItemInvestigationRuleResults from './ItemInvestigationRuleResults';
+
+vi.mock('../../../graphql/generated', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../graphql/generated')>()),
+  useGQLInvestigationItemsQuery: vi.fn(),
+}));
+
+const execution = (
+  ruleId: string,
+  ruleName: string,
+  environment: GQLRuleEnvironment,
+  outcome: 'PASSED' | 'FAILED' | 'ERRORED' | undefined,
+) => ({
+  __typename: 'RuleExecutionResult',
+  date: '2026-01-01T00:00:00Z',
+  ts: '2026-01-01T00:00:00Z',
+  contentId: `${ruleId}-content`,
+  itemTypeName: 'Post',
+  itemTypeId: 'post',
+  content: '{}',
+  environment,
+  passed: outcome === 'PASSED',
+  ruleId,
+  ruleName,
+  policies: [`${ruleId} policy`],
+  tags: [`${ruleId} tag`],
+  result: outcome
+    ? {
+        __typename: 'ConditionSetWithResult',
+        conditions: [],
+        result: { __typename: 'ConditionResult', outcome },
+      }
+    : undefined,
+});
+
+function renderResults() {
+  render(
+    <MemoryRouter>
+      <ItemInvestigationRuleResults
+        itemIdentifier={{} as never}
+        rules={[
+          { id: 'z', actions: [{ name: 'Escalate' }] },
+          { id: 'b', actions: [{ name: 'Escalate' }] },
+          { id: 'a', actions: [{ name: 'Dismiss' }] },
+          { id: 's', actions: [{ name: 'Review' }] },
+          { id: 'p', actions: [{ name: 'Approve' }] },
+        ]}
+      />
+    </MemoryRouter>,
+  );
+}
+
+function ruleNames() {
+  return within(screen.getAllByRole('rowgroup')[1])
+    .getAllByRole('row')
+    .map((row) => within(row).getAllByRole('cell')[0].textContent);
+}
+
+describe('ItemInvestigationRuleResults raw table values', () => {
+  beforeEach(() => {
+    vi.mocked(useGQLInvestigationItemsQuery).mockReturnValue({
+      loading: false,
+      error: undefined,
+      data: {
+        __typename: 'Query',
+        itemWithHistory: {
+          __typename: 'ItemHistoryResult',
+          item: {
+            __typename: 'ContentItem',
+            id: 'item',
+            submissionId: 'submission',
+            type: { __typename: 'ContentItemType', id: 'post' },
+          },
+          executions: [
+            execution('z', 'Zulu Rule', 'LIVE', 'FAILED'),
+            execution('b', 'Backtest Rule', 'BACKTEST', 'FAILED'),
+            execution('a', 'Alpha Rule', 'RETROACTION', 'ERRORED'),
+            execution('s', 'Skipped Rule', 'BACKGROUND', undefined),
+            execution('p', 'Passed Rule', 'MANUAL', 'PASSED'),
+          ],
+        },
+      },
+    } as unknown as ReturnType<typeof useGQLInvestigationItemsQuery>);
+  });
+
+  it('sorts and applies a staged Rule filter using raw rule names', () => {
+    renderResults();
+
+    userEvent.click(screen.getByRole('columnheader', { name: /Rule/ }));
+    expect(ruleNames()).toEqual([
+      'Alpha Rule',
+      'Backtest Rule',
+      'Passed Rule',
+      'Skipped Rule',
+      'Zulu Rule',
+    ]);
+
+    userEvent.click(screen.getByRole('button', { name: /filter/i }));
+    userEvent.click(screen.getByText('Rule', { selector: 'div.text-start' }));
+    userEvent.type(screen.getByRole('textbox'), 'Zulu');
+    expect(ruleNames()).toEqual([
+      'Alpha Rule',
+      'Backtest Rule',
+      'Passed Rule',
+      'Skipped Rule',
+      'Zulu Rule',
+    ]);
+
+    userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(ruleNames()).toEqual(['Zulu Rule']);
+  });
+
+  it('sorts Result by its normalized display value in both directions', () => {
+    renderResults();
+
+    const resultHeader = screen.getByRole('columnheader', { name: /Result/ });
+    userEvent.click(resultHeader);
+    expect(ruleNames()).toEqual([
+      'Alpha Rule',
+      'Zulu Rule',
+      'Backtest Rule',
+      'Skipped Rule',
+      'Passed Rule',
+    ]);
+
+    userEvent.click(resultHeader);
+    expect(ruleNames()).toEqual([
+      'Passed Rule',
+      'Skipped Rule',
+      'Backtest Rule',
+      'Zulu Rule',
+      'Alpha Rule',
+    ]);
+  });
+
+  it('sorts Status by its normalized display value in both directions', () => {
+    renderResults();
+
+    const statusHeader = screen.getByRole('columnheader', { name: /Status/ });
+    userEvent.click(statusHeader);
+    expect(ruleNames()).toEqual([
+      'Skipped Rule',
+      'Backtest Rule',
+      'Zulu Rule',
+      'Passed Rule',
+      'Alpha Rule',
+    ]);
+
+    userEvent.click(statusHeader);
+    expect(ruleNames()).toEqual([
+      'Alpha Rule',
+      'Passed Rule',
+      'Zulu Rule',
+      'Backtest Rule',
+      'Skipped Rule',
+    ]);
+  });
+
+  it('offers normalized result, status, and action filter values', () => {
+    renderResults();
+    userEvent.click(screen.getByRole('button', { name: /filter/i }));
+
+    const expectOptions = (column: string, options: string[]) => {
+      userEvent.click(screen.getByText(column, { selector: 'div.text-start' }));
+      const combobox = screen.getAllByRole('combobox').at(-1)!;
+      userEvent.click(combobox);
+      for (const option of options) {
+        expect(
+          screen.getByText(option, {
+            selector: '.ant-select-item-option-content',
+          }),
+        ).toBeTruthy();
+      }
+      userEvent.type(combobox, '{esc}');
+    };
+
+    expectOptions('Result', ['Failed', 'Errored', 'Inapplicable', 'Passed']);
+    expectOptions('Status', [
+      'Live',
+      'Backtest',
+      'Background',
+      'Manual',
+      'Retroaction',
+    ]);
+    expectOptions('Actions', ['Escalate', 'Dismiss', 'Review', 'Approve']);
+  });
+});

--- a/client/src/webpages/dashboard/investigation/ItemInvestigationRuleResults.tsx
+++ b/client/src/webpages/dashboard/investigation/ItemInvestigationRuleResults.tsx
@@ -15,11 +15,7 @@ import {
   DefaultColumnFilter,
   SelectColumnFilter,
 } from '../components/table/filters';
-import {
-  conditionOutcomeSort,
-  ruleStatusSort,
-  stringSort,
-} from '../components/table/sort';
+import { stringSort } from '../components/table/sort';
 import Table from '../components/table/Table';
 
 import {
@@ -104,7 +100,7 @@ export default function ItemInvestigationRuleResults(props: {
             accessor: 'result',
           }),
         filter: 'includes',
-        sortType: conditionOutcomeSort,
+        sortType: stringSort,
       },
       {
         Header: 'Status',
@@ -115,7 +111,7 @@ export default function ItemInvestigationRuleResults(props: {
             accessor: 'status',
           }),
         filter: 'includes',
-        sortType: ruleStatusSort,
+        sortType: stringSort,
       },
       {
         Header: 'Policies',
@@ -166,6 +162,10 @@ export default function ItemInvestigationRuleResults(props: {
         const outcome = ruleResult.passed
           ? GQLConditionOutcome.Passed
           : ruleResult.result?.result?.outcome;
+        const actionNames =
+          rules
+            ?.find((it) => ruleResult.ruleId === it.id)
+            ?.actions?.map((action) => action.name) ?? [];
         return {
           rule: ruleResult.ruleName,
           result: (
@@ -204,11 +204,9 @@ export default function ItemInvestigationRuleResults(props: {
           ),
           actions: (
             <div className="w-48 mr-10 grid gap-y-1">
-              {rules
-                ?.find((it) => ruleResult.ruleId === it.id)
-                ?.actions?.map((action, i) => (
-                  <InvestigationTag title={action.name} key={i} />
-                ))}
+              {actionNames.map((actionName, i) => (
+                <InvestigationTag title={actionName} key={i} />
+              ))}
             </div>
           ),
           edit: (
@@ -227,6 +225,16 @@ export default function ItemInvestigationRuleResults(props: {
             </div>
           ),
           ruleExecutionResult: ruleResult.result,
+          values: {
+            rule: ruleResult.ruleName,
+            result: capitalize(
+              lowerCase(outcome ?? GQLConditionOutcome.Inapplicable),
+            ),
+            status: capitalize(lowerCase(ruleResult.environment)),
+            policies: ruleResult.policies,
+            tags: ruleResult.tags,
+            actions: actionNames,
+          },
         };
       }),
     [ruleExecutionsHistory, navigate, rules],


### PR DESCRIPTION
## Context & Requests for Reviewers

The table filters on the investigation page were broken. This PR fixes them.


https://github.com/user-attachments/assets/bdbf2db0-e364-4a03-960f-0bc4120864e0



## Tests

Manual testing: see video.

I thought of adding regression tests for this but honestly it felt like too much. If we had to test every single table filter, wow, we'd have a lot of tests.

## (Optional) Rollout Plan

N/A

## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] **If you changed anything user-facing** (i.e. user interface or APIs):
  Did you update the CHANGELOG.md and related docs?

- [ ] **If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**
  Did you update the corresponding history tables and their triggers?

- [ ] **If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?

- [ ] **If you added a new signal in `server/services/signalsService/signals/**`:**
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.