### PR TITLE
Issue templates: update forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       value: >
         Thanks for taking the time to report a bug in Coop! **Please provide as
-        much detail as you can** so we can properly confirm, triage, and
+        much detail as you can below** so we can properly confirm, triage, and
         ultimately fix your bug.
 
   - type: textarea
@@ -49,7 +49,9 @@ body:
     attributes:
       label: Relevant logs/errors
       description: >
-        Please paste any relevant log output or error messages.
+        Please paste any relevant log output or error messages. **Redact sensitive
+        information** such as passwords, API keys, tokens, and personal data before
+        submitting.
       render: shell
     validations:
       required: false
@@ -75,6 +77,7 @@ body:
         [acceptable use policies](https://docs.github.com/en/site-policy/acceptable-use-policies).
     validations:
       required: false
+      accept: ".png,.jpg,.jpeg,.gif,.svg,.webp"
 
   - type: checkboxes
     id: checklist

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -77,7 +77,7 @@ body:
         [acceptable use policies](https://docs.github.com/en/site-policy/acceptable-use-policies).
     validations:
       required: false
-      accept: ".png,.jpg,.jpeg,.gif,.svg,.webp"
+      accept: '.png,.jpg,.jpeg,.gif,.svg,.webp'
 
   - type: checkboxes
     id: checklist

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -61,6 +61,7 @@ body:
         [acceptable use policies](https://docs.github.com/en/site-policy/acceptable-use-policies).
     validations:
       required: false
+      accept: '.png,.jpg,.jpeg,.gif,.svg,.webp'
 
   - type: checkboxes
     id: checklist


### PR DESCRIPTION
Remind to redact sensitive info from logs, and actually only accept image files for screenshots. Inspired by https://github.com/roostorg/osprey/pull/430.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the bug report form to request more detailed information.
  * Added guidance to remove sensitive data from logs and error messages.
  * Limited screenshot uploads to supported image formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->