### PR TITLE
Update default code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # Format: path-pattern @username @org/team-name
 
 # Maintainers: Default owners for all files
-* @juanmrad @vinaysrao1 @cassidyjames @julietshen @dom-notion
+* @roostorg/community @julietshen
 
 # Docs contributors
 docs/ @roostorg/roosters


### PR DESCRIPTION
This is just a suggestion! The current default reviewers from PRs come from our CODEOWNERS file, but it's not quite up to date.

Open to alternative ideas!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership assignments for default file reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->