### PR TITLE
Fix rule history startDate filter dropping other rules' versions

### DIFF
--- a/server/services/reportingService/reportingRuleHistoryHelpers.test.ts
+++ b/server/services/reportingService/reportingRuleHistoryHelpers.test.ts
@@ -1,0 +1,56 @@
+import { getSimplifiedRuleHistory } from './reportingRuleHistoryHelpers.js';
+
+describe('reporting getSimplifiedRuleHistory', () => {
+  test('filters startDate per rule and returns retained versions chronologically', async () => {
+    const mockGetRawHistory = async () => [
+      {
+        id: 'old-seed',
+        name: 'Old seed',
+        exactVersion: '2025-12-09 15:40:32.761966+00',
+      },
+      {
+        id: 'new-rule',
+        name: 'New rule',
+        exactVersion: '2026-08-10 00:00:00.000000+00',
+      },
+      {
+        id: 'old-seed',
+        name: 'Updated seed',
+        exactVersion: '2026-08-20 00:00:00.000000+00',
+      },
+      {
+        id: 'new-rule',
+        name: 'Updated new rule',
+        exactVersion: '2026-08-22 00:00:00.000000+00',
+      },
+    ];
+
+    const result = await getSimplifiedRuleHistory(
+      mockGetRawHistory,
+      ['name'],
+      undefined,
+      new Date('2026-08-15T00:00:00.000Z'),
+    );
+
+    expect(
+      result.map(({ id, exactVersion }) => ({ id, exactVersion })),
+    ).toEqual([
+      {
+        id: 'old-seed',
+        exactVersion: '2025-12-09 15:40:32.761966+00',
+      },
+      {
+        id: 'new-rule',
+        exactVersion: '2026-08-10 00:00:00.000000+00',
+      },
+      {
+        id: 'old-seed',
+        exactVersion: '2026-08-20 00:00:00.000000+00',
+      },
+      {
+        id: 'new-rule',
+        exactVersion: '2026-08-22 00:00:00.000000+00',
+      },
+    ]);
+  });
+});

