### PR TITLE
Fix investigation rule result selection

### DIFF
--- a/client/src/webpages/dashboard/investigation/ItemInvestigation.tsx
+++ b/client/src/webpages/dashboard/investigation/ItemInvestigation.tsx
@@ -436,6 +436,7 @@ export default function ItemInvestigation(props: {
             />
             <ItemInvestigationRuleResults
               itemIdentifier={{ id: item.id, typeId: item.type.id }}
+              itemTypes={(allItemTypes as GQLItemType[] | undefined) ?? []}
               submissionTime={item.submissionTime?.toString()}
               rules={allRules ?? []}
             />

--- a/client/src/webpages/dashboard/investigation/ItemInvestigationRuleResults.test.tsx
+++ b/client/src/webpages/dashboard/investigation/ItemInvestigationRuleResults.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useGQLInvestigationItemsQuery } from '../../../graphql/generated';
+import ItemInvestigationRuleResults from './ItemInvestigationRuleResults';
+
+vi.mock('../../../graphql/generated', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../graphql/generated')>()),
+  useGQLInvestigationItemsQuery: vi.fn(),
+  useGQLMatchingBankNamesQuery: vi.fn(() => ({
+    loading: false,
+    error: undefined,
+    data: undefined,
+  })),
+}));
+
+const execution = (
+  outcome: 'PASSED' | 'FAILED',
+  timestamp: string,
+  conditionDetail: string,
+) => ({
+  __typename: 'RuleExecutionResult',
+  date: timestamp,
+  ts: timestamp,
+  contentId: 'content',
+  itemTypeName: 'Post',
+  itemTypeId: 'post',
+  content: '{}',
+  environment: 'LIVE',
+  passed: outcome === 'PASSED',
+  ruleId: 'repeated-rule',
+  ruleName: 'Repeated Rule',
+  policies: [],
+  tags: [],
+  result: {
+    __typename: 'ConditionSetWithResult',
+    conjunction: 'AND',
+    conditions: [
+      {
+        __typename: 'LeafConditionWithResult',
+        input: {
+          __typename: 'ConditionInputField',
+          type: 'CONTENT_FIELD',
+          name: conditionDetail,
+        },
+        comparator: 'EQUALS',
+        result: { __typename: 'ConditionResult', outcome },
+      },
+    ],
+    result: { __typename: 'ConditionResult', outcome },
+  },
+});
+
+describe('ItemInvestigationRuleResults', () => {
+  it('shows the stored result for the selected execution', () => {
+    vi.mocked(useGQLInvestigationItemsQuery).mockReturnValue({
+      loading: false,
+      error: undefined,
+      data: {
+        __typename: 'Query',
+        itemWithHistory: {
+          __typename: 'ItemHistoryResult',
+          item: {
+            __typename: 'ContentItem',
+            id: 'item',
+            submissionId: 'submission',
+            type: { __typename: 'ContentItemType', id: 'post' },
+          },
+          executions: [
+            execution(
+              'FAILED',
+              '2026-01-01T20:11:00.000Z',
+              'Older execution field',
+            ),
+            execution(
+              'PASSED',
+              '2026-01-01T20:13:00.000Z',
+              'Newer execution field',
+            ),
+          ],
+        },
+      },
+    } as unknown as ReturnType<typeof useGQLInvestigationItemsQuery>);
+
+    render(
+      <MemoryRouter>
+        <ItemInvestigationRuleResults
+          itemIdentifier={{ id: 'item', typeId: 'post' }}
+          itemTypes={[]}
+          rules={[]}
+        />
+      </MemoryRouter>,
+    );
+
+    const failedRow = screen
+      .getAllByRole('row')
+      .find((row) => within(row).queryByText('Did Not Match'))!;
+    userEvent.click(failedRow);
+
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByText('Rule Result: Repeated Rule')).toBeTruthy();
+    const outcome = within(dialog).getByText('Outcome:').parentElement;
+    expect(outcome?.textContent).toContain('Did Not Match');
+    expect(outcome?.textContent).not.toContain('Matched');
+    expect(within(dialog).getByText('Older execution field')).toBeTruthy();
+    expect(within(dialog).queryByText('Newer execution field')).toBeNull();
+  });
+});

--- a/client/src/webpages/dashboard/investigation/ItemInvestigationRuleResults.tsx
+++ b/client/src/webpages/dashboard/investigation/ItemInvestigationRuleResults.tsx
@@ -24,41 +24,48 @@ import Table from '../components/table/Table';
 
 import {
   GQLConditionOutcome,
+  GQLInvestigationItemsQuery,
+  GQLItemType,
   useGQLInvestigationItemsQuery,
 } from '../../../graphql/generated';
 import { ReadonlyDeep } from '../../../utils/typescript-types';
