### PR TITLE
Fix table date sorting

### DIFF
--- a/client/src/webpages/dashboard/components/table/Table.test.tsx
+++ b/client/src/webpages/dashboard/components/table/Table.test.tsx
@@ -8,7 +8,7 @@ import {
   DefaultColumnFilter,
   NumberRangeColumnFilter,
 } from './filters';
-import { stringSort } from './sort';
+import { dateSort, stringSort } from './sort';
 import Table, { TableColumnDef } from './Table';
 
 type TableRow = {
@@ -128,6 +128,50 @@ describe('Table behavior', () => {
       'Rendered Alpine',
       'Rendered Alpha',
     ]);
+  });
+
+  it('sorts a rendered age column by its nested raw date value', () => {
+    type QueueRow = {
+      oldestTaskAge: ReactNode;
+      values: { oldestJobCreatedAt: string };
+    };
+    const queueColumns = [
+      {
+        header: 'Oldest Task Age',
+        accessorKey: 'oldestTaskAge',
+        sortFn: dateSort('oldestJobCreatedAt'),
+        sortDescFirst: false,
+      },
+    ] satisfies TableColumnDef<QueueRow>[];
+    const queueData: QueueRow[] = [
+      {
+        oldestTaskAge: <span>Newest task</span>,
+        values: { oldestJobCreatedAt: '2026-08-11T00:00:00Z' },
+      },
+      {
+        oldestTaskAge: <span>Oldest task</span>,
+        values: { oldestJobCreatedAt: '2026-08-01T00:00:00Z' },
+      },
+      {
+        oldestTaskAge: <span>Middle task</span>,
+        values: { oldestJobCreatedAt: '2026-08-06T00:00:00Z' },
+      },
+    ];
+    render(
+      <MemoryRouter>
+        <Table columns={queueColumns} data={queueData} />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(
+      screen.getByRole('columnheader', { name: /Oldest Task Age/ }),
+    );
+
+    expect(
+      within(screen.getAllByRole('rowgroup')[1])
+        .getAllByRole('row')
+        .map((row) => within(row).getByRole('cell').textContent),
+    ).toEqual(['Oldest task', 'Middle task', 'Newest task']);
   });
 
   it('does not offer filtering unless a column supplies a filter renderer', () => {

--- a/client/src/webpages/dashboard/components/table/sort.tsx
+++ b/client/src/webpages/dashboard/components/table/sort.tsx
@@ -181,8 +181,8 @@ export function userPenaltySeveritySort<TData extends RowWithValues>(
 }
 
 /**
- * Creates a date sort function that sorts by a raw date field from the original row data
- * @param dateKey - the key to access the raw date value from rowA.original/rowB.original
+ * Creates a date sort function that sorts by a raw date field from the row values
+ * @param dateKey - the key to access the raw date value from rowA.original.values/rowB.original.values
  * @returns a sort function compatible with react-table
  */
 export function dateSort(dateKey: string) {
@@ -191,8 +191,8 @@ export function dateSort(dateKey: string) {
     rowB: Row<TData>,
     _columnId: string,
   ) => {
-    const a = (rowA.original as unknown as Record<string, unknown>)[dateKey];
-    const b = (rowB.original as unknown as Record<string, unknown>)[dateKey];
+    const a = rowA.original.values[dateKey];
+    const b = rowB.original.values[dateKey];
 
     // Handle null/undefined - push to bottom
     if (!a && !b) return 0;


### PR DESCRIPTION
## Context & Requests for Reviewers

This fixes a small bug I spotted while upgrading react-table. The queues table wasn't correctly sorting rows by the "Oldest task age" column. This PR fixes that.

## Tests

I tested this manually in my browser.

## (Optional) Rollout Plan

N/A

## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] ~~**If you changed anything user-facing** (i.e. user interface or APIs):~~
  Did you update the CHANGELOG.md and related docs?

- [ ] ~~**If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**~~
  Did you update the corresponding history tables and their triggers?

- [ ] ~~**If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**~~
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?

- [ ] ~~**If you added a new signal in `server/services/signalsService/signals/**`:**~~
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected date sorting for table columns to use the underlying date values.
  * Ensured age/date columns sort from oldest to newest as expected, including values stored within nested row data.

* **Tests**
  * Added coverage verifying date sorting behavior and confirming the correct order after selecting the column header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->