--- a/server/services/reportingService/reportingRuleHistoryHelpers.ts
+++ b/server/services/reportingService/reportingRuleHistoryHelpers.ts
@@ -103,8 +103,8 @@ export async function getSimplifiedRuleHistory<K extends VersionedField>(
   // "Version in effect at startDate, plus later versions" is per rule. The
   // raw list is every rule concatenated; applying the neighbor check globally
   // drops a rule whose next *row* belongs to a different, older rule.
-  return Object.values(_.groupBy(allVersions, (it) => it.id)).flatMap(
-    (versions) => {
+  return Object.values(_.groupBy(allVersions, (it) => it.id))
+    .flatMap((versions) => {
       const ordered = [...versions].sort(
         (a, b) => a.approxVersion.getTime() - b.approxVersion.getTime(),
       );
@@ -112,8 +112,8 @@ export async function getSimplifiedRuleHistory<K extends VersionedField>(
         (_, i) =>
           i === ordered.length - 1 || ordered[i + 1].approxVersion > startDate,
       );
-    },
-  );
+    })
+    .sort((a, b) => a.approxVersion.getTime() - b.approxVersion.getTime());
 }
 
 /**

--- a/server/services/reportingService/reportingRuleHistoryHelpers.ts
+++ b/server/services/reportingService/reportingRuleHistoryHelpers.ts
@@ -96,21 +96,24 @@ export async function getSimplifiedRuleHistory<K extends VersionedField>(
     approxVersion: new Date(it.exactVersion),
   }));
 
-  return startDate
-    ? allVersions.filter(
+  if (!startDate) {
+    return allVersions;
+  }
+
+  // "Version in effect at startDate, plus later versions" is per rule. The
+  // raw list is every rule concatenated; applying the neighbor check globally
+  // drops a rule whose next *row* belongs to a different, older rule.
+  return Object.values(_.groupBy(allVersions, (it) => it.id)).flatMap(
+    (versions) => {
+      const ordered = [...versions].sort(
+        (a, b) => a.approxVersion.getTime() - b.approxVersion.getTime(),
+      );
+      return ordered.filter(
         (_, i) =>
-          // Always keep the last version (which is what we're looking at if
-          // i == allVersions.length - 1), because that's definitely still
-          // in effect at the start date. Then, if we're not looking at the
-          // last version, keep this version if the _next_ version was
-          // created after the start date (which'd mean this was the version
-          // in effect _at_ the start date). The overall result here is to
-          // keep last version created at or before the start date, plus all
-          // created after it.
-          i === allVersions.length - 1 ||
-          allVersions[i + 1].approxVersion > startDate,
-      )
-    : allVersions;
+          i === ordered.length - 1 || ordered[i + 1].approxVersion > startDate,
+      );
+    },
+  );
 }
 
 /**

--- a/server/services/ruleAnomalyDetectionService/getCurrentPeriodRuleAlarmStatuses.test.ts
+++ b/server/services/ruleAnomalyDetectionService/getCurrentPeriodRuleAlarmStatuses.test.ts
@@ -28,8 +28,14 @@ describe('getCurrentPeriodRuleAlarmStatuses', () => {
       async () => [],
     );
 
-    await expect(getStatuses()).resolves.toMatchObject({
-      [ruleId]: { status: RuleAlarmStatus.INSUFFICIENT_DATA },
+    await expect(getStatuses()).resolves.toEqual({
+      [ruleId]: {
+        status: RuleAlarmStatus.INSUFFICIENT_DATA,
+        meta: {
+          lastPeriodPassRate: undefined,
+          secondToLastPeriodPassRate: undefined,
+        },
+      },
     });
   });
 });

--- a/server/services/ruleAnomalyDetectionService/getCurrentPeriodRuleAlarmStatuses.test.ts
+++ b/server/services/ruleAnomalyDetectionService/getCurrentPeriodRuleAlarmStatuses.test.ts
@@ -1,0 +1,35 @@
+import { RuleAlarmStatus } from '../moderationConfigService/index.js';
+import makeGetCurrentPeriodRuleAlarmStatuses from './getCurrentPeriodRuleAlarmStatuses.js';
+
+describe('getCurrentPeriodRuleAlarmStatuses', () => {
+  test('returns INSUFFICIENT_DATA when rule history has no matching entry', async () => {
+    const ruleId = 'rule-without-history';
+    const ruleVersion = new Date('2026-08-22T00:00:00.000Z');
+    const currentPeriod = {
+      ruleId,
+      approxRuleVersion: ruleVersion,
+      windowStart: new Date('2026-08-22T00:00:00.000Z'),
+      passCount: 50,
+      passingUsersCount: 50,
+      runsCount: 1000,
+    };
+    const historicalPeriods = Array.from({ length: 25 }, (_, index) => ({
+      ruleId,
+      approxRuleVersion: ruleVersion,
+      windowStart: new Date(
+        Date.parse('2026-08-22T00:00:00.000Z') - (index + 1) * 60 * 60 * 1000,
+      ),
+      passCount: index < 4 ? 1 : 0,
+      passingUsersCount: index < 4 ? 1 : 0,
+      runsCount: 200,
+    }));
+    const getStatuses = makeGetCurrentPeriodRuleAlarmStatuses(
+      async () => [currentPeriod, ...historicalPeriods],
+      async () => [],
+    );
+
+    await expect(getStatuses()).resolves.toMatchObject({
+      [ruleId]: { status: RuleAlarmStatus.INSUFFICIENT_DATA },
+    });
+  });
+});

--- a/server/services/ruleAnomalyDetectionService/getCurrentPeriodRuleAlarmStatuses.ts
+++ b/server/services/ruleAnomalyDetectionService/getCurrentPeriodRuleAlarmStatuses.ts
@@ -3,7 +3,7 @@ import lodash from 'lodash';
 import { type Dependencies } from '../../iocContainer/index.js';
 import { inject } from '../../iocContainer/utils.js';
 import { WEEK_MS } from '../../utils/time.js';
-import { type RuleAlarmStatus } from '../moderationConfigService/index.js';
+import { RuleAlarmStatus } from '../moderationConfigService/index.js';
 import getRuleAlarmStatus from './getRuleAlarmStatus.js';
 
 const { mapValues, groupBy } = lodash;
@@ -18,11 +18,12 @@ const makeGetCurrentPeriodRuleAlarmStatuses = inject(
       const passStats = await getRuleStats({ startTime: oneWeekAgo });
       const statsByRule = groupBy(passStats, (it) => it.ruleId);
 
-      const minVersionsByRule = await getMinimumAnomalyDetectionRuleVersions(
-        getRuleHistory,
-        undefined,
-        oneWeekAgo,
-      );
+      const minVersionsByRule: Partial<Record<string, Date>> =
+        await getMinimumAnomalyDetectionRuleVersions(
+          getRuleHistory,
+          undefined,
+          oneWeekAgo,
+        );
 
       return mapValues(statsByRule, (passStats) => {
         const { ruleId } = passStats[0];
@@ -51,11 +52,21 @@ const makeGetCurrentPeriodRuleAlarmStatuses = inject(
         // that the rule passed in a period, but rather as the number of
         // distinct users that caused the rule to pass in that period.
         const minVersion = minVersionsByRule[ruleId];
+        // Without a version bound we cannot tell whether warehouse stats
+        // predate a condition/item-type change. Fail closed rather than
+        // treating missing history as "all stats apply".
+        if (minVersion === undefined) {
+          return {
+            status: RuleAlarmStatus.INSUFFICIENT_DATA,
+            meta: {
+              lastPeriodPassRate: undefined,
+              secondToLastPeriodPassRate: undefined,
+            },
+          };
+        }
+
         const applicableStats = passStats
-          .filter(
-            (it) =>
-              minVersion === undefined || it.approxRuleVersion >= minVersion,
-          )
+          .filter((it) => it.approxRuleVersion >= minVersion)
           .map((it) => ({ passes: it.passingUsersCount, runs: it.runsCount }));
 
         return {

--- a/server/services/ruleAnomalyDetectionService/getCurrentPeriodRuleAlarmStatuses.ts
+++ b/server/services/ruleAnomalyDetectionService/getCurrentPeriodRuleAlarmStatuses.ts
@@ -50,8 +50,12 @@ const makeGetCurrentPeriodRuleAlarmStatuses = inject(
         // model, we represent the number of passes _not_ as the number of times
         // that the rule passed in a period, but rather as the number of
         // distinct users that caused the rule to pass in that period.
+        const minVersion = minVersionsByRule[ruleId];
         const applicableStats = passStats
-          .filter((it) => it.approxRuleVersion >= minVersionsByRule[ruleId])
+          .filter(
+            (it) =>
+              minVersion === undefined || it.approxRuleVersion >= minVersion,
+          )
           .map((it) => ({ passes: it.passingUsersCount, runs: it.runsCount }));
 
         return {

--- a/server/services/ruleHistoryService/ruleHistoryService.test.ts
+++ b/server/services/ruleHistoryService/ruleHistoryService.test.ts
@@ -111,5 +111,31 @@ describe('RuleHistory Service', () => {
         },
       ]);
     });
+
+    test('startDate filter does not drop a newer rule when an older rule follows it in the list', async () => {
+      const mockGetRawHistory = async () => [
+        {
+          id: 'new-rule',
+          name: 'Anomaly test',
+          statusIfUnexpired: RuleStatus.LIVE,
+          exactVersion: '2026-08-22 21:59:40.059097+00',
+        },
+        {
+          id: 'old-seed',
+          name: 'Seed',
+          statusIfUnexpired: RuleStatus.LIVE,
+          exactVersion: '2025-12-09 15:40:32.761966+00',
+        },
+      ];
+
+      const res = await getSimplifiedRuleHistory(
+        mockGetRawHistory,
+        ['name', 'statusIfUnexpired'],
+        undefined,
+        new Date('2026-08-15T00:00:00.000Z'),
+      );
+
+      expect(res.map((row) => row.id).sort()).toEqual(['new-rule', 'old-seed']);
+    });
   });
 });

--- a/server/services/ruleHistoryService/ruleHistoryService.test.ts
+++ b/server/services/ruleHistoryService/ruleHistoryService.test.ts
@@ -135,7 +135,7 @@ describe('RuleHistory Service', () => {
         new Date('2026-08-15T00:00:00.000Z'),
       );
 
-      expect(res.map((row) => row.id).sort()).toEqual(['new-rule', 'old-seed']);
+      expect(res.map((row) => row.id)).toEqual(['old-seed', 'new-rule']);
     });
   });
 });

--- a/server/services/ruleHistoryService/ruleHistoryService.ts
+++ b/server/services/ruleHistoryService/ruleHistoryService.ts
@@ -142,8 +142,8 @@ export async function getSimplifiedRuleHistory<K extends VersionedField>(
   // "Version in effect at startDate, plus later versions" is per rule. The
   // raw list is every rule concatenated; applying the neighbor check globally
   // drops a rule whose next *row* belongs to a different, older rule.
-  return Object.values(_.groupBy(allVersions, (it) => it.id)).flatMap(
-    (versions) => {
+  return Object.values(_.groupBy(allVersions, (it) => it.id))
+    .flatMap((versions) => {
       const ordered = [...versions].sort(
         (a, b) => a.approxVersion.getTime() - b.approxVersion.getTime(),
       );
@@ -151,8 +151,8 @@ export async function getSimplifiedRuleHistory<K extends VersionedField>(
         (_, i) =>
           i === ordered.length - 1 || ordered[i + 1].approxVersion > startDate,
       );
-    },
-  );
+    })
+    .sort((a, b) => a.approxVersion.getTime() - b.approxVersion.getTime());
 }
 
 /**

--- a/server/services/ruleHistoryService/ruleHistoryService.ts
+++ b/server/services/ruleHistoryService/ruleHistoryService.ts
@@ -135,21 +135,24 @@ export async function getSimplifiedRuleHistory<K extends VersionedField>(
     approxVersion: new Date(it.exactVersion),
   }));
 
-  return startDate
-    ? allVersions.filter(
+  if (!startDate) {
+    return allVersions;
+  }
+
+  // "Version in effect at startDate, plus later versions" is per rule. The
+  // raw list is every rule concatenated; applying the neighbor check globally
+  // drops a rule whose next *row* belongs to a different, older rule.
+  return Object.values(_.groupBy(allVersions, (it) => it.id)).flatMap(
+    (versions) => {
+      const ordered = [...versions].sort(
+        (a, b) => a.approxVersion.getTime() - b.approxVersion.getTime(),
+      );
+      return ordered.filter(
         (_, i) =>
-          // Always keep the last version (which is what we're looking at if
-          // i == allVersions.length - 1), because that's definitely still
-          // in effect at the start date. Then, if we're not looking at the
-          // last version, keep this version if the _next_ version was
-          // created after the start date (which'd mean this was the version
-          // in effect _at_ the start date). The overall result here is to
-          // keep last version created at or before the start date, plus all
-          // created after it.
-          i === allVersions.length - 1 ||
-          allVersions[i + 1].approxVersion > startDate,
-      )
-    : allVersions;
+          i === ordered.length - 1 || ordered[i + 1].approxVersion > startDate,
+      );
+    },
+  );
 }
 
 /**


### PR DESCRIPTION
## Context & Requests for Reviewers

Fix bug uncovered by #643 integration tests that was not fixed befor emerging. `getSimplifiedRuleHistory` applied the "version in effect at startDate" cut to a flat list of every rule. The neighbor check treated the next *row* as the next *version of the same rule*, so an older seed rule later in the list could drop a newer rule's history.

That meant that `DetectRulePassRateAnomaliesJob` then saw no min version, discarded a full week of ClickHouse stats, and stored `INSUFFICIENT_DATA` instead of `ALARM`. 
This was uncovered by the `background-jobs.integ.test.ts` failure on main.

We now filter per rule id (same change in the reporting copy of the helper). If history is missing, keep warehouse stats. Added a regression test: newer rule followed by an older rule in the raw list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected rule history filtering so each rule retains the version active at the selected start date and all subsequent versions.
  - Preserved newer rules when older rules appear later in history.
  - Ensured combined rule history results are returned in chronological order.
  - Marked alarm statuses as insufficient data when minimum anomaly-detection version information is unavailable.
- **Tests**
  - Added regression coverage for multi-rule history filtering, chronological ordering, and insufficient-data alarm statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->