### PR TITLE
Handle zeros in table filtering

### DIFF
--- a/client/src/webpages/dashboard/components/table/Table.test.tsx
+++ b/client/src/webpages/dashboard/components/table/Table.test.tsx
@@ -549,4 +549,52 @@ describe('Table behavior', () => {
     expect(screen.getByText('Boundary score')).toBeTruthy();
     expect(screen.getByText('High score')).toBeTruthy();
   });
+
+  it('applies zero-valued lower and upper numeric range bounds', () => {
+    type NumericRow = {
+      score: ReactNode;
+      values: { score: number };
+    };
+    const numericData: NumericRow[] = [
+      { score: <span>Negative score</span>, values: { score: -1 } },
+      { score: <span>Zero score</span>, values: { score: 0 } },
+      { score: <span>Positive score</span>, values: { score: 1 } },
+    ];
+    const numericColumns = [
+      {
+        header: 'Score',
+        accessorKey: 'score',
+        cell: ({ getValue }): ReactNode => getValue<ReactNode>(),
+        meta: {
+          filter: (props: ColumnProps<NumericRow>) =>
+            NumberRangeColumnFilter({
+              columnProps: props,
+              accessor: 'score',
+            }),
+        },
+        filterFn: 'range',
+      },
+    ] satisfies TableColumnDef<NumericRow>[];
+    render(
+      <MemoryRouter>
+        <Table columns={numericColumns} data={numericData} />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /filter/i }));
+    const filterMenu = screen
+      .getByRole('button', { name: 'Save' })
+      .closest<HTMLElement>('.absolute')!;
+    fireEvent.click(within(filterMenu).getByText('Score'));
+    fireEvent.change(screen.getByPlaceholderText('min'), {
+      target: { value: '0' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('max'), {
+      target: { value: '0' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(screen.queryByText('Negative score')).toBeNull();
+    expect(screen.getByText('Zero score')).toBeTruthy();
+    expect(screen.queryByText('Positive score')).toBeNull();
+  });
 });

--- a/client/src/webpages/dashboard/components/table/filters.tsx
+++ b/client/src/webpages/dashboard/components/table/filters.tsx
@@ -67,10 +67,10 @@ export function getFilterTypes() {
       const start = filterValue[0];
       const end = filterValue[1];
       const rowValue = raw(row, id);
-      if (start && start > rowValue) {
+      if (start != null && start > rowValue) {
         return false;
       }
-      if (end && end < rowValue) {
+      if (end != null && end < rowValue) {
         return false;
       }
       return true;


### PR DESCRIPTION
## Context & Requests for Reviewers

This fixes a bug found by CodeRabbit. Our table numeric filtering didn't work for zeros. Now it does.

## Tests

See the test.

## (Optional) Rollout Plan

N/A

## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] ~~**If you changed anything user-facing** (i.e. user interface or APIs):~~
  Did you update the CHANGELOG.md and related docs?

- [ ] ~~**If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**~~
  Did you update the corresponding history tables and their triggers?

- [ ] ~~**If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**~~
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?

- [ ] ~~**If you added a new signal in `server/services/signalsService/signals/**`:**~~
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Numeric range filters now correctly apply lower and upper bounds set to zero.
  - Filtering results no longer incorrectly include negative or positive values when zero is specified as a boundary.

- **Tests**
  - Added coverage verifying that zero-valued minimum and maximum range filters return only matching zero values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->