### PR TITLE
Fix merged reports sorting

### DIFF
--- a/client/src/webpages/dashboard/mrt/manual_review_job/MergedReportsComponent.test.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/MergedReportsComponent.test.tsx
@@ -1,5 +1,5 @@
 import { MockedProvider } from '@apollo/client/testing';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
@@ -102,4 +102,120 @@ describe('MergedReportsComponent invalidation actions', () => {
       screen.queryByRole('button', { name: /invalidate all reports/i }),
     ).not.toBeInTheDocument();
   });
+});
+
+const sortableReportHistory = [
+  {
+    reportId: 'sort_primary',
+    reportedAt: '2026-03-01T12:00:00Z',
+    policyId: null,
+    reason: 'Primary',
+    reporterId: null,
+  },
+  {
+    reportId: 'sort_zeta',
+    reportedAt: '2026-01-02T00:00:00Z',
+    policyId: 'policy_zeta',
+    reason: 'Bravo',
+    reporterId: { id: 'charlie', typeId: 'user_type' },
+  },
+  {
+    reportId: 'sort_beta',
+    reportedAt: '2025-12-30T00:00:00Z',
+    policyId: 'policy_beta',
+    reason: 'Charlie',
+    reporterId: { id: 'alpha', typeId: 'user_type' },
+  },
+  {
+    reportId: 'sort_alpha',
+    reportedAt: '2026-02-01T12:00:00Z',
+    policyId: 'policy_alpha',
+    reason: 'Alpha',
+    reporterId: { id: 'bravo', typeId: 'user_type' },
+  },
+];
+
+const sortingMocks = [
+  {
+    request: {
+      query: GQLGetUserItemsDocument,
+      variables: {
+        itemIdentifiers: [
+          { id: 'charlie', typeId: 'user_type' },
+          { id: 'alpha', typeId: 'user_type' },
+          { id: 'bravo', typeId: 'user_type' },
+        ],
+      },
+    },
+    result: { data: { latestItemSubmissions: [] } },
+  },
+  {
+    request: { query: GQLPoliciesDocument },
+    result: {
+      data: {
+        myOrg: {
+          id: 'org',
+          __typename: 'Org',
+          policies: [
+            { id: 'policy_zeta', name: 'Zeta Policy', __typename: 'Policy' },
+            { id: 'policy_beta', name: 'Beta Policy', __typename: 'Policy' },
+            { id: 'policy_alpha', name: 'Alpha Policy', __typename: 'Policy' },
+          ],
+        },
+      },
+    },
+  },
+];
+
+function renderedReasons() {
+  return within(screen.getAllByRole('rowgroup')[1])
+    .getAllByRole('row')
+    .map((row) => within(row).getAllByRole('cell')[2].textContent);
+}
+
+describe('MergedReportsComponent sorting', () => {
+  it.each([
+    [
+      'Reported By',
+      ['Charlie', 'Alpha', 'Bravo'],
+      ['Bravo', 'Alpha', 'Charlie'],
+    ],
+    [
+      'Reported For',
+      ['Alpha', 'Charlie', 'Bravo'],
+      ['Bravo', 'Charlie', 'Alpha'],
+    ],
+    ['Reason', ['Alpha', 'Bravo', 'Charlie'], ['Charlie', 'Bravo', 'Alpha']],
+    [
+      'Report Time',
+      ['Charlie', 'Bravo', 'Alpha'],
+      ['Alpha', 'Bravo', 'Charlie'],
+    ],
+  ])(
+    'sorts %s by visible semantics in ascending and descending order',
+    async (header, ascending, descending) => {
+      render(
+        <MemoryRouter>
+          <MockedProvider
+            mocks={sortingMocks}
+            defaultOptions={{ watchQuery: { fetchPolicy: 'no-cache' } }}
+          >
+            <MergedReportsComponent
+              primaryReportId="sort_primary"
+              reportHistory={sortableReportHistory}
+            />
+          </MockedProvider>
+        </MemoryRouter>,
+      );
+      fireEvent.click(screen.getByRole('button', { name: /show/i }));
+      await screen.findByText('Zeta Policy');
+
+      const columnHeader = screen.getByRole('columnheader', { name: header });
+      fireEvent.click(columnHeader);
+      expect(renderedReasons()).toEqual(ascending);
+
+      fireEvent.click(columnHeader);
+      expect(renderedReasons()).toEqual(descending);
+    },
+  );
 });

