### PR TITLE
Fix sorting some tables by queue name

### DIFF
--- a/client/src/webpages/dashboard/components/table/Table.test.tsx
+++ b/client/src/webpages/dashboard/components/table/Table.test.tsx
@@ -349,6 +349,54 @@ describe('Table behavior', () => {
     expectAllRowsVisible();
   });
 
+  it('prunes staged filters when their columns are removed', () => {
+    const nameColumn = {
+      ...columns[0],
+      meta: { filter: filterFor('name', 'Filter names') },
+      filterFn: 'text',
+    } satisfies TableColumnDef<TableRow>;
+    const statusColumn = {
+      ...columns[1],
+      meta: { filter: filterFor('status', 'Filter statuses') },
+      filterFn: 'text',
+    } satisfies TableColumnDef<TableRow>;
+    const { rerender } = renderTable([nameColumn, statusColumn]);
+
+    fireEvent.click(screen.getByRole('button', { name: /filter/i }));
+    const filterMenu = screen
+      .getByRole('button', { name: 'Save' })
+      .closest<HTMLElement>('.absolute');
+    expect(filterMenu).not.toBeNull();
+    fireEvent.click(within(filterMenu!).getByText('Name'));
+    fireEvent.change(screen.getByPlaceholderText('Filter names'), {
+      target: { value: 'alp' },
+    });
+
+    rerender(
+      <MemoryRouter>
+        <Table columns={[statusColumn]} data={data} />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    rerender(
+      <MemoryRouter>
+        <Table columns={[nameColumn, statusColumn]} data={data} />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /filter/i }));
+    const restoredFilterMenu = screen
+      .getByRole('button', { name: 'Save' })
+      .closest<HTMLElement>('.absolute');
+    expect(restoredFilterMenu).not.toBeNull();
+    if (!screen.queryByPlaceholderText('Filter names')) {
+      fireEvent.click(within(restoredFilterMenu!).getByText('Name'));
+    }
+    expect(
+      (screen.getByPlaceholderText('Filter names') as HTMLInputElement).value,
+    ).toBe('');
+  });
+
   it('renders links and selects a clicked row using its raw data', () => {
     const onSelectRow = vi.fn();
     renderTable(columns, {

--- a/client/src/webpages/dashboard/components/table/Table.test.tsx
+++ b/client/src/webpages/dashboard/components/table/Table.test.tsx
@@ -393,7 +393,7 @@ describe('Table behavior', () => {
       fireEvent.click(within(restoredFilterMenu!).getByText('Name'));
     }
     expect(
-      (screen.getByPlaceholderText('Filter names') as HTMLInputElement).value,
+      screen.getByPlaceholderText<HTMLInputElement>('Filter names').value,
     ).toBe('');
   });
 

--- a/client/src/webpages/dashboard/components/table/TableFilter.tsx
+++ b/client/src/webpages/dashboard/components/table/TableFilter.tsx
@@ -72,10 +72,17 @@ export default function TableFilter<TData extends TableData>(props: {
   };
 
   const onSave = () => {
+    const missingColumnIds: string[] = [];
     for (const [columnId, value] of Object.entries(unsavedFilterValues)) {
-      filterColumns
-        .find((column) => column.id === columnId)!
-        .setFilterValue(value);
+      const column = filterColumns.find((column) => column.id === columnId);
+      if (!column) {
+        missingColumnIds.push(columnId);
+        continue;
+      }
+      column.setFilterValue(value);
+    }
+    if (missingColumnIds.length > 0) {
+      setUnsavedFilterValues(omit(unsavedFilterValues, missingColumnIds));
     }
     setMenuVisible(false);
   };
@@ -92,9 +99,10 @@ export default function TableFilter<TData extends TableData>(props: {
 
   const removeFilter = (columnId: string) => {
     setUnsavedFilterValues(omit(unsavedFilterValues, columnId));
-    filterColumns
-      .find((column) => column.id === columnId)!
-      .setFilterValue(undefined);
+    const column = filterColumns.find((column) => column.id === columnId);
+    if (column) {
+      column.setFilterValue(undefined);
+    }
   };
 
   const activeFilters = filterColumns.filter((column) =>

--- a/client/src/webpages/dashboard/mrt/ManualReviewQueueSorting.test.tsx
+++ b/client/src/webpages/dashboard/mrt/ManualReviewQueueSorting.test.tsx
@@ -1,0 +1,118 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { HelmetProvider } from 'react-helmet-async';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ManualReviewCurrentJobsComponent from './manual_review_job/v2/user/ManualReviewJobCurrentJobsComponent';
+import ManualReviewRecentDecisions from './ManualReviewRecentDecisions';
+
+const queues = [
+  { id: 'queue-zulu', name: 'Zulu' },
+  { id: 'queue-alpha', name: 'Alpha' },
+  { id: 'queue-mike', name: 'Mike' },
+];
+
+const recentDecisions = queues.map((queue, index) => ({
+  __typename: 'ManualReviewDecision',
+  id: `decision-${index}`,
+  jobId: `job-${index}`,
+  queueId: queue.id,
+  reviewerId: null,
+  itemId: `item-${index}`,
+  itemTypeId: 'user',
+  decisions: [{ __typename: 'IgnoreDecisionComponent', type: 'IGNORE' }],
+  relatedActions: [],
+  createdAt: `2026-08-${18 - index}T12:00:00.000Z`,
+  decisionReason: null,
+}));
+
+const getRecentDecisions = vi.fn();
+
+vi.mock('../../../graphql/generated', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../graphql/generated')>()),
+  useGQLGetExistingJobsForItemQuery: () => ({
+    loading: false,
+    data: {
+      getExistingJobsForItem: queues.map((queue, index) => ({
+        queueId: queue.id,
+        job: { createdAt: `2026-08-${18 - index}T12:00:00.000Z` },
+      })),
+      myOrg: { mrtQueues: queues },
+    },
+  }),
+  useGQLOrgLookupDataQuery: () => ({
+    data: {
+      myOrg: { actions: [], policies: [], users: [], mrtQueues: queues },
+    },
+  }),
+  useGQLGetDecidedJobFromJobIdQuery: () => ({ data: undefined }),
+  useGQLGetRecentDecisionsLazyQuery: () => [
+    getRecentDecisions,
+    {
+      loading: false,
+      error: undefined,
+      data: { getRecentDecisions: recentDecisions },
+    },
+  ],
+  useGQLGetSkipsForRecentDecisionsLazyQuery: () => [vi.fn()],
+  useGQLGetDecidedJobLazyQuery: () => [
+    vi.fn(),
+    { loading: false, error: undefined, data: undefined },
+  ],
+}));
+
+vi.mock('./ManualReviewRecentDecisionsFilter', () => ({
+  default: () => null,
+}));
+
+function queueNames() {
+  const header = screen.getByRole('columnheader', { name: /Queue/ });
+  const headers = screen.getAllByRole('columnheader');
+  const queueColumnIndex = headers.indexOf(header);
+  return within(screen.getAllByRole('rowgroup')[1])
+    .getAllByRole('row')
+    .map(
+      (row) => within(row).getAllByRole('cell')[queueColumnIndex].textContent,
+    );
+}
+
+function expectQueueSorting() {
+  const queueHeader = screen.getByRole('columnheader', { name: /Queue/ });
+
+  expect(queueNames()).toEqual(['Zulu', 'Alpha', 'Mike']);
+  fireEvent.click(queueHeader);
+  expect(queueNames()).toEqual(['Zulu', 'Mike', 'Alpha']);
+  fireEvent.click(queueHeader);
+  expect(queueNames()).toEqual(['Alpha', 'Mike', 'Zulu']);
+}
+
+describe('manual review queue sorting', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    getRecentDecisions.mockClear();
+  });
+
+  it('sorts current jobs by the rendered queue name', () => {
+    render(
+      <MemoryRouter>
+        <ManualReviewCurrentJobsComponent
+          userIdentifier={{ id: 'user-1', typeId: 'user' }}
+        />
+      </MemoryRouter>,
+    );
+
+    expectQueueSorting();
+  });
+
+  it('sorts recent decisions by the rendered queue name', () => {
+    render(
+      <HelmetProvider>
+        <MemoryRouter>
+          <ManualReviewRecentDecisions />
+        </MemoryRouter>
+      </HelmetProvider>,
+    );
+
+    expectQueueSorting();
+  });
+});

--- a/client/src/webpages/dashboard/mrt/ManualReviewRecentDecisions.tsx
+++ b/client/src/webpages/dashboard/mrt/ManualReviewRecentDecisions.tsx
@@ -421,6 +421,7 @@ export default function ManualReviewRecentDecisions() {
               header: 'Queue',
               accessorKey: 'queue',
               enableSorting: true,
+              sortFn: stringSort,
             }
           : undefined,
       ]),

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobCurrentJobsComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobCurrentJobsComponent.tsx
@@ -50,6 +50,7 @@ export default function ManualReviewCurrentJobsComponent(props: {
         header: 'Queue',
         accessorKey: 'queue',
         enableSorting: true,
+        sortFn: stringSort,
       },
       {
         header: 'Created At',


### PR DESCRIPTION
## Context & Requests for Reviewers

This fixes sorting in our recent-decisions table and the existing-jobs-for-this-user tables. Before, it would sort the Queue column by a rendered element (which doesn't work). Now it sorts by the actual queue name.

## Tests

See diff.

## (Optional) Rollout Plan

N/A

## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] ~~**If you changed anything user-facing** (i.e. user interface or APIs):~~
  Did you update the CHANGELOG.md and related docs?

- [ ] ~~**If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**~~
  Did you update the corresponding history tables and their triggers?

- [ ] ~~**If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**~~
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?

- [ ] ~~**If you added a new signal in `server/services/signalsService/signals/**`:**~~
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.