### PR TITLE
Fix enum column sorting

### DIFF
--- a/client/src/webpages/dashboard/components/table/Table.test.tsx
+++ b/client/src/webpages/dashboard/components/table/Table.test.tsx
@@ -1,3 +1,4 @@
+import { GQLRuleStatus } from '@/graphql/generated';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
@@ -8,7 +9,7 @@ import {
   DefaultColumnFilter,
   NumberRangeColumnFilter,
 } from './filters';
-import { dateSort, stringSort } from './sort';
+import { dateSort, ruleStatusSort, stringSort } from './sort';
 import Table, { TableColumnDef } from './Table';
 
 type TableRow = {
@@ -128,6 +129,48 @@ describe('Table behavior', () => {
       'Rendered Alpine',
       'Rendered Alpha',
     ]);
+  });
+
+  it('sorts rendered rule statuses by their raw enum values', () => {
+    type StatusRow = {
+      status: ReactNode;
+      values: { status: string };
+    };
+    const statusColumns = [
+      {
+        header: 'Status',
+        accessorKey: 'status',
+        sortFn: ruleStatusSort,
+        sortDescFirst: false,
+      },
+    ] satisfies TableColumnDef<StatusRow>[];
+    const statusData: StatusRow[] = [
+      {
+        status: <span>Background</span>,
+        values: { status: GQLRuleStatus.Background },
+      },
+      {
+        status: <span>Draft</span>,
+        values: { status: GQLRuleStatus.Draft },
+      },
+      {
+        status: <span>Live</span>,
+        values: { status: GQLRuleStatus.Live },
+      },
+    ];
+    render(
+      <MemoryRouter>
+        <Table columns={statusColumns} data={statusData} />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('columnheader', { name: /Status/ }));
+
+    expect(
+      within(screen.getAllByRole('rowgroup')[1])
+        .getAllByRole('row')
+        .map((row) => within(row).getByRole('cell').textContent),
+    ).toEqual(['Live', 'Background', 'Draft']);
   });
 
   it('sorts a rendered age column by its nested raw date value', () => {

--- a/client/src/webpages/dashboard/components/table/sort.tsx
+++ b/client/src/webpages/dashboard/components/table/sort.tsx
@@ -1,5 +1,3 @@
-import capitalize from 'lodash/capitalize';
-
 import {
   GQLConditionOutcome,
   GQLReportingRuleStatus,
@@ -90,7 +88,6 @@ function enumSort<TData extends RowWithValues>(
   if (s1 === s2) {
     return 0;
   }
-  precedence = precedence.map((val) => capitalize(val.toLowerCase()));
   return precedence.indexOf(s1) > precedence.indexOf(s2) ? 1 : -1;
 }
 


### PR DESCRIPTION
## Context & Requests for Reviewers

Found this bug while upgrading to React 19. We were modifying the case of enum values before calling `indexOf`, which meant that `indexOf` always returned -1 -- and this meant that sorting by enum values had no effect. This is now fixed.

## Tests

See the test.

## (Optional) Rollout Plan

N/A

## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] ~~**If you changed anything user-facing** (i.e. user interface or APIs):~~
  Did you update the CHANGELOG.md and related docs?

- [ ] ~~**If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**~~
  Did you update the corresponding history tables and their triggers?

- [ ] ~~**If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**~~
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?

- [ ] ~~**If you added a new signal in `server/services/signalsService/signals/**`:**~~
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.