### PR TITLE
[386] feat: show manual moderator actions in the Recent Decisions log

### DIFF
--- a/client/src/graphql/generated.ts
+++ b/client/src/graphql/generated.ts
@@ -200,6 +200,14 @@ export type GQLActionStatisticsInput = {
   readonly timeZone: Scalars['String']['input'];
 };
 
+export const GQLActivityView = {
+  Actions: 'ACTIONS',
+  All: 'ALL',
+  Decisions: 'DECISIONS',
+} as const;
+
+export type GQLActivityView =
+  (typeof GQLActivityView)[keyof typeof GQLActivityView];
 export type GQLAddAccessibleQueuesToUserInput = {
   readonly queueIds: ReadonlyArray<Scalars['ID']['input']>;
   readonly userId: Scalars['ID']['input'];
@@ -2094,6 +2102,47 @@ export const GQLLookbackVersion = {
 
 export type GQLLookbackVersion =
   (typeof GQLLookbackVersion)[keyof typeof GQLLookbackVersion];
+export type GQLManualActionItem = {
+  readonly __typename: 'ManualActionItem';
+  readonly failed: Scalars['Boolean']['output'];
+  readonly itemId: Scalars['ID']['output'];
+  readonly itemTypeId?: Maybe<Scalars['ID']['output']>;
+};
+
+export type GQLManualActionItemsInput = {
+  readonly correlationId: Scalars['ID']['input'];
+  /** Defaults to 100, capped at 500. */
+  readonly limit?: InputMaybe<Scalars['Int']['input']>;
+  /** max(ts) of the operation, from its feed row. Bounds the partition scan. */
+  readonly occurredAt: Scalars['DateTime']['input'];
+};
+
+export type GQLManualActionItemsPage = {
+  readonly __typename: 'ManualActionItemsPage';
+  readonly items: ReadonlyArray<GQLManualActionItem>;
+  readonly totalCount: Scalars['Int']['output'];
+};
+
+/**
+ * One operation a moderator ran outside a review job, from Bulk Actioning or
+ * Investigation. These produce no manual review decision, so they are otherwise
+ * invisible outside the actioned item's own history. A bulk run writes one
+ * execution per item per action; this collapses those into a single row.
+ */
+export type GQLManualActionRow = GQLModerationActivityRow & {
+  readonly __typename: 'ManualActionRow';
+  readonly actionIds: ReadonlyArray<Scalars['ID']['output']>;
+  readonly actorNote?: Maybe<Scalars['String']['output']>;
+  readonly correlationId: Scalars['ID']['output'];
+  readonly failedCount: Scalars['Int']['output'];
+  readonly id: Scalars['ID']['output'];
+  readonly itemCount: Scalars['Int']['output'];
+  readonly itemTypeId?: Maybe<Scalars['ID']['output']>;
+  readonly policyIds: ReadonlyArray<Scalars['ID']['output']>;
+  readonly reviewerId?: Maybe<Scalars['ID']['output']>;
+  readonly ts: Scalars['DateTime']['output'];
+};
+
 export type GQLManualReviewChartConfigurationsInput = {
   readonly chartConfigurations: ReadonlyArray<GQLManualReviewChartSettingsInput>;
 };
@@ -2327,6 +2376,20 @@ export type GQLModelCardSubsection = {
   readonly __typename: 'ModelCardSubsection';
   readonly fields: ReadonlyArray<GQLModelCardField>;
   readonly title: Scalars['String']['output'];
+};
+
+export type GQLModerationActivityPage = {
+  readonly __typename: 'ModerationActivityPage';
+  /** Null means the end of the feed. */
+  readonly nextCursor?: Maybe<Scalars['Cursor']['output']>;
+  readonly rows: ReadonlyArray<GQLModerationActivityRow>;
+};
+
+/** Fields every row in the merged activity feed carries, regardless of kind. */
+export type GQLModerationActivityRow = {
+  readonly id: Scalars['ID']['output'];
+  readonly reviewerId?: Maybe<Scalars['ID']['output']>;
+  readonly ts: Scalars['DateTime']['output'];
 };
 
 export type GQLModeratorSafetySettingsInput = {
@@ -3476,6 +3539,7 @@ export type GQLQuery = {
   readonly latestItemsCreatedBy: ReadonlyArray<GQLItemSubmissions>;
   readonly latestItemsCreatedByWithThread: ReadonlyArray<GQLThreadWithMessages>;
   readonly locationBank?: Maybe<GQLLocationBank>;
+  readonly manualActionItems: GQLManualActionItemsPage;
   readonly manualReviewQueue?: Maybe<GQLManualReviewQueue>;
   readonly me?: Maybe<GQLUser>;
   readonly myOrg?: Maybe<GQLOrg>;
@@ -3487,6 +3551,7 @@ export type GQLQuery = {
   /** Server-owned grouping + ordering for the role-editor UI. Gated on MANAGE_ROLES. */
   readonly permissionGroups: ReadonlyArray<GQLPermissionGroup>;
   readonly policy?: Maybe<GQLPolicy>;
+  readonly recentModerationActivity: GQLModerationActivityPage;
   readonly recentUserStrikeActions: ReadonlyArray<GQLRecentUserStrikeActions>;
   readonly reportingInsights: GQLReportingInsights;
   readonly reportingRule?: Maybe<GQLReportingRule>;
@@ -3653,6 +3718,10 @@ export type GQLQueryLocationBankArgs = {
   id: Scalars['ID']['input'];
 };
 
+export type GQLQueryManualActionItemsArgs = {
+  input: GQLManualActionItemsInput;
+};
+
 export type GQLQueryManualReviewQueueArgs = {
   id: Scalars['ID']['input'];
 };
@@ -3676,6 +3745,10 @@ export type GQLQueryPartialItemsArgs = {
 
 export type GQLQueryPolicyArgs = {
   id: Scalars['ID']['input'];
+};
+
+export type GQLQueryRecentModerationActivityArgs = {
+  input: GQLRecentModerationActivityInput;
 };
 
 export type GQLQueryRecentUserStrikeActionsArgs = {
@@ -3789,6 +3862,23 @@ export type GQLRecentManualReviewTransformJobAndRecreateInQueueDecision = {
 
 export type GQLRecentManualReviewUserOrRelatedActionDecision = {
   readonly actionIds: ReadonlyArray<Scalars['ID']['input']>;
+};
+
+export type GQLRecentModerationActivityInput = {
+  /** Opaque cursor from a previous page. Absent for the newest page. */
+  readonly cursor?: InputMaybe<Scalars['Cursor']['input']>;
+  readonly decisions?: InputMaybe<
+    ReadonlyArray<GQLRecentManualReviewDecisionType>
+  >;
+  readonly endTime?: InputMaybe<Scalars['DateTime']['input']>;
+  /** Rows per page. Defaults to 100, capped at 200. */
+  readonly limit?: InputMaybe<Scalars['Int']['input']>;
+  readonly policyIds?: InputMaybe<ReadonlyArray<Scalars['ID']['input']>>;
+  readonly queueIds?: InputMaybe<ReadonlyArray<Scalars['ID']['input']>>;
+  readonly reviewerIds?: InputMaybe<ReadonlyArray<Scalars['ID']['input']>>;
+  readonly startTime?: InputMaybe<Scalars['DateTime']['input']>;
+  readonly userSearchString?: InputMaybe<Scalars['String']['input']>;
+  readonly view?: InputMaybe<GQLActivityView>;
 };
 
 export type GQLRecentUserStrikeActions = {
@@ -4000,6 +4090,19 @@ export type GQLRetryNcmecSubmissionResponse = {
    */
   readonly error?: Maybe<Scalars['String']['output']>;
   readonly success: Scalars['Boolean']['output'];
+};
+
+export type GQLReviewJobDecisionRow = GQLModerationActivityRow & {
+  readonly __typename: 'ReviewJobDecisionRow';
+  readonly decisionReason?: Maybe<Scalars['String']['output']>;
+  readonly decisions: ReadonlyArray<GQLManualReviewDecisionComponent>;
+  readonly id: Scalars['ID']['output'];
+  readonly itemId?: Maybe<Scalars['ID']['output']>;
+  readonly itemTypeId?: Maybe<Scalars['ID']['output']>;
+  readonly jobId?: Maybe<Scalars['String']['output']>;
+  readonly queueId?: Maybe<Scalars['ID']['output']>;
+  readonly reviewerId?: Maybe<Scalars['ID']['output']>;
+  readonly ts: Scalars['DateTime']['output'];
 };
 
 export type GQLRole = {
@@ -9749,6 +9852,24 @@ export type GQLGetDecidedJobFromJobIdQuery = {
   } | null;
 };
 
+export type GQLManualActionItemsQueryVariables = Exact<{
+  input: GQLManualActionItemsInput;
+}>;
+
+export type GQLManualActionItemsQuery = {
+  readonly __typename: 'Query';
+  readonly manualActionItems: {
+    readonly __typename: 'ManualActionItemsPage';
+    readonly totalCount: number;
+    readonly items: ReadonlyArray<{
+      readonly __typename: 'ManualActionItem';
+      readonly itemId: string;
+      readonly itemTypeId?: string | null;
+      readonly failed: boolean;
+    }>;
+  };
+};
+
 export type GQLManualReviewMetricsQueryVariables = Exact<{
   [key: string]: never;
 }>;
@@ -10728,6 +10849,11 @@ export type GQLOrgLookupDataQueryVariables = Exact<{ [key: string]: never }>;
 
 export type GQLOrgLookupDataQuery = {
   readonly __typename: 'Query';
+  readonly me?: {
+    readonly __typename: 'User';
+    readonly id: string;
+    readonly permissions: ReadonlyArray<GQLUserPermission>;
+  } | null;
   readonly myOrg?: {
     readonly __typename: 'Org';
     readonly id: string;
@@ -10896,6 +11022,90 @@ export type GQLGetSkipsForRecentDecisionsQuery = {
     readonly queueId: string;
     readonly ts: Date | string;
   }>;
+};
+
+export type GQLGetRecentModerationActivityQueryVariables = Exact<{
+  input: GQLRecentModerationActivityInput;
+}>;
+
+export type GQLGetRecentModerationActivityQuery = {
+  readonly __typename: 'Query';
+  readonly recentModerationActivity: {
+    readonly __typename: 'ModerationActivityPage';
+    readonly nextCursor?: string | null;
+    readonly rows: ReadonlyArray<
+      | {
+          readonly __typename: 'ManualActionRow';
+          readonly correlationId: string;
+          readonly itemTypeId?: string | null;
+          readonly actionIds: ReadonlyArray<string>;
+          readonly policyIds: ReadonlyArray<string>;
+          readonly actorNote?: string | null;
+          readonly itemCount: number;
+          readonly failedCount: number;
+          readonly id: string;
+          readonly ts: Date | string;
+          readonly reviewerId?: string | null;
+        }
+      | {
+          readonly __typename: 'ReviewJobDecisionRow';
+          readonly jobId?: string | null;
+          readonly queueId?: string | null;
+          readonly itemId?: string | null;
+          readonly itemTypeId?: string | null;
+          readonly decisionReason?: string | null;
+          readonly id: string;
+          readonly ts: Date | string;
+          readonly reviewerId?: string | null;
+          readonly decisions: ReadonlyArray<
+            | {
+                readonly __typename: 'AcceptAppealDecisionComponent';
+                readonly appealId: string;
+                readonly type: GQLManualReviewDecisionType;
+              }
+            | {
+                readonly __typename: 'AutomaticCloseDecisionComponent';
+                readonly type: GQLManualReviewDecisionType;
+              }
+            | {
+                readonly __typename: 'IgnoreDecisionComponent';
+                readonly type: GQLManualReviewDecisionType;
+              }
+            | {
+                readonly __typename: 'RejectAppealDecisionComponent';
+                readonly appealId: string;
+                readonly type: GQLManualReviewDecisionType;
+              }
+            | {
+                readonly __typename: 'SubmitNCMECReportDecisionComponent';
+                readonly type: GQLManualReviewDecisionType;
+                readonly reportedMedia: ReadonlyArray<{
+                  readonly __typename: 'NcmecReportedMediaDetails';
+                  readonly id: string;
+                  readonly typeId: string;
+                  readonly url: string;
+                  readonly fileAnnotations: ReadonlyArray<GQLNcmecFileAnnotation>;
+                  readonly industryClassification: GQLNcmecIndustryClassification;
+                }>;
+              }
+            | {
+                readonly __typename: 'TransformJobAndRecreateInQueueDecisionComponent';
+                readonly newQueueId?: string | null;
+                readonly originalQueueId?: string | null;
+                readonly type: GQLManualReviewDecisionType;
+              }
+            | {
+                readonly __typename: 'UserOrRelatedActionDecisionComponent';
+                readonly itemTypeId: string;
+                readonly itemIds: ReadonlyArray<string>;
+                readonly actionIds: ReadonlyArray<string>;
+                readonly policyIds: ReadonlyArray<string>;
+                readonly type: GQLManualReviewDecisionType;
+              }
+          >;
+        }
+    >;
+  };
 };
 
 export type GQLGetDecidedJobQueryVariables = Exact<{
@@ -32272,6 +32482,114 @@ export type GQLGetDecidedJobFromJobIdQueryResult = Apollo.QueryResult<
   GQLGetDecidedJobFromJobIdQuery,
   GQLGetDecidedJobFromJobIdQueryVariables
 >;
+export const GQLManualActionItemsDocument = gql`
+  query ManualActionItems($input: ManualActionItemsInput!) {
+    manualActionItems(input: $input) {
+      totalCount
+      items {
+        itemId
+        itemTypeId
+        failed
+      }
+    }
+  }
+`;
+
+/**
+ * __useGQLManualActionItemsQuery__
+ *
+ * To run a query within a React component, call `useGQLManualActionItemsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGQLManualActionItemsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGQLManualActionItemsQuery({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useGQLManualActionItemsQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GQLManualActionItemsQuery,
+    GQLManualActionItemsQueryVariables
+  > &
+    (
+      | { variables: GQLManualActionItemsQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    ),
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GQLManualActionItemsQuery,
+    GQLManualActionItemsQueryVariables
+  >(GQLManualActionItemsDocument, options);
+}
+export function useGQLManualActionItemsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GQLManualActionItemsQuery,
+    GQLManualActionItemsQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GQLManualActionItemsQuery,
+    GQLManualActionItemsQueryVariables
+  >(GQLManualActionItemsDocument, options);
+}
+// @ts-ignore
+export function useGQLManualActionItemsSuspenseQuery(
+  baseOptions?: Apollo.SuspenseQueryHookOptions<
+    GQLManualActionItemsQuery,
+    GQLManualActionItemsQueryVariables
+  >,
+): Apollo.UseSuspenseQueryResult<
+  GQLManualActionItemsQuery,
+  GQLManualActionItemsQueryVariables
+>;
+export function useGQLManualActionItemsSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GQLManualActionItemsQuery,
+        GQLManualActionItemsQueryVariables
+      >,
+): Apollo.UseSuspenseQueryResult<
+  GQLManualActionItemsQuery | undefined,
+  GQLManualActionItemsQueryVariables
+>;
+export function useGQLManualActionItemsSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GQLManualActionItemsQuery,
+        GQLManualActionItemsQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GQLManualActionItemsQuery,
+    GQLManualActionItemsQueryVariables
+  >(GQLManualActionItemsDocument, options);
+}
+export type GQLManualActionItemsQueryHookResult = ReturnType<
+  typeof useGQLManualActionItemsQuery
+>;
+export type GQLManualActionItemsLazyQueryHookResult = ReturnType<
+  typeof useGQLManualActionItemsLazyQuery
+>;
+export type GQLManualActionItemsSuspenseQueryHookResult = ReturnType<
+  typeof useGQLManualActionItemsSuspenseQuery
+>;
+export type GQLManualActionItemsQueryResult = Apollo.QueryResult<
+  GQLManualActionItemsQuery,
+  GQLManualActionItemsQueryVariables
+>;
 export const GQLManualReviewMetricsDocument = gql`
   query ManualReviewMetrics {
     getTotalPendingJobsCount
@@ -33890,6 +34208,10 @@ export type GQLRecentDecisionsSummaryDataQueryResult = Apollo.QueryResult<
 >;
 export const GQLOrgLookupDataDocument = gql`
   query OrgLookupData {
+    me {
+      id
+      permissions
+    }
     myOrg {
       id
       actions {
@@ -34234,6 +34556,140 @@ export type GQLGetSkipsForRecentDecisionsSuspenseQueryHookResult = ReturnType<
 export type GQLGetSkipsForRecentDecisionsQueryResult = Apollo.QueryResult<
   GQLGetSkipsForRecentDecisionsQuery,
   GQLGetSkipsForRecentDecisionsQueryVariables
+>;
+export const GQLGetRecentModerationActivityDocument = gql`
+  query GetRecentModerationActivity($input: RecentModerationActivityInput!) {
+    recentModerationActivity(input: $input) {
+      nextCursor
+      rows {
+        __typename
+        id
+        ts
+        reviewerId
+        ... on ReviewJobDecisionRow {
+          jobId
+          queueId
+          itemId
+          itemTypeId
+          decisions {
+            ... on ManualReviewDecisionComponentBase {
+              ...ManualReviewDecisionComponentFields
+            }
+          }
+          decisionReason
+        }
+        ... on ManualActionRow {
+          correlationId
+          itemTypeId
+          actionIds
+          policyIds
+          actorNote
+          itemCount
+          failedCount
+        }
+      }
+    }
+  }
+  ${GQLManualReviewDecisionComponentFieldsFragmentDoc}
+`;
+
+/**
+ * __useGQLGetRecentModerationActivityQuery__
+ *
+ * To run a query within a React component, call `useGQLGetRecentModerationActivityQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGQLGetRecentModerationActivityQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGQLGetRecentModerationActivityQuery({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useGQLGetRecentModerationActivityQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GQLGetRecentModerationActivityQuery,
+    GQLGetRecentModerationActivityQueryVariables
+  > &
+    (
+      | {
+          variables: GQLGetRecentModerationActivityQueryVariables;
+          skip?: boolean;
+        }
+      | { skip: boolean }
+    ),
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GQLGetRecentModerationActivityQuery,
+    GQLGetRecentModerationActivityQueryVariables
+  >(GQLGetRecentModerationActivityDocument, options);
+}
+export function useGQLGetRecentModerationActivityLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GQLGetRecentModerationActivityQuery,
+    GQLGetRecentModerationActivityQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GQLGetRecentModerationActivityQuery,
+    GQLGetRecentModerationActivityQueryVariables
+  >(GQLGetRecentModerationActivityDocument, options);
+}
+// @ts-ignore
+export function useGQLGetRecentModerationActivitySuspenseQuery(
+  baseOptions?: Apollo.SuspenseQueryHookOptions<
+    GQLGetRecentModerationActivityQuery,
+    GQLGetRecentModerationActivityQueryVariables
+  >,
+): Apollo.UseSuspenseQueryResult<
+  GQLGetRecentModerationActivityQuery,
+  GQLGetRecentModerationActivityQueryVariables
+>;
+export function useGQLGetRecentModerationActivitySuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GQLGetRecentModerationActivityQuery,
+        GQLGetRecentModerationActivityQueryVariables
+      >,
+): Apollo.UseSuspenseQueryResult<
+  GQLGetRecentModerationActivityQuery | undefined,
+  GQLGetRecentModerationActivityQueryVariables
+>;
+export function useGQLGetRecentModerationActivitySuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GQLGetRecentModerationActivityQuery,
+        GQLGetRecentModerationActivityQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GQLGetRecentModerationActivityQuery,
+    GQLGetRecentModerationActivityQueryVariables
+  >(GQLGetRecentModerationActivityDocument, options);
+}
+export type GQLGetRecentModerationActivityQueryHookResult = ReturnType<
+  typeof useGQLGetRecentModerationActivityQuery
+>;
+export type GQLGetRecentModerationActivityLazyQueryHookResult = ReturnType<
+  typeof useGQLGetRecentModerationActivityLazyQuery
+>;
+export type GQLGetRecentModerationActivitySuspenseQueryHookResult = ReturnType<
+  typeof useGQLGetRecentModerationActivitySuspenseQuery
+>;
+export type GQLGetRecentModerationActivityQueryResult = Apollo.QueryResult<
+  GQLGetRecentModerationActivityQuery,
+  GQLGetRecentModerationActivityQueryVariables
 >;
 export const GQLGetDecidedJobDocument = gql`
   query GetDecidedJob($id: ID!) {
@@ -45372,6 +45828,7 @@ export const namedOperations = {
     ItemTypes: 'ItemTypes',
     ItemActionHistory: 'ItemActionHistory',
     getDecidedJobFromJobId: 'getDecidedJobFromJobId',
+    ManualActionItems: 'ManualActionItems',
     ManualReviewMetrics: 'ManualReviewMetrics',
     getAverageTimeToReview: 'getAverageTimeToReview',
     getDecisionsTable: 'getDecisionsTable',
@@ -45386,6 +45843,7 @@ export const namedOperations = {
     OrgLookupData: 'OrgLookupData',
     GetRecentDecisions: 'GetRecentDecisions',
     getSkipsForRecentDecisions: 'getSkipsForRecentDecisions',
+    GetRecentModerationActivity: 'GetRecentModerationActivity',
     GetDecidedJob: 'GetDecidedJob',
     ManualReviewSafetySettings: 'ManualReviewSafetySettings',
     ManualReviewJobInfo: 'ManualReviewJobInfo',

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -140,6 +140,7 @@ const client = new ApolloClient({
         'SubmitNCMECReportDecisionComponent',
         'TransformJobAndRecreateInQueueDecisionComponent',
       ],
+      ModerationActivityRow: ['ReviewJobDecisionRow', 'ManualActionRow'],
     },
   }),
 });

--- a/client/src/webpages/dashboard/mrt/ManualActionItemsPanel.tsx
+++ b/client/src/webpages/dashboard/mrt/ManualActionItemsPanel.tsx
@@ -1,0 +1,140 @@
+import { parseDatetimeToReadableStringInCurrentTimeZone } from '@/utils/time';
+import { gql } from '@apollo/client';
+import { Link } from 'react-router-dom';
+
+import CloseButton from '@/components/common/CloseButton';
+
+import { useGQLManualActionItemsQuery } from '../../../graphql/generated';
+
+gql`
+  query ManualActionItems($input: ManualActionItemsInput!) {
+    manualActionItems(input: $input) {
+      totalCount
+      items {
+        itemId
+        itemTypeId
+        failed
+      }
+    }
+  }
+`;
+
+// Server default/cap (see `ManualActionItemsInput` in
+// `server/graphql/modules/moderationActivity.ts`). There is deliberately no
+// `offset` field: `totalCount` rides on the same window function as the
+// returned rows, so paging past the end would report `0` — indistinguishable
+// from a run with no items. We fetch a single page and, when the run has more
+// items than that, say so rather than implying more can be loaded.
+// Bulk Actioning caps a run at 1000 ids, so this covers everything the UI can
+// produce and truncation becomes the exception rather than routine. At 100 a
+// 250-item run hid 22 of its 36 failures, and which items you saw was
+// arbitrary (`ORDER BY item_id`) — failures are the reason this panel exists.
+//
+// That 1000 limit is client-side only and `bulkExecuteActions` caps nothing,
+// so a programmatic caller can still exceed it; the truncation notice below
+// stays for that case.
+const PAGE_SIZE = 1000;
+
+/**
+ * The items one bulk (manual-action) run touched, fetched on selection
+ * rather than alongside the feed — a run can touch a thousand items, and
+ * every feed row would carry that weight if we fetched eagerly.
+ *
+ * Renders in the page's detail side panel — the same slot a selected
+ * decision uses (`ManualReviewRecentDecisionSummary` +
+ * `ManualReviewJobReview`) — not inside the feed table, so a wide run's
+ * item list has room to breathe instead of wrapping inside a table cell.
+ */
+export default function ManualActionItemsPanel({
+  correlationId,
+  occurredAt,
+  actionNames,
+  reviewerName,
+  onClose,
+}: {
+  correlationId: string;
+  occurredAt: Date | string;
+  /** Names of the action(s) this run applied, for the panel heading. */
+  actionNames: readonly string[];
+  /** The moderator (or "Automatic") who ran this action, for the heading. */
+  reviewerName: string;
+  onClose?: () => void;
+}) {
+  const { data, loading, error } = useGQLManualActionItemsQuery({
+    variables: {
+      input: { correlationId, occurredAt, limit: PAGE_SIZE },
+    },
+  });
+
+  return (
+    <div className="flex w-full flex-col items-start gap-3">
+      <div className="flex w-full items-start justify-between gap-3">
+        <div>
+          <div className="text-lg font-bold">
+            {actionNames.length > 0 ? actionNames.join(', ') : 'Manual Action'}
+          </div>
+          <div className="text-sm font-medium text-slate-500">
+            {reviewerName} &middot;{' '}
+            {parseDatetimeToReadableStringInCurrentTimeZone(occurredAt)}
+          </div>
+        </div>
+        {onClose ? <CloseButton onClose={onClose} customWidth="w-5" /> : null}
+      </div>
+      <div className="w-full rounded border border-solid border-slate-200 bg-slate-50 p-3">
+        {loading ? (
+          <div className="text-sm text-slate-400">Loading items…</div>
+        ) : error ? (
+          <div className="text-sm font-medium text-coop-alert-red">
+            Could not load the items for this action.
+          </div>
+        ) : !data?.manualActionItems ||
+          data.manualActionItems.items.length === 0 ? (
+          <div className="text-sm text-slate-400">No items recorded.</div>
+        ) : (
+          <>
+            <div className="pb-2 text-sm text-slate-400">
+              {data.manualActionItems.totalCount} item
+              {data.manualActionItems.totalCount === 1 ? '' : 's'}
+              {data.manualActionItems.totalCount >
+              data.manualActionItems.items.length ? (
+                // Items come back ordered by id, so a truncated list is an
+                // arbitrary slice — failures can fall outside it. Say that
+                // rather than letting the reader assume they see every one.
+                <span className="text-coop-alert-red">
+                  {` — showing first ${data.manualActionItems.items.length}; some failures may not be listed`}
+                </span>
+              ) : (
+                ''
+              )}
+            </div>
+            <ul className="flex max-h-[65vh] flex-col gap-1 overflow-y-auto">
+              {data.manualActionItems.items.map((item) => (
+                <li
+                  key={item.itemId}
+                  className="flex items-center gap-2 text-sm"
+                >
+                  {item.itemTypeId ? (
+                    <Link
+                      to={`/dashboard/manual_review/investigation?id=${item.itemId}&typeId=${item.itemTypeId}`}
+                      target="_blank"
+                      className="text-indigo-600 underline"
+                    >
+                      {item.itemId}
+                    </Link>
+                  ) : (
+                    <span>{item.itemId}</span>
+                  )}
+                  {item.failed ? (
+                    <span className="font-medium text-coop-alert-red">
+                      Failed
+                    </span>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/webpages/dashboard/mrt/ManualReviewRecentDecisions.test.tsx
+++ b/client/src/webpages/dashboard/mrt/ManualReviewRecentDecisions.test.tsx
@@ -1,0 +1,828 @@
+import { MockedProvider } from '@apollo/client/testing';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HelmetProvider } from 'react-helmet-async';
+import { MemoryRouter } from 'react-router-dom';
+
+import '@testing-library/jest-dom/extend-expect';
+
+import {
+  GQLDequeueManualReviewJobDocument,
+  GQLGetDecidedJobDocument,
+  GQLGetRecentModerationActivityDocument,
+  GQLManualActionItemsDocument,
+  GQLManualReviewDecisionInsightsFilterByInfoDocument,
+  GQLManualReviewJobInfoDocument,
+  GQLOrgLookupDataDocument,
+  GQLRecentDecisionsSummaryDataDocument,
+  GQLUserPermission,
+  type GQLRecentModerationActivityInput,
+} from '@/graphql/generated';
+
+import ManualReviewRecentDecisions from './ManualReviewRecentDecisions';
+
+// jsdom implements neither the Pointer Events capture API nor
+// `scrollIntoView`. The `Show` control (`@/coop-ui/Select`, a Radix select)
+// opens on a native `pointerdown` and calls `hasPointerCapture` from that
+// handler, so without these stubs simply clicking it throws.
+beforeAll(() => {
+  window.HTMLElement.prototype.hasPointerCapture ||= () => false;
+  window.HTMLElement.prototype.releasePointerCapture ||= () => {};
+  window.HTMLElement.prototype.setPointerCapture ||= () => {};
+  window.HTMLElement.prototype.scrollIntoView ||= () => {};
+});
+
+// Mirrors exactly what `ManualReviewRecentDecisions` sends on mount: no
+// filters saved, no search string, no cursor. If the component's initial
+// query variables ever drift from this, MockedProvider will report "no
+// matching mock" rather than a useful diff, so keep this in lockstep with
+// `buildActivityInput({}, undefined)`.
+const initialActivityInput: GQLRecentModerationActivityInput = {
+  cursor: undefined,
+  view: 'ALL',
+  userSearchString: undefined,
+  policyIds: undefined,
+  reviewerIds: undefined,
+  queueIds: undefined,
+  startTime: undefined,
+  endTime: undefined,
+  decisions: undefined,
+};
+
+const orgLookupMock = {
+  request: {
+    query: GQLOrgLookupDataDocument,
+  },
+  result: {
+    data: {
+      __typename: 'Query',
+      // Manual actions require VIEW_INVESTIGATION. Every role but
+      // EXTERNAL_MODERATOR holds it, so this is the ordinary reviewer.
+      me: {
+        __typename: 'User',
+        id: 'user-1',
+        permissions: [
+          GQLUserPermission.ViewMrt,
+          GQLUserPermission.ViewInvestigation,
+        ],
+      },
+      myOrg: {
+        __typename: 'Org',
+        id: 'org-1',
+        actions: [],
+        policies: [],
+        users: [],
+        mrtQueues: [],
+      },
+    },
+  },
+};
+
+// Once the table mounts, it renders `ManualReviewRecentDecisionsFilter` as
+// its `topRightComponent`, which fires this query itself on mount — it isn't
+// visible from reading only ManualReviewRecentDecisions.tsx.
+const filterByInfoMock = {
+  request: {
+    query: GQLManualReviewDecisionInsightsFilterByInfoDocument,
+  },
+  result: {
+    data: {
+      __typename: 'Query',
+      myOrg: {
+        __typename: 'Org',
+        actions: [],
+        itemTypes: [],
+        users: [],
+        policies: [],
+        mrtQueues: [
+          { __typename: 'ManualReviewQueue', id: 'q-appeals', name: 'Appeals' },
+        ],
+        rules: [],
+      },
+    },
+  },
+};
+
+function activityMocks(rows: readonly unknown[]) {
+  return [
+    orgLookupMock,
+    filterByInfoMock,
+    {
+      request: {
+        query: GQLGetRecentModerationActivityDocument,
+        variables: { input: initialActivityInput },
+      },
+      result: {
+        data: {
+          __typename: 'Query',
+          recentModerationActivity: {
+            __typename: 'ModerationActivityPage',
+            nextCursor: null,
+            rows,
+          },
+        },
+      },
+    },
+  ];
+}
+
+// `__typename` is included explicitly on every mocked object below (the
+// interface requires it for fragment matching), so `MockedProvider` doesn't
+// need `addTypename` — Apollo Client 3.14 rejects that prop outright.
+const renderPage = (mocks: readonly unknown[]) =>
+  render(
+    <HelmetProvider>
+      <MockedProvider mocks={mocks as never}>
+        <MemoryRouter>
+          <ManualReviewRecentDecisions />
+        </MemoryRouter>
+      </MockedProvider>
+    </HelmetProvider>,
+  );
+
+const reviewJobRow = {
+  __typename: 'ReviewJobDecisionRow',
+  id: 'd-9',
+  ts: '2026-08-05T13:58:00.000Z',
+  reviewerId: 'u-1',
+  jobId: 'job-1',
+  queueId: 'q-1',
+  itemId: 'i-1',
+  itemTypeId: 't-1',
+  decisions: [],
+  decisionReason: null,
+};
+
+const manualActionRow = (overrides: {
+  itemCount: number;
+  failedCount: number;
+}) => ({
+  __typename: 'ManualActionRow',
+  id: 'manual-action-run:abc',
+  ts: '2026-08-05T13:51:00.000Z',
+  reviewerId: 'u-2',
+  correlationId: 'manual-action-run:abc',
+  itemTypeId: 't-1',
+  actionIds: ['act-1'],
+  policyIds: [],
+  actorNote: null,
+  ...overrides,
+});
+
+// Builds an activity mock whose variables are `initialActivityInput` with the
+// given overrides applied — keeps each `Show`-control test's mock focused on
+// just the fields it cares about instead of restating the whole input shape.
+function activityMockFor(
+  variablesOverride: Partial<GQLRecentModerationActivityInput>,
+  rows: readonly unknown[],
+) {
+  return {
+    request: {
+      query: GQLGetRecentModerationActivityDocument,
+      variables: { input: { ...initialActivityInput, ...variablesOverride } },
+    },
+    result: {
+      data: {
+        __typename: 'Query',
+        recentModerationActivity: {
+          __typename: 'ModerationActivityPage',
+          nextCursor: null,
+          rows,
+        },
+      },
+    },
+  };
+}
+
+// Like `activityMockFor`, but lets a test set `nextCursor` so cursor paging
+// can be driven end to end. `cursorIn` is what the client should send for
+// that page — `undefined` on page 1.
+function activityPageMock(
+  cursorIn: string | undefined,
+  rows: readonly unknown[],
+  nextCursor: string | null,
+) {
+  return {
+    request: {
+      query: GQLGetRecentModerationActivityDocument,
+      variables: { input: { ...initialActivityInput, cursor: cursorIn } },
+    },
+    result: {
+      data: {
+        __typename: 'Query',
+        recentModerationActivity: {
+          __typename: 'ModerationActivityPage',
+          nextCursor,
+          rows,
+        },
+      },
+    },
+  };
+}
+
+const decisionRowWith = (id: string, reason: string) => ({
+  ...reviewJobRow,
+  id,
+  decisionReason: reason,
+});
+
+// Drives the existing filter UI (not something Task 13 owns) through
+// opening it, expanding Queues, picking the one seeded queue ("Appeals"),
+// and saving — the same path a moderator would use.
+async function applyQueueFilter(container: HTMLElement) {
+  fireEvent.click(await screen.findByText('Select any'));
+  fireEvent.click(await screen.findByText('Queues'));
+  const queueSelector = container.querySelector('.ant-select-selector');
+  expect(queueSelector).not.toBeNull();
+  fireEvent.mouseDown(queueSelector as Element);
+  fireEvent.click(await screen.findByText('Appeals'));
+  fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+}
+
+// Drives the `Show` control (a Radix `Select`, not a native <select>): open
+// it via its trigger (labelled "Show"), then click the option with the given
+// visible label.
+async function chooseFeedView(label: 'All' | 'Decisions' | 'Actions') {
+  userEvent.click(await screen.findByLabelText('Show'));
+  userEvent.click(await screen.findByRole('option', { name: label }));
+}
+
+// Builds a mock for the per-run item list `ManualActionItemsPanel` fetches
+// on expand. `totalCount` defaults to `items.length`; pass it explicitly to
+// simulate a run whose item count exceeds what a single page returns.
+function manualActionItemsMock(
+  correlationId: string,
+  occurredAt: string,
+  items: readonly {
+    itemId: string;
+    itemTypeId: string | null;
+    failed: boolean;
+  }[],
+  totalCount: number = items.length,
+) {
+  return {
+    request: {
+      query: GQLManualActionItemsDocument,
+      variables: { input: { correlationId, occurredAt, limit: 1000 } },
+    },
+    result: {
+      data: {
+        __typename: 'Query',
+        manualActionItems: {
+          __typename: 'ManualActionItemsPage',
+          totalCount,
+          items: items.map((item) => ({
+            __typename: 'ManualActionItem',
+            ...item,
+          })),
+        },
+      },
+    },
+  };
+}
+
+// Selecting a decision (`reviewJobRow` below, id `d-9`) always fires
+// `getDecidedJob({ id: selection.decision.id })` and always mounts
+// `ManualReviewRecentDecisionSummary` (which fires its own
+// `RecentDecisionsSummaryData` query independent of `getDecidedJob`). The
+// parent throws whatever error `getDecidedJob` produces, so any test that
+// selects a decision needs this mocked with a *non-error* result or the
+// render blows up — the actual job body isn't relevant to selection tests,
+// so `getDecidedJob: null` (a real, if empty, state `ManualReviewJobReview`
+// already handles by staying in its loading view) is enough.
+const decidedJobMock = {
+  request: {
+    query: GQLGetDecidedJobDocument,
+    variables: { id: 'd-9' },
+  },
+  result: {
+    data: {
+      __typename: 'Query',
+      getDecidedJob: null,
+    },
+  },
+};
+
+const recentDecisionsSummaryDataMock = {
+  request: {
+    query: GQLRecentDecisionsSummaryDataDocument,
+  },
+  result: {
+    data: {
+      __typename: 'Query',
+      myOrg: {
+        __typename: 'Org',
+        users: [],
+        mrtQueues: [],
+        actions: [],
+        policies: [],
+        itemTypes: [],
+      },
+    },
+  },
+};
+
+// `ManualReviewJobReview` (mounted once `getDecidedJob` resolves, even to
+// `null` — see `decidedJobMock` above) unconditionally fires this query on
+// mount, and — because there's no `closedJob` and no route-param `lockToken`
+// in this embedded context — stays permanently in its own loading state
+// rather than reaching the job body. Left unmocked, the missing response
+// surfaces as an unhandled rejection (not a rendering throw, since it's
+// caught inside that component's own query state), which is still worth
+// avoiding.
+const manualReviewJobInfoMock = {
+  request: {
+    query: GQLManualReviewJobInfoDocument,
+    variables: { jobIds: [] },
+  },
+  result: {
+    data: {
+      __typename: 'Query',
+      myOrg: {
+        __typename: 'Org',
+        id: 'org-1',
+        hasNCMECReportingEnabled: false,
+        requiresPolicyForDecisionsInMrt: false,
+        requiresDecisionReasonInMrt: false,
+        requiresDecisionReasonOnIgnoreInMrt: false,
+        allowMultiplePoliciesPerAction: false,
+        hideSkipButtonForNonAdmins: false,
+        policies: [],
+        itemTypes: [],
+        actions: [],
+        mrtQueues: [],
+      },
+      me: {
+        __typename: 'User',
+        id: 'u-1',
+        permissions: [],
+        reviewableQueues: [],
+      },
+    },
+  },
+};
+
+// With no `closedJob` and no route-param `jobId`, `ManualReviewJobReview`
+// treats itself as "on the live queue" and auto-fires this mutation to fetch
+// a job to review. That's the live-queue-review behavior, irrelevant here,
+// but it fires regardless — mock it to a no-op result so it doesn't dangle
+// as an unhandled rejection.
+const dequeueManualReviewJobMock = {
+  request: {
+    query: GQLDequeueManualReviewJobDocument,
+    variables: { queueId: undefined },
+  },
+  result: {
+    data: {
+      __typename: 'Mutation',
+      dequeueManualReviewJob: null,
+    },
+  },
+};
+
+describe('ManualReviewRecentDecisions', () => {
+  beforeEach(() => {
+    // The `Show` control persists its choice to real (jsdom) localStorage,
+    // which otherwise leaks between tests in this file.
+    localStorage.clear();
+  });
+
+  it('labels a review job row and a manual action row differently', async () => {
+    renderPage(
+      activityMocks([
+        reviewJobRow,
+        manualActionRow({ itemCount: 84, failedCount: 0 }),
+      ]),
+    );
+
+    expect(await screen.findByText('Review Job')).toBeInTheDocument();
+    expect(await screen.findByText('Manual Action')).toBeInTheDocument();
+  });
+
+  // Regression guard: an earlier task removed offset paging and, with it,
+  // both CSV export buttons (they read the `page` state the activity feed
+  // no longer uses). Both must stay present regardless of how the table
+  // itself is paged.
+  it('shows both the Download and Download Skips buttons', async () => {
+    renderPage(activityMocks([]));
+
+    expect(
+      await screen.findByRole('button', { name: 'Download' }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: 'Download Skips' }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the item count on a bulk run', async () => {
+    renderPage(
+      activityMocks([manualActionRow({ itemCount: 84, failedCount: 0 })]),
+    );
+
+    expect(await screen.findByText('84 items')).toBeInTheDocument();
+  });
+
+  it('reports how many items an action failed on', async () => {
+    renderPage(
+      activityMocks([manualActionRow({ itemCount: 84, failedCount: 3 })]),
+    );
+
+    expect(await screen.findByText('3 of 84 failed')).toBeInTheDocument();
+  });
+
+  describe('Show control', () => {
+    it('sends view: ACTIONS when Actions is selected', async () => {
+      renderPage([
+        ...activityMocks([]),
+        activityMockFor({ view: 'ACTIONS' }, [
+          manualActionRow({ itemCount: 7, failedCount: 0 }),
+        ]),
+      ]);
+
+      await chooseFeedView('Actions');
+
+      // Only the ACTIONS-view mock resolves to a row with "7 items", so this
+      // only passes if `view: 'ACTIONS'` was actually sent as a variable.
+      expect(await screen.findByText('7 items')).toBeInTheDocument();
+    });
+
+    it('moves Show to Decisions and explains why when a queue filter is applied', async () => {
+      const { container } = renderPage([
+        ...activityMocks([]),
+        activityMockFor({ view: 'DECISIONS', queueIds: ['q-appeals'] }, []),
+      ]);
+
+      await applyQueueFilter(container);
+
+      expect(await screen.findByLabelText('Show')).toHaveTextContent(
+        'Decisions',
+      );
+      expect(await screen.findByLabelText('Show')).toBeDisabled();
+      expect(
+        await screen.findByText(/manual actions have no queue/i),
+      ).toBeInTheDocument();
+    });
+
+    it("restores the user's previously chosen view when the queue filter is cleared", async () => {
+      const { container } = renderPage([
+        ...activityMocks([]),
+        activityMockFor({ view: 'DECISIONS', queueIds: ['q-appeals'] }, []),
+        // Clearing the filter re-issues the original (no-filter, ALL-view)
+        // request, so the initial mount mock is needed a second time.
+        ...activityMocks([]),
+      ]);
+
+      await applyQueueFilter(container);
+      expect(await screen.findByLabelText('Show')).toHaveTextContent(
+        'Decisions',
+      );
+
+      const filterBadge = await screen.findByText('1 Filter');
+      const clearIcon = filterBadge.querySelector('svg');
+      expect(clearIcon).not.toBeNull();
+      fireEvent.click(clearIcon as Element);
+
+      expect(await screen.findByLabelText('Show')).toHaveTextContent('All');
+      expect(await screen.findByLabelText('Show')).not.toBeDisabled();
+    });
+
+    it('shows the child-safety disclosure unless the view is Decisions', async () => {
+      renderPage([
+        ...activityMocks([]),
+        activityMockFor({ view: 'DECISIONS' }, []),
+      ]);
+
+      expect(
+        await screen.findByText(
+          /manual actions are not filtered by child-safety permissions/i,
+        ),
+      ).toBeInTheDocument();
+
+      await chooseFeedView('Decisions');
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText(
+            /manual actions are not filtered by child-safety permissions/i,
+          ),
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Manual action side panel', () => {
+    it('loads and lists the items, and narrows the table, when a bulk row is selected', async () => {
+      renderPage([
+        ...activityMocks([manualActionRow({ itemCount: 2, failedCount: 1 })]),
+        manualActionItemsMock(
+          'manual-action-run:abc',
+          '2026-08-05T13:51:00.000Z',
+          [
+            { itemId: 'usr_8813', itemTypeId: 't-1', failed: false },
+            { itemId: 'usr_8815', itemTypeId: 't-1', failed: true },
+          ],
+        ),
+      ]);
+
+      // The "Columns" control only shows when nothing is selected (it's part
+      // of `tableControls`, which the table hides in favor of the detail
+      // side panel) — asserting it's there first, then gone, is proof the
+      // panel opened in the side panel rather than in-cell beneath the row.
+      expect(
+        await screen.findByRole('button', { name: 'Columns' }),
+      ).toBeInTheDocument();
+
+      userEvent.click(await screen.findByRole('button', { name: /2 items/i }));
+
+      expect(await screen.findByText('usr_8813')).toBeInTheDocument();
+      expect(await screen.findByText('usr_8815')).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Columns' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('opens the panel when the row itself is clicked, not just the item-count control', async () => {
+      renderPage([
+        ...activityMocks([manualActionRow({ itemCount: 2, failedCount: 0 })]),
+        manualActionItemsMock(
+          'manual-action-run:abc',
+          '2026-08-05T13:51:00.000Z',
+          [{ itemId: 'usr_8813', itemTypeId: 't-1', failed: false }],
+        ),
+      ]);
+
+      // "Manual Action" is the row's origin badge, not the "2 items"
+      // control — clicking it should select the row the same way clicking
+      // anywhere on a decision row does.
+      userEvent.click(await screen.findByText('Manual Action'));
+
+      expect(await screen.findByText('usr_8813')).toBeInTheDocument();
+    });
+
+    it('marks a failed item distinctly from a successful one', async () => {
+      renderPage([
+        ...activityMocks([manualActionRow({ itemCount: 2, failedCount: 1 })]),
+        manualActionItemsMock(
+          'manual-action-run:abc',
+          '2026-08-05T13:51:00.000Z',
+          [
+            { itemId: 'usr_8813', itemTypeId: 't-1', failed: false },
+            { itemId: 'usr_8815', itemTypeId: 't-1', failed: true },
+          ],
+        ),
+      ]);
+
+      userEvent.click(await screen.findByRole('button', { name: /2 items/i }));
+
+      const failedRow = (await screen.findByText('usr_8815')).closest('li');
+      expect(failedRow).not.toBeNull();
+      expect(
+        within(failedRow as HTMLElement).getByText(/failed/i),
+      ).toBeInTheDocument();
+
+      const okRow = (await screen.findByText('usr_8813')).closest('li');
+      expect(okRow).not.toBeNull();
+      expect(
+        within(okRow as HTMLElement).queryByText(/failed/i),
+      ).not.toBeInTheDocument();
+    });
+
+    it('states the truncation when the run has more items than the page returned', async () => {
+      renderPage([
+        ...activityMocks([manualActionRow({ itemCount: 84, failedCount: 0 })]),
+        manualActionItemsMock(
+          'manual-action-run:abc',
+          '2026-08-05T13:51:00.000Z',
+          [
+            { itemId: 'usr_1', itemTypeId: 't-1', failed: false },
+            { itemId: 'usr_2', itemTypeId: 't-1', failed: false },
+          ],
+          84,
+        ),
+      ]);
+
+      userEvent.click(await screen.findByRole('button', { name: /84 items/i }));
+
+      // Items come back ordered by id, so a truncated list is an arbitrary
+      // slice and failures can fall outside it. The notice has to say so —
+      // a reader who sees a clean list must not conclude nothing failed.
+      expect(await screen.findByText(/84 items/)).toBeInTheDocument();
+      expect(
+        await screen.findByText(
+          /showing first 2; some failures may not be listed/,
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('shows an error, not an empty list, when the item query fails', async () => {
+      renderPage([
+        ...activityMocks([manualActionRow({ itemCount: 2, failedCount: 0 })]),
+        {
+          request: {
+            query: GQLManualActionItemsDocument,
+            variables: {
+              input: {
+                correlationId: 'manual-action-run:abc',
+                occurredAt: '2026-08-05T13:51:00.000Z',
+                limit: 100,
+              },
+            },
+          },
+          error: new Error('boom'),
+        },
+      ]);
+
+      userEvent.click(await screen.findByRole('button', { name: /2 items/i }));
+
+      expect(
+        await screen.findByText(/could not load the items/i),
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/no items recorded/i)).not.toBeInTheDocument();
+    });
+
+    it('clears the action panel when a decision row is selected, and vice versa', async () => {
+      const { container } = renderPage([
+        ...activityMocks([
+          reviewJobRow,
+          manualActionRow({ itemCount: 2, failedCount: 0 }),
+        ]),
+        manualActionItemsMock(
+          'manual-action-run:abc',
+          '2026-08-05T13:51:00.000Z',
+          [{ itemId: 'usr_8813', itemTypeId: 't-1', failed: false }],
+        ),
+        decidedJobMock,
+        recentDecisionsSummaryDataMock,
+        manualReviewJobInfoMock,
+        dequeueManualReviewJobMock,
+      ]);
+
+      userEvent.click(await screen.findByRole('button', { name: /2 items/i }));
+      expect(await screen.findByText('usr_8813')).toBeInTheDocument();
+
+      // Selecting is unified into one piece of state, so selecting the
+      // decision row must replace the action selection outright rather than
+      // leaving both panels (or the wrong one) rendered. Once a row is
+      // selected the table collapses (`isCollapsed`), so the decision row's
+      // per-column cells — including any dedicated click target — are gone;
+      // the row itself is still the click target, same as before selection.
+      const dataRows = container.querySelectorAll('tbody tr');
+      expect(dataRows).toHaveLength(2);
+      fireEvent.click(dataRows[0]); // reviewJobRow was passed in first
+
+      expect(await screen.findByText('Decision Summary')).toBeInTheDocument();
+      expect(screen.queryByText('usr_8813')).not.toBeInTheDocument();
+
+      // ...and vice versa: reselecting the action row replaces the decision.
+      fireEvent.click(dataRows[1]); // manualActionRow was passed in second
+
+      expect(await screen.findByText('usr_8813')).toBeInTheDocument();
+      expect(screen.queryByText('Decision Summary')).not.toBeInTheDocument();
+    });
+  });
+
+  it('states the manual-action window, so an empty tail is not read as no activity', async () => {
+    // Paging past the window returns no more actions and no has-more signal,
+    // which is indistinguishable from "nobody bulk-actioned anything".
+    // Decisions are unbounded, so the notice must not appear for them.
+    renderPage(activityMocks([reviewJobRow]));
+
+    expect(
+      await screen.findByText(/Manual actions cover the last 30 days/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Set a start date to look further back/),
+    ).toBeInTheDocument();
+  });
+
+  it('offers no Show control to a reviewer without VIEW_INVESTIGATION', async () => {
+    // EXTERNAL_MODERATOR — read-only access for external moderation partners —
+    // is the only role lacking it, and holds VIEW_MRT alone. The server refuses
+    // manual actions for such a caller, so every option but Decisions would
+    // return nothing; offer no control rather than two dead choices.
+    const externalModeratorOrgMock = {
+      request: { query: GQLOrgLookupDataDocument },
+      result: {
+        data: {
+          ...(orgLookupMock.result.data as Record<string, unknown>),
+          me: {
+            __typename: 'User',
+            id: 'user-1',
+            permissions: [GQLUserPermission.ViewMrt],
+          },
+        },
+      },
+    };
+
+    renderPage([
+      externalModeratorOrgMock,
+      ...activityMocks([reviewJobRow]).filter(
+        (m) =>
+          (m as { request: { query: unknown } }).request.query !==
+          GQLOrgLookupDataDocument,
+      ),
+    ]);
+
+    expect(await screen.findByText('Review Job')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Show')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/not filtered by child-safety permissions/i),
+    ).not.toBeInTheDocument();
+  });
+
+  describe('cursor paging', () => {
+    // The riskiest thing this page does: it replaced offset paging with a
+    // server-issued cursor across two stores. A regression here silently drops
+    // or repeats rows in an audit log, which is exactly what nobody notices.
+
+    it('sends the cursor the server returned and advances the page label', async () => {
+      renderPage([
+        orgLookupMock,
+        filterByInfoMock,
+        activityPageMock(
+          undefined,
+          [decisionRowWith('d-1', 'page one')],
+          'CURSOR_2',
+        ),
+        activityPageMock(
+          'CURSOR_2',
+          [decisionRowWith('d-2', 'page two')],
+          null,
+        ),
+      ]);
+
+      expect(await screen.findByText('page one')).toBeInTheDocument();
+      expect(screen.getByText('Page 1')).toBeInTheDocument();
+
+      userEvent.click(screen.getByLabelText('Next page'));
+
+      expect(await screen.findByText('page two')).toBeInTheDocument();
+      expect(screen.getByText('Page 2')).toBeInTheDocument();
+      expect(screen.queryByText('page one')).not.toBeInTheDocument();
+    });
+
+    it('returns to the first page with no cursor when Previous is used', async () => {
+      renderPage([
+        orgLookupMock,
+        filterByInfoMock,
+        activityPageMock(
+          undefined,
+          [decisionRowWith('d-1', 'page one')],
+          'CURSOR_2',
+        ),
+        activityPageMock(
+          'CURSOR_2',
+          [decisionRowWith('d-2', 'page two')],
+          null,
+        ),
+        // Page 1 is re-fetched on the way back — same variables as the initial
+        // load, i.e. no cursor at all rather than an empty-string one.
+        activityPageMock(
+          undefined,
+          [decisionRowWith('d-1', 'page one')],
+          'CURSOR_2',
+        ),
+      ]);
+
+      userEvent.click(await screen.findByLabelText('Next page'));
+      expect(await screen.findByText('page two')).toBeInTheDocument();
+
+      userEvent.click(screen.getByLabelText('Previous page'));
+
+      expect(await screen.findByText('page one')).toBeInTheDocument();
+      expect(screen.getByText('Page 1')).toBeInTheDocument();
+    });
+
+    it('disables Previous on the first page and Next at the end of the feed', async () => {
+      renderPage([
+        orgLookupMock,
+        filterByInfoMock,
+        activityPageMock(
+          undefined,
+          [decisionRowWith('d-1', 'only page')],
+          null,
+        ),
+      ]);
+
+      await screen.findByText('only page');
+
+      // A click that silently does nothing is indistinguishable from one that
+      // failed, so both ends must be visibly unavailable.
+      expect(screen.getByLabelText('Previous page')).toBeDisabled();
+      expect(screen.getByLabelText('Next page')).toBeDisabled();
+    });
+
+    // Not covered here: the double-click race that ran the page counter ahead
+    // of the content. `handleNext` guards on `activityLoading` and the button
+    // carries the same disabled state, but neither is observable under
+    // jsdom — MockedProvider resolves the next page before a second click or
+    // a `waitFor` can land, so any test written for it passes against the bug
+    // too. Verified instead by driving a real browser.
+  });
+});

--- a/client/src/webpages/dashboard/mrt/ManualReviewRecentDecisions.tsx
+++ b/client/src/webpages/dashboard/mrt/ManualReviewRecentDecisions.tsx
@@ -1,3 +1,10 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/coop-ui/Select';
 import ChevronLeft from '@/icons/lni/Direction/chevron-left.svg?react';
 import ChevronRight from '@/icons/lni/Direction/chevron-right.svg?react';
 import CrossCircle from '@/icons/lni/Interface and Sign/cross-circle.svg?react';
@@ -14,19 +21,22 @@ import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import ComponentLoading from '../../../components/common/ComponentLoading';
 import CoopBadge, { type BadgeColorVariant } from '../components/CoopBadge';
 import FormHeader from '../components/FormHeader';
-import { stringSort } from '../components/table/sort';
 import Table from '../components/table/Table';
 import UserWithAvatar from '../components/UserWithAvatar';
 
 import {
-  GQLGetRecentDecisionsQuery,
+  GQLGetRecentModerationActivityQuery,
   GQLManualReviewDecision,
+  GQLRecentDecisionsFilterInput,
+  GQLRecentModerationActivityInput,
+  GQLUserPermission,
   useGQLGetDecidedJobFromJobIdQuery,
   useGQLGetDecidedJobLazyQuery,
-  useGQLGetRecentDecisionsLazyQuery,
+  useGQLGetRecentModerationActivityLazyQuery,
   useGQLGetSkipsForRecentDecisionsLazyQuery,
   useGQLOrgLookupDataQuery,
 } from '../../../graphql/generated';
+import { userHasPermissions } from '../../../routing/permissions';
 import { assertUnreachable } from '../../../utils/misc';
 import {
   parseDatetimeToReadableStringInCurrentTimeZone,
@@ -36,10 +46,16 @@ import { jsonParse } from '../../../utils/typescript-types';
 import { ITEM_TYPE_FRAGMENT } from '../rules/rule_form/RuleForm';
 import { JOB_FRAGMENT } from './manual_review_job/jobFragment';
 import ManualReviewJobReview from './manual_review_job/ManualReviewJobReview';
+import ManualActionItemsPanel from './ManualActionItemsPanel';
 import ManualReviewRecentDecisionsFilter, {
   RecentDecisionsFilterInput,
 } from './ManualReviewRecentDecisionsFilter';
 import ManualReviewRecentDecisionSummary from './ManualReviewRecentDecisionSummary';
+import {
+  buildActivityCsv,
+  escapeCsvField,
+  type CsvRow,
+} from './moderationActivityCsv';
 
 gql`
   ${ITEM_TYPE_FRAGMENT}
@@ -74,6 +90,10 @@ gql`
   }
 
   query OrgLookupData {
+    me {
+      id
+      permissions
+    }
     myOrg {
       id
       actions {
@@ -98,6 +118,12 @@ gql`
     }
   }
 
+  # This page no longer queries getRecentDecisions directly (it uses
+  # recentModerationActivity below), but the operation stays defined here:
+  # ItemActionHistory.tsx still calls useGQLGetRecentDecisionsQuery, and
+  # graphql-codegen only generates a hook for an operation whose document
+  # text exists somewhere in the client. Removing this would silently break
+  # that unrelated page's codegen output.
   query GetRecentDecisions($input: RecentDecisionsInput!) {
     getRecentDecisions(input: $input) {
       id
@@ -121,12 +147,48 @@ gql`
     }
   }
 
+  # Skips CSV export. This is untouched by the merged-feed cursor paging
+  # above: skips are offset-paged via RecentDecisionsInput { filter, page },
+  # not the activity feed's cursor.
   query getSkipsForRecentDecisions($input: RecentDecisionsInput!) {
     getSkipsForRecentDecisions(input: $input) {
       jobId
       userId
       queueId
       ts
+    }
+  }
+
+  query GetRecentModerationActivity($input: RecentModerationActivityInput!) {
+    recentModerationActivity(input: $input) {
+      nextCursor
+      rows {
+        __typename
+        id
+        ts
+        reviewerId
+        ... on ReviewJobDecisionRow {
+          jobId
+          queueId
+          itemId
+          itemTypeId
+          decisions {
+            ... on ManualReviewDecisionComponentBase {
+              ...ManualReviewDecisionComponentFields
+            }
+          }
+          decisionReason
+        }
+        ... on ManualActionRow {
+          correlationId
+          itemTypeId
+          actionIds
+          policyIds
+          actorNote
+          itemCount
+          failedCount
+        }
+      }
     }
   }
 
@@ -138,11 +200,77 @@ gql`
   }
 `;
 
-type RecentDecision =
-  GQLGetRecentDecisionsQuery['getRecentDecisions'][number]['decisions'][number];
+type ActivityRow =
+  GQLGetRecentModerationActivityQuery['recentModerationActivity']['rows'][number];
+type ReviewJobRow = Extract<
+  ActivityRow,
+  { __typename: 'ReviewJobDecisionRow' }
+>;
+type ManualActionRowData = Extract<
+  ActivityRow,
+  { __typename: 'ManualActionRow' }
+>;
+type RecentDecision = ReviewJobRow['decisions'][number];
+
+/** One row of the merged feed, normalized for the table regardless of which
+ * concrete row type (`ReviewJobDecisionRow` or `ManualActionRow`) it came from. */
+type NormalizedActivityRow = {
+  rowId: string;
+  origin: 'Review Job' | 'Manual Action';
+  ts: ActivityRow['ts'];
+  decisionColorNamePairs: { name: string; colorVariant: BadgeColorVariant }[];
+  policies: string[];
+  reviewer: string;
+  queue: string;
+  reason: string | null | undefined;
+  decision: ReviewJobRow | undefined;
+  action: ManualActionRowData | undefined;
+};
+
+/**
+ * The side panel shows exactly one thing at a time — a decision or a manual
+ * action, never both. Modeling the selection as a single discriminated union
+ * (rather than two independent `useState`s) makes that invariant structural:
+ * setting one always replaces the other, so there's no separate "clear the
+ * other one" call to remember at each call site.
+ */
+type ActivitySelection =
+  | { kind: 'decision'; decision: GQLManualReviewDecision }
+  | { kind: 'action'; action: ManualActionRowData };
+
+/**
+ * The decision-detail side panel and the `getDecidedJob` lookup both predate
+ * the merged feed and still expect a `ManualReviewDecision`-shaped object.
+ * `ReviewJobDecisionRow.id` is the same underlying decision id `getRecentDecisions`
+ * used to return (see `mapDecisionRow` server-side), so this mapping is safe.
+ * `relatedActions` has no equivalent on the row — the merged feed never
+ * fetched it — so it's always empty here.
+ */
+function toManualReviewDecision(row: ReviewJobRow): GQLManualReviewDecision {
+  return {
+    __typename: 'ManualReviewDecision',
+    id: row.id,
+    jobId: row.jobId ?? '',
+    itemId: row.itemId,
+    itemTypeId: row.itemTypeId,
+    queueId: row.queueId ?? '',
+    reviewerId: row.reviewerId,
+    // `ManualReviewDecisionComponentFields` (reused verbatim from the old
+    // GetRecentDecisions query) selects fewer fields per component than the
+    // full schema type declares — e.g. it doesn't fetch `actionIds` on an
+    // accept/reject appeal component. `ManualReviewRecentDecisionSummary`
+    // only ever reads the fields the fragment does select, so this narrowing
+    // is safe; TS can't see that without a cast.
+    decisions: row.decisions as unknown as GQLManualReviewDecision['decisions'],
+    relatedActions: [],
+    createdAt: row.ts,
+    decisionReason: row.decisionReason,
+  };
+}
 
 // Column visibility configuration
 type ColumnId =
+  | 'origin'
   | 'decisionTime'
   | 'decisions'
   | 'policies'
@@ -153,6 +281,7 @@ type ColumnId =
 const COLUMN_VISIBILITY_STORAGE_KEY = 'mrt-recent-decisions-column-visibility';
 
 const defaultColumnVisibility: Record<ColumnId, boolean> = {
+  origin: true,
   decisionTime: true,
   decisions: true,
   decisionReason: true,
@@ -162,6 +291,7 @@ const defaultColumnVisibility: Record<ColumnId, boolean> = {
 };
 
 const columnLabels: Record<ColumnId, string> = {
+  origin: 'Origin',
   decisionTime: 'Decision Time',
   decisions: 'Decisions',
   decisionReason: 'Decision Reason',
@@ -172,31 +302,85 @@ const columnLabels: Record<ColumnId, string> = {
 
 const DECISION_REASON_PREVIEW_LENGTH = 50;
 
-// Escape a value for a CSV field per RFC 4180: wrap in double quotes and double
-// any embedded quotes so free-form text (e.g. decision reasons containing
-// quotes or newlines) doesn't corrupt the output. Also neutralize spreadsheet
-// formula prefixes (=, +, -, @) so a cell can't be interpreted as a formula.
-const toCsvField = (value: unknown): string => {
-  let str = String(value ?? '');
-  if (/^[=+\-@]/.test(str)) {
-    str = `'${str}`;
-  }
-  return `"${str.replace(/"/g, '""')}"`;
+// Runaway guard for both CSV exports: stop paging after this many requests
+// even if the server keeps returning more (e.g. `nextCursor` never goes
+// null, or the offset loop never runs dry).
+const CSV_MAX_PAGES = 100;
+
+// Feed view: which rows `recentModerationActivity` returns. Persisted so a
+// moderator's preference survives a reload.
+type FeedView = 'ALL' | 'DECISIONS' | 'ACTIONS';
+
+const FEED_VIEW_STORAGE_KEY = 'mrt-recent-decisions-feed-view';
+
+/**
+ * Mirrors `MERGED_VIEW_WINDOW_MS` in `ModerationActivityFeed` — the server
+ * bounds how far back a page scans ClickHouse for manual actions. Stated in
+ * the UI because a feed that has run out of window looks exactly like one that
+ * has run out of data. Keep the two in step.
+ */
+const MANUAL_ACTION_WINDOW_DAYS = 30;
+
+const feedViewLabels: Record<FeedView, string> = {
+  ALL: 'All',
+  DECISIONS: 'Decisions',
+  ACTIONS: 'Actions',
 };
+
+/**
+ * Filters only a decision can satisfy. A manual action has no queue and no
+ * decision type, so leaving `Show` on `All` while these are active would leave
+ * the control claiming something the table isn't doing.
+ */
+const isDecisionOnlyFilter = (input: RecentDecisionsFilterInput) =>
+  (input.queueIds?.length ?? 0) > 0 || (input.decisions?.length ?? 0) > 0;
 
 export default function ManualReviewRecentDecisions() {
   const [searchParams] = useSearchParams();
   const [decisionId] = [searchParams.get('decisionId') ?? undefined];
   const [jobId] = [searchParams.get('jobId') ?? undefined];
-  const [selectedDecision, setSelectedDecision] = useState<
-    GQLManualReviewDecision | undefined
-  >(undefined);
+  const [correlationId] = [searchParams.get('correlationId') ?? undefined];
+  const [selection, setSelection] = useState<ActivitySelection | undefined>(
+    undefined,
+  );
+  // Convenience views onto `selection` — kept as plain `const`s (not
+  // separate state) so the "only one selected at a time" invariant lives in
+  // the `ActivitySelection` type rather than needing to be maintained by
+  // hand at every call site that used to clear a second variable.
+  const selectedDecision =
+    selection?.kind === 'decision' ? selection.decision : undefined;
+  const selectedAction =
+    selection?.kind === 'action' ? selection.action : undefined;
   const [userSearchString, setUserSearchString] = useState<string | undefined>(
     searchParams.get('reviewerId') ?? undefined,
   );
   const [unsavedFilterValue, setUnsavedFilterValue] = useState<
     RecentDecisionsFilterInput | undefined
   >(undefined);
+
+  // The `Show` control's value as the user last chose it. Kept separate from
+  // `effectiveView` (below) so a decisions-only filter can force the view
+  // without discarding what the user picked — clearing the filter restores it.
+  const [chosenView, setChosenView] = useState<FeedView>(() => {
+    try {
+      const stored = localStorage.getItem(FEED_VIEW_STORAGE_KEY);
+      return stored === 'DECISIONS' || stored === 'ACTIONS' || stored === 'ALL'
+        ? stored
+        : 'ALL';
+    } catch (e) {
+      // localStorage unavailable (e.g. private browsing); default is fine.
+      return 'ALL';
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(FEED_VIEW_STORAGE_KEY, chosenView);
+    } catch (e) {
+      // localStorage unavailable (e.g. private browsing); the in-memory
+      // choice still works for the rest of the session.
+    }
+  }, [chosenView]);
 
   // Column visibility state
   const [columnVisibility, setColumnVisibility] = useState<
@@ -262,31 +446,55 @@ export default function ManualReviewRecentDecisions() {
     fetchPolicy: 'cache-and-network',
   });
 
+  // Manual actions are only ever taken from Investigation or Bulk Actioning,
+  // so the server gates them on VIEW_INVESTIGATION. EXTERNAL_MODERATOR — the
+  // read-only role for external moderation partners — is the only role without
+  // it. Mirror the gate here so such a reviewer gets the decisions-only page
+  // they had before this feature, rather than a Show control whose other two
+  // options silently return nothing.
+  // Permissive until permissions actually load, so the common case never
+  // changes the query variables mid-flight and refetches. The server enforces
+  // this gate regardless; this is only about not offering dead controls.
+  const loadedPermissions = orgLookupData?.me?.permissions;
+  const canViewManualActions =
+    loadedPermissions == null ||
+    userHasPermissions(loadedPermissions, [
+      GQLUserPermission.ViewInvestigation,
+    ]);
+
+  // A queue or decision-type filter can only ever match a review-job
+  // decision — a manual action has neither — so applying either forces the
+  // view to Decisions rather than silently rendering only decisions while
+  // the control still reads "All".
+  const decisionsOnly = isDecisionOnlyFilter(unsavedFilterValue ?? {});
+  const effectiveView: FeedView =
+    decisionsOnly || !canViewManualActions ? 'DECISIONS' : chosenView;
+
   const { data: decidedJobFromJobIdData } = useGQLGetDecidedJobFromJobIdQuery({
     variables: { id: jobId! },
     skip: !jobId,
     onCompleted: (data) => {
       if (data.getDecidedJobFromJobId) {
-        setSelectedDecision(
-          data.getDecidedJobFromJobId.decision as GQLManualReviewDecision,
-        );
+        setSelection({
+          kind: 'decision',
+          decision: data.getDecidedJobFromJobId
+            .decision as GQLManualReviewDecision,
+        });
       }
     },
   });
 
   const [
-    getRecentDecisions,
-    {
-      loading: allDecisionsLoading,
-      error: allDecisionsError,
-      data: allDecisionsData,
-    },
-  ] = useGQLGetRecentDecisionsLazyQuery();
+    getModerationActivity,
+    { loading: activityLoading, error: activityError, data: activityData },
+  ] = useGQLGetRecentModerationActivityLazyQuery();
 
+  // Separate lazy-query instances from `getModerationActivity` above so a CSV
+  // export's paging loop doesn't clobber the table's own query state (loading
+  // flag, cached data) while it runs.
+  const [getActivityForDownload] = useGQLGetRecentModerationActivityLazyQuery();
   const [getSkipsForRecentDecisions] =
     useGQLGetSkipsForRecentDecisionsLazyQuery();
-
-  const [getRecentDecisionsForDownload] = useGQLGetRecentDecisionsLazyQuery();
 
   // Confusingly, getDecidedJob is used to get the job associated with a decision
   // whereas getDecidedJobFromJobId is used to get the decision associated with a job
@@ -301,74 +509,249 @@ export default function ManualReviewRecentDecisions() {
 
   const navigate = useNavigate();
 
-  const [page, setPage] = useState(0);
+  // Cursor paging: the server returns the page already ordered, and
+  // `nextCursor` (null at the end of the feed) is all we need to advance.
+  // `cursorStack` remembers each page's starting cursor so "Previous" can
+  // step back through pages already seen without re-deriving an offset.
+  const [cursor, setCursor] = useState<string | undefined>(undefined);
+  const [cursorStack, setCursorStack] = useState<string[]>([]);
+
+  // CSV export loading flags — separate from `activityLoading` (the table's
+  // own query) since a download's paging loop runs on its own lazy-query
+  // instance and shouldn't make the table look like it's refetching.
+  const [downloadingActivity, setDownloadingActivity] = useState(false);
+  const [downloadingSkips, setDownloadingSkips] = useState(false);
+
+  // Shared by both the cursor-paged activity feed and the offset-paged skips
+  // CSV below — the two queries take different paging shapes but the same
+  // filter fields, so this is the one place that maps the filter UI's value
+  // to the GraphQL decision-filter shape.
+  const buildFilterInput = useCallback(
+    (input: RecentDecisionsFilterInput) => {
+      const decisionOrActions = input.decisions?.map((it) => jsonParse(it));
+      return {
+        userSearchString,
+        policyIds: input.policyIds,
+        reviewerIds: input.reviewerIds,
+        queueIds: input.queueIds,
+        startTime: input.dateRange?.startDate,
+        endTime: input.dateRange?.endDate,
+        decisions: decisionOrActions?.map((it) => {
+          switch (it.type) {
+            case 'CUSTOM_ACTION':
+              return {
+                userOrRelatedActionDecision: {
+                  actionIds: [it.actionId],
+                },
+              };
+            case 'IGNORE':
+              return {
+                ignoreDecision: {
+                  _: true,
+                },
+              };
+            case 'AUTOMATIC_CLOSE':
+              return {
+                automaticClose: {
+                  _: true,
+                },
+              };
+            case 'REJECT_APPEAL':
+              return {
+                rejectAppealDecision: {
+                  _: true,
+                },
+              };
+            case 'ACCEPT_APPEAL':
+              return {
+                acceptAppealDecision: {
+                  _: true,
+                },
+              };
+            case 'SUBMIT_NCMEC_REPORT':
+              return {
+                submitNcmecReportDecision: {
+                  _: true,
+                },
+              };
+            case 'TRANSFORM_JOB_AND_RECREATE_IN_QUEUE':
+              return {
+                transformJobAndRecreateInQueueDecision: {
+                  _: true,
+                },
+              };
+            default:
+              assertUnreachable(it);
+          }
+        }),
+      };
+    },
+    [userSearchString],
+  );
+
+  const buildActivityInput = useCallback(
+    (
+      input: RecentDecisionsFilterInput,
+      cursorArg: string | undefined,
+      view: FeedView,
+    ): GQLRecentModerationActivityInput => ({
+      cursor: cursorArg,
+      view,
+      ...buildFilterInput(input),
+    }),
+    [buildFilterInput],
+  );
+
+  // Skips CSV input: same filter fields as the activity feed, offset-paged
+  // instead of cursor-paged (see `getSkipsForRecentDecisions` above — its
+  // schema is untouched and still takes `{ filter, page }`).
+  const buildSkipsInput = useCallback(
+    (
+      input: RecentDecisionsFilterInput,
+      page: number,
+    ): { filter: GQLRecentDecisionsFilterInput; page: number } => ({
+      filter: buildFilterInput(input),
+      page,
+    }),
+    [buildFilterInput],
+  );
+
   // Handle clicking the page left icon
   const handlePrevious = () => {
-    setPage((prevOffset) => Math.max(0, prevOffset - 1));
-    getRecentDecisions({
+    const previous = cursorStack[cursorStack.length - 1];
+    // Same re-entry guard as `handleNext` — a double-click would pop twice
+    // while only one fetch lands.
+    if (previous === undefined || activityLoading) {
+      return;
+    }
+    const previousCursor = previous === '' ? undefined : previous;
+    setCursorStack((stack) => stack.slice(0, -1));
+    setCursor(previousCursor);
+    setSelection(undefined);
+    getModerationActivity({
       fetchPolicy: 'network-only',
       variables: {
-        input: getRecentDecisionsInput(unsavedFilterValue ?? {}, page),
+        input: buildActivityInput(
+          unsavedFilterValue ?? {},
+          previousCursor,
+          effectiveView,
+        ),
       },
     });
   };
 
   // Handle clicking the page right icon
   const handleNext = () => {
-    setPage((prevOffset) => prevOffset + 1);
-    getRecentDecisions({
+    const next = activityData?.recentModerationActivity.nextCursor ?? undefined;
+    // `activityLoading` is the re-entry guard. Without it a double-click read
+    // the same `nextCursor` twice and pushed twice onto `cursorStack`, so the
+    // page counter ran ahead of the content permanently — content on page 2
+    // labelled "Page 3", and Previous never resynced.
+    if (!next || activityLoading) {
+      return;
+    }
+    setCursorStack((stack) => [...stack, cursor ?? '']);
+    setCursor(next);
+    setSelection(undefined);
+    getModerationActivity({
       fetchPolicy: 'network-only',
       variables: {
-        input: getRecentDecisionsInput(unsavedFilterValue ?? {}, page),
+        input: buildActivityInput(
+          unsavedFilterValue ?? {},
+          next,
+          effectiveView,
+        ),
       },
     });
   };
 
   useEffect(() => {
+    const activeRow = activityData?.recentModerationActivity.rows.find(
+      (it): it is ReviewJobRow =>
+        it.__typename === 'ReviewJobDecisionRow' && it.id === decisionId,
+    );
     const decision =
-      allDecisionsData?.getRecentDecisions.find((it) => it.id === decisionId) ??
+      (activeRow && toManualReviewDecision(activeRow)) ??
       (decidedJobFromJobIdData?.getDecidedJobFromJobId?.decision?.id ===
       decisionId
         ? decidedJobFromJobIdData?.getDecidedJobFromJobId?.decision
         : undefined);
     if (decision) {
-      setSelectedDecision(decision as GQLManualReviewDecision);
+      setSelection({
+        kind: 'decision',
+        decision: decision as GQLManualReviewDecision,
+      });
     }
   }, [
-    allDecisionsData?.getRecentDecisions,
+    activityData?.recentModerationActivity.rows,
     decidedJobFromJobIdData?.getDecidedJobFromJobId?.decision,
     decisionId,
     jobId,
   ]);
 
+  // Deep-link restore for a manual action, mirroring the decision restore
+  // above — but with one gap: a decision can be restored even when it isn't
+  // on the currently loaded feed page, because `getDecidedJobFromJobId`
+  // looks it up directly. There is no equivalent lookup-by-correlationId
+  // query for manual actions, so this can only restore a selection whose row
+  // is present in `activityData` (i.e. still on the loaded page) — a link
+  // shared while looking at that page still works; a link to an older run
+  // that has since paged out of view does not. Adding that lookup would mean
+  // a new backend query, which is out of scope here.
   useEffect(() => {
-    if (selectedDecision) {
+    if (!correlationId) {
+      return;
+    }
+    const activeActionRow = activityData?.recentModerationActivity.rows.find(
+      (it): it is ManualActionRowData =>
+        it.__typename === 'ManualActionRow' &&
+        it.correlationId === correlationId,
+    );
+    if (activeActionRow) {
+      setSelection({ kind: 'action', action: activeActionRow });
+    }
+  }, [activityData?.recentModerationActivity.rows, correlationId]);
+
+  useEffect(() => {
+    if (selection?.kind === 'decision') {
       getDecidedJob({
-        variables: { id: selectedDecision.id },
+        variables: { id: selection.decision.id },
       });
       navigate(
-        `/dashboard/manual_review/recent/?decisionId=${selectedDecision.id}&jobId=${selectedDecision.jobId}`,
+        `/dashboard/manual_review/recent/?decisionId=${selection.decision.id}&jobId=${selection.decision.jobId}`,
+        {
+          replace: true,
+        },
+      );
+    } else if (selection?.kind === 'action') {
+      navigate(
+        `/dashboard/manual_review/recent/?correlationId=${selection.action.correlationId}`,
         {
           replace: true,
         },
       );
     }
-  }, [
-    getDecidedJob,
-    selectedDecision,
-    navigate,
-    decidedJobData?.getDecidedJob,
-  ]);
+  }, [getDecidedJob, selection, navigate, decidedJobData?.getDecidedJob]);
 
   const columns = useMemo(
     () =>
       filterNullOrUndefined([
+        columnVisibility.origin
+          ? {
+              Header: 'Origin',
+              accessor: 'origin',
+              canSort: false,
+            }
+          : undefined,
         columnVisibility.decisionTime
           ? {
               Header: 'Decision Time',
-              accessor: 'decisionTime',
-              sortDescFirst: true,
-              sortType: stringSort,
+              accessor: 'ts',
+              // The server returns each page already ordered by (ts, kind, id)
+              // descending across both stores. A client-side sort could only
+              // reorder the hundred rows currently loaded, which reads as a
+              // global sort and is not one.
+              canSort: false,
             }
           : undefined,
         columnVisibility.decisions
@@ -403,7 +786,9 @@ export default function ManualReviewRecentDecisions() {
           ? {
               Header: 'Queue',
               accessor: 'queue',
-              canSort: true,
+              // Same reason as Decision Time — and this column renders JSX, so
+              // a comparator would be sorting React elements, not queue names.
+              canSort: false,
             }
           : undefined,
       ]),
@@ -528,121 +913,202 @@ export default function ManualReviewRecentDecisions() {
     [getPolicyName],
   );
 
-  const dataValues = useMemo(() => {
-    if (!allDecisionsData || !orgLookupData?.myOrg) {
+  // A manual action has no decision components of its own — it's just a set
+  // of actions applied directly. Badge them the same way a decision's custom
+  // actions are badged (`UserOrRelatedActionDecisionComponent`, above) so the
+  // merged Decisions column reads consistently regardless of a row's origin.
+  const getActionColorNamePairs = useCallback(
+    (
+      actionIds: readonly string[],
+    ): { name: string; colorVariant: BadgeColorVariant }[] =>
+      actionIds.map((actionId) => ({
+        name: getActionName(actionId),
+        colorVariant: 'soft-red',
+      })),
+    [getActionName],
+  );
+
+  // Normalizes one merged-feed row into the flat, string-only shape the CSV
+  // export writes out. Kept separate from `NormalizedActivityRow` (used by
+  // the table) since the CSV needs raw item/failed counts rather than the
+  // table's pre-rendered JSX.
+  const toCsvRow = useCallback(
+    (row: ActivityRow): CsvRow => {
+      if (row.__typename === 'ManualActionRow') {
+        return {
+          origin: 'Manual Action',
+          outcome: getActionColorNamePairs(row.actionIds).map(
+            ({ name }) => name,
+          ),
+          policies: row.policyIds.map((id) => getPolicyName(id)),
+          reviewer: getReviewerName(row.reviewerId),
+          queue: '',
+          time: parseDatetimeToReadableStringInUTC(new Date(row.ts)),
+          reason: row.actorNote ?? null,
+          itemCount: row.itemCount,
+          failedCount: row.failedCount,
+          link: '',
+        };
+      }
+      return {
+        origin: 'Review Job',
+        outcome: row.decisions.flatMap((it) =>
+          getDecisionColorNamePairs(it, false).map(({ name }) => name),
+        ),
+        policies: row.decisions.flatMap((it) => getPoliciesFromDecision(it)),
+        reviewer: getReviewerName(row.reviewerId),
+        queue: row.queueId ? getQueueName(row.queueId) : '',
+        time: parseDatetimeToReadableStringInUTC(new Date(row.ts)),
+        reason: row.decisionReason ?? null,
+        itemCount: null,
+        failedCount: null,
+        link: `${HOST_URL}/dashboard/manual_review/recent?jobId=${row.jobId ?? ''}`,
+      };
+    },
+    [
+      getActionColorNamePairs,
+      getDecisionColorNamePairs,
+      getPoliciesFromDecision,
+      getPolicyName,
+      getQueueName,
+      getReviewerName,
+    ],
+  );
+
+  const tableRows: NormalizedActivityRow[] | undefined = useMemo(() => {
+    if (!activityData || !orgLookupData?.myOrg) {
       return undefined;
     }
-    const fetchedDecision =
-      decidedJobFromJobIdData?.getDecidedJobFromJobId?.decision;
-    const allDecisions = [
-      ...allDecisionsData.getRecentDecisions,
-      ...(fetchedDecision &&
-      !allDecisionsData.getRecentDecisions.some(
-        (decision) => decision.id === fetchedDecision.id,
-      )
-        ? [fetchedDecision]
-        : []),
-    ];
-
-    return allDecisions.map((decisionData) => {
-      const isSelected = selectedDecision?.id === decisionData.id;
-      return {
-        ...decisionData,
-        decisions: decisionData.decisions
-          .map((decision) =>
-            getDecisionColorNamePairs(decision, isSelected).map(
-              ({ name }) => name,
-            ),
-          )
-          .flat(),
-        decisionColorNamePairs: decisionData.decisions
-          .map((decision) => getDecisionColorNamePairs(decision, isSelected))
-          .flat(),
-        policies: decisionData.decisions.flatMap((decision) =>
-          getPoliciesFromDecision(decision),
-        ),
-        reviewer: getReviewerName(decisionData.reviewerId),
-        queue: getQueueName(decisionData.queueId),
-        decisionTime: decisionData.createdAt,
-        originalDecisionData: decisionData,
-        decisionReason: decisionData.decisionReason,
-      };
-    });
+    return activityData.recentModerationActivity.rows.map(
+      (row): NormalizedActivityRow => {
+        if (row.__typename === 'ManualActionRow') {
+          return {
+            rowId: row.id,
+            origin: 'Manual Action',
+            ts: row.ts,
+            decisionColorNamePairs: getActionColorNamePairs(row.actionIds),
+            policies: row.policyIds.map((id) => getPolicyName(id)),
+            reviewer: getReviewerName(row.reviewerId),
+            queue: '',
+            reason: row.actorNote,
+            decision: undefined,
+            action: row,
+          };
+        }
+        return {
+          rowId: row.id,
+          origin: 'Review Job',
+          ts: row.ts,
+          decisionColorNamePairs: row.decisions.flatMap((it) =>
+            getDecisionColorNamePairs(it, false),
+          ),
+          policies: row.decisions.flatMap((it) => getPoliciesFromDecision(it)),
+          reviewer: getReviewerName(row.reviewerId),
+          queue: row.queueId ? getQueueName(row.queueId) : '',
+          reason: row.decisionReason,
+          decision: row,
+          action: undefined,
+        };
+      },
+    );
   }, [
-    allDecisionsData,
+    activityData,
     orgLookupData?.myOrg,
-    decidedJobFromJobIdData?.getDecidedJobFromJobId?.decision,
+    getActionColorNamePairs,
     getDecisionColorNamePairs,
     getPoliciesFromDecision,
+    getPolicyName,
     getQueueName,
     getReviewerName,
-    selectedDecision?.id,
   ]);
 
+  // No client-side sort: the server returns the page already ordered.
   const tableData = useMemo(() => {
-    if (!dataValues) {
+    if (!tableRows) {
       return undefined;
     }
-    return (
-      dataValues
-        .map((value) => {
-          return {
-            decisions: (
-              <div className="flex flex-wrap gap-1">
-                {value.decisionColorNamePairs.map(
-                  ({ name, colorVariant }, index) => (
-                    <CoopBadge
-                      key={index}
-                      colorVariant={colorVariant}
-                      label={name}
-                      shapeVariant="pill"
-                    />
-                  ),
-                )}
-              </div>
-            ),
-            policies: (
-              <div className="max-w-[220px] whitespace-normal break-words">
-                {value.policies.join(', ')}
-              </div>
-            ),
-            reviewer: <UserWithAvatar name={value.reviewer} />,
-            queue: <div>{value.queue}</div>,
-            decisionTime: (
-              <div>
-                {parseDatetimeToReadableStringInCurrentTimeZone(
-                  new Date(value.decisionTime),
-                )}
-              </div>
-            ),
-            decisionReason: value.decisionReason ? (
-              <Tooltip title={value.decisionReason}>
-                <div className="max-w-xs truncate">
-                  {value.decisionReason.length > DECISION_REASON_PREVIEW_LENGTH
-                    ? `${value.decisionReason.slice(
-                        0,
-                        DECISION_REASON_PREVIEW_LENGTH,
-                      )}…`
-                    : value.decisionReason}
-                </div>
-              </Tooltip>
-            ) : (
-              <div className="text-slate-400">—</div>
-            ),
-            values: value,
-          };
-        })
-        // Sort in reverse-chronological order
-        .sort(
-          (a, b) =>
-            new Date(b.values.decisionTime).valueOf() -
-            new Date(a.values.decisionTime).valueOf(),
-        )
-    );
-  }, [dataValues]);
+    return tableRows.map((row) => ({
+      origin: (
+        <div className="flex flex-col gap-0.5 whitespace-nowrap">
+          <CoopBadge
+            colorVariant={
+              row.origin === 'Review Job' ? 'soft-blue' : 'soft-gray'
+            }
+            label={row.origin}
+            shapeVariant="pill"
+          />
+          {row.action && row.action.itemCount > 1 ? (
+            <button
+              type="button"
+              className="w-fit cursor-pointer text-xs text-slate-400 underline decoration-dotted hover:text-slate-600"
+              onClick={(event) => {
+                // Selecting the action opens the side panel, the same slot a
+                // selected decision uses — not something that should also
+                // fire the row's own `onClick` (which would select the same
+                // thing a second time via the enclosing `<tr onClick>`).
+                event.stopPropagation();
+                if (row.action) {
+                  setSelection({ kind: 'action', action: row.action });
+                }
+              }}
+            >
+              {row.action.itemCount} items
+            </button>
+          ) : null}
+          {row.action && row.action.failedCount > 0 ? (
+            <span className="text-xs font-medium text-coop-alert-red">
+              {row.action.failedCount} of {row.action.itemCount} failed
+            </span>
+          ) : null}
+        </div>
+      ),
+      decisions: (
+        <div className="flex flex-wrap gap-1">
+          {row.decisionColorNamePairs.map(({ name, colorVariant }, index) => (
+            <CoopBadge
+              key={index}
+              colorVariant={colorVariant}
+              label={name}
+              shapeVariant="pill"
+            />
+          ))}
+        </div>
+      ),
+      policies: (
+        <div className="max-w-[220px] whitespace-normal break-words">
+          {row.policies.join(', ')}
+        </div>
+      ),
+      reviewer: <UserWithAvatar name={row.reviewer} />,
+      queue: <div>{row.queue}</div>,
+      decisionTime: (
+        <div>
+          {parseDatetimeToReadableStringInCurrentTimeZone(new Date(row.ts))}
+        </div>
+      ),
+      decisionReason: row.reason ? (
+        <Tooltip title={row.reason}>
+          <div className="max-w-xs truncate">
+            {row.reason.length > DECISION_REASON_PREVIEW_LENGTH
+              ? `${row.reason.slice(0, DECISION_REASON_PREVIEW_LENGTH)}…`
+              : row.reason}
+          </div>
+        </Tooltip>
+      ) : (
+        <div className="text-slate-400">—</div>
+      ),
+      values: row,
+    }));
+  }, [tableRows]);
 
-  if (allDecisionsError || allDecisionsError || decidedJobError) {
-    throw allDecisionsError ?? allDecisionsError ?? decidedJobError!;
+  // Only a feed failure is fatal — without it there is no page. A
+  // `getDecidedJob` failure concerns one selected row, and the panel below
+  // renders an inline message for it. Throwing here ran during render and so
+  // took the whole page to the error boundary, making that inline handler
+  // unreachable: one decision whose item type had been deleted turned the
+  // entire log into "Something Went Wrong".
+  if (activityError) {
+    throw activityError;
   }
 
   const refreshButton = (
@@ -650,221 +1116,172 @@ export default function ManualReviewRecentDecisions() {
       icon={<RedoOutlined className="self-center" />}
       className="!inline-flex"
       onClick={async () =>
-        getRecentDecisions({
+        getModerationActivity({
           fetchPolicy: 'network-only',
           variables: {
-            input: getRecentDecisionsInput(unsavedFilterValue ?? {}, page),
+            input: buildActivityInput(
+              unsavedFilterValue ?? {},
+              cursor,
+              effectiveView,
+            ),
           },
         })
       }
-      loading={allDecisionsLoading || allDecisionsLoading}
+      loading={activityLoading}
     >
       Refresh Table
     </Button>
   );
 
+  // Activity export: pages the same cursor-paged query the table uses, via
+  // its own lazy-query instance (`getActivityForDownload`), looping until
+  // `nextCursor` is null. Capped at `CSV_MAX_PAGES` as a runaway guard.
   const downloadButton = (
     <Button
       className="rounded"
+      loading={downloadingActivity}
       onClick={async () => {
-        const decisions: GQLGetRecentDecisionsQuery[] = [];
-        for (let i = 0; i < 100; i++) {
-          const result = await getRecentDecisionsForDownload({
-            variables: {
-              input: getRecentDecisionsInput(
-                unsavedFilterValue ?? {},
-                page + i,
-              ),
-            },
-          });
-          if (result.data) {
-            decisions.push(result.data);
+        setDownloadingActivity(true);
+        try {
+          const collected: CsvRow[] = [];
+          let downloadCursor: string | undefined;
+
+          for (let page = 0; page < CSV_MAX_PAGES; page++) {
+            const result = await getActivityForDownload({
+              variables: {
+                input: buildActivityInput(
+                  unsavedFilterValue ?? {},
+                  downloadCursor,
+                  effectiveView,
+                ),
+              },
+            });
+            const feed = result.data?.recentModerationActivity;
+            if (!feed) {
+              break;
+            }
+            collected.push(...feed.rows.map(toCsvRow));
+            if (!feed.nextCursor) {
+              break;
+            }
+            downloadCursor = feed.nextCursor;
           }
+
+          const includeActions = effectiveView !== 'DECISIONS';
+          const blob = new Blob([buildActivityCsv(collected, includeActions)], {
+            type: 'text/csv',
+          });
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = includeActions
+            ? 'moderation-activity.csv'
+            : 'decisions.csv';
+          a.click();
+          URL.revokeObjectURL(url);
+        } finally {
+          setDownloadingActivity(false);
         }
-        const allDecisions = decisions.flatMap((it) => it.getRecentDecisions);
-        const allDecisionsCsv = allDecisions.map((decision) => {
-          const decisions = decision.decisions.flatMap((it) =>
-            getDecisionColorNamePairs(it, false).map(({ name }) => name),
-          );
-          const policies = decision.decisions.flatMap((decision) =>
-            getPoliciesFromDecision(decision),
-          );
-
-          return {
-            jobId: decision.jobId,
-            queue: getQueueName(decision.queueId),
-            reviewer: getReviewerName(decision.reviewerId),
-            decisions,
-            createdAt: parseDatetimeToReadableStringInUTC(
-              new Date(decision.createdAt),
-            ),
-            policies,
-            decisionReason: decision.decisionReason ?? '',
-          };
-        });
-        // Define the CSV headers
-        const headers = [
-          'Decisions',
-          'Policies',
-          'Reviewer',
-          'Queue',
-          'Decision Time',
-          'Decision Reason',
-          'Link',
-        ];
-
-        // Map the data to CSV rows
-        const rows = allDecisionsCsv.map((item) => [
-          JSON.stringify(item.decisions),
-          JSON.stringify(item.policies), // Convert array/object to JSON string if necessary
-          item.reviewer,
-          item.queue,
-          item.createdAt,
-          item.decisionReason,
-          `${HOST_URL}/dashboard/manual_review/recent?jobId=${item.jobId}`,
-        ]);
-
-        // Combine the headers and rows into a CSV string
-        const csvContent = [headers, ...rows]
-          .map((row) => row.map(toCsvField).join(',')) // RFC 4180: quote fields and escape embedded quotes
-          .join('\n');
-
-        // Create a Blob from the CSV content
-        const blob = new Blob([csvContent], { type: 'text/csv' });
-        const url = URL.createObjectURL(blob);
-
-        // Create a temporary link to download the Blob
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = 'decisions.csv'; // Set the desired file name
-        a.click();
-
-        // Clean up
-        URL.revokeObjectURL(url);
       }}
-      loading={allDecisionsLoading || allDecisionsLoading}
     >
       Download
     </Button>
   );
 
+  // Skips export: `getSkipsForRecentDecisions` is untouched in the schema
+  // and still takes `{ filter, page }` — an offset, not the activity feed's
+  // cursor. It shares filters with the activity feed, not a paging
+  // position, so this loop is entirely separate from the one above.
   const downloadSkips = (
     <Button
       className="rounded"
+      loading={downloadingSkips}
       onClick={async () => {
-        const result = await getSkipsForRecentDecisions({
-          variables: {
-            input: getRecentDecisionsInput(unsavedFilterValue ?? {}, page),
-          },
-        });
+        setDownloadingSkips(true);
+        try {
+          const collected: {
+            reviewer: string;
+            queue: string;
+            time: string;
+            link: string;
+          }[] = [];
+          // `SkipOperations.getSkippedJobsForRecentDecisions` (server-side)
+          // ignores `page` entirely today and always returns the full
+          // matching set in one call, so a page-index loop alone would never
+          // terminate on "empty" and would append the same rows repeatedly.
+          // Track which skips have already been collected and stop once a
+          // page adds nothing new — correct against today's unpaginated
+          // resolver, and still correct if it's paginated for real later.
+          const seenSkipKeys = new Set<string>();
 
-        const skips = result.data?.getSkipsForRecentDecisions;
+          for (let page = 0; page < CSV_MAX_PAGES; page++) {
+            const result = await getSkipsForRecentDecisions({
+              variables: {
+                input: buildSkipsInput(unsavedFilterValue ?? {}, page),
+              },
+            });
+            const skips = result.data?.getSkipsForRecentDecisions;
+            if (!skips || skips.length === 0) {
+              break;
+            }
+            const newSkips = skips.filter((skip) => {
+              const key = `${skip.jobId}:${skip.userId}:${skip.ts}`;
+              if (seenSkipKeys.has(key)) {
+                return false;
+              }
+              seenSkipKeys.add(key);
+              return true;
+            });
+            if (newSkips.length === 0) {
+              break;
+            }
+            collected.push(
+              ...newSkips.map((skip) => ({
+                reviewer: getReviewerName(skip.userId),
+                queue: getQueueName(skip.queueId),
+                time: parseDatetimeToReadableStringInUTC(new Date(skip.ts)),
+                link: `${HOST_URL}/dashboard/manual_review/recent?jobId=${skip.jobId}`,
+              })),
+            );
+          }
 
-        if (skips === undefined) {
-          return;
+          const headers = ['Reviewer', 'Queue', 'Decision Time', 'Link'];
+          const csvContent = [
+            headers,
+            ...collected.map((row) => [
+              row.reviewer,
+              row.queue,
+              row.time,
+              row.link,
+            ]),
+          ]
+            .map((row) => row.map(escapeCsvField).join(','))
+            .join('\n');
+
+          const blob = new Blob([csvContent], { type: 'text/csv' });
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = 'skips.csv';
+          a.click();
+          URL.revokeObjectURL(url);
+        } finally {
+          setDownloadingSkips(false);
         }
-        const rows = skips.map((skip) => {
-          return [
-            getReviewerName(skip.userId),
-            getQueueName(skip.queueId),
-            parseDatetimeToReadableStringInUTC(new Date(skip.ts)),
-            `${HOST_URL}/dashboard/manual_review/recent?jobId=${skip.jobId}`,
-          ];
-        });
-        // Define the CSV headers
-        const headers = ['Reviewer', 'Queue', 'Decision Time', 'Link'];
-
-        // Combine the headers and rows into a CSV string
-        const csvContent = [headers, ...rows]
-          .map((row) => row.map(toCsvField).join(',')) // RFC 4180: quote fields and escape embedded quotes
-          .join('\n');
-
-        // Create a Blob from the CSV content
-        const blob = new Blob([csvContent], { type: 'text/csv' });
-        const url = URL.createObjectURL(blob);
-
-        // Create a temporary link to download the Blob
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = 'skips.csv'; // Set the desired file name
-        a.click();
-
-        // Clean up
-        URL.revokeObjectURL(url);
       }}
     >
       Download Skips
     </Button>
   );
 
-  const getRecentDecisionsInput = useCallback(
-    (input: RecentDecisionsFilterInput, page: number) => {
-      const decisionOrActions = input.decisions?.map((it) => jsonParse(it));
-      const filter = {
-        userSearchString,
-        policyIds: input.policyIds,
-        reviewerIds: input.reviewerIds,
-        queueIds: input.queueIds,
-        startTime: input.dateRange?.startDate,
-        endTime: input.dateRange?.endDate,
-
-        decisions: decisionOrActions?.map((it) => {
-          switch (it.type) {
-            case 'CUSTOM_ACTION':
-              return {
-                userOrRelatedActionDecision: {
-                  actionIds: [it.actionId],
-                },
-              };
-            case 'IGNORE':
-              return {
-                ignoreDecision: {
-                  _: true,
-                },
-              };
-            case 'AUTOMATIC_CLOSE':
-              return {
-                automaticClose: {
-                  _: true,
-                },
-              };
-            case 'REJECT_APPEAL':
-              return {
-                rejectAppealDecision: {
-                  _: true,
-                },
-              };
-            case 'ACCEPT_APPEAL':
-              return {
-                acceptAppealDecision: {
-                  _: true,
-                },
-              };
-            case 'SUBMIT_NCMEC_REPORT':
-              return {
-                submitNcmecReportDecision: {
-                  _: true,
-                },
-              };
-            case 'TRANSFORM_JOB_AND_RECREATE_IN_QUEUE':
-              return {
-                transformJobAndRecreateInQueueDecision: {
-                  _: true,
-                },
-              };
-            default:
-              assertUnreachable(it);
-          }
-        }),
-      };
-      return { filter, page };
-    },
-    [userSearchString],
-  );
   useEffect(() => {
-    getRecentDecisions({
+    getModerationActivity({
       variables: {
-        input: getRecentDecisionsInput(unsavedFilterValue ?? {}, page),
+        input: buildActivityInput(
+          unsavedFilterValue ?? {},
+          cursor,
+          effectiveView,
+        ),
       },
     });
     // NB: We only want to run this once, so we intentionally do not include
@@ -874,10 +1291,16 @@ export default function ManualReviewRecentDecisions() {
 
   const searchForUser = () => {
     if (userSearchString) {
-      setSelectedDecision(undefined);
-      getRecentDecisions({
+      setSelection(undefined);
+      setCursor(undefined);
+      setCursorStack([]);
+      getModerationActivity({
         variables: {
-          input: getRecentDecisionsInput(unsavedFilterValue ?? {}, page),
+          input: buildActivityInput(
+            unsavedFilterValue ?? {},
+            undefined,
+            effectiveView,
+          ),
         },
       });
       navigate(
@@ -975,15 +1398,101 @@ export default function ManualReviewRecentDecisions() {
     </div>
   );
 
+  // A cursor from one view is meaningless in another (it points into a
+  // different underlying dataset), so switching the feed view resets paging
+  // the same way applying a filter does.
+  const handleViewChange = (nextView: FeedView) => {
+    setChosenView(nextView);
+    setSelection(undefined);
+    setCursor(undefined);
+    setCursorStack([]);
+    getModerationActivity({
+      variables: {
+        input: buildActivityInput(
+          unsavedFilterValue ?? {},
+          undefined,
+          nextView,
+        ),
+      },
+    });
+  };
+
+  // Without VIEW_INVESTIGATION every option but Decisions returns nothing, so
+  // offer no control at all rather than two dead choices.
+  const showControl = !canViewManualActions ? null : (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center gap-2">
+        <label
+          htmlFor="mrt-recent-decisions-feed-view"
+          className="font-semibold text-slate-500 whitespace-nowrap"
+        >
+          Show
+        </label>
+        <Select
+          value={effectiveView}
+          disabled={decisionsOnly}
+          onValueChange={(value) => handleViewChange(value as FeedView)}
+        >
+          <SelectTrigger
+            id="mrt-recent-decisions-feed-view"
+            size="small"
+            className="w-32"
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {(Object.keys(feedViewLabels) as FeedView[]).map((view) => (
+              <SelectItem key={view} value={view}>
+                {feedViewLabels[view]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      {decisionsOnly ? (
+        <div className="text-xs text-slate-400">
+          Manual actions have no queue, so this filter shows decisions only.
+        </div>
+      ) : null}
+      {effectiveView !== 'DECISIONS' ? (
+        <>
+          {/*
+            Without this, a feed that has simply run out of window is
+            indistinguishable from one that has run out of data: paging back
+            past the window returns no more manual actions and no "has more"
+            signal, which reads as "nobody bulk-actioned anything that month".
+            Queue decisions have no such bound.
+          */}
+          <div className="text-xs text-slate-400">
+            Manual actions cover the last {MANUAL_ACTION_WINDOW_DAYS} days. Set
+            a start date to look further back.
+          </div>
+          <div className="text-xs text-slate-400">
+            Manual actions are not filtered by child-safety permissions.
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+
   const filter = (
     <ManualReviewRecentDecisionsFilter
       input={unsavedFilterValue ?? {}}
       onSave={(input) => {
-        setPage(0);
-        setSelectedDecision(undefined);
+        setSelection(undefined);
         setUnsavedFilterValue(input);
-        getRecentDecisions({
-          variables: { input: getRecentDecisionsInput(input, page) },
+        setCursor(undefined);
+        setCursorStack([]);
+        // `chosenView` state hasn't updated yet (we didn't change it here),
+        // so re-derive the view for *this* filter directly from `input`
+        // rather than reading the (stale, pre-update) `effectiveView`.
+        const viewForFilter: FeedView = isDecisionOnlyFilter(input)
+          ? 'DECISIONS'
+          : chosenView;
+        getModerationActivity({
+          variables: {
+            input: buildActivityInput(input, undefined, viewForFilter),
+          },
         });
         navigate(`/dashboard/manual_review/recent/`, {
           replace: true,
@@ -1003,56 +1512,63 @@ export default function ManualReviewRecentDecisions() {
       </Helmet>
       <FormHeader
         title="Recent Decisions"
-        subtitle="This is a list of all the most recent moderator decisions, in reverse chronological order with the most recent decision first, and the least recent decision last. You can search for decisions about a given user by entering that user's ID or username."
+        subtitle="This is a list of all the most recent moderator decisions and manual actions, in reverse chronological order with the most recent activity first, and the least recent activity last. You can search for activity about a given user by entering that user's ID or username."
       />
-      {selectedDecision ? userSearchAndRefresh : null}
-      {allDecisionsLoading || !tableData ? (
+      {selection ? userSearchAndRefresh : null}
+      {activityLoading || !tableData ? (
         <ComponentLoading />
       ) : (
         <div className="flex w-full">
-          <div className={selectedDecision ? undefined : 'w-full min-w-0'}>
+          <div className={selection ? undefined : 'w-full min-w-0'}>
             <Table
               columns={columns}
               // @ts-ignore
               data={tableData}
               alwaysShowScrollbar
-              containerClassName={selectedDecision ? undefined : 'w-full'}
-              onSelectRow={(rowData) =>
-                setSelectedDecision(
-                  rowData.original.values.originalDecisionData,
-                )
+              containerClassName={selection ? undefined : 'w-full'}
+              onSelectRow={(rowData) => {
+                const values = rowData.original.values as NormalizedActivityRow;
+                if (values.decision) {
+                  setSelection({
+                    kind: 'decision',
+                    decision: toManualReviewDecision(values.decision),
+                  });
+                } else if (values.action) {
+                  setSelection({ kind: 'action', action: values.action });
+                }
+              }}
+              topLeftComponent={selection ? null : tableControls}
+              topRightComponent={
+                <div className="flex items-start gap-4 pb-8">
+                  {showControl}
+                  {filter}
+                </div>
               }
-              topLeftComponent={selectedDecision ? null : tableControls}
-              topRightComponent={<div className="pb-8">{filter}</div>}
-              isCollapsed={selectedDecision != null}
+              isCollapsed={selection != null}
               collapsedColumnTitle="Decisions"
               renderCollapsedCell={(row) => {
-                const values = row.original.values as {
-                  decisionColorNamePairs: { name: string; colors: string }[];
-                  reviewerId: string;
-                  createdAt: string | Date;
-                };
+                const values = row.original.values as NormalizedActivityRow;
 
                 return (
                   <div className="flex flex-col gap-0.5">
                     <div className="flex flex-wrap gap-1">
                       {values.decisionColorNamePairs.map(
-                        ({ name, colors }, index) => (
-                          <div
+                        ({ name, colorVariant }, index) => (
+                          <CoopBadge
                             key={index}
-                            className={`flex px-2 py-0.5 rounded font-medium text-xs ${colors}`}
-                          >
-                            {name}
-                          </div>
+                            colorVariant={colorVariant}
+                            label={name}
+                            shapeVariant="pill"
+                          />
                         ),
                       )}
                     </div>
                     <div className="text-xs font-medium text-slate-500">
-                      {getReviewerName(values.reviewerId)}
+                      {values.reviewer}
                     </div>
                     <div className="text-xs text-slate-400 whitespace-nowrap">
                       {parseDatetimeToReadableStringInCurrentTimeZone(
-                        values.createdAt,
+                        new Date(values.ts),
                       )}
                     </div>
                   </div>
@@ -1060,17 +1576,35 @@ export default function ManualReviewRecentDecisions() {
               }}
             />
 
-            {decidedJobLoading || selectedDecision ? null : (
+            {decidedJobLoading || selection ? null : (
+              // Buttons rather than bare `<svg onClick>`: these need a
+              // disabled state at the ends of the feed (a click that does
+              // nothing is indistinguishable from one that failed), and they
+              // were previously unreachable by keyboard and unnamed for
+              // assistive tech.
               <div className="flex justify-between w-full mb-10">
-                <ChevronLeft
-                  className="font-bold cursor-pointer w-7 fill-slate-500"
+                <button
+                  type="button"
+                  aria-label="Previous page"
+                  disabled={cursorStack.length === 0 || activityLoading}
                   onClick={() => handlePrevious()}
-                />
-                <span>Page {page + 1}</span>
-                <ChevronRight
-                  className="font-bold cursor-pointer w-7 fill-slate-500"
+                  className="bg-transparent border-none cursor-pointer disabled:cursor-default disabled:opacity-40"
+                >
+                  <ChevronLeft className="font-bold w-7 fill-slate-500" />
+                </button>
+                <span>Page {cursorStack.length + 1}</span>
+                <button
+                  type="button"
+                  aria-label="Next page"
+                  disabled={
+                    !activityData?.recentModerationActivity.nextCursor ||
+                    activityLoading
+                  }
                   onClick={() => handleNext()}
-                />
+                  className="bg-transparent border-none cursor-pointer disabled:cursor-default disabled:opacity-40"
+                >
+                  <ChevronRight className="font-bold w-7 fill-slate-500" />
+                </button>
               </div>
             )}
           </div>
@@ -1084,7 +1618,7 @@ export default function ManualReviewRecentDecisions() {
                 selectedDecision={selectedDecision}
                 showCloseButton={true}
                 closeButtonOnClick={() => {
-                  setSelectedDecision(undefined);
+                  setSelection(undefined);
                   navigate(`/dashboard/manual_review/recent/`, {
                     replace: true,
                   });
@@ -1118,6 +1652,23 @@ export default function ManualReviewRecentDecisions() {
                   />
                 </div>
               ) : null}
+            </div>
+          ) : selectedAction ? (
+            <div className="flex flex-col items-start w-full h-full p-3 mb-4 ml-3 border border-r-0 border-solid rounded border-slate-200">
+              <ManualActionItemsPanel
+                correlationId={selectedAction.correlationId}
+                occurredAt={selectedAction.ts}
+                actionNames={getActionColorNamePairs(
+                  selectedAction.actionIds,
+                ).map(({ name }) => name)}
+                reviewerName={getReviewerName(selectedAction.reviewerId)}
+                onClose={() => {
+                  setSelection(undefined);
+                  navigate(`/dashboard/manual_review/recent/`, {
+                    replace: true,
+                  });
+                }}
+              />
             </div>
           ) : null}
         </div>

--- a/client/src/webpages/dashboard/mrt/moderationActivityCsv.test.ts
+++ b/client/src/webpages/dashboard/mrt/moderationActivityCsv.test.ts
@@ -1,0 +1,62 @@
+import { buildActivityCsv, type CsvRow } from './moderationActivityCsv';
+
+const decisionRow: CsvRow = {
+  origin: 'Review Job',
+  outcome: ['Ban user'],
+  policies: ['Spam'],
+  reviewer: 'jane@example.com',
+  queue: 'Appeals',
+  time: '2026-08-05 13:58:00 UTC',
+  reason: 'repeat offender',
+  itemCount: null,
+  failedCount: null,
+  link: 'https://example.com/job/1',
+};
+
+const actionRow: CsvRow = {
+  origin: 'Manual Action',
+  outcome: ['Ban user'],
+  policies: [],
+  reviewer: 'sam@example.com',
+  queue: '',
+  time: '2026-08-05 13:51:00 UTC',
+  reason: null,
+  itemCount: 84,
+  failedCount: 3,
+  link: '',
+};
+
+describe('buildActivityCsv', () => {
+  it('keeps the original columns for a decisions-only export', () => {
+    // Existing tooling parses this file; adding columns unconditionally would
+    // break it.
+    const csv = buildActivityCsv([decisionRow], false);
+
+    expect(csv.split('\n')[0]).toBe(
+      '"Decisions","Policies","Reviewer","Queue","Decision Time","Decision Reason","Link"',
+    );
+  });
+
+  it('adds Origin, Items and Failed when actions are included', () => {
+    const csv = buildActivityCsv([decisionRow, actionRow], true);
+
+    expect(csv.split('\n')[0]).toBe(
+      '"Origin","Decisions","Policies","Reviewer","Queue","Decision Time","Decision Reason","Items","Failed","Link"',
+    );
+  });
+
+  it('escapes quotes and neutralizes spreadsheet formulas', () => {
+    const csv = buildActivityCsv(
+      [{ ...decisionRow, reason: '=cmd|"/c calc"!A1' }],
+      false,
+    );
+
+    expect(csv).toContain('\'=cmd|""/c calc""!A1');
+  });
+
+  it('leaves the failed column blank when nothing failed', () => {
+    const csv = buildActivityCsv([{ ...actionRow, failedCount: 0 }], true);
+
+    expect(csv.split('\n')[1]).toContain(',"84","",');
+  });
+});

--- a/client/src/webpages/dashboard/mrt/moderationActivityCsv.ts
+++ b/client/src/webpages/dashboard/mrt/moderationActivityCsv.ts
@@ -1,0 +1,72 @@
+export type CsvRow = {
+  origin: 'Review Job' | 'Manual Action';
+  outcome: string[];
+  policies: string[];
+  reviewer: string;
+  queue: string;
+  time: string;
+  reason: string | null;
+  itemCount: number | null;
+  failedCount: number | null;
+  link: string;
+};
+
+/**
+ * Escape per RFC 4180 and neutralize spreadsheet formula injection. A leading
+ * =, +, - or @ is prefixed with an apostrophe so Excel treats it as text.
+ * This is a moderation audit log; a decision reason is free text a moderator
+ * typed, so it can't be trusted not to look like a formula.
+ *
+ * Exported so the skips CSV export (which isn't built from `CsvRow`s — it
+ * pages a different, offset-based query — see `ManualReviewRecentDecisions`)
+ * can format its fields the same way rather than duplicating this logic.
+ */
+export function escapeCsvField(value: string): string {
+  const neutralized = /^[=+\-@]/.test(value) ? `'${value}` : value;
+  return `"${neutralized.replace(/"/g, '""')}"`;
+}
+
+/**
+ * Column layout follows the Show control. A decisions-only export keeps the
+ * original column set (`Decisions, Policies, Reviewer, Queue, Decision Time,
+ * Decision Reason, Link`) so existing downstream tooling that parses this
+ * file is unaffected. `Origin`, `Items` and `Failed` only appear once actions
+ * are mixed into the export.
+ */
+export function buildActivityCsv(
+  rows: readonly CsvRow[],
+  includeActions: boolean,
+): string {
+  const headers = [
+    ...(includeActions ? ['Origin'] : []),
+    'Decisions',
+    'Policies',
+    'Reviewer',
+    'Queue',
+    'Decision Time',
+    'Decision Reason',
+    ...(includeActions ? ['Items', 'Failed'] : []),
+    'Link',
+  ];
+
+  const body = rows.map((row) => [
+    ...(includeActions ? [row.origin] : []),
+    JSON.stringify(row.outcome),
+    JSON.stringify(row.policies),
+    row.reviewer,
+    row.queue,
+    row.time,
+    row.reason ?? '',
+    ...(includeActions
+      ? [
+          row.itemCount === null ? '' : String(row.itemCount),
+          row.failedCount ? String(row.failedCount) : '',
+        ]
+      : []),
+    row.link,
+  ]);
+
+  return [headers, ...body]
+    .map((line) => line.map(escapeCsvField).join(','))
+    .join('\n');
+}

--- a/docs/user/bulk-actioning.md
+++ b/docs/user/bulk-actioning.md
@@ -33,3 +33,14 @@ For routine moderation, prefer queue review, which gives reviewers per-item cont
 ## Logging
 
 Bulk actions appear in the **Recent Decisions** log alongside queue-based decisions, so there is a full audit trail of what was actioned, by whom, and under which policies.
+
+Use the **Show** control there to switch between all activity, queue decisions only, or manual actions only. The **Origin** column marks where each row came from — `Review Job` for a queue decision, `Manual Action` for anything taken from Bulk Actioning or Investigation.
+
+A few things specific to manual action rows:
+
+- Each bulk run is **one row**, not one per item, with a count of the items it touched. Expand the row to see every item the run touched, with failures marked.
+- If any action failed to reach your platform, the row shows how many failed. The failure reason is not recorded.
+- Manual actions have no queue and no decision type, so applying a **Queue** or **decision-type** filter switches the log's Show control to `Decisions` and explains why. Clearing the filter restores your previous view.
+- Manual actions are **not** filtered by child-safety permissions — unlike review-job decisions on NCMEC jobs, which stay restricted to reviewers with the child-safety permission.
+- When manual actions are included, the log only covers a bounded recent window; switch to `Decisions` for unbounded history.
+- The **Download** button exports whatever the Show control is set to. A decisions-only export keeps the original columns, so existing tooling is unaffected.

--- a/docs/user/investigation.md
+++ b/docs/user/investigation.md
@@ -19,6 +19,8 @@ You can take action on an item directly from Investigation without being in a re
 
 This is useful for acting on content outside of a normal review flow, for example when investigating a user after receiving a report through another channel, or taking a follow-up action after an earlier decision.
 
+Actions taken here are recorded in the [Recent Decisions](metrics.md#recent-decisions) log alongside queue decisions, marked `Manual Action` in the **Origin** column, so supervisors can see work done outside a review queue.
+
 ## Reversing an action
 
 Coop has no built-in undo. To reverse an action (like unbanning a user), you need a custom action in Settings that calls your platform's reverse endpoint, for example an "Unban user" action that calls your platform's unban API.

--- a/docs/user/metrics.md
+++ b/docs/user/metrics.md
@@ -28,9 +28,23 @@ The Overview dashboard gives a high-level picture of moderation activity. All me
 
 Visit **Review Console** → **Recent Decisions** to review every action taken in Coop: who made the decision, on what content, and when. You can click through to the full job from any entry to investigate further or take an additional action.
 
+The log covers two kinds of work, told apart by the **Origin** column:
+
+- **Review Job** — a moderator resolved a job in a review queue.
+- **Manual Action** — a moderator acted outside a queue, from [Bulk Actioning](bulk-actioning.md) or [Investigation](investigation.md).
+
+Use the **Show** control to view all activity, queue decisions only, or manual actions only. Manual actions differ from decisions in a few ways worth knowing:
+
+- A bulk run appears as **one row** with a count of the items it touched, not one row per item. Expand the row to list every item the run touched, with failures marked.
+- Rows show how many items an action failed on, if any. This is the only place execution failures surface — a decision is recorded even when the actions it names never reached your platform. The failure reason is not recorded.
+- Manual actions have no queue and no decision type. Applying a **Queue** or **decision-type** filter switches **Show** to `Decisions` and explains why, since neither filter can match a manual action. Clearing the filter restores whichever view you had chosen before.
+- When actions are included in the feed, coverage is limited to a bounded recent window (the last 30 days). Switch **Show** to `Decisions` for the full, unbounded history — don't read an empty stretch further back as "nothing happened."
+
+Manual actions are **not** filtered by child-safety permissions, and the log says so while they're shown. Review-job decisions on NCMEC jobs remain restricted to reviewers with the child-safety permission.
+
 ![Recent Decisions being filtered](../images/recent-decisions-filter.png)
 
-The log can be downloaded in its entirety, or filtered according to decisions, policies, queues, moderators and date ranges and then downloaded. This makes it particularly useful for:
+The log can be downloaded in its entirety, or filtered according to decisions, policies, queues, moderators and date ranges and then downloaded. The export follows the **Show** control, so a decisions-only download keeps the original columns. This makes it particularly useful for:
 
 - **Transparency reporting**: export decisions to include in reports to regulators or oversight bodies
 


### PR DESCRIPTION
## Context & Requests for Reviewers

Last of four for #386.

Recent Decisions now shows queue decisions and manual actions in one list, with an Origin column telling them apart.

A control switches between All, Decisions and Actions. A bulk run is one row with item and failure counts. The side panel lists every item and failures marked. Filtering by queue or decision type flips Show to Decisions and says why.

## Tests

224 tests across 34 files.

<img width="3008" height="1512" alt="multiday-run-count-mismatch" src="https://github.com/user-attachments/assets/45fad96d-faef-439c-b604-ce10f3466394" />
<img width="1280" height="1512" alt="narrow-viewport" src="https://github.com/user-attachments/assets/112adc7e-28d1-4837-b7ed-7fd1b522a070" />

<img width="3008" height="1512" alt="panel-error-kills-whole-page" src="https://github.com/user-attachments/assets/72d4ddc8-082b-416a-8f06-a0b4be389de2" />
<img width="3008" height="1512" alt="queue-filter-forces-decisions" src="https://github.com/user-attachments/assets/351650c6-c03c-4009-bd3a-613770eb1162" />

<img width="3008" height="1512" alt="05-show-actions-only" src="https://github.com/user-attachments/assets/a730bb7f-7de1-41cd-8a49-803389bb58b1" />

<img width="3008" height="1512" alt="30day-window-drops-action" src="https://github.com/user-attachments/assets/3e561c72-ead2-4f1b-b90c-85161654885a" />
<img width="3008" height="1512" alt="baseline" src="https://github.com/user-attachments/assets/77e5d7a6-caaa-4c20-8a30-85c0c894bdf2" />
<img width="3008" height="1512" alt="bulk250-truncated-failures" src="https://github.com/user-attachments/assets/c202f0f2-0835-43ca-a533-671a2a383eff" />
<img width="3008" height="1512" alt="decision-panel-crash-repeat" src="https://github.com/user-attachments/assets/70550ad3-e600-4227-a6e2-6b0e88806346" />

<img width="3008" height="1512" alt="01-merged-feed-interleaved" src="https://github.com/user-attachments/assets/a7a869dd-9593-4bab-b952-955cc8ee0290" />
<img width="3008" height="1512" alt="02-side-panel-item-list" src="https://github.com/user-attachments/assets/3f0784ac-e826-47af-b91b-af0f42b63e88" />
<img width="3008" height="1512" alt="03-queue-filter-selected" src="https://github.com/user-attachments/assets/9261014a-1951-4f77-8ebf-2e189c30c820" />
<img width="3008" height="1512" alt="04-filter-flip-applied" src="https://github.com/user-attachments/assets/d6f22f2a-5ba7-4af9-a78b-faf5a4088225" />
