### PR TITLE
Handle filters for removed table columns

### DIFF
--- a/client/src/webpages/dashboard/components/table/Table.test.tsx
+++ b/client/src/webpages/dashboard/components/table/Table.test.tsx
@@ -349,6 +349,54 @@ describe('Table behavior', () => {
     expectAllRowsVisible();
   });
 
+  it('prunes staged filters when their columns are removed', () => {
+    const nameColumn = {
+      ...columns[0],
+      meta: { filter: filterFor('name', 'Filter names') },
+      filterFn: 'text',
+    } satisfies TableColumnDef<TableRow>;
+    const statusColumn = {
+      ...columns[1],
+      meta: { filter: filterFor('status', 'Filter statuses') },
+      filterFn: 'text',
+    } satisfies TableColumnDef<TableRow>;
+    const { rerender } = renderTable([nameColumn, statusColumn]);
+
+    fireEvent.click(screen.getByRole('button', { name: /filter/i }));
+    const filterMenu = screen
+      .getByRole('button', { name: 'Save' })
+      .closest<HTMLElement>('.absolute');
+    expect(filterMenu).not.toBeNull();
+    fireEvent.click(within(filterMenu!).getByText('Name'));
+    fireEvent.change(screen.getByPlaceholderText('Filter names'), {
+      target: { value: 'alp' },
+    });
+
+    rerender(
+      <MemoryRouter>
+        <Table columns={[statusColumn]} data={data} />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    rerender(
+      <MemoryRouter>
+        <Table columns={[nameColumn, statusColumn]} data={data} />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /filter/i }));
+    const restoredFilterMenu = screen
+      .getByRole('button', { name: 'Save' })
+      .closest<HTMLElement>('.absolute');
+    expect(restoredFilterMenu).not.toBeNull();
+    if (!screen.queryByPlaceholderText('Filter names')) {
+      fireEvent.click(within(restoredFilterMenu!).getByText('Name'));
+    }
+    expect(
+      (screen.getByPlaceholderText('Filter names') as HTMLInputElement).value,
+    ).toBe('');
+  });
+
   it('renders links and selects a clicked row using its raw data', () => {
     const onSelectRow = vi.fn();
     renderTable(columns, {

--- a/client/src/webpages/dashboard/components/table/Table.test.tsx
+++ b/client/src/webpages/dashboard/components/table/Table.test.tsx
@@ -393,7 +393,7 @@ describe('Table behavior', () => {
       fireEvent.click(within(restoredFilterMenu!).getByText('Name'));
     }
     expect(
-      (screen.getByPlaceholderText('Filter names') as HTMLInputElement).value,
+      screen.getByPlaceholderText<HTMLInputElement>('Filter names').value,
     ).toBe('');
   });
 

--- a/client/src/webpages/dashboard/components/table/TableFilter.tsx
+++ b/client/src/webpages/dashboard/components/table/TableFilter.tsx
@@ -72,10 +72,17 @@ export default function TableFilter<TData extends TableData>(props: {
   };
 
   const onSave = () => {
+    const missingColumnIds: string[] = [];
     for (const [columnId, value] of Object.entries(unsavedFilterValues)) {
-      filterColumns
-        .find((column) => column.id === columnId)!
-        .setFilterValue(value);
+      const column = filterColumns.find((column) => column.id === columnId);
+      if (!column) {
+        missingColumnIds.push(columnId);
+        continue;
+      }
+      column.setFilterValue(value);
+    }
+    if (missingColumnIds.length > 0) {
+      setUnsavedFilterValues(omit(unsavedFilterValues, missingColumnIds));
     }
     setMenuVisible(false);
   };
@@ -92,9 +99,10 @@ export default function TableFilter<TData extends TableData>(props: {
 
   const removeFilter = (columnId: string) => {
     setUnsavedFilterValues(omit(unsavedFilterValues, columnId));
-    filterColumns
-      .find((column) => column.id === columnId)!
-      .setFilterValue(undefined);
+    const column = filterColumns.find((column) => column.id === columnId);
+    if (column) {
+      column.setFilterValue(undefined);
+    }
   };
 
   const activeFilters = filterColumns.filter((column) =>


### PR DESCRIPTION
## Context & Requests for Reviewers

This PR fixes a kind of niche bug that CodeRabbit found. To repro it:

- Click "Filter" on a table and start entering a value, but don't hit Save
- Click "Columns" while the filter menu remains open
- Uncheck the column you started writing a filter for
- Click "Save" in the filter menu

Before, this would crash. No more.

I'm unsure if this is worth the added complexity. What do you think?

## Tests

Manually tested.

## (Optional) Rollout Plan

N/A

## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] ~~**If you changed anything user-facing** (i.e. user interface or APIs):~~
  Did you update the CHANGELOG.md and related docs?

- [ ] ~~**If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**~~
  Did you update the corresponding history tables and their triggers?

- [ ] ~~**If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**~~
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?

- [ ] ~~**If you added a new signal in `server/services/signalsService/signals/**`:**~~
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.