-import { LookbackVersion } from '../rules/info/insights/RuleInsightsSamplesTable';
-import RuleInsightsSampleDetailResults, {
+import {
   getDisplayName,
   outcomeIcon,
+  RuleInsightsSampleDetailResultsImpl,
 } from '../rules/info/insights/sample_details/RuleInsightsSampleDetailResults';
+import type { ConditionSetWithResult } from '../rules/types';
 import InvestigationTag from './InvestigationTag';
+
+type InvestigationExecution = Extract<
+  GQLInvestigationItemsQuery['itemWithHistory'],
+  { readonly __typename: 'ItemHistoryResult' }
+>['executions'][number];
+type InvestigationExecutionResult = InvestigationExecution['result'];
 
 export default function ItemInvestigationRuleResults(props: {
   itemIdentifier: ItemIdentifier;
+  itemTypes: readonly GQLItemType[];
   submissionTime?: string;
   rules: Readonly<ReadonlyDeep<{ id: string; actions: { name: string }[] }>[]>;
 }) {
-  const { rules, itemIdentifier, submissionTime } = props;
+  const { rules, itemIdentifier, submissionTime, itemTypes } = props;
   const navigate = useNavigate();
   const [modalInfo, setModalInfo] = useState<
     | {
         visible: false;
         title: undefined;
-        ruleId: undefined;
-        contentId: undefined;
+        result: undefined;
       }
     | {
         visible: true;
         title: string;
-        ruleId: string;
-        contentId: string;
+        result: InvestigationExecutionResult;
       }
   >({
     visible: false,
     title: undefined,
-    ruleId: undefined,
-    contentId: undefined,
+    result: undefined,
   });
 
   const {
@@ -250,8 +257,7 @@ export default function ItemInvestigationRuleResults(props: {
     setModalInfo({
       visible: false,
       title: undefined,
-      ruleId: undefined,
-      contentId: undefined,
+      result: undefined,
     });
 
   const modal = (
@@ -262,28 +268,27 @@ export default function ItemInvestigationRuleResults(props: {
     >
       {modalInfo.visible && (
         <div className="p-4">
-          <RuleInsightsSampleDetailResults
-            ruleId={modalInfo.ruleId}
-            itemIdentifier={itemIdentifier}
-            itemSubmissionDate={submissionTime}
-            lookback={LookbackVersion.LATEST}
-          />
+          {modalInfo.result ? (
+            <RuleInsightsSampleDetailResultsImpl
+              itemTypes={itemTypes}
+              conditionSetWithResult={
+                modalInfo.result as unknown as ConditionSetWithResult
+              }
+              loading={false}
+            />
+          ) : (
+            <div className="m-2 text-red-500">Rule result is unavailable</div>
+          )}
         </div>
       )}
     </CoopModal>
   );
 
   const onSelectRow = (rowData: Row<any>) => {
-    const executionResult = ruleExecutionsHistory[rowData.index];
-    if (executionResult == null) {
-      return;
-    }
-
     setModalInfo({
       visible: true,
       title: `Rule Result: ${rowData.original.rule}`,
-      ruleId: executionResult.ruleId,
-      contentId: executionResult.contentId,
+      result: rowData.original.ruleExecutionResult,
     });
   };
 


### PR DESCRIPTION
## Context & Requests for Reviewers

This is a small bug my LLM found. In the investigation tool, when looking up an item, we show a list of rules that it matched on. You can click each row to see some more details in a modal.

However, in the modal that appears, we were always showing the results from the *latest* version of that item. However, the item might've been updated and earlier versions might have different results on the same rule! This video shows what happened before:


https://github.com/user-attachments/assets/5399f3ff-058b-48d9-8a95-ab336a903d0b

This PR fixes this bug, so the modal shows the correct data:


https://github.com/user-attachments/assets/a0d187b4-15e4-486a-b9bb-0c9e06c59673



## Tests

Tested manually (see videos). Also added tests (see the diff).

## (Optional) Rollout Plan

N/A

## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] **If you changed anything user-facing** (i.e. user interface or APIs):
  Did you update the CHANGELOG.md and related docs?

- [ ] **If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**
  Did you update the corresponding history tables and their triggers?

- [ ] **If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?

- [ ] **If you added a new signal in `server/services/signalsService/signals/**`:**
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.