### PR TITLE
Hover unblurs a blurred video the same way as an image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Review Console
 
+- Fixed hovering a blurred video not lifting blur the way images already do; the player now unblurs on hover without requiring play (#524)
 - Fixed a "Job submission failed" error that prevented reviewers from clearing jobs whose item had an unparseable `Created At` value; the decision now records instead of failing (#913)
 - Fixed a "Something Went Wrong" page when opening a job or queue whose `Created At` value was unparseable; the affected date now shows `Unknown` instead of blanking the view (#916)
 - Fixed "Oldest Task Age" on the MRT queues dashboard showing the newest job's age instead of the oldest (#909)

--- a/client/src/webpages/dashboard/mrt/manual_review_job/ManualReviewJobContentBlurableVideo.test.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/ManualReviewJobContentBlurableVideo.test.tsx
@@ -1,0 +1,31 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import '@testing-library/jest-dom/extend-expect';
+
+import ManualReviewJobContentBlurableVideo from './ManualReviewJobContentBlurableVideo';
+
+vi.mock('react-player', () => ({
+  default: function MockPlayer() {
+    return <div data-testid="player" />;
+  },
+}));
+
+describe('ManualReviewJobContentBlurableVideo hover unblur', () => {
+  it('keeps play-to-unblur and adds group-hover unblur on a blurred video', () => {
+    const { container } = render(
+      <ManualReviewJobContentBlurableVideo
+        url="https://example.test/sample.mp4"
+        options={{ shouldBlur: true }}
+      />,
+    );
+
+    const wrapper = container.firstElementChild;
+    expect(wrapper?.className).toMatch(/\bgroup\b/);
+
+    const blurred = wrapper?.querySelector('.blur-sm');
+    expect(blurred).toBeTruthy();
+    expect(blurred?.className).toMatch(/group-hover:blur-none/);
+    expect(blurred?.className).not.toMatch(/\bblur-0\b/);
+  });
+});

--- a/client/src/webpages/dashboard/mrt/manual_review_job/ManualReviewJobContentBlurableVideo.test.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/ManualReviewJobContentBlurableVideo.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import '@testing-library/jest-dom/extend-expect';
 
-import ManualReviewJobContentBlurableVideo from './ManualReviewJobContentBlurableVideo';
+import ManualReviewJobContentBlurableVideo from '@/webpages/dashboard/mrt/manual_review_job/ManualReviewJobContentBlurableVideo';
 
 vi.mock('react-player', () => ({
   default: function MockPlayer() {

--- a/client/src/webpages/dashboard/mrt/manual_review_job/ManualReviewJobContentBlurableVideo.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/ManualReviewJobContentBlurableVideo.tsx
@@ -65,7 +65,10 @@ export default function ManualReviewJobContentBlurableVideo(props: {
   });
 
   return (
-    <div className={`${className} relative rounded-lg shadow h-fit`} ref={ref}>
+    <div
+      className={`${className} relative rounded-lg shadow h-fit group`}
+      ref={ref}
+    >
       <div
         className={`shadow ${
           shouldBlur
@@ -75,7 +78,7 @@ export default function ManualReviewJobContentBlurableVideo(props: {
                 ? 'blur-sm'
                 : 'blur-0'
             : 'blur-0'
-        }`}
+        } group-hover:blur-none`}
       >
         <ReactPlayer
           style={{ display: 'flex', maxWidth, maxHeight }}


### PR DESCRIPTION
# Hover unblurs a blurred video the same way as an image

Closes roostorg/coop#524.

## Context & Requests for Reviewers

Images already use Tailwind `hover:blur-none`. Videos only drop blur when `playing` is true, so hover does nothing unless the reviewer hits play or turns blurring off. ThatKoffe named hover.

This puts `group` on the outer player wrapper and `group-hover:blur-none` on the blurred inner div so hovering the play button or the video unblurs, matching the image control. Play-to-unblur is unchanged. Wellness docs still say play-to-unblur only. Juliet pointed at #194; that is a different still-open migration, not this PR.

## Tests

Dest check, Ubuntu Node v24.18.0, vitest 4.1.10:

```
✓ src/webpages/dashboard/mrt/manual_review_job/ManualReviewJobContentBlurableVideo.test.tsx (1 test) 272ms
Test Files  1 passed (1)
     Tests  1 passed (1)
```

The test renders a blurred video and asserts `group` on the wrapper plus `group-hover:blur-none` and `blur-sm` on the inner player. No live job with a video was hovered.

## (Optional) Rollout Plan

Not this PR. Local UI hover class only.

## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [x] **If you changed anything user-facing** (i.e. user interface or APIs):
  Did you update the CHANGELOG.md and related docs?

- [ ] **If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**
  Did you update the corresponding history tables and their triggers?

- [ ] **If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?

- [ ] **If you added a new signal in `server/services/signalsService/signals/**`:**
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.

User-facing. CHANGELOG has the Review Console line. History / db scripts / signals are not this PR. Wellness docs were not rewritten.

## Files

1. `client/src/webpages/dashboard/mrt/manual_review_job/ManualReviewJobContentBlurableVideo.tsx`
2. `client/src/webpages/dashboard/mrt/manual_review_job/ManualReviewJobContentBlurableVideo.test.tsx`
3. `CHANGELOG.md`

## Out of scope

- Wellness docs rewrite (`docs/user/review-console.md` still says play-to-unblur)
- Coop #768 (Unblur All Media / iframes)
- Coop #194 (content-review-filters migration)
- Coop #683 / #628 / #551 / #202 / #704 / #703
- Changing `BLUR_LEVELS` or wellness defaults
- CASE / CAC / CaseLinker

## How to review

On a job with a blurred video, hover the player. Blur should lift and return when the cursor leaves, without pressing play. Images should still behave as they do.

I am a volunteer. Thank you for the time. I am trying to become more useful on this work, so I welcome a critical look. If this is the wrong cut, or you want me to stand down, say so and I will recut from notes.
