### PR TITLE
Fix users table sorting

### DIFF
--- a/client/src/webpages/settings/ManageUsers.test.tsx
+++ b/client/src/webpages/settings/ManageUsers.test.tsx
@@ -1,0 +1,99 @@
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
+import { HelmetProvider } from 'react-helmet-async';
+import { MemoryRouter } from 'react-router-dom';
+
+import '@testing-library/jest-dom/extend-expect';
+
+import {
+  GQLManageUsersDocument,
+  GQLRolesForOrgDocument,
+  GQLUserPermission,
+  GQLUserRole,
+} from '@/graphql/generated';
+
+import ManageUsers from './ManageUsers';
+
+const mocks: MockedResponse[] = [
+  {
+    request: { query: GQLManageUsersDocument },
+    result: {
+      data: {
+        myOrg: {
+          id: 'org-1',
+          name: 'Test Org',
+          hasNCMECReportingEnabled: false,
+          users: [
+            {
+              id: 'user-1',
+              firstName: 'Approved',
+              lastName: 'User',
+              email: 'approved@example.com',
+              role: GQLUserRole.Admin,
+              createdAt: '1723334400000',
+              approvedByAdmin: true,
+              rejectedByAdmin: false,
+            },
+          ],
+          pendingInvites: [
+            {
+              id: 'invite-1',
+              email: 'invited@example.com',
+              role: GQLUserRole.Admin,
+              createdAt: '2024-08-10T00:00:00.000Z',
+            },
+          ],
+        },
+        me: {
+          id: 'user-1',
+          email: 'approved@example.com',
+          firstName: 'Approved',
+          lastName: 'User',
+          permissions: [GQLUserPermission.ManageUsers],
+        },
+      },
+    },
+  },
+  {
+    request: { query: GQLRolesForOrgDocument },
+    result: { data: { rolesForOrg: [] } },
+  },
+];
+
+function approvalStatuses() {
+  return within(screen.getAllByRole('rowgroup')[1])
+    .getAllByRole('row')
+    .map((row) => within(row).getAllByRole('cell')[3].textContent);
+}
+
+it('sorts approval statuses by their raw string values in both directions', async () => {
+  render(
+    <HelmetProvider>
+      <MockedProvider mocks={mocks}>
+        <MemoryRouter initialEntries={['/dashboard/settings/users?tab=users']}>
+          <ManageUsers />
+        </MemoryRouter>
+      </MockedProvider>
+    </HelmetProvider>,
+  );
+
+  await waitFor(() =>
+    expect(screen.getByText('approved@example.com')).toBeInTheDocument(),
+  );
+
+  const approvalStatusHeader = screen.getByRole('columnheader', {
+    name: /Approval Status/,
+  });
+
+  fireEvent.click(approvalStatusHeader);
+  expect(approvalStatuses()).toEqual(['Pending Invite', 'Approved']);
+
+  fireEvent.click(approvalStatusHeader);
+  expect(approvalStatuses()).toEqual(['Approved', 'Pending Invite']);
+});

--- a/client/src/webpages/settings/ManageUsers.tsx
+++ b/client/src/webpages/settings/ManageUsers.tsx
@@ -17,11 +17,7 @@ import {
   DefaultColumnFilter,
   SelectColumnFilter,
 } from '../dashboard/components/table/filters';
-import {
-  boolSort,
-  stringSort,
-  userRoleSort,
-} from '../dashboard/components/table/sort';
+import { stringSort, userRoleSort } from '../dashboard/components/table/sort';
 import Table from '../dashboard/components/table/Table';
 import UserWithAvatar from '../dashboard/components/UserWithAvatar';
 
@@ -367,7 +363,7 @@ export default function ManageUsers() {
             }),
         },
         filterFn: 'includes' as const,
-        sortFn: boolSort,
+        sortFn: stringSort,
       },
       {
         header: 'Date Created',


### PR DESCRIPTION
## Context & Requests for Reviewers

Sorting the users table by approval status wasn't working, because we were using the wrong table sort function. This PR fixes that.

## Tests

I added a regression test for this. Maybe unnecessary? Let me know what you think.

## (Optional) Rollout Plan

N/A

## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] ~~**If you changed anything user-facing** (i.e. user interface or APIs):~~
  Did you update the CHANGELOG.md and related docs?

- [ ] ~~**If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**~~
  Did you update the corresponding history tables and their triggers?

- [ ] ~~**If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**~~
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?

- [ ] ~~**If you added a new signal in `server/services/signalsService/signals/**`:**~~
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sorting for the Approval Status column in user management, with accurate ascending and descending results.

* **Tests**
  * Added coverage to verify approval-status sorting for organization users and pending invitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->