### PR TITLE
Fix scylla healthcheck to probe CQL readiness, not just gossip

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -93,7 +93,16 @@ services:
     ports:
       - '9042:9042'
     healthcheck:
-      test: ['CMD-SHELL', 'nodetool status || exit 1']
+      # nodetool status only confirms gossip is up, not that the CQL port
+      # (9042) is accepting and completing queries yet — that gap lets
+      # dependents (e.g. db:create/db:update via cassandra-driver) connect
+      # before Scylla is actually ready, causing timeouts even though
+      # Compose reports the container healthy.
+      test:
+        [
+          'CMD-SHELL',
+          'cqlsh -e "SELECT release_version FROM system.local" || exit 1',
+        ]
       interval: 5s
       timeout: 5s
       retries: 28


### PR DESCRIPTION
The existing healthcheck uses nodetool status, which only confirms gossip is up, not that the CQL port (9042) is accepting and completing queries. That gap let dependents (db:create/db:update via cassandra-driver) connect before Scylla was actually ready, causing connection timeouts even though Compose reported the container healthy.

I've only tested to confirm it works, but the original bug was a race condition that only occurred sporadically, so tricky to confirm it's really gone. But this should be a strict improvement anyways.

Note: this is actually what we already do in docker-compose.images.yaml, assume we just forgot to copy it back to docker-compose.yaml.

## Tests

Booted up a couple of dev workspace instances and confirmed that everything came up fine.

## Checklist

None apply, leaving unchecked.

- [ ] **If you changed anything user-facing** (i.e. user interface or APIs):
  Did you update the CHANGELOG.md and related docs?

- [ ] **If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**
  Did you update the corresponding history tables and their triggers?

- [ ] **If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?

- [ ] **If you added a new signal in `server/services/signalsService/signals/**`:**
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Scylla health monitoring by validating database connectivity with a CQL query.
  * Health checks now report failure when the database query cannot be completed successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->