--- a/client/src/webpages/dashboard/mrt/manual_review_job/MergedReportsComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/MergedReportsComponent.tsx
@@ -223,7 +223,7 @@ export default function MergedReportsComponent(props: {
         ) : (
           '—'
         ),
-        reason: report.reason?.trim() ? report.reason : '—',
+        reason,
         reportTime: parseDatetimeToReadableStringInCurrentTimeZone(
           report.reportedAt,
         ),

--- a/client/src/webpages/dashboard/mrt/manual_review_job/MergedReportsComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/MergedReportsComponent.tsx
@@ -10,6 +10,7 @@ import { ChevronDown, ChevronUp, ExternalLink } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 
+import { dateSort, stringSort } from '../../components/table/sort';
 import Table from '../../components/table/Table';
 
 import InvalidateReportsButton from './InvalidateReportsButton';
@@ -103,10 +104,30 @@ export default function MergedReportsComponent(props: {
 
   const columns = useMemo(
     () => [
-      { header: 'Reported By', accessorKey: 'reportedBy' },
-      { header: 'Reported For', accessorKey: 'reportedFor' },
-      { header: 'Reason', accessorKey: 'reason' },
-      { header: 'Report Time', accessorKey: 'reportTime' },
+      {
+        header: 'Reported By',
+        accessorKey: 'reportedBy',
+        sortFn: stringSort,
+        sortDescFirst: false,
+      },
+      {
+        header: 'Reported For',
+        accessorKey: 'reportedFor',
+        sortFn: stringSort,
+        sortDescFirst: false,
+      },
+      {
+        header: 'Reason',
+        accessorKey: 'reason',
+        sortFn: stringSort,
+        sortDescFirst: false,
+      },
+      {
+        header: 'Report Time',
+        accessorKey: 'reportTime',
+        sortFn: dateSort('reportTime'),
+        sortDescFirst: false,
+      },
     ],
     [],
   );
@@ -141,6 +162,8 @@ export default function MergedReportsComponent(props: {
         hasReporter && report.displayInfo?.typeName
           ? `${report.displayInfo.typeName}: `
           : '';
+      const reportedFor = policy?.name ?? '—';
+      const reason = report.reason?.trim() || '—';
       return {
         reportedBy: (
           <div className="flex flex-wrap items-center gap-x-2">
@@ -204,6 +227,12 @@ export default function MergedReportsComponent(props: {
         reportTime: parseDatetimeToReadableStringInCurrentTimeZone(
           report.reportedAt,
         ),
+        values: {
+          reportedBy: `${reportedByPrefix}${reportedByLabel}`,
+          reportedFor,
+          reason,
+          reportTime: report.reportedAt,
+        },
       };
     });
   }, [


### PR DESCRIPTION
## Context & Requests for Reviewers

The merged reports table was using the wrong sort functions, so sorting the table was broken. Now fixed.

## Tests

See regression test.

Also tested manually.

<img width="1626" height="580" alt="CleanShot 2026-08-18 at 12 21 26@2x" src="https://github.com/user-attachments/assets/b19fd20b-ab64-471f-a5f2-47825ccd54f5" />


## (Optional) Rollout Plan

N/A

## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] ~~**If you changed anything user-facing** (i.e. user interface or APIs):~~
  Did you update the CHANGELOG.md and related docs?

- [ ] ~~**If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**~~
  Did you update the corresponding history tables and their triggers?

- [ ] ~~**If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**~~
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?

- [ ] ~~**If you added a new signal in `server/services/signalsService/signals/**`:**~~
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved sorting for merged reports by Reported By, Reported For, Reason, and Report Time.
  * Sorting now follows the values displayed in the table, with support for ascending and descending order.

* **Tests**
  * Added coverage to verify sorting behavior across all supported report columns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->