### PR TITLE
Make table sorting keyboard accessible

### DIFF
--- a/client/src/webpages/dashboard/components/table/Table.test.tsx
+++ b/client/src/webpages/dashboard/components/table/Table.test.tsx
@@ -1,5 +1,6 @@
 import { GQLRuleStatus } from '@/graphql/generated';
 import { fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
@@ -100,6 +101,38 @@ describe('Table behavior', () => {
     expect(
       within(headerRows[1]).getByRole('columnheader', { name: 'Status' }),
     ).toBeTruthy();
+  });
+
+  it('makes sortable headers keyboard accessible and reports their sort direction', () => {
+    renderTable();
+
+    const nameHeader = screen.getByRole('columnheader', { name: /Name/ });
+    const nameSortButton = within(nameHeader).getByRole('button', {
+      name: /Name/,
+    });
+    const statusHeader = screen.getByRole('columnheader', { name: 'Status' });
+
+    expect(nameHeader.getAttribute('aria-sort')).toBe('none');
+    expect(within(statusHeader).queryByRole('button')).toBeNull();
+    expect(statusHeader.hasAttribute('aria-sort')).toBe(false);
+
+    nameSortButton.focus();
+    expect(document.activeElement).toBe(nameSortButton);
+    userEvent.type(nameSortButton, '{enter}', { skipClick: true });
+    expect(renderedNames()).toEqual([
+      'Rendered Alpha',
+      'Rendered Alpine',
+      'Rendered Zulu',
+    ]);
+    expect(nameHeader.getAttribute('aria-sort')).toBe('ascending');
+
+    userEvent.type(nameSortButton, '{space}', { skipClick: true });
+    expect(renderedNames()).toEqual([
+      'Rendered Zulu',
+      'Rendered Alpine',
+      'Rendered Alpha',
+    ]);
+    expect(nameHeader.getAttribute('aria-sort')).toBe('descending');
   });
 
   it('renders accessor values and sorts by raw values only on sortable headers', () => {

--- a/client/src/webpages/dashboard/components/table/Table.test.tsx
+++ b/client/src/webpages/dashboard/components/table/Table.test.tsx
@@ -103,6 +103,38 @@ describe('Table behavior', () => {
     ).toBeTruthy();
   });
 
+  it('keeps placeholder headers inert while grouped sortable headers stay accessible', () => {
+    const groupedColumns = [
+      columns[0],
+      {
+        header: 'Details',
+        columns: [columns[1]],
+      },
+    ] satisfies TableColumnDef<TableRow>[];
+    renderTable(groupedColumns);
+
+    const placeholderHeader = screen
+      .getAllByRole('columnheader')
+      .find((header) => header.textContent === '');
+    expect(placeholderHeader).toBeTruthy();
+    expect(within(placeholderHeader!).queryByRole('button')).toBeNull();
+    expect(placeholderHeader!.hasAttribute('aria-sort')).toBe(false);
+
+    const nameHeader = screen.getByRole('columnheader', { name: /Name/ });
+    const nameSortButton = within(nameHeader).getByRole('button', {
+      name: /Name/,
+    });
+    expect(nameHeader.getAttribute('aria-sort')).toBe('none');
+
+    nameSortButton.focus();
+    userEvent.type(nameSortButton, '{enter}', { skipClick: true });
+    expect(renderedNames()).toEqual([
+      'Rendered Alpha',
+      'Rendered Alpine',
+      'Rendered Zulu',
+    ]);
+  });
+
   it('makes sortable headers keyboard accessible and reports their sort direction', () => {
     renderTable();
 
@@ -124,7 +156,11 @@ describe('Table behavior', () => {
       'Rendered Alpine',
       'Rendered Zulu',
     ]);
-    expect(nameHeader.getAttribute('aria-sort')).toBe('ascending');
+    expect(
+      screen
+        .getByRole('columnheader', { name: /Name/ })
+        .getAttribute('aria-sort'),
+    ).toBe('ascending');
 
     userEvent.type(nameSortButton, '{space}', { skipClick: true });
     expect(renderedNames()).toEqual([
@@ -132,7 +168,11 @@ describe('Table behavior', () => {
       'Rendered Alpine',
       'Rendered Alpha',
     ]);
-    expect(nameHeader.getAttribute('aria-sort')).toBe('descending');
+    expect(
+      screen
+        .getByRole('columnheader', { name: /Name/ })
+        .getAttribute('aria-sort'),
+    ).toBe('descending');
   });
 
   it('renders accessor values and sorts by raw values only on sortable headers', () => {

--- a/client/src/webpages/dashboard/components/table/Table.tsx
+++ b/client/src/webpages/dashboard/components/table/Table.tsx
@@ -108,11 +108,36 @@ export default function Table<TData extends Record<string, any>>(
                   ) : (
                     headerGroup.headers.map((header, index) => {
                       const sorted = header.column.getIsSorted();
+                      const canSort = header.column.getCanSort();
+                      const headerContent = header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          );
+                      const sortIcon = canSort ? (
+                        sorted === 'desc' ? (
+                          <SortAmountDsc className="bg-[#40ace920] w-6 p-1 fill-primary rounded-full" />
+                        ) : sorted === 'asc' ? (
+                          <SortAmountAsc className="bg-[#40ace920] w-6 p-1 fill-primary rounded-full scale-y-[-1]" />
+                        ) : (
+                          <SortAmountDsc className="w-4 rounded-full fill-gray-500" />
+                        )
+                      ) : null;
                       return (
                         <th
                           key={header.id}
                           colSpan={header.colSpan}
                           onClick={header.column.getToggleSortingHandler()}
+                          aria-sort={
+                            canSort
+                              ? sorted === 'asc'
+                                ? 'ascending'
+                                : sorted === 'desc'
+                                  ? 'descending'
+                                  : 'none'
+                              : undefined
+                          }
                           className={`align-center font-bold text-gray-500 text-start text-base !p-0 ${
                             index === 0
                               ? 'rounded-tl-md'
@@ -121,23 +146,19 @@ export default function Table<TData extends Record<string, any>>(
                                 : ''
                           }`}
                         >
-                          <div className="flex flex-row items-center p-4 flex-nowrap whitespace-nowrap gap-3">
-                            {header.isPlaceholder
-                              ? null
-                              : flexRender(
-                                  header.column.columnDef.header,
-                                  header.getContext(),
-                                )}
-                            {header.column.getCanSort() ? (
-                              sorted === 'desc' ? (
-                                <SortAmountDsc className="bg-[#40ace920] w-6 p-1 fill-primary rounded-full" />
-                              ) : sorted === 'asc' ? (
-                                <SortAmountAsc className="bg-[#40ace920] w-6 p-1 fill-primary rounded-full scale-y-[-1]" />
-                              ) : (
-                                <SortAmountDsc className="w-4 rounded-full fill-gray-500" />
-                              )
-                            ) : null}
-                          </div>
+                          {canSort && !header.isPlaceholder ? (
+                            <button
+                              type="button"
+                              className="flex flex-row items-center p-4 flex-nowrap whitespace-nowrap gap-3"
+                            >
+                              {headerContent}
+                              {sortIcon}
+                            </button>
+                          ) : (
+                            <div className="flex flex-row items-center p-4 flex-nowrap whitespace-nowrap gap-3">
+                              {headerContent}
+                            </div>
+                          )}
                         </th>
                       );
                     })

--- a/client/src/webpages/dashboard/components/table/Table.tsx
+++ b/client/src/webpages/dashboard/components/table/Table.tsx
@@ -108,14 +108,15 @@ export default function Table<TData extends Record<string, any>>(
                   ) : (
                     headerGroup.headers.map((header, index) => {
                       const sorted = header.column.getIsSorted();
-                      const canSort = header.column.getCanSort();
+                      const isSortableHeader =
+                        !header.isPlaceholder && header.column.getCanSort();
                       const headerContent = header.isPlaceholder
                         ? null
                         : flexRender(
                             header.column.columnDef.header,
                             header.getContext(),
                           );
-                      const sortIcon = canSort ? (
+                      const sortIcon = isSortableHeader ? (
                         sorted === 'desc' ? (
                           <SortAmountDsc className="bg-[#40ace920] w-6 p-1 fill-primary rounded-full" />
                         ) : sorted === 'asc' ? (
@@ -128,9 +129,13 @@ export default function Table<TData extends Record<string, any>>(
                         <th
                           key={header.id}
                           colSpan={header.colSpan}
-                          onClick={header.column.getToggleSortingHandler()}
+                          onClick={
+                            isSortableHeader
+                              ? header.column.getToggleSortingHandler()
+                              : undefined
+                          }
                           aria-sort={
-                            canSort
+                            isSortableHeader
                               ? sorted === 'asc'
                                 ? 'ascending'
                                 : sorted === 'desc'
@@ -146,7 +151,7 @@ export default function Table<TData extends Record<string, any>>(
                                 : ''
                           }`}
                         >
-                          {canSort && !header.isPlaceholder ? (
+                          {isSortableHeader ? (
                             <button
                               type="button"
                               className="flex flex-row items-center p-4 flex-nowrap whitespace-nowrap gap-3"


### PR DESCRIPTION
## Context & Requests for Reviewers

This addresses a CodeRabbit comment from the @tanstack/react-table v9 upgrade. It was a pre-existing issue: our table sorting was not keyboard-accessible.

## Tests

Manually tested. Example here:


https://github.com/user-attachments/assets/e04d52c8-c8e5-46dc-8b73-6460d85848e5



## (Optional) Rollout Plan

N/A

## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] ~~**If you changed anything user-facing** (i.e. user interface or APIs):~~
  Did you update the CHANGELOG.md and related docs?

- [ ] ~~**If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**~~
  Did you update the corresponding history tables and their triggers?

- [ ] ~~**If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**~~
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?

- [ ] ~~**If you added a new signal in `server/services/signalsService/signals/**`:**~~
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved keyboard support for sorting table columns using Enter and Space.
  * Added accurate `aria-sort` status reporting for sortable headers.
  * Prevented grouped-column placeholder headers from appearing interactive or exposing unnecessary accessibility attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->