### PR TITLE
Fix manual review pie legend toggling

### DIFF
--- a/client/src/webpages/dashboard/mrt/visualization/ManualReviewDashboardInsightsChart.test.ts
+++ b/client/src/webpages/dashboard/mrt/visualization/ManualReviewDashboardInsightsChart.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { getPieChartData } from './ManualReviewDashboardInsightsChart';
+
+describe('getPieChartData', () => {
+  it('zeros a hidden category and restores its value without changing legend order', () => {
+    const sums = { foo: 6, bar: 4 };
+
+    expect(getPieChartData(sums, ['foo'])).toEqual([
+      { name: 'foo', value: 0 },
+      { name: 'bar', value: 4 },
+    ]);
+    expect(getPieChartData(sums, [])).toEqual([
+      { name: 'foo', value: 6 },
+      { name: 'bar', value: 4 },
+    ]);
+  });
+});

--- a/client/src/webpages/dashboard/mrt/visualization/ManualReviewDashboardInsightsChart.tsx
+++ b/client/src/webpages/dashboard/mrt/visualization/ManualReviewDashboardInsightsChart.tsx
@@ -36,6 +36,7 @@ import {
   CartesianGrid,
   Cell,
   ComposedChart,
+  Curve,
   Legend,
   Line,
   Pie,
@@ -1136,7 +1137,18 @@ export default function ManualReviewDashboardInsightsChart(props: {
         cy="50%"
         outerRadius={80}
         fill={PRIMARY_COLOR}
-        label
+        label={({ value }) => (value === 0 ? <></> : value)}
+        labelLine={(props) =>
+          props.value === 0 ? (
+            <></>
+          ) : (
+            <Curve
+              {...props}
+              type="linear"
+              className="recharts-pie-label-line"
+            />
+          )
+        }
       >
         {pieChartData.map((_, index) => (
           <Cell

--- a/client/src/webpages/dashboard/mrt/visualization/ManualReviewDashboardInsightsChart.tsx
+++ b/client/src/webpages/dashboard/mrt/visualization/ManualReviewDashboardInsightsChart.tsx
@@ -179,6 +179,16 @@ gql`
 export type ManualReviewDashboardInsightsChartMetric =
   'DECISIONS' | 'JOBS' | 'REVIEWED_JOBS' | 'SKIPPED_JOBS';
 
+export function getPieChartData(
+  chartDataSums: Record<string, number>,
+  hiddenLines: string[],
+) {
+  return Object.entries(chartDataSums).map(([name, value]) => ({
+    name,
+    value: hiddenLines.includes(name) ? 0 : value,
+  }));
+}
+
 export function getEmptyFilterState(
   metric: ManualReviewDashboardInsightsChartMetric,
   timeWindow: TimeWindow,
@@ -1113,23 +1123,22 @@ export default function ManualReviewDashboardInsightsChart(props: {
     />
   ));
 
+  const pieChartData = getPieChartData(chartDataSums, hiddenLines);
+
   const pieChart = (
     <PieChart width={400} height={400}>
       <Pie
         dataKey="value"
         nameKey="name"
         isAnimationActive={false}
-        data={Object.entries(chartDataSums).map(([key, value]) => ({
-          name: key,
-          value,
-        }))}
+        data={pieChartData}
         cx="50%"
         cy="50%"
         outerRadius={80}
         fill={PRIMARY_COLOR}
         label
       >
-        {Object.entries(chartDataSums).map((_, index) => (
+        {pieChartData.map((_, index) => (
           <Cell
             key={`cell-${index}`}
             fill={chartColors[index % chartColors.length]}


### PR DESCRIPTION
## Context & Requests for Reviewers

Fixes a small bug on e.g. `/dashboard/manual_review/analytics`. If you showed a pie chart, then toggling a series from the legend would not actually hide it from the pie chart like you'd expect. This PR fixes that.

## Tests

Tested manually and added a unit test.

## (Optional) Rollout Plan

N/A

## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] **If you changed anything user-facing** (i.e. user interface or APIs):
  Did you update the CHANGELOG.md and related docs?

- [ ] **If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**
  Did you update the corresponding history tables and their triggers?

- [ ] **If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?

- [ ] **If you added a new signal in `server/services/signalsService/signals/**`:**
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pie chart behavior when categories are hidden.
  - Hidden categories now display zero values while preserving legend order.
  - Zero-value slices no longer show labels or label lines.
  - Restoring all categories returns the chart to its original values.

- **Tests**
  - Added coverage for hidden-category handling and value restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->