### PR TITLE
[386] feat: merge review decisions and manual actions into one

### DIFF
--- a/client/src/graphql/generated.ts
+++ b/client/src/graphql/generated.ts
@@ -200,6 +200,14 @@ export type GQLActionStatisticsInput = {
   readonly timeZone: Scalars['String']['input'];
 };
 
+export const GQLActivityView = {
+  Actions: 'ACTIONS',
+  All: 'ALL',
+  Decisions: 'DECISIONS',
+} as const;
+
+export type GQLActivityView =
+  (typeof GQLActivityView)[keyof typeof GQLActivityView];
 export type GQLAddAccessibleQueuesToUserInput = {
   readonly queueIds: ReadonlyArray<Scalars['ID']['input']>;
   readonly userId: Scalars['ID']['input'];
@@ -2094,6 +2102,47 @@ export const GQLLookbackVersion = {
 
 export type GQLLookbackVersion =
   (typeof GQLLookbackVersion)[keyof typeof GQLLookbackVersion];
+export type GQLManualActionItem = {
+  readonly __typename: 'ManualActionItem';
+  readonly failed: Scalars['Boolean']['output'];
+  readonly itemId: Scalars['ID']['output'];
+  readonly itemTypeId?: Maybe<Scalars['ID']['output']>;
+};
+
+export type GQLManualActionItemsInput = {
+  readonly correlationId: Scalars['ID']['input'];
+  /** Defaults to 100, capped at 500. */
+  readonly limit?: InputMaybe<Scalars['Int']['input']>;
+  /** max(ts) of the operation, from its feed row. Bounds the partition scan. */
+  readonly occurredAt: Scalars['DateTime']['input'];
+};
+
+export type GQLManualActionItemsPage = {
+  readonly __typename: 'ManualActionItemsPage';
+  readonly items: ReadonlyArray<GQLManualActionItem>;
+  readonly totalCount: Scalars['Int']['output'];
+};
+
+/**
+ * One operation a moderator ran outside a review job, from Bulk Actioning or
+ * Investigation. These produce no manual review decision, so they are otherwise
+ * invisible outside the actioned item's own history. A bulk run writes one
+ * execution per item per action; this collapses those into a single row.
+ */
+export type GQLManualActionRow = GQLModerationActivityRow & {
+  readonly __typename: 'ManualActionRow';
+  readonly actionIds: ReadonlyArray<Scalars['ID']['output']>;
+  readonly actorNote?: Maybe<Scalars['String']['output']>;
+  readonly correlationId: Scalars['ID']['output'];
+  readonly failedCount: Scalars['Int']['output'];
+  readonly id: Scalars['ID']['output'];
+  readonly itemCount: Scalars['Int']['output'];
+  readonly itemTypeId?: Maybe<Scalars['ID']['output']>;
+  readonly policyIds: ReadonlyArray<Scalars['ID']['output']>;
+  readonly reviewerId?: Maybe<Scalars['ID']['output']>;
+  readonly ts: Scalars['DateTime']['output'];
+};
+
 export type GQLManualReviewChartConfigurationsInput = {
   readonly chartConfigurations: ReadonlyArray<GQLManualReviewChartSettingsInput>;
 };
@@ -2327,6 +2376,20 @@ export type GQLModelCardSubsection = {
   readonly __typename: 'ModelCardSubsection';
   readonly fields: ReadonlyArray<GQLModelCardField>;
   readonly title: Scalars['String']['output'];
+};
+
+export type GQLModerationActivityPage = {
+  readonly __typename: 'ModerationActivityPage';
+  /** Null means the end of the feed. */
+  readonly nextCursor?: Maybe<Scalars['Cursor']['output']>;
+  readonly rows: ReadonlyArray<GQLModerationActivityRow>;
+};
+
+/** Fields every row in the merged activity feed carries, regardless of kind. */
+export type GQLModerationActivityRow = {
+  readonly id: Scalars['ID']['output'];
+  readonly reviewerId?: Maybe<Scalars['ID']['output']>;
+  readonly ts: Scalars['DateTime']['output'];
 };
 
 export type GQLModeratorSafetySettingsInput = {
@@ -3476,6 +3539,7 @@ export type GQLQuery = {
   readonly latestItemsCreatedBy: ReadonlyArray<GQLItemSubmissions>;
   readonly latestItemsCreatedByWithThread: ReadonlyArray<GQLThreadWithMessages>;
   readonly locationBank?: Maybe<GQLLocationBank>;
+  readonly manualActionItems: GQLManualActionItemsPage;
   readonly manualReviewQueue?: Maybe<GQLManualReviewQueue>;
   readonly me?: Maybe<GQLUser>;
   readonly myOrg?: Maybe<GQLOrg>;
@@ -3487,6 +3551,7 @@ export type GQLQuery = {
   /** Server-owned grouping + ordering for the role-editor UI. Gated on MANAGE_ROLES. */
   readonly permissionGroups: ReadonlyArray<GQLPermissionGroup>;
   readonly policy?: Maybe<GQLPolicy>;
+  readonly recentModerationActivity: GQLModerationActivityPage;
   readonly recentUserStrikeActions: ReadonlyArray<GQLRecentUserStrikeActions>;
   readonly reportingInsights: GQLReportingInsights;
   readonly reportingRule?: Maybe<GQLReportingRule>;
@@ -3653,6 +3718,10 @@ export type GQLQueryLocationBankArgs = {
   id: Scalars['ID']['input'];
 };
 
+export type GQLQueryManualActionItemsArgs = {
+  input: GQLManualActionItemsInput;
+};
+
 export type GQLQueryManualReviewQueueArgs = {
   id: Scalars['ID']['input'];
 };
@@ -3676,6 +3745,10 @@ export type GQLQueryPartialItemsArgs = {
 
 export type GQLQueryPolicyArgs = {
   id: Scalars['ID']['input'];
+};
+
+export type GQLQueryRecentModerationActivityArgs = {
+  input: GQLRecentModerationActivityInput;
 };
 
 export type GQLQueryRecentUserStrikeActionsArgs = {
@@ -3789,6 +3862,23 @@ export type GQLRecentManualReviewTransformJobAndRecreateInQueueDecision = {
 
 export type GQLRecentManualReviewUserOrRelatedActionDecision = {
   readonly actionIds: ReadonlyArray<Scalars['ID']['input']>;
+};
+
+export type GQLRecentModerationActivityInput = {
+  /** Opaque cursor from a previous page. Absent for the newest page. */
+  readonly cursor?: InputMaybe<Scalars['Cursor']['input']>;
+  readonly decisions?: InputMaybe<
+    ReadonlyArray<GQLRecentManualReviewDecisionType>
+  >;
+  readonly endTime?: InputMaybe<Scalars['DateTime']['input']>;
+  /** Rows per page. Defaults to 100, capped at 200. */
+  readonly limit?: InputMaybe<Scalars['Int']['input']>;
+  readonly policyIds?: InputMaybe<ReadonlyArray<Scalars['ID']['input']>>;
+  readonly queueIds?: InputMaybe<ReadonlyArray<Scalars['ID']['input']>>;
+  readonly reviewerIds?: InputMaybe<ReadonlyArray<Scalars['ID']['input']>>;
+  readonly startTime?: InputMaybe<Scalars['DateTime']['input']>;
+  readonly userSearchString?: InputMaybe<Scalars['String']['input']>;
+  readonly view?: InputMaybe<GQLActivityView>;
 };
 
 export type GQLRecentUserStrikeActions = {
@@ -4000,6 +4090,19 @@ export type GQLRetryNcmecSubmissionResponse = {
    */
   readonly error?: Maybe<Scalars['String']['output']>;
   readonly success: Scalars['Boolean']['output'];
+};
+
+export type GQLReviewJobDecisionRow = GQLModerationActivityRow & {
+  readonly __typename: 'ReviewJobDecisionRow';
+  readonly decisionReason?: Maybe<Scalars['String']['output']>;
+  readonly decisions: ReadonlyArray<GQLManualReviewDecisionComponent>;
+  readonly id: Scalars['ID']['output'];
+  readonly itemId?: Maybe<Scalars['ID']['output']>;
+  readonly itemTypeId?: Maybe<Scalars['ID']['output']>;
+  readonly jobId?: Maybe<Scalars['String']['output']>;
+  readonly queueId?: Maybe<Scalars['ID']['output']>;
+  readonly reviewerId?: Maybe<Scalars['ID']['output']>;
+  readonly ts: Scalars['DateTime']['output'];
 };
 
 export type GQLRole = {

--- a/codegen.yaml
+++ b/codegen.yaml
@@ -157,3 +157,9 @@ generates:
         ManualReviewJob: ../services/manualReviewToolService/index.js#ManualReviewJobOrAppeal
         SignalWithScore: ../services/analyticsQueries/RuleActionInsights.js#SignalWithScore
         ReportingRuleInsights: ../services/reportingService/ReportingRules.js#ReportingRuleWithoutVersion
+        # The merged activity feed returns one shared `ActivityRow` shape for
+        # both rows kinds; each type's field resolvers project out of its
+        # `payload`. See `moderationActivityFeed/mergeActivityRows.ts`.
+        ModerationActivityRow: ../services/moderationActivityFeed/index.js#ActivityRow
+        ReviewJobDecisionRow: ../services/moderationActivityFeed/index.js#ActivityRow
+        ManualActionRow: ../services/moderationActivityFeed/index.js#ActivityRow

--- a/server/api.ts
+++ b/server/api.ts
@@ -439,6 +439,7 @@ function makeGqlServices(deps: Dependencies) {
       'getItemTypeEventuallyConsistent',
       'getEnabledRulesForItemTypeEventuallyConsistent',
       'ItemInvestigationService',
+      'ModerationActivityFeed',
       'ModerationConfigService',
       'ManualReviewToolService',
       'HMAHashBankService',

--- a/server/graphql/generated.ts
+++ b/server/graphql/generated.ts
@@ -40,6 +40,7 @@ import type {
 } from '../services/manualReviewToolService/index.js';
 import type { ManualReviewJobComment } from '../services/manualReviewToolService/modules/CommentOperations.js';
 import type { RoutingRuleWithoutVersion } from '../services/manualReviewToolService/modules/JobRouting.js';
+import type { ActivityRow } from '../services/moderationActivityFeed/index.js';
 import type {
   Condition,
   ConditionSet,
@@ -268,6 +269,14 @@ export type GQLActionStatisticsInput = {
   readonly timeZone: Scalars['String']['input'];
 };
 
+export const GQLActivityView = {
+  Actions: 'ACTIONS',
+  All: 'ALL',
+  Decisions: 'DECISIONS',
+} as const;
+
+export type GQLActivityView =
+  (typeof GQLActivityView)[keyof typeof GQLActivityView];
 export type GQLAddAccessibleQueuesToUserInput = {
   readonly queueIds: ReadonlyArray<Scalars['ID']['input']>;
   readonly userId: Scalars['ID']['input'];
@@ -2162,6 +2171,47 @@ export const GQLLookbackVersion = {
 
 export type GQLLookbackVersion =
   (typeof GQLLookbackVersion)[keyof typeof GQLLookbackVersion];
+export type GQLManualActionItem = {
+  readonly __typename?: 'ManualActionItem';
+  readonly failed: Scalars['Boolean']['output'];
+  readonly itemId: Scalars['ID']['output'];
+  readonly itemTypeId?: Maybe<Scalars['ID']['output']>;
+};
+
+export type GQLManualActionItemsInput = {
+  readonly correlationId: Scalars['ID']['input'];
+  /** Defaults to 100, capped at 500. */
+  readonly limit?: InputMaybe<Scalars['Int']['input']>;
+  /** max(ts) of the operation, from its feed row. Bounds the partition scan. */
+  readonly occurredAt: Scalars['DateTime']['input'];
+};
+
+export type GQLManualActionItemsPage = {
+  readonly __typename?: 'ManualActionItemsPage';
+  readonly items: ReadonlyArray<GQLManualActionItem>;
+  readonly totalCount: Scalars['Int']['output'];
+};
+
+/**
+ * One operation a moderator ran outside a review job, from Bulk Actioning or
+ * Investigation. These produce no manual review decision, so they are otherwise
+ * invisible outside the actioned item's own history. A bulk run writes one
+ * execution per item per action; this collapses those into a single row.
+ */
+export type GQLManualActionRow = GQLModerationActivityRow & {
+  readonly __typename?: 'ManualActionRow';
+  readonly actionIds: ReadonlyArray<Scalars['ID']['output']>;
+  readonly actorNote?: Maybe<Scalars['String']['output']>;
+  readonly correlationId: Scalars['ID']['output'];
+  readonly failedCount: Scalars['Int']['output'];
+  readonly id: Scalars['ID']['output'];
+  readonly itemCount: Scalars['Int']['output'];
+  readonly itemTypeId?: Maybe<Scalars['ID']['output']>;
+  readonly policyIds: ReadonlyArray<Scalars['ID']['output']>;
+  readonly reviewerId?: Maybe<Scalars['ID']['output']>;
+  readonly ts: Scalars['DateTime']['output'];
+};
+
 export type GQLManualReviewChartConfigurationsInput = {
   readonly chartConfigurations: ReadonlyArray<GQLManualReviewChartSettingsInput>;
 };
@@ -2395,6 +2445,20 @@ export type GQLModelCardSubsection = {
   readonly __typename?: 'ModelCardSubsection';
   readonly fields: ReadonlyArray<GQLModelCardField>;
   readonly title: Scalars['String']['output'];
+};
+
+export type GQLModerationActivityPage = {
+  readonly __typename?: 'ModerationActivityPage';
+  /** Null means the end of the feed. */
+  readonly nextCursor?: Maybe<Scalars['Cursor']['output']>;
+  readonly rows: ReadonlyArray<GQLModerationActivityRow>;
+};
+
+/** Fields every row in the merged activity feed carries, regardless of kind. */
+export type GQLModerationActivityRow = {
+  readonly id: Scalars['ID']['output'];
+  readonly reviewerId?: Maybe<Scalars['ID']['output']>;
+  readonly ts: Scalars['DateTime']['output'];
 };
 
 export type GQLModeratorSafetySettingsInput = {
@@ -3544,6 +3608,7 @@ export type GQLQuery = {
   readonly latestItemsCreatedBy: ReadonlyArray<GQLItemSubmissions>;
   readonly latestItemsCreatedByWithThread: ReadonlyArray<GQLThreadWithMessages>;
   readonly locationBank?: Maybe<GQLLocationBank>;
+  readonly manualActionItems: GQLManualActionItemsPage;
   readonly manualReviewQueue?: Maybe<GQLManualReviewQueue>;
   readonly me?: Maybe<GQLUser>;
   readonly myOrg?: Maybe<GQLOrg>;
@@ -3555,6 +3620,7 @@ export type GQLQuery = {
   /** Server-owned grouping + ordering for the role-editor UI. Gated on MANAGE_ROLES. */
   readonly permissionGroups: ReadonlyArray<GQLPermissionGroup>;
   readonly policy?: Maybe<GQLPolicy>;
+  readonly recentModerationActivity: GQLModerationActivityPage;
   readonly recentUserStrikeActions: ReadonlyArray<GQLRecentUserStrikeActions>;
   readonly reportingInsights: GQLReportingInsights;
   readonly reportingRule?: Maybe<GQLReportingRule>;
@@ -3721,6 +3787,10 @@ export type GQLQueryLocationBankArgs = {
   id: Scalars['ID']['input'];
 };
 
+export type GQLQueryManualActionItemsArgs = {
+  input: GQLManualActionItemsInput;
+};
+
 export type GQLQueryManualReviewQueueArgs = {
   id: Scalars['ID']['input'];
 };
@@ -3744,6 +3814,10 @@ export type GQLQueryPartialItemsArgs = {
 
 export type GQLQueryPolicyArgs = {
   id: Scalars['ID']['input'];
+};
+
+export type GQLQueryRecentModerationActivityArgs = {
+  input: GQLRecentModerationActivityInput;
 };
 
 export type GQLQueryRecentUserStrikeActionsArgs = {
@@ -3857,6 +3931,23 @@ export type GQLRecentManualReviewTransformJobAndRecreateInQueueDecision = {
 
 export type GQLRecentManualReviewUserOrRelatedActionDecision = {
   readonly actionIds: ReadonlyArray<Scalars['ID']['input']>;
+};
+
+export type GQLRecentModerationActivityInput = {
+  /** Opaque cursor from a previous page. Absent for the newest page. */
+  readonly cursor?: InputMaybe<Scalars['Cursor']['input']>;
+  readonly decisions?: InputMaybe<
+    ReadonlyArray<GQLRecentManualReviewDecisionType>
+  >;
+  readonly endTime?: InputMaybe<Scalars['DateTime']['input']>;
+  /** Rows per page. Defaults to 100, capped at 200. */
+  readonly limit?: InputMaybe<Scalars['Int']['input']>;
+  readonly policyIds?: InputMaybe<ReadonlyArray<Scalars['ID']['input']>>;
+  readonly queueIds?: InputMaybe<ReadonlyArray<Scalars['ID']['input']>>;
+  readonly reviewerIds?: InputMaybe<ReadonlyArray<Scalars['ID']['input']>>;
+  readonly startTime?: InputMaybe<Scalars['DateTime']['input']>;
+  readonly userSearchString?: InputMaybe<Scalars['String']['input']>;
+  readonly view?: InputMaybe<GQLActivityView>;
 };
 
 export type GQLRecentUserStrikeActions = {
@@ -4068,6 +4159,19 @@ export type GQLRetryNcmecSubmissionResponse = {
    */
   readonly error?: Maybe<Scalars['String']['output']>;
   readonly success: Scalars['Boolean']['output'];
+};
+
+export type GQLReviewJobDecisionRow = GQLModerationActivityRow & {
+  readonly __typename?: 'ReviewJobDecisionRow';
+  readonly decisionReason?: Maybe<Scalars['String']['output']>;
+  readonly decisions: ReadonlyArray<GQLManualReviewDecisionComponent>;
+  readonly id: Scalars['ID']['output'];
+  readonly itemId?: Maybe<Scalars['ID']['output']>;
+  readonly itemTypeId?: Maybe<Scalars['ID']['output']>;
+  readonly jobId?: Maybe<Scalars['String']['output']>;
+  readonly queueId?: Maybe<Scalars['ID']['output']>;
+  readonly reviewerId?: Maybe<Scalars['ID']['output']>;
+  readonly ts: Scalars['DateTime']['output'];
 };
 
 export type GQLRole = {
@@ -5748,6 +5852,7 @@ export type GQLResolversInterfaceTypes<
     | GQLSubmitNcmecReportDecisionComponent
     | GQLTransformJobAndRecreateInQueueDecisionComponent
     | GQLUserOrRelatedActionDecisionComponent;
+  ModerationActivityRow: ActivityRow | ActivityRow;
   Rule: GraphQLRuleParent | GraphQLRuleParent;
 };
 
@@ -5771,6 +5876,7 @@ export type GQLResolversTypes = {
   ActionStatisticsFilters: GQLActionStatisticsFilters;
   ActionStatisticsGroupByColumns: GQLActionStatisticsGroupByColumns;
   ActionStatisticsInput: GQLActionStatisticsInput;
+  ActivityView: GQLActivityView;
   AddAccessibleQueuesToUserInput: GQLAddAccessibleQueuesToUserInput;
   AddAccessibleQueuesToUserResponse: ResolverTypeWrapper<
     GQLResolversUnionTypes<GQLResolversTypes>['AddAccessibleQueuesToUserResponse']
@@ -6115,6 +6221,10 @@ export type GQLResolversTypes = {
   >;
   LoginUserDoesNotExistError: ResolverTypeWrapper<GQLLoginUserDoesNotExistError>;
   LookbackVersion: GQLLookbackVersion;
+  ManualActionItem: ResolverTypeWrapper<GQLManualActionItem>;
+  ManualActionItemsInput: GQLManualActionItemsInput;
+  ManualActionItemsPage: ResolverTypeWrapper<GQLManualActionItemsPage>;
+  ManualActionRow: ResolverTypeWrapper<ActivityRow>;
   ManualReviewChartConfigurationsInput: GQLManualReviewChartConfigurationsInput;
   ManualReviewChartMetric: GQLManualReviewChartMetric;
   ManualReviewChartSettings: ResolverTypeWrapper<
@@ -6173,6 +6283,12 @@ export type GQLResolversTypes = {
   ModelCardField: ResolverTypeWrapper<GQLModelCardField>;
   ModelCardSection: ResolverTypeWrapper<GQLModelCardSection>;
   ModelCardSubsection: ResolverTypeWrapper<GQLModelCardSubsection>;
+  ModerationActivityPage: ResolverTypeWrapper<
+    Omit<GQLModerationActivityPage, 'rows'> & {
+      rows: ReadonlyArray<GQLResolversTypes['ModerationActivityRow']>;
+    }
+  >;
+  ModerationActivityRow: ResolverTypeWrapper<ActivityRow>;
   ModeratorSafetySettingsInput: GQLModeratorSafetySettingsInput;
   MrtClearReportsDisposition: GQLMrtClearReportsDisposition;
   MrtClearReportsScope: GQLMrtClearReportsScope;
@@ -6339,6 +6455,7 @@ export type GQLResolversTypes = {
   RecentManualReviewSubmitNCMECReportDecision: GQLRecentManualReviewSubmitNcmecReportDecision;
   RecentManualReviewTransformJobAndRecreateInQueueDecision: GQLRecentManualReviewTransformJobAndRecreateInQueueDecision;
   RecentManualReviewUserOrRelatedActionDecision: GQLRecentManualReviewUserOrRelatedActionDecision;
+  RecentModerationActivityInput: GQLRecentModerationActivityInput;
   RecentUserStrikeActions: ResolverTypeWrapper<GQLRecentUserStrikeActions>;
   RecentUserStrikeActionsInput: GQLRecentUserStrikeActionsInput;
   RecommendedThresholds: ResolverTypeWrapper<GQLRecommendedThresholds>;
@@ -6381,6 +6498,7 @@ export type GQLResolversTypes = {
   ResetPasswordInput: GQLResetPasswordInput;
   ResolvedJobCount: ResolverTypeWrapper<GQLResolvedJobCount>;
   RetryNcmecSubmissionResponse: ResolverTypeWrapper<GQLRetryNcmecSubmissionResponse>;
+  ReviewJobDecisionRow: ResolverTypeWrapper<ActivityRow>;
   Role: ResolverTypeWrapper<RoleParent>;
   RotateApiKeyError: ResolverTypeWrapper<GQLRotateApiKeyError>;
   RotateApiKeyInput: GQLRotateApiKeyInput;
@@ -6880,6 +6998,10 @@ export type GQLResolversParentTypes = {
     user: GQLResolversParentTypes['User'];
   };
   LoginUserDoesNotExistError: GQLLoginUserDoesNotExistError;
+  ManualActionItem: GQLManualActionItem;
+  ManualActionItemsInput: GQLManualActionItemsInput;
+  ManualActionItemsPage: GQLManualActionItemsPage;
+  ManualActionRow: ActivityRow;
   ManualReviewChartConfigurationsInput: GQLManualReviewChartConfigurationsInput;
   ManualReviewChartSettings: GQLResolversUnionTypes<GQLResolversParentTypes>['ManualReviewChartSettings'];
   ManualReviewChartSettingsInput: GQLManualReviewChartSettingsInput;
@@ -6924,6 +7046,10 @@ export type GQLResolversParentTypes = {
   ModelCardField: GQLModelCardField;
   ModelCardSection: GQLModelCardSection;
   ModelCardSubsection: GQLModelCardSubsection;
+  ModerationActivityPage: Omit<GQLModerationActivityPage, 'rows'> & {
+    rows: ReadonlyArray<GQLResolversParentTypes['ModerationActivityRow']>;
+  };
+  ModerationActivityRow: ActivityRow;
   ModeratorSafetySettingsInput: GQLModeratorSafetySettingsInput;
   MrtJobEnqueueSourceInfo: GQLMrtJobEnqueueSourceInfo;
   MutateAccessibleQueuesForUserSuccessResponse: GQLMutateAccessibleQueuesForUserSuccessResponse;
@@ -7044,6 +7170,7 @@ export type GQLResolversParentTypes = {
   RecentManualReviewSubmitNCMECReportDecision: GQLRecentManualReviewSubmitNcmecReportDecision;
   RecentManualReviewTransformJobAndRecreateInQueueDecision: GQLRecentManualReviewTransformJobAndRecreateInQueueDecision;
   RecentManualReviewUserOrRelatedActionDecision: GQLRecentManualReviewUserOrRelatedActionDecision;
+  RecentModerationActivityInput: GQLRecentModerationActivityInput;
   RecentUserStrikeActions: GQLRecentUserStrikeActions;
   RecentUserStrikeActionsInput: GQLRecentUserStrikeActionsInput;
   RecommendedThresholds: GQLRecommendedThresholds;
@@ -7080,6 +7207,7 @@ export type GQLResolversParentTypes = {
   ResetPasswordInput: GQLResetPasswordInput;
   ResolvedJobCount: GQLResolvedJobCount;
   RetryNcmecSubmissionResponse: GQLRetryNcmecSubmissionResponse;
+  ReviewJobDecisionRow: ActivityRow;
   Role: RoleParent;
   RotateApiKeyError: GQLRotateApiKeyError;
   RotateApiKeyInput: GQLRotateApiKeyInput;
@@ -10217,6 +10345,71 @@ export type GQLLoginUserDoesNotExistErrorResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type GQLManualActionItemResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ManualActionItem'] =
+    GQLResolversParentTypes['ManualActionItem'],
+> = {
+  failed?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
+  itemId?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
+  itemTypeId?: Resolver<
+    Maybe<GQLResolversTypes['ID']>,
+    ParentType,
+    ContextType
+  >;
+};
+
+export type GQLManualActionItemsPageResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ManualActionItemsPage'] =
+    GQLResolversParentTypes['ManualActionItemsPage'],
+> = {
+  items?: Resolver<
+    ReadonlyArray<GQLResolversTypes['ManualActionItem']>,
+    ParentType,
+    ContextType
+  >;
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
+};
+
+export type GQLManualActionRowResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ManualActionRow'] =
+    GQLResolversParentTypes['ManualActionRow'],
+> = {
+  actionIds?: Resolver<
+    ReadonlyArray<GQLResolversTypes['ID']>,
+    ParentType,
+    ContextType
+  >;
+  actorNote?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  correlationId?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
+  failedCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
+  itemCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
+  itemTypeId?: Resolver<
+    Maybe<GQLResolversTypes['ID']>,
+    ParentType,
+    ContextType
+  >;
+  policyIds?: Resolver<
+    ReadonlyArray<GQLResolversTypes['ID']>,
+    ParentType,
+    ContextType
+  >;
+  reviewerId?: Resolver<
+    Maybe<GQLResolversTypes['ID']>,
+    ParentType,
+    ContextType
+  >;
+  ts?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type GQLManualReviewChartSettingsResolvers<
   ContextType = Context,
   ParentType extends GQLResolversParentTypes['ManualReviewChartSettings'] =
@@ -10715,6 +10908,35 @@ export type GQLModelCardSubsectionResolvers<
     ContextType
   >;
   title?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+};
+
+export type GQLModerationActivityPageResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ModerationActivityPage'] =
+    GQLResolversParentTypes['ModerationActivityPage'],
+> = {
+  nextCursor?: Resolver<
+    Maybe<GQLResolversTypes['Cursor']>,
+    ParentType,
+    ContextType
+  >;
+  rows?: Resolver<
+    ReadonlyArray<GQLResolversTypes['ModerationActivityRow']>,
+    ParentType,
+    ContextType
+  >;
+};
+
+export type GQLModerationActivityRowResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ModerationActivityRow'] =
+    GQLResolversParentTypes['ModerationActivityRow'],
+> = {
+  __resolveType: TypeResolveFn<
+    'ManualActionRow' | 'ReviewJobDecisionRow',
+    ParentType,
+    ContextType
+  >;
 };
 
 export type GQLMrtJobEnqueueSourceInfoResolvers<
@@ -12689,6 +12911,12 @@ export type GQLQueryResolvers<
     ContextType,
     RequireFields<GQLQueryLocationBankArgs, 'id'>
   >;
+  manualActionItems?: Resolver<
+    GQLResolversTypes['ManualActionItemsPage'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLQueryManualActionItemsArgs, 'input'>
+  >;
   manualReviewQueue?: Resolver<
     Maybe<GQLResolversTypes['ManualReviewQueue']>,
     ParentType,
@@ -12736,6 +12964,12 @@ export type GQLQueryResolvers<
     ParentType,
     ContextType,
     RequireFields<GQLQueryPolicyArgs, 'id'>
+  >;
+  recentModerationActivity?: Resolver<
+    GQLResolversTypes['ModerationActivityPage'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLQueryRecentModerationActivityArgs, 'input'>
   >;
   recentUserStrikeActions?: Resolver<
     ReadonlyArray<GQLResolversTypes['RecentUserStrikeActions']>,
@@ -13235,6 +13469,39 @@ export type GQLRetryNcmecSubmissionResponseResolvers<
 > = {
   error?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   success?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
+};
+
+export type GQLReviewJobDecisionRowResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ReviewJobDecisionRow'] =
+    GQLResolversParentTypes['ReviewJobDecisionRow'],
+> = {
+  decisionReason?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  decisions?: Resolver<
+    ReadonlyArray<GQLResolversTypes['ManualReviewDecisionComponent']>,
+    ParentType,
+    ContextType
+  >;
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
+  itemId?: Resolver<Maybe<GQLResolversTypes['ID']>, ParentType, ContextType>;
+  itemTypeId?: Resolver<
+    Maybe<GQLResolversTypes['ID']>,
+    ParentType,
+    ContextType
+  >;
+  jobId?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
+  queueId?: Resolver<Maybe<GQLResolversTypes['ID']>, ParentType, ContextType>;
+  reviewerId?: Resolver<
+    Maybe<GQLResolversTypes['ID']>,
+    ParentType,
+    ContextType
+  >;
+  ts?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type GQLRoleResolvers<
@@ -15213,6 +15480,9 @@ export type GQLResolvers<ContextType = Context> = {
   LoginSsoRequiredError?: GQLLoginSsoRequiredErrorResolvers<ContextType>;
   LoginSuccessResponse?: GQLLoginSuccessResponseResolvers<ContextType>;
   LoginUserDoesNotExistError?: GQLLoginUserDoesNotExistErrorResolvers<ContextType>;
+  ManualActionItem?: GQLManualActionItemResolvers<ContextType>;
+  ManualActionItemsPage?: GQLManualActionItemsPageResolvers<ContextType>;
+  ManualActionRow?: GQLManualActionRowResolvers<ContextType>;
   ManualReviewChartSettings?: GQLManualReviewChartSettingsResolvers<ContextType>;
   ManualReviewDecision?: GQLManualReviewDecisionResolvers<ContextType>;
   ManualReviewDecisionComponent?: GQLManualReviewDecisionComponentResolvers<ContextType>;
@@ -15235,6 +15505,8 @@ export type GQLResolvers<ContextType = Context> = {
   ModelCardField?: GQLModelCardFieldResolvers<ContextType>;
   ModelCardSection?: GQLModelCardSectionResolvers<ContextType>;
   ModelCardSubsection?: GQLModelCardSubsectionResolvers<ContextType>;
+  ModerationActivityPage?: GQLModerationActivityPageResolvers<ContextType>;
+  ModerationActivityRow?: GQLModerationActivityRowResolvers<ContextType>;
   MrtJobEnqueueSourceInfo?: GQLMrtJobEnqueueSourceInfoResolvers<ContextType>;
   MutateAccessibleQueuesForUserSuccessResponse?: GQLMutateAccessibleQueuesForUserSuccessResponseResolvers<ContextType>;
   MutateActionResponse?: GQLMutateActionResponseResolvers<ContextType>;
@@ -15311,6 +15583,7 @@ export type GQLResolvers<ContextType = Context> = {
   ReportingRulePassRateData?: GQLReportingRulePassRateDataResolvers<ContextType>;
   ResolvedJobCount?: GQLResolvedJobCountResolvers<ContextType>;
   RetryNcmecSubmissionResponse?: GQLRetryNcmecSubmissionResponseResolvers<ContextType>;
+  ReviewJobDecisionRow?: GQLReviewJobDecisionRowResolvers<ContextType>;
   Role?: GQLRoleResolvers<ContextType>;
   RotateApiKeyError?: GQLRotateApiKeyErrorResolvers<ContextType>;
   RotateApiKeyResponse?: GQLRotateApiKeyResponseResolvers<ContextType>;

--- a/server/graphql/modules/moderationActivity.test.ts
+++ b/server/graphql/modules/moderationActivity.test.ts
@@ -1,0 +1,35 @@
+import { typeDefs } from './moderationActivity.js';
+
+describe('moderationActivity schema', () => {
+  it('exposes both queries', () => {
+    expect(typeDefs).toContain('recentModerationActivity(');
+    expect(typeDefs).toContain('manualActionItems(');
+  });
+
+  it('models rows as an interface so the client discriminates on __typename', () => {
+    expect(typeDefs).toContain('interface ModerationActivityRow');
+    expect(typeDefs).toContain(
+      'type ReviewJobDecisionRow implements ModerationActivityRow',
+    );
+    expect(typeDefs).toContain(
+      'type ManualActionRow implements ModerationActivityRow',
+    );
+  });
+
+  it('caps page sizes', () => {
+    expect(typeDefs).toContain('limit: Int');
+  });
+
+  it('uses the opaque Cursor scalar rather than a bare string', () => {
+    expect(typeDefs).toContain('cursor: Cursor');
+    expect(typeDefs).toContain('nextCursor: Cursor');
+  });
+
+  it('does not expose offset on manualActionItems', () => {
+    const inputBlock = typeDefs.slice(
+      typeDefs.indexOf('input ManualActionItemsInput'),
+      typeDefs.indexOf('type ManualActionItem'),
+    );
+    expect(inputBlock).not.toContain('offset');
+  });
+});

--- a/server/graphql/modules/moderationActivity.ts
+++ b/server/graphql/modules/moderationActivity.ts
@@ -1,0 +1,285 @@
+import { type ItemInvestigationService } from '../../services/itemInvestigationService/index.js';
+import { type ManualReviewToolService } from '../../services/manualReviewToolService/index.js';
+import { type ActivityFeedFilterInput } from '../../services/moderationActivityFeed/index.js';
+import { UserPermission } from '../../services/userManagementService/index.js';
+import { filterNullOrUndefined } from '../../utils/collections.js';
+import {
+  type GQLManualActionRowResolvers,
+  type GQLModerationActivityRowResolvers,
+  type GQLQueryResolvers,
+  type GQLRecentManualReviewDecisionType,
+  type GQLReviewJobDecisionRowResolvers,
+} from '../generated.js';
+import { forbiddenError, unauthenticatedError } from '../utils/errors.js';
+
+/** Matches the decisions feed's page size so the two merge evenly. */
+const DEFAULT_PAGE_SIZE = 100;
+const MAX_PAGE_SIZE = 200;
+const DEFAULT_ITEM_PAGE_SIZE = 100;
+/**
+ * Covers any run Bulk Actioning can produce — its 1000-item limit is enforced
+ * client-side only (`BulkActioningDashboard`), and `bulkExecuteActions` caps
+ * nothing server-side, so a programmatic caller can still exceed this. The
+ * panel keeps its truncation notice for that case rather than pretending the
+ * list is always complete.
+ */
+const MAX_ITEM_PAGE_SIZE = 1000;
+
+const typeDefs = /* GraphQL */ `
+  input RecentModerationActivityInput {
+    "Opaque cursor from a previous page. Absent for the newest page."
+    cursor: Cursor
+    "Rows per page. Defaults to 100, capped at 200."
+    limit: Int
+    view: ActivityView
+    startTime: DateTime
+    endTime: DateTime
+    reviewerIds: [ID!]
+    policyIds: [ID!]
+    queueIds: [ID!]
+    decisions: [RecentManualReviewDecisionType!]
+    userSearchString: String
+  }
+
+  enum ActivityView {
+    ALL
+    DECISIONS
+    ACTIONS
+  }
+
+  "Fields every row in the merged activity feed carries, regardless of kind."
+  interface ModerationActivityRow {
+    id: ID!
+    ts: DateTime!
+    reviewerId: ID
+  }
+
+  type ReviewJobDecisionRow implements ModerationActivityRow {
+    id: ID!
+    ts: DateTime!
+    reviewerId: ID
+    jobId: String
+    queueId: ID
+    itemId: ID
+    itemTypeId: ID
+    decisions: [ManualReviewDecisionComponent!]!
+    decisionReason: String
+  }
+
+  """
+  One operation a moderator ran outside a review job, from Bulk Actioning or
+  Investigation. These produce no manual review decision, so they are otherwise
+  invisible outside the actioned item's own history. A bulk run writes one
+  execution per item per action; this collapses those into a single row.
+  """
+  type ManualActionRow implements ModerationActivityRow {
+    id: ID!
+    ts: DateTime!
+    reviewerId: ID
+    correlationId: ID!
+    itemTypeId: ID
+    actionIds: [ID!]!
+    policyIds: [ID!]!
+    actorNote: String
+    itemCount: Int!
+    failedCount: Int!
+  }
+
+  type ModerationActivityPage {
+    rows: [ModerationActivityRow!]!
+    "Null means the end of the feed."
+    nextCursor: Cursor
+  }
+
+  input ManualActionItemsInput {
+    correlationId: ID!
+    "max(ts) of the operation, from its feed row. Bounds the partition scan."
+    occurredAt: DateTime!
+    "Defaults to 100, capped at 500."
+    limit: Int
+  }
+
+  type ManualActionItem {
+    itemId: ID!
+    itemTypeId: ID
+    failed: Boolean!
+  }
+
+  type ManualActionItemsPage {
+    items: [ManualActionItem!]!
+    totalCount: Int!
+  }
+
+  type Query {
+    recentModerationActivity(
+      input: RecentModerationActivityInput!
+    ): ModerationActivityPage!
+
+    manualActionItems(input: ManualActionItemsInput!): ManualActionItemsPage!
+  }
+`;
+
+/** The exact shape `ModerationActivityFeed.getPage` puts in a DECISION row's `payload`. */
+type DecisionRowPayload = Awaited<
+  ReturnType<ManualReviewToolService['getDecisionsForActivityFeed']>
+>[number];
+
+/** The exact shape `ModerationActivityFeed.getPage` puts in a MANUAL_ACTION row's `payload`. */
+type ManualActionRowPayload = Awaited<
+  ReturnType<ItemInvestigationService['getRecentModeratorActions']>
+>[number];
+
+type DecisionFilterEntry = NonNullable<
+  ActivityFeedFilterInput['decisions']
+>[number];
+
+/**
+ * Maps the GraphQL oneof-style decision filter to the service's tagged-union
+ * shape. Mirrors the equivalent mapping in `manualReviewTool.ts`'s
+ * `getRecentDecisions` resolver — kept separate rather than shared, since
+ * touching that resolver is out of scope here.
+ */
+function toDecisionFilterEntry(
+  it: GQLRecentManualReviewDecisionType,
+): DecisionFilterEntry | undefined {
+  if (it.userOrRelatedActionDecision) {
+    return {
+      type: 'CUSTOM_ACTION',
+      actionIds: it.userOrRelatedActionDecision.actionIds,
+    };
+  }
+  if (it.ignoreDecision) {
+    return { type: 'IGNORE', actionIds: undefined };
+  }
+  if (it.automaticCloseDecision) {
+    return { type: 'AUTOMATIC_CLOSE', actionIds: undefined };
+  }
+  if (it.submitNcmecReportDecision) {
+    return { type: 'SUBMIT_NCMEC_REPORT', actionIds: undefined };
+  }
+  if (it.transformJobAndRecreateInQueueDecision) {
+    return {
+      type: 'TRANSFORM_JOB_AND_RECREATE_IN_QUEUE',
+      actionIds: undefined,
+    };
+  }
+  if (it.acceptAppealDecision) {
+    return { type: 'ACCEPT_APPEAL', actionIds: undefined };
+  }
+  if (it.rejectAppealDecision) {
+    return { type: 'REJECT_APPEAL', actionIds: undefined };
+  }
+  return undefined;
+}
+
+function toActivityFeedDecisionFilter(
+  decisions:
+    ReadonlyArray<GQLRecentManualReviewDecisionType> | null | undefined,
+): ActivityFeedFilterInput['decisions'] {
+  if (!decisions) {
+    return undefined;
+  }
+  return filterNullOrUndefined(decisions.map(toDecisionFilterEntry));
+}
+
+const Query: GQLQueryResolvers = {
+  async recentModerationActivity(_, { input }, context) {
+    const user = context.getUser();
+    if (user == null) {
+      throw unauthenticatedError('Authenticated user required');
+    }
+
+    return context.services.ModerationActivityFeed.getPage({
+      userPermissions: user.getPermissions(),
+      orgId: user.orgId,
+      input: {
+        startTime: input.startTime ? new Date(input.startTime) : undefined,
+        endTime: input.endTime ? new Date(input.endTime) : undefined,
+        reviewerIds: input.reviewerIds ?? undefined,
+        policyIds: input.policyIds ?? undefined,
+        queueIds: input.queueIds ?? undefined,
+        decisions: toActivityFeedDecisionFilter(input.decisions),
+        userSearchString: input.userSearchString ?? undefined,
+      },
+      view: input.view ?? 'ALL',
+      limit: Math.min(
+        Math.max(1, input.limit ?? DEFAULT_PAGE_SIZE),
+        MAX_PAGE_SIZE,
+      ),
+      // Already decoded by the `Cursor` scalar; `parseActivityCursor` handles
+      // shape validation from here.
+      cursor: input.cursor ?? undefined,
+    });
+  },
+
+  async manualActionItems(_, { input }, context) {
+    const user = context.getUser();
+    if (user == null) {
+      throw unauthenticatedError('Authenticated user required');
+    }
+    // Manual actions are only ever taken from Investigation or Bulk Actioning,
+    // so viewing them requires the permission that gates Investigation itself.
+    // EXTERNAL_MODERATOR — read-only access for external moderation partners —
+    // is the only role without it, and this resolver returns the full item-id
+    // list of a run, which is the one thing such an account must not enumerate.
+    if (!user.getPermissions().includes(UserPermission.VIEW_INVESTIGATION)) {
+      throw forbiddenError(
+        'VIEW_INVESTIGATION permission required to view manual action items.',
+      );
+    }
+
+    return context.services.ModerationActivityFeed.getManualActionItems({
+      orgId: user.orgId,
+      correlationId: input.correlationId,
+      occurredAt: new Date(input.occurredAt),
+      limit: Math.min(
+        Math.max(1, input.limit ?? DEFAULT_ITEM_PAGE_SIZE),
+        MAX_ITEM_PAGE_SIZE,
+      ),
+      // `offset` stays internal, not part of the public schema:
+      // `totalCount` rides on a `count() OVER ()` window over the returned
+      // rows, so paging past the end would make it report 0 — indistinguishable
+      // from "this operation had no items".
+      offset: 0,
+    });
+  },
+};
+
+const ModerationActivityRow: GQLModerationActivityRowResolvers = {
+  __resolveType: (row) =>
+    row.kind === 'MANUAL_ACTION' ? 'ManualActionRow' : 'ReviewJobDecisionRow',
+};
+
+const ReviewJobDecisionRow: GQLReviewJobDecisionRowResolvers = {
+  id: (row) => row.id,
+  ts: (row) => row.ts,
+  reviewerId: (row) => (row.payload as DecisionRowPayload).reviewerId,
+  jobId: (row) => (row.payload as DecisionRowPayload).jobId,
+  queueId: (row) => (row.payload as DecisionRowPayload).queueId,
+  itemId: (row) => (row.payload as DecisionRowPayload).itemId,
+  itemTypeId: (row) => (row.payload as DecisionRowPayload).itemTypeId,
+  decisions: (row) => (row.payload as DecisionRowPayload).decisions,
+  decisionReason: (row) => (row.payload as DecisionRowPayload).decisionReason,
+};
+
+const ManualActionRow: GQLManualActionRowResolvers = {
+  id: (row) => row.id,
+  ts: (row) => row.ts,
+  reviewerId: (row) => (row.payload as ManualActionRowPayload).actorId,
+  correlationId: (row) => (row.payload as ManualActionRowPayload).correlationId,
+  itemTypeId: (row) => (row.payload as ManualActionRowPayload).itemTypeId,
+  actionIds: (row) => (row.payload as ManualActionRowPayload).actionIds,
+  policyIds: (row) => (row.payload as ManualActionRowPayload).policyIds,
+  actorNote: (row) => (row.payload as ManualActionRowPayload).actorNote,
+  itemCount: (row) => (row.payload as ManualActionRowPayload).itemCount,
+  failedCount: (row) => (row.payload as ManualActionRowPayload).failedCount,
+};
+
+const resolvers = {
+  Query,
+  ModerationActivityRow,
+  ReviewJobDecisionRow,
+  ManualActionRow,
+};
+
+export { typeDefs, resolvers };

--- a/server/graphql/resolvers.ts
+++ b/server/graphql/resolvers.ts
@@ -25,6 +25,7 @@ import { resolvers as investigationResolvers } from './modules/investigation.js'
 import { resolvers as itemTypeResolvers } from './modules/itemType.js';
 import { resolvers as locationBankResolvers } from './modules/locationBank.js';
 import { resolvers as manualReviewToolResolvers } from './modules/manualReviewTool.js';
+import { resolvers as moderationActivityResolvers } from './modules/moderationActivity.js';
 import { resolvers as ncmecResolvers } from './modules/ncmec.js';
 import { resolvers as orgResolvers } from './modules/org.js';
 import { resolvers as policyResolvers } from './modules/policy.js';
@@ -279,6 +280,7 @@ export default mergeResolvers([
   locationBankResolvers,
   manualReviewToolResolvers,
   hashBankResolvers,
+  moderationActivityResolvers,
   ncmecResolvers,
   orgResolvers,
   policyResolvers,

--- a/server/graphql/schema.ts
+++ b/server/graphql/schema.ts
@@ -15,6 +15,7 @@ import { typeDefs as investigationTypeDefs } from './modules/investigation.js';
 import { typeDefs as itemTypeTypeDefs } from './modules/itemType.js';
 import { typeDefs as locationBankTypeDefs } from './modules/locationBank.js';
 import { typeDefs as manualReviewToolTypeDefs } from './modules/manualReviewTool.js';
+import { typeDefs as moderationActivityTypeDefs } from './modules/moderationActivity.js';
 import { typeDefs as ncmecTypeDefs } from './modules/ncmec.js';
 import { typeDefs as orgTypeDefs } from './modules/org.js';
 import { typeDefs as policyTypeDefs } from './modules/policy.js';
@@ -497,6 +498,7 @@ export default mergeTypeDefs([
   itemTypeTypeDefs,
   locationBankTypeDefs,
   manualReviewToolTypeDefs,
+  moderationActivityTypeDefs,
   ncmecTypeDefs,
   orgTypeDefs,
   policyTypeDefs,

--- a/server/iocContainer/index.ts
+++ b/server/iocContainer/index.ts
@@ -131,6 +131,7 @@ import {
   // owned by the MRT service)
   // eslint-disable-next-line import/no-restricted-paths
 } from '../services/manualReviewToolService/manualReviewToolQueries.js';
+import { ModerationActivityFeed } from '../services/moderationActivityFeed/index.js';
 import {
   ModerationConfigService,
   type Action,
@@ -371,6 +372,7 @@ export interface Dependencies {
   ManualReviewToolService: ManualReviewToolService;
   SignalsService: SignalsService;
   ItemInvestigationService: ItemInvestigationService;
+  ModerationActivityFeed: ModerationActivityFeed;
   DerivedFieldsService: DerivedFieldsService;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   UserStatisticsService: any; // TODO: Fix circular reference with Dependencies
@@ -1485,6 +1487,13 @@ export default async function getBottle() {
         _input: ManualReviewJobInput | ManualReviewAppealJobInput,
         _queueId: string,
       ) {},
+    );
+  });
+
+  bottle.factory('ModerationActivityFeed', (container) => {
+    return new ModerationActivityFeed(
+      container.ManualReviewToolService,
+      container.ItemInvestigationService,
     );
   });
 

--- a/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.test.ts
+++ b/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.test.ts
@@ -142,6 +142,468 @@ describe('ClickhouseActionExecutionsAdapter.findInferredUserIdentity', () => {
   });
 });
 
+describe('ClickhouseActionExecutionsAdapter.getRecentModeratorActions', () => {
+  const groupRow = (overrides: Record<string, unknown> = {}) => ({
+    correlation_id: 'manual-action-run:abc',
+    last_ts: '2026-08-05 12:00:00.000',
+    actor_id: 'user-7',
+    item_type_id: 'post',
+    actor_note: 'spam sweep',
+    policies: '[{"id":"pol-1","name":"Spam"}]',
+    action_ids: ['act-1', 'act-2'],
+    item_count: '3',
+    failed_count: '0',
+    ...overrides,
+  });
+
+  it('collapses one bulk operation into a single record', async () => {
+    const { adapter } = makeAdapter([groupRow()]);
+
+    const result = await adapter.getRecentModeratorActions({
+      orgId: 'org-1',
+      limit: 100,
+    });
+
+    expect(result).toEqual([
+      {
+        correlationId: 'manual-action-run:abc',
+        actorId: 'user-7',
+        itemTypeId: 'post',
+        actionIds: ['act-1', 'act-2'],
+        policyIds: ['pol-1'],
+        actorNote: 'spam sweep',
+        itemCount: 3,
+        failedCount: 0,
+        occurredAt: new Date('2026-08-05T12:00:00.000Z'),
+      },
+    ]);
+  });
+
+  it('reports how many executions failed', async () => {
+    const { adapter } = makeAdapter([
+      groupRow({ item_count: '500', failed_count: '3' }),
+    ]);
+
+    const [group] = await adapter.getRecentModeratorActions({
+      orgId: 'org-1',
+      limit: 100,
+    });
+
+    expect(group.itemCount).toBe(500);
+    expect(group.failedCount).toBe(3);
+  });
+
+  it('counts items exactly rather than estimating', async () => {
+    // uniq() is HyperLogLog. An "84 items" label that reads 83 is a bug the
+    // reader cannot detect.
+    const { adapter, query } = makeAdapter([]);
+
+    await adapter.getRecentModeratorActions({ orgId: 'org-1', limit: 100 });
+
+    const sentSql = query.mock.calls[0][0];
+    expect(sentSql).toContain('uniqExact(item_id)');
+    expect(sentSql).not.toMatch(/[^a-zA-Z]uniq\(/);
+  });
+
+  it('counts failures in items, not executions', async () => {
+    // countIf counts (item, action) rows, so a 2-item x 2-action run that fails
+    // completely would report "4 of 2 failed".
+    const { adapter, query } = makeAdapter([]);
+
+    await adapter.getRecentModeratorActions({ orgId: 'org-1', limit: 100 });
+
+    const sentSql = query.mock.calls[0][0];
+    expect(sentSql).toContain('uniqExactIf(item_id, failed = 1)');
+    expect(sentSql).not.toContain('countIf(');
+  });
+
+  it('scopes to moderator action sources rather than a null job id', async () => {
+    // Rule-driven and user-strike executions also carry a null job_id, so
+    // filtering on that would pull automation into the feed.
+    const { adapter, query } = makeAdapter([]);
+
+    await adapter.getRecentModeratorActions({ orgId: 'org-1', limit: 100 });
+
+    const sentSql = query.mock.calls[0][0];
+    expect(sentSql).toContain("action_source IN ('manual-action-run')");
+    expect(sentSql).not.toContain('job_id');
+    expect(sentSql).toContain('GROUP BY correlation_id');
+  });
+
+  it('bounds the partition scan with a ds floor derived from the cursor', async () => {
+    const { adapter, query } = makeAdapter([]);
+
+    await adapter.getRecentModeratorActions({
+      orgId: 'org-1',
+      limit: 100,
+      cursor: {
+        ts: new Date('2026-08-05T12:00:00.000Z'),
+        correlationId: 'manual-action-run:abc',
+      },
+      lookbackWindowMs: 24 * 60 * 60 * 1000,
+    });
+
+    const sentSql = query.mock.calls[0][0];
+    expect(sentSql).toContain("toDate('2026-08-04')");
+  });
+
+  it('reaches forward to an endTime later than now, so a future-dated row is recoverable', async () => {
+    // Deriving the ds ceiling from the cursor alone made a row dated ahead of
+    // the server clock permanently unreachable — page 1's ceiling is `now`,
+    // paging only moves backwards, and no filter could widen it. Clock skew on
+    // a writer host is enough to produce one.
+    const { adapter, query } = makeAdapter([]);
+    const future = new Date(Date.now() + 5 * 24 * 60 * 60 * 1000);
+
+    await adapter.getRecentModeratorActions({
+      orgId: 'org-1',
+      limit: 100,
+      before: future,
+    });
+
+    const sentSql = query.mock.calls[0][0];
+    expect(sentSql).toContain(
+      `ds <= toDate('${future.toISOString().slice(0, 10)}') + 1`,
+    );
+    expect(sentSql).toContain(
+      `max(ts) <= '${future.toISOString().replace('T', ' ').replace('Z', '')}'`,
+    );
+  });
+
+  it('anchors the lookback window to endTime, not to now', async () => {
+    // With an endTime and no startTime, anchoring the floor at `now` put the
+    // partitions at [now-window, now] while HAVING max(ts) <= endTime excluded
+    // every one of them — the feed returned nothing, with no error.
+    const { adapter, query } = makeAdapter([]);
+
+    await adapter.getRecentModeratorActions({
+      orgId: 'org-1',
+      limit: 100,
+      before: new Date('2026-01-31T23:59:59.000Z'),
+      lookbackWindowMs: 30 * 24 * 60 * 60 * 1000,
+    });
+
+    const sentSql = query.mock.calls[0][0];
+    expect(sentSql).toContain("ds >= toDate('2026-01-01') - 1");
+    expect(sentSql).toContain("ds <= toDate('2026-01-31') + 1");
+  });
+
+  it('keeps a run straddling the start date whole', async () => {
+    // A bulk run beginning just before the start date and finishing just after
+    // must not lose its earlier rows — that would group into a partial record
+    // with a wrong item count, the same defect the cursor fix addresses.
+    const { adapter, query } = makeAdapter([]);
+
+    await adapter.getRecentModeratorActions({
+      orgId: 'org-1',
+      limit: 100,
+      after: new Date('2026-08-01T00:00:00.000Z'),
+    });
+
+    expect(query.mock.calls[0][0]).toContain("toDate('2026-08-01') - 1");
+  });
+
+  it('filters to operations that touched a given item', async () => {
+    const { adapter, query } = makeAdapter([]);
+
+    await adapter.getRecentModeratorActions({
+      orgId: 'org-1',
+      limit: 100,
+      itemId: 'usr_8813',
+    });
+
+    expect(query.mock.calls[0][0]).toContain(
+      "has(groupUniqArray(item_id), 'usr_8813')",
+    );
+  });
+
+  it('does not alias the aggregate to `ts`', async () => {
+    // ClickHouse resolves `ts < ?` in WHERE against a `max(ts) AS ts` alias and
+    // rejects the query with ILLEGAL_AGGREGATION. Mocked rows can't catch this,
+    // so assert the alias directly.
+    const { adapter, query } = makeAdapter([]);
+
+    await adapter.getRecentModeratorActions({ orgId: 'org-1', limit: 100 });
+
+    const sentSql = query.mock.calls[0][0];
+    expect(sentSql).toContain('max(ts) AS last_ts');
+    expect(sentSql).not.toContain('max(ts) AS ts');
+    expect(sentSql).toContain('ORDER BY last_ts DESC');
+  });
+
+  it('reads timestamps as UTC even though ClickHouse omits the zone', async () => {
+    const { adapter } = makeAdapter([
+      groupRow({ last_ts: '2026-08-05 12:00:00.000' }),
+    ]);
+
+    const [group] = await adapter.getRecentModeratorActions({
+      orgId: 'org-1',
+      limit: 100,
+    });
+
+    expect(group.occurredAt.toISOString()).toBe('2026-08-05T12:00:00.000Z');
+  });
+
+  it('scopes to the requested moderators', async () => {
+    // Without this the reviewer filter would narrow decisions while still
+    // showing every other moderator's actions.
+    const { adapter, query } = makeAdapter([]);
+
+    await adapter.getRecentModeratorActions({
+      orgId: 'org-1',
+      limit: 100,
+      actorIds: ['user-7', 'user-8'],
+    });
+
+    expect(query.mock.calls[0][0]).toContain(
+      "actor_id IN ('user-7', 'user-8')",
+    );
+  });
+
+  it('matches policies through the policies JSON, not the unpopulated column', async () => {
+    const { adapter, query } = makeAdapter([]);
+
+    await adapter.getRecentModeratorActions({
+      orgId: 'org-1',
+      limit: 100,
+      policyIds: ['pol-1'],
+    });
+
+    const sentSql = query.mock.calls[0][0];
+    expect(sentSql).toContain('JSONExtractArrayRaw(policies)');
+    expect(sentSql).toContain("['pol-1']");
+    expect(sentSql).not.toContain('policy_ids');
+  });
+
+  it('omits optional filters entirely when not supplied', async () => {
+    const { adapter, query } = makeAdapter([]);
+
+    await adapter.getRecentModeratorActions({
+      orgId: 'org-1',
+      limit: 100,
+      actorIds: [],
+      policyIds: [],
+    });
+
+    const sentSql = query.mock.calls[0][0];
+    expect(sentSql).not.toContain('actor_id IN');
+    expect(sentSql).not.toContain('JSONExtractArrayRaw');
+  });
+
+  it('tightens the ds floor to a user-set start date', async () => {
+    const { adapter, query } = makeAdapter([]);
+
+    await adapter.getRecentModeratorActions({
+      orgId: 'org-1',
+      limit: 100,
+      cursor: {
+        ts: new Date('2026-08-05T12:00:00.000Z'),
+        correlationId: 'manual-action-run:abc',
+      },
+      after: new Date('2026-08-01T00:00:00.000Z'),
+    });
+
+    const sentSql = query.mock.calls[0][0];
+    // The rolling window would reach back months; the start date wins, minus a
+    // day of slack so a run straddling midnight is not truncated.
+    expect(sentSql).toContain("toDate('2026-08-01') - 1");
+    // `after` is an exact bound on the complete group, so it lives in HAVING.
+    expect(sentSql).toContain("max(ts) >= '2026-08-01 00:00:00.000'");
+  });
+
+  it('honours a start date older than the rolling window', async () => {
+    const { adapter, query } = makeAdapter([]);
+
+    await adapter.getRecentModeratorActions({
+      orgId: 'org-1',
+      limit: 100,
+      cursor: {
+        ts: new Date('2026-08-05T12:00:00.000Z'),
+        correlationId: 'manual-action-run:abc',
+      },
+      after: new Date('2026-01-01T00:00:00.000Z'),
+      lookbackWindowMs: 30 * 24 * 60 * 60 * 1000,
+    });
+
+    const sentSql = query.mock.calls[0][0];
+    // The 30-day window would floor at 2026-07-06 and silently hide January.
+    expect(sentSql).toContain("toDate('2026-01-01') - 1");
+    expect(sentSql).not.toContain("toDate('2026-07-06')");
+  });
+
+  it('tolerates null aggregate columns', async () => {
+    const { adapter } = makeAdapter([
+      groupRow({
+        actor_id: null,
+        item_type_id: null,
+        actor_note: null,
+        policies: null,
+        action_ids: null,
+        item_count: null,
+        failed_count: null,
+      }),
+    ]);
+
+    const [group] = await adapter.getRecentModeratorActions({
+      orgId: 'org-1',
+      limit: 100,
+    });
+
+    expect(group.actionIds).toEqual([]);
+    expect(group.policyIds).toEqual([]);
+    expect(group.itemCount).toBe(0);
+    expect(group.failedCount).toBe(0);
+  });
+
+  it('applies the cursor to the complete group, not to raw rows', async () => {
+    // A bulk run trickles in over seconds (pLimit(10) in ActionApi). Bounding
+    // raw `ts` before GROUP BY truncates a run straddling the cursor into a
+    // partial group with a lower max(ts) and itemCount, so the same run lands
+    // on two consecutive pages with wrong counts on both.
+    const { adapter, query } = makeAdapter([]);
+
+    await adapter.getRecentModeratorActions({
+      orgId: 'org-1',
+      limit: 100,
+      cursor: {
+        ts: new Date('2026-08-05T12:00:00.000Z'),
+        correlationId: 'manual-action-run:abc',
+      },
+    });
+
+    const sentSql = query.mock.calls[0][0];
+    expect(sentSql).toContain('HAVING');
+    expect(sentSql).toContain(
+      "(max(ts), correlation_id) < ('2026-08-05 12:00:00.000', 'manual-action-run:abc')",
+    );
+    // The cursor must not appear as a raw-row predicate.
+    expect(sentSql).not.toMatch(/WHERE[\s\S]*\bts\s*<\s*'/);
+  });
+
+  it('orders by the composite key so ties cannot repeat or vanish', async () => {
+    const { adapter, query } = makeAdapter([]);
+
+    await adapter.getRecentModeratorActions({ orgId: 'org-1', limit: 100 });
+
+    expect(query.mock.calls[0][0]).toContain(
+      'ORDER BY last_ts DESC, correlation_id DESC',
+    );
+  });
+
+  it('bounds the upper end of a date range on the complete group', async () => {
+    // Without this, a January filter renders today's bulk runs beside January
+    // decisions: endTime reaches Postgres but never reaches this store.
+    const { adapter, query } = makeAdapter([]);
+
+    await adapter.getRecentModeratorActions({
+      orgId: 'org-1',
+      limit: 100,
+      after: new Date('2026-01-01T00:00:00.000Z'),
+      before: new Date('2026-01-31T23:59:59.000Z'),
+    });
+
+    const sentSql = query.mock.calls[0][0];
+    expect(sentSql).toContain("max(ts) <= '2026-01-31 23:59:59.000'");
+    expect(sentSql).toContain("max(ts) >= '2026-01-01 00:00:00.000'");
+  });
+});
+
+describe('ClickhouseActionExecutionsAdapter.getManualActionItems', () => {
+  it('returns one record per item with its failure state', async () => {
+    const { adapter } = makeAdapter([
+      { item_id: 'i-1', item_type_id: 'post', failed: 0, total_count: '3' },
+      { item_id: 'i-2', item_type_id: 'post', failed: 1, total_count: '3' },
+    ]);
+
+    const result = await adapter.getManualActionItems({
+      orgId: 'org-1',
+      correlationId: 'manual-action-run:abc',
+      occurredAt: new Date('2026-08-05T12:00:00.000Z'),
+      limit: 100,
+      offset: 0,
+    });
+
+    expect(result).toEqual({
+      items: [
+        { itemId: 'i-1', itemTypeId: 'post', failed: false },
+        { itemId: 'i-2', itemTypeId: 'post', failed: true },
+      ],
+      totalCount: 3,
+    });
+  });
+
+  it('scans back at least as far as the feed groups, so the two agree', async () => {
+    // The feed groups a run over the whole lookback window. Bounding this to
+    // `occurredAt ± 1 day` made a row and its own detail panel disagree: the
+    // row read "8 items / 1 of 8 failed" while the panel showed 3 items and no
+    // failures at all — the audit log dropping the failures it exists to
+    // record. `correlation_id` is not in the sort key, so a ds bound is still
+    // required; it just has to be the feed's, not a narrower one.
+    const { adapter, query } = makeAdapter([]);
+
+    await adapter.getManualActionItems({
+      orgId: 'org-1',
+      correlationId: 'manual-action-run:abc',
+      occurredAt: new Date('2026-08-05T12:00:00.000Z'),
+      limit: 100,
+      offset: 0,
+      lookbackWindowMs: 30 * 24 * 60 * 60 * 1000,
+    });
+
+    const sentSql = query.mock.calls[0][0];
+    expect(sentSql).toContain("ds >= toDate('2026-07-06')");
+    expect(sentSql).toContain("ds <= toDate('2026-08-05') + 1");
+    expect(sentSql).toContain("correlation_id = 'manual-action-run:abc'");
+  });
+
+  it('defaults its window to the feed lookback rather than a single day', async () => {
+    const { adapter, query } = makeAdapter([]);
+
+    await adapter.getManualActionItems({
+      orgId: 'org-1',
+      correlationId: 'manual-action-run:abc',
+      occurredAt: new Date('2026-08-05T12:00:00.000Z'),
+      limit: 100,
+      offset: 0,
+    });
+
+    // 3 months back, matching DEFAULT_ACTION_FEED_LOOKBACK_MS — not 08-04.
+    expect(query.mock.calls[0][0]).toContain("ds >= toDate('2026-05-07')");
+  });
+
+  it('reads only moderator actions, not any correlation id', async () => {
+    // mrt-decision / rule-driven correlation ids must not resolve here — their
+    // item lists are what the NCMEC permission gate exists to hide.
+    const { adapter, query } = makeAdapter([]);
+
+    await adapter.getManualActionItems({
+      orgId: 'org-1',
+      correlationId: 'mrt-decision:abc',
+      occurredAt: new Date('2026-08-05T12:00:00.000Z'),
+      limit: 100,
+      offset: 0,
+    });
+
+    expect(query.mock.calls[0][0]).toContain(
+      "action_source IN ('manual-action-run')",
+    );
+  });
+
+  it('reports zero total when the operation has no rows', async () => {
+    const { adapter } = makeAdapter([]);
+
+    const result = await adapter.getManualActionItems({
+      orgId: 'org-1',
+      correlationId: 'manual-action-run:missing',
+      occurredAt: new Date('2026-08-05T12:00:00.000Z'),
+      limit: 100,
+      offset: 0,
+    });
+
+    expect(result).toEqual({ items: [], totalCount: 0 });
+  });
+});
+
 describe('ClickhouseActionExecutionsAdapter.findContentCreatorIdentity', () => {
   it('returns null when no rows match', async () => {
     const { adapter } = makeAdapter([]);

--- a/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.ts
+++ b/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.ts
@@ -1,8 +1,19 @@
 import type { IDataWarehouse } from '../../../storage/dataWarehouse/IDataWarehouse.js';
-import { jsonParse, type JsonOf } from '../../../utils/encoding.js';
 import type SafeTracer from '../../../utils/SafeTracer.js';
-import { SIX_MONTHS_MS } from '../../../utils/time.js';
+import { MONTH_MS, SIX_MONTHS_MS } from '../../../utils/time.js';
 import { formatClickhouseQuery } from '../utils/clickhouseSql.js';
+import {
+  deriveActionScanWindow,
+  formatWarehouseDateTime,
+  parseWarehouseDateTime,
+  toDsString,
+} from '../utils/warehouseDateTime.js';
+import {
+  type ClickhouseActionExecutionRow,
+  type ClickhouseManualActionItemRow,
+  type ClickhouseModeratorActionGroupRow,
+} from './clickhouseActionExecutionRows.js';
+import { extractIds, parseJsonIdArray } from './clickhouseJsonIdArray.js';
 import {
   type ContentCreatorIdentityInput,
   type ContentCreatorIdentityRecord,
@@ -11,24 +22,28 @@ import {
   type InferredUserIdentityRecord,
   type ItemActionHistoryInput,
   type ItemActionHistoryRecord,
+  type ManualActionItemsInput,
+  type ManualActionItemsResult,
+  type ModeratorActionGroupRecord,
+  type RecentModeratorActionsInput,
   type UserStrikeActionRecord,
   type UserStrikeActionsInput,
 } from './IActionExecutionsAdapter.js';
 
-interface ClickhouseActionExecutionRow {
-  ts: string;
-  item_id: string | null;
-  item_type_id: string | null;
-  item_type_kind: string;
-  item_creator_id: string | null;
-  item_creator_type_id: string | null;
-  actor_id: string | null;
-  job_id: string | null;
-  policies?: string | null;
-  rules?: string | null;
-  action_id: string;
-  action_source?: string;
-}
+/**
+ * `action_source` values written by the moderator-facing action UIs. Bulk
+ * Actioning and Investigation both publish under `manual-action-run` (see
+ * `ActionApi.bulkExecuteActions`).
+ *
+ * This allowlist — not `job_id IS NULL` — is what separates moderator work from
+ * automation. Rule-driven and user-strike executions also carry a null
+ * `job_id`, and `actor_id IS NOT NULL` would still admit the programmatic
+ * `/action` API route, which sets an actor whenever a user is attached.
+ */
+const MODERATOR_ACTION_SOURCES = ['manual-action-run'];
+
+/** How far back a single page of the moderator action feed may scan. */
+const DEFAULT_ACTION_FEED_LOOKBACK_MS = 3 * MONTH_MS;
 
 export class ClickhouseActionExecutionsAdapter implements IActionExecutionsAdapter {
   constructor(
@@ -84,10 +99,202 @@ export class ClickhouseActionExecutionsAdapter implements IActionExecutionsAdapt
         jobId: row.job_id ?? null,
         userId: row.item_creator_id ?? null,
         userTypeId: row.item_creator_type_id ?? null,
-        policies: this.extractIds(this.parseJsonArray(row.policies)),
-        ruleIds: this.extractIds(this.parseJsonArray(row.rules)),
+        policies: extractIds(parseJsonIdArray(row.policies)),
+        ruleIds: extractIds(parseJsonIdArray(row.rules)),
         occurredAt: new Date(row.ts),
       }));
+  }
+
+  async getRecentModeratorActions(
+    input: RecentModeratorActionsInput,
+  ): Promise<ReadonlyArray<ModeratorActionGroupRecord>> {
+    const {
+      orgId,
+      cursor,
+      after,
+      before,
+      limit,
+      actorIds,
+      policyIds,
+      itemId,
+      lookbackWindowMs = DEFAULT_ACTION_FEED_LOOKBACK_MS,
+    } = input;
+
+    const { start: lookbackStart, end: upperBound } = deriveActionScanWindow({
+      cursorTs: cursor?.ts,
+      after,
+      before,
+      lookbackWindowMs,
+    });
+
+    // `ds` bounds the partition scan only. The cursor and `after` are applied
+    // in HAVING, against the complete group.
+    //
+    // Each bound carries a day of slack so it never truncates a group we
+    // intend to keep whole. A group whose max(ts) sits just past the cursor
+    // day may still have earlier rows filed under the cursor's own ds day, so
+    // the upper bound reaches one day past it. Symmetrically, a group whose
+    // rows start just before the lookback/`after` floor may have later rows
+    // on the floor's own ds day, so the lower bound reaches one day before it.
+    const conditions = [
+      'org_id = ?',
+      'ds >= toDate(?) - 1',
+      'ds <= toDate(?) + 1',
+      `action_source IN (${MODERATOR_ACTION_SOURCES.map(() => '?').join(', ')})`,
+    ];
+    const params: unknown[] = [
+      orgId,
+      toDsString(lookbackStart),
+      toDsString(upperBound),
+      ...MODERATOR_ACTION_SOURCES,
+    ];
+
+    if (actorIds && actorIds.length > 0) {
+      conditions.push(`actor_id IN (${actorIds.map(() => '?').join(', ')})`);
+      params.push(...actorIds);
+    }
+    if (policyIds && policyIds.length > 0) {
+      // `policies` is a JSON array of objects; `policy_ids` exists on the table
+      // but ActionExecutionLogger never populates it, so extract from the JSON.
+      conditions.push(
+        `hasAny(arrayMap(p -> JSONExtractString(p, 'id'), JSONExtractArrayRaw(policies)), ?)`,
+      );
+      params.push([...policyIds]);
+    }
+
+    const having: string[] = [];
+    if (cursor) {
+      having.push('(max(ts), correlation_id) < (?, ?)');
+      params.push(formatWarehouseDateTime(cursor.ts), cursor.correlationId);
+    }
+    if (after) {
+      having.push('max(ts) >= ?');
+      params.push(formatWarehouseDateTime(after));
+    }
+    if (before) {
+      having.push('max(ts) <= ?');
+      params.push(formatWarehouseDateTime(before));
+    }
+    if (itemId) {
+      having.push('has(groupUniqArray(item_id), ?)');
+      params.push(itemId);
+    }
+
+    // Grouping by correlation_id collapses the one-row-per-(item, action) fan
+    // out into a single record per moderator operation. Without it, a bulk
+    // submit of 500 ids with 2 actions contributes 1,000 rows and buries every
+    // other entry in the merged feed.
+    const sql = `
+      SELECT
+        correlation_id,
+        -- Deliberately not aliased to "ts". ClickHouse would resolve a ts
+        -- bound against this aggregate and reject the query with
+        -- ILLEGAL_AGGREGATION. (Placeholders are substituted across the whole
+        -- string, so never put one in a comment either.)
+        max(ts) AS last_ts,
+        any(actor_id) AS actor_id,
+        any(item_type_id) AS item_type_id,
+        any(actor_note) AS actor_note,
+        any(policies) AS policies,
+        groupUniqArray(action_id) AS action_ids,
+        uniqExact(item_id) AS item_count,
+        uniqExactIf(item_id, failed = 1) AS failed_count
+      FROM analytics.ACTION_EXECUTIONS
+      WHERE ${conditions.join('\n        AND ')}
+      GROUP BY correlation_id
+      ${having.length > 0 ? `HAVING ${having.join('\n        AND ')}` : ''}
+      ORDER BY last_ts DESC, correlation_id DESC
+      LIMIT ${Number(limit)}
+    `;
+
+    const rows = await this.query<ClickhouseModeratorActionGroupRow>(
+      sql,
+      params,
+    );
+
+    return rows.map<ModeratorActionGroupRecord>((row) => ({
+      correlationId: row.correlation_id,
+      actorId: row.actor_id ?? null,
+      itemTypeId: row.item_type_id ?? null,
+      actionIds: row.action_ids ?? [],
+      policyIds: extractIds(parseJsonIdArray(row.policies)),
+      actorNote: row.actor_note ?? null,
+      itemCount: Number(row.item_count) || 0,
+      failedCount: Number(row.failed_count) || 0,
+      occurredAt: parseWarehouseDateTime(row.last_ts),
+    }));
+  }
+
+  async getManualActionItems(
+    input: ManualActionItemsInput,
+  ): Promise<ManualActionItemsResult> {
+    const {
+      orgId,
+      correlationId,
+      occurredAt,
+      limit,
+      offset,
+      lookbackWindowMs = DEFAULT_ACTION_FEED_LOOKBACK_MS,
+    } = input;
+
+    // The `ds` bounds must span at least as much as the feed query's window,
+    // or a row and its own detail panel disagree. The feed groups a run over
+    // the whole lookback window; bounding this to `occurredAt ± 1 day` made an
+    // 8-item run render as "8 items / 1 of 8 failed" in the row and "3 items,
+    // no failures" in the panel — the audit log silently dropping the failures
+    // it exists to record. `occurredAt` is `max(ts)`, so reach backwards by
+    // the window and forwards by a day.
+    const windowStart = new Date(
+      occurredAt.valueOf() - Math.max(1, lookbackWindowMs),
+    );
+
+    // One row per (item, action); an item appears once per action applied.
+    // Group so the caller sees items, and treat an item as failed if any of
+    // its executions failed.
+    //
+    // `correlation_id` alone is not enough: mrt-decision, post-items,
+    // submit-report, and user-strike-action-execution runs are also grouped
+    // under a correlation id, and their item lists must not be resolvable
+    // here (mrt-decision's in particular is what the NCMEC permission gate
+    // exists to hide). The same allowlist the feed query uses keeps this to
+    // moderator-initiated runs only.
+    const sql = `
+      SELECT
+        item_id,
+        any(item_type_id) AS item_type_id,
+        max(failed) AS failed,
+        count() OVER () AS total_count
+      FROM (
+        SELECT item_id, item_type_id, failed
+        FROM analytics.ACTION_EXECUTIONS
+        WHERE org_id = ?
+          AND ds >= toDate(?)
+          AND ds <= toDate(?) + 1
+          AND correlation_id = ?
+          AND item_id IS NOT NULL
+          AND action_source IN (${MODERATOR_ACTION_SOURCES.map(() => '?').join(', ')})
+      )
+      GROUP BY item_id
+      ORDER BY item_id ASC
+      LIMIT ${Number(limit)} OFFSET ${Number(offset)}
+    `;
+
+    const rows = await this.query<ClickhouseManualActionItemRow>(sql, [
+      orgId,
+      toDsString(windowStart),
+      toDsString(occurredAt),
+      correlationId,
+      ...MODERATOR_ACTION_SOURCES,
+    ]);
+
+    return {
+      items: rows.map((row) => ({
+        itemId: row.item_id,
+        itemTypeId: row.item_type_id ?? null,
+        failed: Number(row.failed) === 1,
+      })),
+      totalCount: Number(rows[0]?.total_count ?? 0) || 0,
+    };
   }
 
   async getRecentUserStrikeActions(
@@ -265,40 +472,6 @@ export class ClickhouseActionExecutionsAdapter implements IActionExecutionsAdapt
       creatorTypeId: row.item_creator_type_id,
       lastSeenAt: new Date(row.ts),
     };
-  }
-
-  private parseJsonArray(
-    jsonString: string | null | undefined,
-  ): Array<{ id: string }> | null {
-    if (!jsonString || jsonString === '[]') {
-      return null;
-    }
-    try {
-      const parsed = jsonParse(jsonString as JsonOf<unknown>);
-      if (Array.isArray(parsed)) {
-        return parsed.filter(
-          (item): item is { id: string } =>
-            typeof item === 'object' &&
-            item !== null &&
-            'id' in item &&
-            typeof item.id === 'string',
-        );
-      }
-      return null;
-    } catch {
-      return null;
-    }
-  }
-
-  private extractIds(
-    values: Array<{ id: string }> | null | undefined,
-  ): readonly string[] {
-    if (!values) {
-      return [];
-    }
-    return values
-      .map((entry) => entry.id)
-      .filter((id): id is string => typeof id === 'string' && id.length > 0);
   }
 
   private async query<T>(

--- a/server/plugins/warehouse/queries/IActionExecutionsAdapter.ts
+++ b/server/plugins/warehouse/queries/IActionExecutionsAdapter.ts
@@ -26,6 +26,90 @@ export interface ItemActionHistoryInput {
   itemSubmissionTime?: Date;
 }
 
+/**
+ * Position in the moderator action feed. Composite because timestamps collide —
+ * a `ts`-only cursor either skips rows sharing the boundary instant or repeats
+ * them, and the exclusion set that patches around that grows without bound.
+ */
+export interface ModeratorActionCursor {
+  /** `max(ts)` of the last group already returned. */
+  ts: Date;
+  correlationId: string;
+}
+
+export interface RecentModeratorActionsInput {
+  orgId: string;
+  /** Absent for the newest page. */
+  cursor?: ModeratorActionCursor;
+  /** Inclusive lower bound on `max(ts)`, from a user-set date range. */
+  after?: Date;
+  /** Inclusive upper bound on `max(ts)`, from a user-set date range. */
+  before?: Date;
+  limit: number;
+  /** Restrict to actions taken by these moderators. */
+  actorIds?: readonly string[];
+  /** Restrict to actions carrying at least one of these policies. */
+  policyIds?: readonly string[];
+  /** Restrict to operations that touched this item. */
+  itemId?: string;
+  /**
+   * How far back a single fetch may scan, relative to the cursor.
+   * `ACTION_EXECUTIONS` is partitioned by `ds`, so without a floor every page
+   * reads all partitions older than the cursor.
+   */
+  lookbackWindowMs?: number;
+}
+
+/**
+ * One moderator operation, collapsed from the many `(item, action)` rows it
+ * wrote. A single bulk submit of 500 ids with 2 actions selected produces 1,000
+ * rows sharing one `correlation_id`; this is that operation as one record.
+ */
+export interface ModeratorActionGroupRecord {
+  correlationId: string;
+  actorId: string | null;
+  itemTypeId: string | null;
+  actionIds: readonly string[];
+  policyIds: readonly string[];
+  actorNote: string | null;
+  /** Distinct items the operation touched. Exact, not estimated. */
+  itemCount: number;
+  /** `(item, action)` executions that failed after retries. */
+  failedCount: number;
+  occurredAt: Date;
+}
+
+export interface ManualActionItemsInput {
+  orgId: string;
+  correlationId: string;
+  /**
+   * `max(ts)` of the operation, from the feed row. Bounds the partition scan —
+   * `correlation_id` is not in the table's sort key, so without this every
+   * lookup scans the whole retention window.
+   */
+  occurredAt: Date;
+  limit: number;
+  offset: number;
+  /**
+   * How far back of `occurredAt` to scan. Must be at least the feed query's
+   * lookback, or a run's row and its own item list disagree — the feed groups
+   * over the whole window while this would group over a narrower one, silently
+   * dropping items and their failures. Defaults to the feed's window.
+   */
+  lookbackWindowMs?: number;
+}
+
+export interface ManualActionItemRecord {
+  itemId: string;
+  itemTypeId: string | null;
+  failed: boolean;
+}
+
+export interface ManualActionItemsResult {
+  items: readonly ManualActionItemRecord[];
+  totalCount: number;
+}
+
 export interface UserStrikeActionsInput {
   orgId: string;
   filterBy?: {
@@ -65,6 +149,20 @@ export interface IActionExecutionsAdapter {
   getItemActionHistory(
     input: ItemActionHistoryInput,
   ): Promise<ReadonlyArray<ItemActionHistoryRecord>>;
+
+  /**
+   * Feed of actions a moderator took outside a review job — from Bulk
+   * Actioning or Investigation. These never produce a `manual_review_decisions`
+   * row, so this is the only record of them.
+   */
+  getRecentModeratorActions(
+    input: RecentModeratorActionsInput,
+  ): Promise<ReadonlyArray<ModeratorActionGroupRecord>>;
+
+  /** Every item one moderator operation touched, paged. */
+  getManualActionItems(
+    input: ManualActionItemsInput,
+  ): Promise<ManualActionItemsResult>;
 
   getRecentUserStrikeActions(
     input: UserStrikeActionsInput,

--- a/server/plugins/warehouse/queries/clickhouseActionExecutionRows.ts
+++ b/server/plugins/warehouse/queries/clickhouseActionExecutionRows.ts
@@ -1,0 +1,34 @@
+export interface ClickhouseActionExecutionRow {
+  ts: string;
+  item_id: string | null;
+  item_type_id: string | null;
+  item_type_kind: string;
+  item_creator_id: string | null;
+  item_creator_type_id: string | null;
+  actor_id: string | null;
+  job_id: string | null;
+  policies?: string | null;
+  rules?: string | null;
+  action_id: string;
+  action_source?: string;
+}
+
+export interface ClickhouseModeratorActionGroupRow {
+  correlation_id: string;
+  last_ts: string;
+  actor_id: string | null;
+  item_type_id: string | null;
+  actor_note: string | null;
+  policies?: string | null;
+  action_ids: string[] | null;
+  // ClickHouse returns UInt64 aggregates as strings over the JSON interface.
+  item_count: string | number;
+  failed_count: string | number;
+}
+
+export interface ClickhouseManualActionItemRow {
+  item_id: string;
+  item_type_id: string | null;
+  failed: string | number;
+  total_count: string | number;
+}

--- a/server/plugins/warehouse/queries/clickhouseJsonIdArray.ts
+++ b/server/plugins/warehouse/queries/clickhouseJsonIdArray.ts
@@ -1,0 +1,41 @@
+import { jsonParse, type JsonOf } from '../../../utils/encoding.js';
+
+/**
+ * Parses a ClickHouse column holding a JSON array of `{ id, ... }` objects
+ * (e.g. `policies`, `rules`). Returns `null` for empty/absent/malformed input
+ * so callers can distinguish "nothing there" from "zero ids after filtering".
+ */
+export function parseJsonIdArray(
+  jsonString: string | null | undefined,
+): Array<{ id: string }> | null {
+  if (!jsonString || jsonString === '[]') {
+    return null;
+  }
+  try {
+    const parsed = jsonParse(jsonString as JsonOf<unknown>);
+    if (Array.isArray(parsed)) {
+      return parsed.filter(
+        (item): item is { id: string } =>
+          typeof item === 'object' &&
+          item !== null &&
+          'id' in item &&
+          typeof item.id === 'string',
+      );
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Projects the `id` field out of {@link parseJsonIdArray}'s result. */
+export function extractIds(
+  values: Array<{ id: string }> | null | undefined,
+): readonly string[] {
+  if (!values) {
+    return [];
+  }
+  return values
+    .map((entry) => entry.id)
+    .filter((id): id is string => typeof id === 'string' && id.length > 0);
+}

--- a/server/plugins/warehouse/utils/warehouseDateTime.ts
+++ b/server/plugins/warehouse/utils/warehouseDateTime.ts
@@ -1,0 +1,65 @@
+/**
+ * Render a `Date` the way `ts` was written, so comparisons are like-for-like.
+ * Writes go through `ClickhouseAnalyticsAdapter.formatDate`, which stores UTC
+ * wall-clock with no zone suffix (`YYYY-MM-DD HH:MM:SS.mmm`).
+ */
+export function formatWarehouseDateTime(date: Date): string {
+  return date.toISOString().replace('T', ' ').replace('Z', '');
+}
+
+/** `YYYY-MM-DD`, for comparison against the `ds` partition column. */
+export function toDsString(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Parse a warehouse timestamp as UTC. ClickHouse returns `DateTime64` without a
+ * zone suffix, and `new Date('2026-08-05 12:00:00.000')` reads that shape as
+ * *local* time — which would shift every row on a non-UTC host and interleave
+ * this feed incorrectly against the Postgres decisions it merges with.
+ */
+export function parseWarehouseDateTime(value: string): Date {
+  const isoish = value.includes('T') ? value : value.replace(' ', 'T');
+  const hasZone = /(?:Z|[+-]\d{2}:?\d{2})$/.test(isoish);
+  return new Date(hasZone ? isoish : `${isoish}Z`);
+}
+
+/**
+ * The `ds` partition range a moderator-action feed page must scan.
+ *
+ * `ACTION_EXECUTIONS` is partitioned by `ds`, so every query needs a bounded
+ * range — but deriving it from the wrong anchor silently loses rows, and a
+ * feed that lost rows looks exactly like one that has none.
+ *
+ * - `end` is the newest row the call can return. `HAVING` enforces both
+ *   `< cursor` and `<= before`, so it is the tighter of the two. On the first
+ *   page there is no cursor, and defaulting to `now` was itself an upper
+ *   bound: it made a row dated ahead of the server clock permanently
+ *   unreachable, since paging only moves backwards and `before` never widened
+ *   the ceiling. Clock skew on a writer host is enough to produce one.
+ * - `start` reaches back from `end`, not from `now`. With an `endTime` and no
+ *   `startTime` the two differ: anchoring at `now` put the partitions at
+ *   `[now - window, now]` while `HAVING max(ts) <= before` excluded every one
+ *   of them, so the feed returned nothing at all.
+ * - A user-set `after` replaces the rolling window rather than competing with
+ *   it. Taking whichever is later silently drops a start date older than the
+ *   window: `HAVING` passes but the partitions are already gone.
+ */
+export function deriveActionScanWindow(opts: {
+  cursorTs: Date | undefined;
+  after: Date | undefined;
+  before: Date | undefined;
+  lookbackWindowMs: number;
+}): { start: Date; end: Date } {
+  const { cursorTs, after, before, lookbackWindowMs } = opts;
+
+  const end = cursorTs
+    ? before && before.valueOf() < cursorTs.valueOf()
+      ? before
+      : cursorTs
+    : (before ?? new Date());
+
+  const windowStart = new Date(end.valueOf() - Math.max(1, lookbackWindowMs));
+
+  return { start: after ?? windowStart, end };
+}

--- a/server/services/itemInvestigationService/itemInvestigationService.ts
+++ b/server/services/itemInvestigationService/itemInvestigationService.ts
@@ -3,7 +3,11 @@ import type { ItemIdentifier } from '@roostorg/coop-types';
 import _ from 'lodash';
 
 import { type Dependencies } from '../../iocContainer/index.js';
-import { type IActionExecutionsAdapter } from '../../plugins/warehouse/queries/IActionExecutionsAdapter.js';
+import {
+  type IActionExecutionsAdapter,
+  type ManualActionItemsInput,
+  type RecentModeratorActionsInput,
+} from '../../plugins/warehouse/queries/IActionExecutionsAdapter.js';
 import {
   type ContentApiRequestByIpRecord,
   type ContentApiRequestRecord,
@@ -1154,6 +1158,23 @@ export class ItemInvestigationService {
         };
       }),
     );
+  }
+
+  /**
+   * Org-wide feed of actions moderators took outside a review job, one record
+   * per operation. These never write a manual review decision, so the warehouse
+   * is the only place they exist.
+   *
+   * Records pass through unmapped — `ModerationActivityFeed` owns the shape the
+   * GraphQL layer sees.
+   */
+  async getRecentModeratorActions(input: RecentModeratorActionsInput) {
+    return this.actionExecutionsAdapter.getRecentModeratorActions(input);
+  }
+
+  /** Every item one moderator operation touched, paged. */
+  async getManualActionItems(input: ManualActionItemsInput) {
+    return this.actionExecutionsAdapter.getManualActionItems(input);
   }
 }
 

--- a/server/services/itemInvestigationService/itemInvestigationServiceAdapter.ts
+++ b/server/services/itemInvestigationService/itemInvestigationServiceAdapter.ts
@@ -2,7 +2,11 @@ import { ReadableStream } from 'node:stream/web';
 import type { ItemIdentifier } from '@roostorg/coop-types';
 
 import { type Dependencies } from '../../iocContainer/index.js';
-import { type IActionExecutionsAdapter } from '../../plugins/warehouse/queries/IActionExecutionsAdapter.js';
+import {
+  type IActionExecutionsAdapter,
+  type ManualActionItemsInput,
+  type RecentModeratorActionsInput,
+} from '../../plugins/warehouse/queries/IActionExecutionsAdapter.js';
 import { type IContentApiRequestsAdapter } from '../../plugins/warehouse/queries/IContentApiRequestsAdapter.js';
 import { type Scylla } from '../../scylla/index.js';
 import { type CorrelationId } from '../../utils/correlationIds.js';
@@ -290,6 +294,14 @@ export class ItemInvestigationServiceAdapter {
     itemSubmissionTime: Date | undefined;
   }) {
     return this.service.getItemActionHistory(opts);
+  }
+
+  async getRecentModeratorActions(input: RecentModeratorActionsInput) {
+    return this.service.getRecentModeratorActions(input);
+  }
+
+  async getManualActionItems(input: ManualActionItemsInput) {
+    return this.service.getManualActionItems(input);
   }
 
   /** See `synthesizeUserItemFromCreatorReferences.ts`. */

--- a/server/services/manualReviewToolService/manualReviewToolService.ts
+++ b/server/services/manualReviewToolService/manualReviewToolService.ts
@@ -1183,6 +1183,16 @@ export class ManualReviewToolService {
     return this.decisionAnalytics.getRecentDecisions(opts);
   }
 
+  async getDecisionsForActivityFeed(opts: {
+    userPermissions: UserPermission[];
+    orgId: string;
+    input: RecentDecisionsFilterInput;
+    cursor?: { ts: Date; id: string };
+    limit: number;
+  }) {
+    return this.decisionAnalytics.getDecisionsForActivityFeed(opts);
+  }
+
   async getSkippedJobsForRecentDecisions(opts: {
     orgId: string;
     input: Omit<RecentDecisionsFilterInput, 'page' | 'startTime' | 'endTime'>;

--- a/server/services/manualReviewToolService/modules/DecisionAnalytics.test.ts
+++ b/server/services/manualReviewToolService/modules/DecisionAnalytics.test.ts
@@ -1,0 +1,235 @@
+import { sql } from 'kysely';
+import { uid } from 'uid';
+import { v1 as uuidv1 } from 'uuid';
+
+import { type Dependencies } from '../../../iocContainer/index.js';
+import createMrtQueue from '../../../test/fixtureHelpers/createMrtQueue.js';
+import createOrg from '../../../test/fixtureHelpers/createOrg.js';
+import createUser from '../../../test/fixtureHelpers/createUser.js';
+import makeDummyMrtJobPayload from '../../../test/fixtureHelpers/makeDummyMrtJobPayload.js';
+import { makeTransactionalTestWithFixture } from '../../../test/harness/transactionalTest.js';
+import {
+  type JobId,
+  type ManualReviewJob,
+} from '../manualReviewToolService.js';
+
+describe('DecisionAnalytics', () => {
+  const testWithDecisions = () =>
+    makeTransactionalTestWithFixture(async ({ deps }) => {
+      const { org } = await createOrg(
+        {
+          KyselyPg: deps.KyselyPg,
+          ModerationConfigService: deps.ModerationConfigService,
+          ApiKeyService: deps.ApiKeyService,
+        },
+        uid(),
+      );
+      const { user } = await createUser(deps.KyselyPg, org.id);
+      const { queue } = await createMrtQueue({
+        orgId: org.id,
+        mrtService: deps.ManualReviewToolService,
+        userId: user.id,
+      });
+
+      // `manual_review_decisions.created_at` is `GeneratedAlways` in the
+      // Kysely schema (DB default now()), so a typed `.values()` insert
+      // can't set it. `insertDecision` inserts the row, then overwrites
+      // `created_at` with a raw update so tests can control ordering
+      // deterministically.
+      const insertDecision = async (createdAt: Date) => {
+        const id = uuidv1();
+        const jobPayload: ManualReviewJob = {
+          ...makeDummyMrtJobPayload(),
+          id: uuidv1() as JobId,
+          orgId: org.id,
+        };
+        await deps.KyselyPg.insertInto(
+          'manual_review_tool.manual_review_decisions',
+        )
+          .values({
+            id,
+            job_payload: jobPayload,
+            queue_id: queue.id,
+            reviewer_id: user.id,
+            org_id: org.id,
+            decision_components: [{ type: 'IGNORE' }],
+            related_actions: [],
+          })
+          .execute();
+        await sql`
+          update manual_review_tool.manual_review_decisions
+          set created_at = ${createdAt}
+          where id = ${id}
+        `.execute(deps.KyselyPg);
+        return id;
+      };
+
+      return {
+        org,
+        user,
+        queue,
+        mrtService: deps.ManualReviewToolService,
+        insertDecision,
+      };
+    });
+
+  const baseTime = new Date('2026-01-01T00:00:00.000Z');
+  const minutesAfterBase = (minutes: number) =>
+    new Date(baseTime.getTime() + minutes * 60_000);
+
+  /**
+   * Pages through the entire activity feed for `orgId` via
+   * `getDecisionsForActivityFeed`, following each page's last row into the
+   * next cursor, and returns every decision id encountered in page order.
+   */
+  const collectAllPages = async (opts: {
+    mrtService: Dependencies['ManualReviewToolService'];
+    orgId: string;
+    limit: number;
+  }) => {
+    const { mrtService, orgId, limit } = opts;
+    let ids: string[] = [];
+    let cursor: { ts: Date; id: string } | undefined;
+    for (;;) {
+      const page = await mrtService.getDecisionsForActivityFeed({
+        userPermissions: [],
+        orgId,
+        input: { page: 0 },
+        cursor,
+        limit,
+      });
+      ids = [...ids, ...page.map((decision) => decision.id)];
+      if (page.length < limit) {
+        break;
+      }
+      const last = page[page.length - 1];
+      cursor = { ts: last.createdAt, id: last.id };
+    }
+    return ids;
+  };
+
+  testWithDecisions()(
+    'pages a real cursor across the id-cast boundary without erroring',
+    async ({ org, mrtService, insertDecision }) => {
+      const ids = await Promise.all([
+        insertDecision(minutesAfterBase(0)),
+        insertDecision(minutesAfterBase(1)),
+        insertDecision(minutesAfterBase(2)),
+      ]);
+
+      const firstPage = await mrtService.getDecisionsForActivityFeed({
+        userPermissions: [],
+        orgId: org.id,
+        input: { page: 0 },
+        limit: 2,
+      });
+      expect(firstPage.map((d) => d.id)).toEqual([ids[2], ids[1]]);
+
+      const last = firstPage[firstPage.length - 1];
+      // The cursor's `id` is a real uuid pulled from a previous row, exactly
+      // as a real caller would pass it. If the `::uuid` cast on the cursor
+      // predicate were missing or wrong, this call raises
+      // `22P02 invalid input syntax for type uuid` instead of returning.
+      const secondPage = await mrtService.getDecisionsForActivityFeed({
+        userPermissions: [],
+        orgId: org.id,
+        input: { page: 0 },
+        cursor: { ts: last.createdAt, id: last.id },
+        limit: 2,
+      });
+      expect(secondPage.map((d) => d.id)).toEqual([ids[0]]);
+    },
+  );
+
+  testWithDecisions()(
+    'returns every seeded decision exactly once across pages, with no gaps',
+    async ({ org, mrtService, insertDecision }) => {
+      const ids = await Promise.all([
+        insertDecision(minutesAfterBase(0)),
+        insertDecision(minutesAfterBase(1)),
+        insertDecision(minutesAfterBase(2)),
+        insertDecision(minutesAfterBase(3)),
+        insertDecision(minutesAfterBase(4)),
+      ]);
+
+      const collected = await collectAllPages({
+        mrtService,
+        orgId: org.id,
+        limit: 2,
+      });
+
+      expect(collected.length).toEqual(ids.length);
+      expect(new Set(collected).size).toEqual(ids.length);
+      expect(new Set(collected)).toEqual(new Set(ids));
+    },
+  );
+
+  testWithDecisions()(
+    'neither loses nor repeats rows that share a created_at, across a page boundary that splits them',
+    async ({ org, mrtService, insertDecision }) => {
+      const tiedTimestamp = minutesAfterBase(5);
+      const earlier = await insertDecision(minutesAfterBase(0));
+      const tiedIds = await Promise.all([
+        insertDecision(tiedTimestamp),
+        insertDecision(tiedTimestamp),
+      ]);
+      const allIds = [earlier, ...tiedIds];
+
+      // limit: 1 forces the two tied rows onto separate pages, exercising
+      // the `id` tie-break leg of the `(created_at, id)` sort key.
+      const collected = await collectAllPages({
+        mrtService,
+        orgId: org.id,
+        limit: 1,
+      });
+
+      expect(collected.length).toEqual(allIds.length);
+      expect(new Set(collected)).toEqual(new Set(allIds));
+    },
+  );
+
+  testWithDecisions()(
+    'returns the newest page in created_at DESC order when there is no cursor',
+    async ({ org, mrtService, insertDecision }) => {
+      const oldest = await insertDecision(minutesAfterBase(0));
+      const middle = await insertDecision(minutesAfterBase(1));
+      const newest = await insertDecision(minutesAfterBase(2));
+
+      const page = await mrtService.getDecisionsForActivityFeed({
+        userPermissions: [],
+        orgId: org.id,
+        input: { page: 0 },
+        limit: 10,
+      });
+
+      expect(page.map((d) => d.id)).toEqual([newest, middle, oldest]);
+      const timestamps = page.map((d) => d.createdAt.getTime());
+      expect(timestamps).toEqual([...timestamps].sort((a, b) => b - a));
+    },
+  );
+
+  testWithDecisions()(
+    'getRecentDecisions still returns offset-paged decisions in created_at DESC order after the extraction',
+    async ({ org, mrtService, insertDecision }) => {
+      const oldest = await insertDecision(minutesAfterBase(0));
+      const middle = await insertDecision(minutesAfterBase(1));
+      const newest = await insertDecision(minutesAfterBase(2));
+
+      const firstPage = await mrtService.getRecentDecisions({
+        userPermissions: [],
+        orgId: org.id,
+        input: { page: 0 },
+      });
+      expect(firstPage.map((d) => d.id)).toEqual([newest, middle, oldest]);
+
+      // Offset paging: page 100 rows at a time, so page 1 is past the end of
+      // a 3-row result set and must come back empty.
+      const secondPage = await mrtService.getRecentDecisions({
+        userPermissions: [],
+        orgId: org.id,
+        input: { page: 1 },
+      });
+      expect(secondPage).toEqual([]);
+    },
+  );
+});

--- a/server/services/manualReviewToolService/modules/DecisionAnalytics.ts
+++ b/server/services/manualReviewToolService/modules/DecisionAnalytics.ts
@@ -9,7 +9,11 @@ import {
   type ManualReviewJob,
   type ManualReviewJobEnqueueSource,
 } from '../manualReviewToolService.js';
-import { type ManualReviewDecisionType } from './JobDecisioning.js';
+import {
+  type ManualReviewDecisionComponent,
+  type ManualReviewDecisionRelatedAction,
+  type ManualReviewDecisionType,
+} from './JobDecisioning.js';
 
 export type RecentDecisionsFilterInput = {
   userSearchString?: string;
@@ -233,7 +237,14 @@ export default class DecisionAnalytics {
       .execute();
   }
 
-  async getRecentDecisions(opts: {
+  /**
+   * Shared query body for `getRecentDecisions` and
+   * `getDecisionsForActivityFeed`: the select list, every filter predicate,
+   * the `userSearchString` branch, and the NCMEC permission gate. Stops
+   * short of `orderBy`/`limit`/`offset` so each caller applies its own
+   * paging.
+   */
+  private buildRecentDecisionsQuery(opts: {
     userPermissions: UserPermission[];
     orgId: string;
     input: RecentDecisionsFilterInput;
@@ -247,156 +258,192 @@ export default class DecisionAnalytics {
       queueIds,
       startTime,
       endTime,
-      page,
     } = input;
-    const limit = 100;
-    const decisions = await this.pgQuery
-      .selectFrom('manual_review_tool.manual_review_decisions')
-      .select([
-        'id',
-        'queue_id',
-        'reviewer_id',
-        'decision_components',
-        'related_actions',
-        'created_at',
-        sql<string>`((job_payload->'payload'::text)->'item'::text) -> 'itemId'::text`.as(
-          'item_id',
-        ),
-        sql<string>`(((job_payload->'payload'::text)->'item'::text) -> 'itemTypeIdentifier'::text) ->> 'id'::text`.as(
-          'item_type_id',
-        ),
-        'decision_reason',
-        sql<string>`(job_payload->>'id')::text`.as('job_id'),
-      ])
-      .where('org_id', '=', orgId)
-      .where(({ eb, selectFrom }) => {
-        return eb.and([
-          ...(startTime ? [eb('created_at', '>=', new Date(startTime))] : []),
-          ...(endTime ? [eb('created_at', '<=', new Date(endTime))] : []),
-          ...(queueIds && queueIds.length > 0
-            ? [eb('queue_id', 'in', queueIds)]
-            : []),
-          ...(reviewerIds && reviewerIds.length > 0
-            ? [eb('reviewer_id', 'in', reviewerIds)]
-            : []),
-          ...(policyIds
-            ? [
-                eb.exists(
-                  selectFrom(
-                    sql`unnest(manual_review_tool.manual_review_decisions.decision_components)`.as(
-                      'decision_component',
-                    ),
-                  )
-                    .selectAll()
-                    .where(
-                      eb.or(
-                        policyIds.map((policyId) =>
-                          eb(
-                            sql<string>`decision_component->>'policies'`,
-                            'like',
-                            `%"${policyId}"%`,
+    return (
+      this.pgQuery
+        .selectFrom('manual_review_tool.manual_review_decisions')
+        .select([
+          'id',
+          'queue_id',
+          'reviewer_id',
+          'decision_components',
+          'related_actions',
+          'created_at',
+          sql<string>`((job_payload->'payload'::text)->'item'::text) -> 'itemId'::text`.as(
+            'item_id',
+          ),
+          sql<string>`(((job_payload->'payload'::text)->'item'::text) -> 'itemTypeIdentifier'::text) ->> 'id'::text`.as(
+            'item_type_id',
+          ),
+          'decision_reason',
+          sql<string>`(job_payload->>'id')::text`.as('job_id'),
+        ])
+        .where('org_id', '=', orgId)
+        .where(({ eb, selectFrom }) => {
+          return eb.and([
+            ...(startTime ? [eb('created_at', '>=', new Date(startTime))] : []),
+            ...(endTime ? [eb('created_at', '<=', new Date(endTime))] : []),
+            ...(queueIds && queueIds.length > 0
+              ? [eb('queue_id', 'in', queueIds)]
+              : []),
+            ...(reviewerIds && reviewerIds.length > 0
+              ? [eb('reviewer_id', 'in', reviewerIds)]
+              : []),
+            ...(policyIds
+              ? [
+                  eb.exists(
+                    selectFrom(
+                      sql`unnest(manual_review_tool.manual_review_decisions.decision_components)`.as(
+                        'decision_component',
+                      ),
+                    )
+                      .selectAll()
+                      .where(
+                        eb.or(
+                          policyIds.map((policyId) =>
+                            eb(
+                              sql<string>`decision_component->>'policies'`,
+                              'like',
+                              `%"${policyId}"%`,
+                            ),
                           ),
                         ),
                       ),
-                    ),
-                ),
-              ]
-            : []),
-          ...(decisionsFilter
-            ? [
-                eb.or(
-                  decisionsFilter.flatMap((it) => [
-                    eb.exists(
-                      selectFrom(
-                        sql`unnest(manual_review_tool.manual_review_decisions.decision_components)`.as(
-                          'decision_component',
-                        ),
-                      )
-                        .selectAll()
-                        .where(
-                          sql<string>`decision_component->>'type'`,
-                          '=',
-                          it.type,
+                  ),
+                ]
+              : []),
+            ...(decisionsFilter
+              ? [
+                  eb.or(
+                    decisionsFilter.flatMap((it) => [
+                      eb.exists(
+                        selectFrom(
+                          sql`unnest(manual_review_tool.manual_review_decisions.decision_components)`.as(
+                            'decision_component',
+                          ),
                         )
-                        .$if(it.actionIds !== undefined, (qb) =>
-                          qb.where(
-                            eb.or(
-                              it.actionIds!.map((actionId) =>
-                                eb(
-                                  sql<string>`decision_component->>'actions'`,
-                                  'like',
-                                  `%"${actionId}"%`,
+                          .selectAll()
+                          .where(
+                            sql<string>`decision_component->>'type'`,
+                            '=',
+                            it.type,
+                          )
+                          .$if(it.actionIds !== undefined, (qb) =>
+                            qb.where(
+                              eb.or(
+                                it.actionIds!.map((actionId) =>
+                                  eb(
+                                    sql<string>`decision_component->>'actions'`,
+                                    'like',
+                                    `%"${actionId}"%`,
+                                  ),
                                 ),
                               ),
                             ),
                           ),
-                        ),
-                    ),
-                  ]),
-                ),
-              ]
-            : []),
-        ]);
-      })
-      .$if(userSearchString !== undefined, (qb) =>
-        // See https://stackoverflow.com/a/55607847
-        qb.where(({ and, eb, val }) =>
-          and([
-            eb('created_at', '>', val(new Date(Date.now() - 3 * MONTH_MS))),
-            eb(
-              sql<string>`(manual_review_tool.manual_review_decisions.job_payload->'payload'->'item'->>'itemId')`,
-              '=',
-              // Above, the 'itemId' field is of type jsonb, so we cast it to a string using ::text, but that
-              // cast will leave quotes around the resulting string because it's just stringifying what it thinks
-              // is a jsonb object. The easiest way to handle this is to just add quotes around the userSearchString
-              // to match the quotes in the value above.
-              val(`${userSearchString}`),
-            ),
-          ]),
-        ),
-      )
-      // If the user doesn't have the VIEW_CHILD_SAFETY_DATA permission, filter out decisions on
-      // all NCMEC jobs
-      .$if(
-        !userPermissions.includes(UserPermission.VIEW_CHILD_SAFETY_DATA),
-        (qb) =>
-          qb.where(({ eb, val }) =>
-            eb(
-              sql<string>`(job_payload->'payload'->'kind')::text`,
-              '!=',
-              val('"NCMEC"'),
-            ),
+                      ),
+                    ]),
+                  ),
+                ]
+              : []),
+          ]);
+        })
+        .$if(userSearchString !== undefined, (qb) =>
+          // See https://stackoverflow.com/a/55607847
+          qb.where(({ and, eb, val }) =>
+            and([
+              eb('created_at', '>', val(new Date(Date.now() - 3 * MONTH_MS))),
+              eb(
+                sql<string>`(manual_review_tool.manual_review_decisions.job_payload->'payload'->'item'->>'itemId')`,
+                '=',
+                // Above, the 'itemId' field is of type jsonb, so we cast it to a string using ::text, but that
+                // cast will leave quotes around the resulting string because it's just stringifying what it thinks
+                // is a jsonb object. The easiest way to handle this is to just add quotes around the userSearchString
+                // to match the quotes in the value above.
+                val(`${userSearchString}`),
+              ),
+            ]),
           ),
-      )
+        )
+        // If the user doesn't have the VIEW_CHILD_SAFETY_DATA permission, filter out decisions on
+        // all NCMEC jobs
+        .$if(
+          !userPermissions.includes(UserPermission.VIEW_CHILD_SAFETY_DATA),
+          (qb) =>
+            qb.where(({ eb, val }) =>
+              eb(
+                sql<string>`(job_payload->'payload'->'kind')::text`,
+                '!=',
+                val('"NCMEC"'),
+              ),
+            ),
+        )
+    );
+  }
+
+  async getRecentDecisions(opts: {
+    userPermissions: UserPermission[];
+    orgId: string;
+    input: RecentDecisionsFilterInput;
+  }) {
+    const { userPermissions, orgId, input } = opts;
+    const { page } = input;
+    const limit = 100;
+    const decisions = await this.buildRecentDecisionsQuery({
+      userPermissions,
+      orgId,
+      input,
+    })
       .orderBy('created_at', 'desc')
       .limit(limit)
       .offset(page * limit)
       .execute();
-    return decisions.map((decision) => ({
-      id: decision.id,
-      itemId: decision.item_id,
-      itemTypeId: decision.item_type_id,
-      queueId: decision.queue_id,
-      reviewerId: decision.reviewer_id,
-      decisions: decision.decision_components.map((it) => {
-        if (it.type !== 'CUSTOM_ACTION') {
-          return it;
-        }
-        return {
-          ...it,
-          actionIds: it.actions.map((it) => it.id),
-          policyIds: it.policies.map((it) => it.id),
-          itemTypeId: it.itemTypeId,
-        };
-      }),
-      relatedActions: decision.related_actions.map((action) => ({
-        ...action,
-        type: 'RELATED_ACTION' as const,
-      })),
-      createdAt: decision.created_at,
-      decisionReason: decision.decision_reason,
-      jobId: decision.job_id,
-    }));
+    return decisions.map(mapDecisionRow);
+  }
+
+  /**
+   * Cursor-paged twin of `getRecentDecisions`, for the merged activity feed.
+   *
+   * Kept separate rather than folded into `getRecentDecisions`: that query is
+   * offset-paged and consumed elsewhere, and changing its contract would
+   * break callers this feature has no reason to touch.
+   *
+   * Ordering is `(created_at, id)` descending. The id leg makes each row's
+   * position unique so the merged feed's cursor is exact — a
+   * `created_at`-only bound would drop or repeat decisions sharing an
+   * instant.
+   */
+  async getDecisionsForActivityFeed(opts: {
+    userPermissions: UserPermission[];
+    orgId: string;
+    input: RecentDecisionsFilterInput;
+    // The DECISIONS side of a per-store cursor. The caller must never pass
+    // the actions side's id here: `id` is uuid, and a non-uuid string raises
+    // 22P02 invalid input syntax for type uuid.
+    cursor?: { ts: Date; id: string };
+    limit: number;
+  }) {
+    const { userPermissions, orgId, input, cursor, limit } = opts;
+    const decisions = await this.buildRecentDecisionsQuery({
+      userPermissions,
+      orgId,
+      input,
+    })
+      .$if(cursor !== undefined, (qb) =>
+        qb.where(
+          sql`(created_at, id)`,
+          '<',
+          // `id` is uuid. The cast is load-bearing: without it Postgres
+          // infers the bind type from the column and a non-uuid string
+          // raises 22P02.
+          sql`(${cursor!.ts}, ${cursor!.id}::uuid)`,
+        ),
+      )
+      .orderBy('created_at', 'desc')
+      .orderBy('id', 'desc')
+      .limit(limit)
+      .execute();
+    return decisions.map(mapDecisionRow);
   }
 
   async getResolvedJobCounts(input: JobCountsInput) {
@@ -524,6 +571,57 @@ export default class DecisionAnalytics {
       },
     };
   }
+}
+
+/**
+ * Row shape shared by `getRecentDecisions` and `getDecisionsForActivityFeed`,
+ * as selected by `DecisionAnalytics['buildRecentDecisionsQuery']`.
+ */
+type RecentDecisionRow = {
+  id: string;
+  item_id: string;
+  item_type_id: string;
+  queue_id: string;
+  reviewer_id: string | null;
+  decision_components: ManualReviewDecisionComponent[];
+  related_actions: ManualReviewDecisionRelatedAction[];
+  created_at: Date;
+  decision_reason: string | null;
+  job_id: string;
+};
+
+/**
+ * Projects a raw `manual_review_decisions` row into the shape both
+ * `getRecentDecisions` and `getDecisionsForActivityFeed` return. Moved
+ * verbatim out of `getRecentDecisions` — do not alter any field here without
+ * updating both callers' consumers.
+ */
+function mapDecisionRow(decision: RecentDecisionRow) {
+  return {
+    id: decision.id,
+    itemId: decision.item_id,
+    itemTypeId: decision.item_type_id,
+    queueId: decision.queue_id,
+    reviewerId: decision.reviewer_id,
+    decisions: decision.decision_components.map((it) => {
+      if (it.type !== 'CUSTOM_ACTION') {
+        return it;
+      }
+      return {
+        ...it,
+        actionIds: it.actions.map((it) => it.id),
+        policyIds: it.policies.map((it) => it.id),
+        itemTypeId: it.itemTypeId,
+      };
+    }),
+    relatedActions: decision.related_actions.map((action) => ({
+      ...action,
+      type: 'RELATED_ACTION' as const,
+    })),
+    createdAt: decision.created_at,
+    decisionReason: decision.decision_reason,
+    jobId: decision.job_id,
+  };
 }
 
 /**

--- a/server/services/moderationActivityFeed/ModerationActivityFeed.test.ts
+++ b/server/services/moderationActivityFeed/ModerationActivityFeed.test.ts
@@ -1,0 +1,188 @@
+import { UserPermission } from '../userManagementService/index.js';
+import { ModerationActivityFeed } from './ModerationActivityFeed.js';
+
+/**
+ * Manual actions require VIEW_INVESTIGATION. Every role except
+ * EXTERNAL_MODERATOR holds it, so this is the ordinary case.
+ */
+const CAN_VIEW_ACTIONS = [UserPermission.VIEW_INVESTIGATION];
+
+const mrt = (decisions: unknown[]) => ({
+  getDecisionsForActivityFeed: jest.fn(
+    async (_opts: { limit: number }) => decisions,
+  ),
+});
+
+const investigation = (actions: unknown[]) => ({
+  getRecentModeratorActions: jest.fn(
+    async (_opts: { limit: number }) => actions,
+  ),
+  getManualActionItems: jest.fn(async () => ({ items: [], totalCount: 0 })),
+});
+
+const decisionRow = (id: string, iso: string) => ({ id, createdAt: iso });
+const actionRow = (correlationId: string, iso: string) => ({
+  correlationId,
+  occurredAt: new Date(iso),
+  actionIds: [],
+  policyIds: [],
+  itemCount: 1,
+  failedCount: 0,
+  actorId: null,
+  itemTypeId: null,
+  actorNote: null,
+});
+
+describe('ModerationActivityFeed.getPage', () => {
+  it('asks each source for one more row than the page size', async () => {
+    // Worst case a whole page comes from one store, so `limit` from each is
+    // the minimum; the extra row is what reveals whether more exists.
+    const m = mrt([]);
+    const i = investigation([]);
+    const feed = new ModerationActivityFeed(m as never, i as never);
+
+    await feed.getPage({
+      userPermissions: CAN_VIEW_ACTIONS,
+      orgId: 'org-1',
+      input: {},
+      view: 'ALL',
+      limit: 100,
+    });
+
+    expect(m.getDecisionsForActivityFeed.mock.calls[0][0].limit).toBe(101);
+    expect(i.getRecentModeratorActions.mock.calls[0][0].limit).toBe(101);
+  });
+
+  it('skips the action store entirely when the view is DECISIONS', async () => {
+    const m = mrt([decisionRow('d-1', '2026-08-05T14:00:00Z')]);
+    const i = investigation([]);
+    const feed = new ModerationActivityFeed(m as never, i as never);
+
+    const page = await feed.getPage({
+      userPermissions: CAN_VIEW_ACTIONS,
+      orgId: 'org-1',
+      input: {},
+      view: 'DECISIONS',
+      limit: 100,
+    });
+
+    expect(i.getRecentModeratorActions).not.toHaveBeenCalled();
+    expect(page.rows).toHaveLength(1);
+  });
+
+  it('skips the decisions store entirely when the view is ACTIONS', async () => {
+    const m = mrt([]);
+    const i = investigation([actionRow('a-1', '2026-08-05T14:00:00Z')]);
+    const feed = new ModerationActivityFeed(m as never, i as never);
+
+    const page = await feed.getPage({
+      userPermissions: CAN_VIEW_ACTIONS,
+      orgId: 'org-1',
+      input: {},
+      view: 'ACTIONS',
+      limit: 100,
+    });
+
+    expect(m.getDecisionsForActivityFeed).not.toHaveBeenCalled();
+    expect(page.rows).toHaveLength(1);
+  });
+
+  it('hides actions when a decisions-only filter is active', async () => {
+    // Queue and decision-type filters can only ever match decisions; running
+    // the action query would waste a ClickHouse scan to return nothing.
+    const m = mrt([]);
+    const i = investigation([]);
+    const feed = new ModerationActivityFeed(m as never, i as never);
+
+    await feed.getPage({
+      userPermissions: CAN_VIEW_ACTIONS,
+      orgId: 'org-1',
+      input: { queueIds: ['q-1'] },
+      view: 'ALL',
+      limit: 100,
+    });
+
+    expect(i.getRecentModeratorActions).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a store failure instead of returning half a log', async () => {
+    // Silently rendering only decisions is worse than an error: the reader
+    // cannot tell "no actions" from "actions unavailable".
+    const m = mrt([]);
+    const i = {
+      getRecentModeratorActions: jest.fn(async () => {
+        throw new Error('clickhouse unreachable');
+      }),
+      getManualActionItems: jest.fn(),
+    };
+    const feed = new ModerationActivityFeed(m as never, i as never);
+
+    await expect(
+      feed.getPage({
+        userPermissions: CAN_VIEW_ACTIONS,
+        orgId: 'org-1',
+        input: {},
+        view: 'ALL',
+        limit: 100,
+      }),
+    ).rejects.toThrow('clickhouse unreachable');
+  });
+
+  it('interleaves both sources newest first', async () => {
+    const m = mrt([
+      decisionRow('d-9', '2026-08-05T14:02:00Z'),
+      decisionRow('d-8', '2026-08-05T13:47:00Z'),
+    ]);
+    const i = investigation([actionRow('a-4', '2026-08-05T13:58:00Z')]);
+    const feed = new ModerationActivityFeed(m as never, i as never);
+
+    const page = await feed.getPage({
+      userPermissions: CAN_VIEW_ACTIONS,
+      orgId: 'org-1',
+      input: {},
+      view: 'ALL',
+      limit: 100,
+    });
+
+    expect(page.rows.map((r) => r.id)).toEqual(['d-9', 'a-4', 'd-8']);
+  });
+
+  it('hides manual actions from a caller without VIEW_INVESTIGATION', async () => {
+    // EXTERNAL_MODERATOR (read-only access for external moderation partners)
+    // is the only role lacking this permission, and holds VIEW_MRT alone.
+    // Manual actions are by construction taken from Investigation or Bulk
+    // Actioning, so such an account must not see them — nor be able to expand
+    // one into an enumeration of the item ids it touched.
+    const m = mrt([decisionRow('d-1', '2026-08-05T14:00:00Z')]);
+    const i = investigation([actionRow('a-1', '2026-08-05T13:00:00Z')]);
+    const feed = new ModerationActivityFeed(m as never, i as never);
+
+    const page = await feed.getPage({
+      userPermissions: [UserPermission.VIEW_MRT],
+      orgId: 'org-1',
+      input: {},
+      view: 'ALL',
+      limit: 100,
+    });
+
+    expect(i.getRecentModeratorActions).not.toHaveBeenCalled();
+    expect(page.rows.map((r) => r.kind)).toEqual(['DECISION']);
+  });
+
+  it('does not let an explicit ACTIONS view bypass the permission', async () => {
+    const m = mrt([]);
+    const i = investigation([actionRow('a-1', '2026-08-05T13:00:00Z')]);
+    const feed = new ModerationActivityFeed(m as never, i as never);
+
+    const page = await feed.getPage({
+      userPermissions: [UserPermission.VIEW_MRT],
+      orgId: 'org-1',
+      input: {},
+      view: 'ACTIONS',
+      limit: 100,
+    });
+
+    expect(i.getRecentModeratorActions).not.toHaveBeenCalled();
+    expect(page.rows).toEqual([]);
+  });
+});

--- a/server/services/moderationActivityFeed/ModerationActivityFeed.ts
+++ b/server/services/moderationActivityFeed/ModerationActivityFeed.ts
@@ -1,0 +1,163 @@
+import type { JsonValue } from 'type-fest';
+
+import type { ItemInvestigationService } from '../itemInvestigationService/index.js';
+import type { ManualReviewToolService } from '../manualReviewToolService/index.js';
+import type { RecentDecisionsFilterInput } from '../manualReviewToolService/modules/DecisionAnalytics.js';
+import { UserPermission } from '../userManagementService/index.js';
+import { parseActivityCursor } from './activityCursor.js';
+import { mergeActivityRows, type ActivityRow } from './mergeActivityRows.js';
+
+export type ActivityView = 'ALL' | 'DECISIONS' | 'ACTIONS';
+
+/**
+ * `RecentDecisionsFilterInput.page` drives offset paging on `getRecentDecisions`
+ * — the offset-paged sibling of the cursor-paged query this feed calls. The
+ * activity feed pages by cursor instead, so it never has a page number to
+ * supply; the placeholder below is inert because `getDecisionsForActivityFeed`
+ * never reads `page`.
+ */
+export type ActivityFeedFilterInput = Omit<RecentDecisionsFilterInput, 'page'>;
+
+/** Placeholder for the `page` field `getDecisionsForActivityFeed` never reads. */
+const UNUSED_PAGE = 0;
+
+/** Merged-view lookback. See the spec's "Time window" section. */
+const MERGED_VIEW_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Filters that only a decision can satisfy. A manual action has no queue and no
+ * decision type, so running the action query under either one can only ever
+ * return nothing — the UI moves `Show` to `Decisions` and says why.
+ */
+function isDecisionOnlyFilter(input: ActivityFeedFilterInput): boolean {
+  return (
+    (input.queueIds?.length ?? 0) > 0 || (input.decisions?.length ?? 0) > 0
+  );
+}
+
+/**
+ * Manual actions are only ever taken from Investigation or Bulk Actioning, so
+ * seeing them requires the permission that gates Investigation itself.
+ *
+ * This is not a formality. `EXTERNAL_MODERATOR` — described in
+ * `systemRoleDefaults` as read-only access for external moderation partners —
+ * is the only role in `UserPermissionsForRole` without `VIEW_INVESTIGATION`,
+ * holding `VIEW_MRT` alone. Without this check an outsourced vendor account
+ * could expand any bulk run into a full enumeration of the item ids it touched,
+ * including runs a `CHILD_SAFETY_MODERATOR` performed. Every role the issue's
+ * supervisor use case cares about already holds this permission.
+ */
+function canViewManualActions(
+  userPermissions: readonly UserPermission[],
+): boolean {
+  return userPermissions.includes(UserPermission.VIEW_INVESTIGATION);
+}
+
+/**
+ * The Recent Decisions feed, merged from two stores.
+ *
+ * Review-job decisions live in Postgres and manual moderator actions live in
+ * ClickHouse. Nothing outside this module knows that.
+ */
+export class ModerationActivityFeed {
+  constructor(
+    private readonly manualReviewToolService: ManualReviewToolService,
+    private readonly itemInvestigationService: ItemInvestigationService,
+  ) {}
+
+  async getPage(opts: {
+    userPermissions: UserPermission[];
+    orgId: string;
+    input: ActivityFeedFilterInput;
+    view: ActivityView;
+    limit: number;
+    /** Already decoded by the `Cursor` scalar; absent for the newest page. */
+    cursor?: unknown;
+  }): Promise<{ rows: ActivityRow[]; nextCursor: JsonValue | null }> {
+    const { userPermissions, orgId, input, view, limit, cursor } = opts;
+
+    const decoded = parseActivityCursor(cursor);
+    const includeDecisions = view !== 'ACTIONS';
+    const includeActions =
+      view !== 'DECISIONS' &&
+      !isDecisionOnlyFilter(input) &&
+      canViewManualActions(userPermissions);
+
+    // limit + 1 from each: worst case a whole page comes from one store.
+    const fetchSize = limit + 1;
+
+    const [decisions, actions] = await Promise.all([
+      includeDecisions
+        ? this.manualReviewToolService.getDecisionsForActivityFeed({
+            userPermissions,
+            orgId,
+            // `page` drives a different, offset-paged query; this one pages by
+            // cursor and never reads it. See `ActivityFeedFilterInput`.
+            input: { ...input, page: UNUSED_PAGE },
+            // Each store gets ITS OWN side of the cursor. Handing the actions
+            // position to Postgres would bind `manual-action-run:<uuid>`
+            // against a uuid column and fail with 22P02.
+            cursor: decoded?.decisions ?? undefined,
+            limit: fetchSize,
+          })
+        : Promise.resolve([]),
+      includeActions
+        ? this.itemInvestigationService.getRecentModeratorActions({
+            orgId,
+            cursor: decoded?.actions
+              ? {
+                  ts: decoded.actions.ts,
+                  correlationId: decoded.actions.id,
+                }
+              : undefined,
+            after: input.startTime ? new Date(input.startTime) : undefined,
+            // Both ends of the range must reach this store. Passing only
+            // `after` leaves its upper bound at "now", so a January filter
+            // renders today's bulk runs beside January decisions.
+            before: input.endTime ? new Date(input.endTime) : undefined,
+            limit: fetchSize,
+            actorIds: input.reviewerIds ?? undefined,
+            policyIds: input.policyIds ?? undefined,
+            itemId: input.userSearchString ?? undefined,
+            lookbackWindowMs: MERGED_VIEW_WINDOW_MS,
+          })
+        : Promise.resolve([]),
+    ]);
+
+    return mergeActivityRows(
+      decisions.map((decision) => ({
+        kind: 'DECISION' as const,
+        id: decision.id,
+        ts: new Date(decision.createdAt),
+        payload: decision,
+      })),
+      actions.map((action) => ({
+        kind: 'MANUAL_ACTION' as const,
+        id: action.correlationId,
+        ts: action.occurredAt,
+        payload: action,
+      })),
+      limit,
+      decoded,
+    );
+  }
+
+  /**
+   * Every item id one manual action run touched.
+   *
+   * Callers MUST check `VIEW_INVESTIGATION` first — see `canViewManualActions`.
+   * The resolver owns that check, matching how `org.ts` and `ncmec.ts` gate on
+   * `VIEW_CHILD_SAFETY_DATA`. This is the enumeration primitive behind the
+   * feed, and `correlationId` is a client-supplied argument, so it is directly
+   * reachable rather than only via `getPage`.
+   */
+  async getManualActionItems(opts: {
+    orgId: string;
+    correlationId: string;
+    occurredAt: Date;
+    limit: number;
+    offset: number;
+  }) {
+    return this.itemInvestigationService.getManualActionItems(opts);
+  }
+}

--- a/server/services/moderationActivityFeed/activityCursor.test.ts
+++ b/server/services/moderationActivityFeed/activityCursor.test.ts
@@ -1,0 +1,59 @@
+import {
+  parseActivityCursor,
+  serializeActivityCursor,
+} from './activityCursor.js';
+
+describe('activityCursor', () => {
+  it('round-trips both store positions', () => {
+    const cursor = {
+      decisions: {
+        ts: new Date('2026-08-05T12:00:00.000Z'),
+        id: '3f1a5c7e-0000-4000-8000-000000000001',
+      },
+      actions: {
+        ts: new Date('2026-08-05T11:00:00.000Z'),
+        id: 'manual-action-run:abc',
+      },
+    };
+
+    expect(parseActivityCursor(serializeActivityCursor(cursor))).toEqual(
+      cursor,
+    );
+  });
+
+  it('round-trips a cursor where one store is exhausted', () => {
+    const cursor = {
+      decisions: null,
+      actions: {
+        ts: new Date('2026-08-05T11:00:00.000Z'),
+        id: 'manual-action-run:abc',
+      },
+    };
+
+    expect(parseActivityCursor(serializeActivityCursor(cursor))).toEqual(
+      cursor,
+    );
+  });
+
+  it('treats an absent cursor as the newest page', () => {
+    expect(parseActivityCursor(undefined)).toBeUndefined();
+    expect(parseActivityCursor(null)).toBeUndefined();
+  });
+
+  it('rejects a malformed cursor rather than silently restarting the feed', () => {
+    // Silently returning "newest page" would make a paging bug look like the
+    // reader simply reached the top again.
+    expect(() => parseActivityCursor('not-an-object')).toThrow(/cursor/i);
+    expect(() => parseActivityCursor({})).toThrow(/cursor/i);
+    expect(() =>
+      parseActivityCursor({
+        decisions: { ts: 'nonsense', id: 'x' },
+        actions: null,
+      }),
+    ).toThrow(/cursor/i);
+    // A bare single-position cursor is the old broken shape; reject it.
+    expect(() =>
+      parseActivityCursor({ ts: '2026-08-05T12:00:00.000Z', id: 'x' }),
+    ).toThrow(/cursor/i);
+  });
+});

--- a/server/services/moderationActivityFeed/activityCursor.ts
+++ b/server/services/moderationActivityFeed/activityCursor.ts
@@ -1,0 +1,101 @@
+import { type JsonValue } from 'type-fest';
+
+import { makeBadRequestError } from '../../utils/errors.js';
+
+/** One store's position. `id` is only ever compared within its own store. */
+export type StorePosition = {
+  ts: Date;
+  id: string;
+};
+
+/**
+ * Position in the merged activity feed — one per store, not one shared.
+ *
+ * Decision ids are `uuid`; action ids are `manual-action-run:<uuid>` strings.
+ * A shared id would be bound against a uuid column and rejected, and casting to
+ * text gives three different orderings (JS UTF-16, ClickHouse UTF-8, Postgres
+ * collation). Each side pages from its own last-returned row instead.
+ *
+ * `null` means "start from the newest" for that store.
+ */
+export type ActivityCursor = {
+  decisions: StorePosition | null;
+  actions: StorePosition | null;
+};
+
+/**
+ * Serializes a {@link StorePosition} into a value the `Cursor` scalar can
+ * carry — it base64+JSON-encodes whatever plain JSON value we hand it, so this
+ * module only has to worry about shape, not encoding.
+ */
+function serializeSide(side: StorePosition | null) {
+  return side === null ? null : { ts: side.ts.toISOString(), id: side.id };
+}
+
+/**
+ * Builds the JSON value the `Cursor` scalar serializes into an opaque,
+ * base64-encoded string. The scalar owns the base64/JSON transport; this
+ * function only owns the `{ decisions, actions }` shape.
+ */
+export function serializeActivityCursor(cursor: ActivityCursor): JsonValue {
+  return {
+    decisions: serializeSide(cursor.decisions),
+    actions: serializeSide(cursor.actions),
+  };
+}
+
+/**
+ * Validates and reconstructs an {@link ActivityCursor} from the JSON value the
+ * `Cursor` scalar already decoded from base64. Opaque to callers by design —
+ * the client passes back exactly what it got.
+ *
+ * Throws rather than treating a malformed cursor as "start from the newest",
+ * so a paging bug surfaces as an error instead of looking like the reader
+ * reached the top again.
+ */
+export function parseActivityCursor(
+  value: unknown,
+): ActivityCursor | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  const invalid = () =>
+    makeBadRequestError('Invalid activity feed cursor.', {
+      shouldErrorSpan: false,
+    });
+
+  if (
+    typeof value !== 'object' ||
+    Array.isArray(value) ||
+    !('decisions' in value) ||
+    !('actions' in value)
+  ) {
+    throw invalid();
+  }
+
+  const decodeSide = (side: unknown): StorePosition | null => {
+    if (side === null) {
+      return null;
+    }
+    if (
+      typeof side !== 'object' ||
+      !('ts' in side) ||
+      !('id' in side) ||
+      typeof side.ts !== 'string' ||
+      typeof side.id !== 'string'
+    ) {
+      throw invalid();
+    }
+    const ts = new Date(side.ts);
+    if (Number.isNaN(ts.valueOf())) {
+      throw invalid();
+    }
+    return { ts, id: side.id };
+  };
+
+  return {
+    decisions: decodeSide((value as { decisions: unknown }).decisions),
+    actions: decodeSide((value as { actions: unknown }).actions),
+  };
+}

--- a/server/services/moderationActivityFeed/index.ts
+++ b/server/services/moderationActivityFeed/index.ts
@@ -1,0 +1,6 @@
+export {
+  ModerationActivityFeed,
+  type ActivityFeedFilterInput,
+  type ActivityView,
+} from './ModerationActivityFeed.js';
+export { type ActivityRow } from './mergeActivityRows.js';

--- a/server/services/moderationActivityFeed/mergeActivityRows.test.ts
+++ b/server/services/moderationActivityFeed/mergeActivityRows.test.ts
@@ -1,0 +1,133 @@
+import { parseActivityCursor } from './activityCursor.js';
+import { mergeActivityRows, type ActivityRow } from './mergeActivityRows.js';
+
+const decision = (id: string, iso: string): ActivityRow => ({
+  kind: 'DECISION',
+  id,
+  ts: new Date(iso),
+  payload: { id },
+});
+
+const action = (id: string, iso: string): ActivityRow => ({
+  kind: 'MANUAL_ACTION',
+  id,
+  ts: new Date(iso),
+  payload: { id },
+});
+
+describe('mergeActivityRows', () => {
+  it('interleaves both sources newest first', () => {
+    const result = mergeActivityRows(
+      [
+        decision('d-9', '2026-08-05T14:02:00Z'),
+        decision('d-8', '2026-08-05T13:47:00Z'),
+      ],
+      [
+        action('a-4', '2026-08-05T13:58:00Z'),
+        action('a-3', '2026-08-05T13:51:00Z'),
+      ],
+      10,
+      undefined,
+    );
+
+    expect(result.rows.map((r) => r.id)).toEqual(['d-9', 'a-4', 'a-3', 'd-8']);
+  });
+
+  it('has no next cursor when both sources are exhausted', () => {
+    const result = mergeActivityRows(
+      [decision('d-9', '2026-08-05T14:02:00Z')],
+      [],
+      10,
+      undefined,
+    );
+
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it('advances each store to its own last surviving row', () => {
+    const result = mergeActivityRows(
+      [
+        decision('d-9', '2026-08-05T14:02:00Z'),
+        decision('d-8', '2026-08-05T13:47:00Z'),
+      ],
+      [action('a-4', '2026-08-05T13:58:00Z')],
+      2,
+      undefined,
+    );
+
+    expect(result.rows.map((r) => r.id)).toEqual(['d-9', 'a-4']);
+    expect(parseActivityCursor(result.nextCursor)).toEqual({
+      decisions: { ts: new Date('2026-08-05T14:02:00Z'), id: 'd-9' },
+      actions: { ts: new Date('2026-08-05T13:58:00Z'), id: 'a-4' },
+    });
+  });
+
+  it('keeps a store’s incoming position when it contributes nothing', () => {
+    // Resetting an idle store to null would restart it from the newest row and
+    // replay everything the reader has already paged past.
+    const incoming = {
+      decisions: null,
+      actions: { ts: new Date('2026-08-05T09:00:00Z'), id: 'a-1' },
+    };
+
+    const result = mergeActivityRows(
+      [
+        decision('d-3', '2026-08-05T13:00:00Z'),
+        decision('d-2', '2026-08-05T12:00:00Z'),
+        decision('d-1', '2026-08-05T11:00:00Z'),
+      ],
+      [],
+      2,
+      incoming,
+    );
+
+    expect(parseActivityCursor(result.nextCursor)).toEqual({
+      decisions: { ts: new Date('2026-08-05T12:00:00Z'), id: 'd-2' },
+      actions: { ts: new Date('2026-08-05T09:00:00Z'), id: 'a-1' },
+    });
+  });
+
+  it('never compares ids across stores on a timestamp tie', () => {
+    // A uuid decision id and a `manual-action-run:` action id have no shared
+    // ordering. Kind breaks the tie before id is ever consulted.
+    const result = mergeActivityRows(
+      [
+        decision(
+          '00000000-0000-4000-8000-000000000001',
+          '2026-08-05T13:00:00Z',
+        ),
+      ],
+      [action('manual-action-run:zzz', '2026-08-05T13:00:00Z')],
+      10,
+      undefined,
+    );
+
+    expect(result.rows.map((r) => r.kind)).toEqual([
+      'DECISION',
+      'MANUAL_ACTION',
+    ]);
+  });
+
+  it('fills a full page from one source when the other is empty', () => {
+    const result = mergeActivityRows(
+      [
+        decision('d-3', '2026-08-05T13:00:00Z'),
+        decision('d-2', '2026-08-05T12:00:00Z'),
+        decision('d-1', '2026-08-05T11:00:00Z'),
+      ],
+      [],
+      2,
+      undefined,
+    );
+
+    expect(result.rows.map((r) => r.id)).toEqual(['d-3', 'd-2']);
+    expect(result.nextCursor).not.toBeNull();
+  });
+
+  it('returns an empty page with no cursor', () => {
+    expect(mergeActivityRows([], [], 10, undefined)).toEqual({
+      rows: [],
+      nextCursor: null,
+    });
+  });
+});

--- a/server/services/moderationActivityFeed/mergeActivityRows.ts
+++ b/server/services/moderationActivityFeed/mergeActivityRows.ts
@@ -1,0 +1,94 @@
+import { type JsonValue } from 'type-fest';
+
+import {
+  serializeActivityCursor,
+  type ActivityCursor,
+  type StorePosition,
+} from './activityCursor.js';
+
+export type ActivityKind = 'DECISION' | 'MANUAL_ACTION';
+
+export type ActivityRow = {
+  kind: ActivityKind;
+  /** Decision uuid, or action correlation id. Unique within its own store. */
+  id: string;
+  ts: Date;
+  payload: unknown;
+};
+
+/**
+ * Interleave two already-sorted feeds into one page.
+ *
+ * Callers fetch `limit + 1` from each source: in the worst case every row on a
+ * page comes from one store, so `limit` from each is the minimum to guarantee
+ * a full page, and the extra row is what reveals whether more exists. The
+ * surplus is discarded here and re-fetched by the next page — inherent to
+ * merging two stores that share no index.
+ */
+export function mergeActivityRows(
+  decisions: readonly ActivityRow[],
+  actions: readonly ActivityRow[],
+  limit: number,
+  incoming: ActivityCursor | undefined,
+): { rows: ActivityRow[]; nextCursor: JsonValue | null } {
+  const merged = [...decisions, ...actions].sort(byTimeThenKindThenIdDesc);
+  const hasMore = merged.length > limit;
+  const rows = merged.slice(0, limit);
+
+  if (!hasMore) {
+    return { rows, nextCursor: null };
+  }
+
+  // Each store advances to the last row OF ITS OWN that survived the cut. A
+  // store that contributed nothing to this page keeps its incoming position —
+  // resetting it to null would restart that store from the newest row and
+  // replay rows the reader has already seen.
+  return {
+    rows,
+    nextCursor: serializeActivityCursor({
+      decisions:
+        lastPositionOfKind(rows, 'DECISION') ?? incoming?.decisions ?? null,
+      actions:
+        lastPositionOfKind(rows, 'MANUAL_ACTION') ?? incoming?.actions ?? null,
+    }),
+  };
+}
+
+function lastPositionOfKind(
+  rows: readonly ActivityRow[],
+  kind: ActivityKind,
+): StorePosition | null {
+  for (let i = rows.length - 1; i >= 0; i--) {
+    const row = rows[i];
+    if (row.kind === kind) {
+      return { ts: row.ts, id: row.id };
+    }
+  }
+  return null;
+}
+
+/**
+ * Descending by time, then by kind, then by id.
+ *
+ * The kind leg keeps ordering deterministic when a decision and an action share
+ * an instant, and — critically — means ids are only ever compared against ids
+ * of the same kind. Decision uuids and action correlation ids live in different
+ * namespaces with different collation semantics; comparing across them is what
+ * the per-store cursor exists to avoid.
+ */
+function byTimeThenKindThenIdDesc(a: ActivityRow, b: ActivityRow): number {
+  const byTime = b.ts.valueOf() - a.ts.valueOf();
+  if (byTime !== 0) {
+    return byTime;
+  }
+  if (a.kind !== b.kind) {
+    return a.kind === 'DECISION' ? -1 : 1;
+  }
+  if (a.id > b.id) {
+    return -1;
+  }
+  if (a.id < b.id) {
+    return 1;
+  }
+  return 0;
+}


### PR DESCRIPTION
## Context & Requests for Reviewers

Third of four for #386. Stacked on #B.

`ModerationActivityFeed` merges PG review-job decisions with manual Clickhouse actions into one list.

Two things to call out:

The cursor keeps a separate position per store. Decision ids are uuids,  action ids are strings like `manual-action-run:abc`. One shared cursor throws a PG type error on any page ending on an action, and casting to text doesn't help because JS, CH and PG each sort strings differently.

## Tests

24 unit tests, full server suite passes, typechecks standalone.
