### PR TITLE
fix: add password length and match in Forgot Password flow

### DIFF
--- a/client/src/graphql/generated.ts
+++ b/client/src/graphql/generated.ts
@@ -3328,6 +3328,11 @@ export type GQLPartialItemsSuccessResponse = {
   readonly items: ReadonlyArray<GQLItem>;
 };
 
+export type GQLPasswordRequirements = {
+  readonly __typename: 'PasswordRequirements';
+  readonly minLength: Scalars['Int']['output'];
+};
+
 export type GQLPendingInvite = {
   readonly __typename: 'PendingInvite';
   readonly createdAt: Scalars['DateTime']['output'];
@@ -3483,6 +3488,7 @@ export type GQLQuery = {
   readonly ncmecThreads: ReadonlyArray<GQLThreadWithMessagesAndIpAddress>;
   readonly org?: Maybe<GQLOrg>;
   readonly partialItems: GQLPartialItemsResponse;
+  readonly passwordRequirements: GQLPasswordRequirements;
   /** Server-owned grouping + ordering for the role-editor UI. Gated on MANAGE_ROLES. */
   readonly permissionGroups: ReadonlyArray<GQLPermissionGroup>;
   readonly policy?: Maybe<GQLPolicy>;
@@ -5494,6 +5500,18 @@ export type GQLUpdateExchangeCredentialsMutationVariables = Exact<{
 export type GQLUpdateExchangeCredentialsMutation = {
   readonly __typename: 'Mutation';
   readonly updateExchangeCredentials: boolean;
+};
+
+export type GQLPasswordRequirementsQueryVariables = Exact<{
+  [key: string]: never;
+}>;
+
+export type GQLPasswordRequirementsQuery = {
+  readonly __typename: 'Query';
+  readonly passwordRequirements: {
+    readonly __typename: 'PasswordRequirements';
+    readonly minLength: number;
+  };
 };
 
 export type GQLUserAndOrgQueryVariables = Exact<{ [key: string]: never }>;
@@ -27192,6 +27210,104 @@ export type GQLUpdateExchangeCredentialsMutationOptions =
     GQLUpdateExchangeCredentialsMutation,
     GQLUpdateExchangeCredentialsMutationVariables
   >;
+export const GQLPasswordRequirementsDocument = gql`
+  query PasswordRequirements {
+    passwordRequirements {
+      minLength
+    }
+  }
+`;
+
+/**
+ * __useGQLPasswordRequirementsQuery__
+ *
+ * To run a query within a React component, call `useGQLPasswordRequirementsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGQLPasswordRequirementsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGQLPasswordRequirementsQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGQLPasswordRequirementsQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    GQLPasswordRequirementsQuery,
+    GQLPasswordRequirementsQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GQLPasswordRequirementsQuery,
+    GQLPasswordRequirementsQueryVariables
+  >(GQLPasswordRequirementsDocument, options);
+}
+export function useGQLPasswordRequirementsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GQLPasswordRequirementsQuery,
+    GQLPasswordRequirementsQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GQLPasswordRequirementsQuery,
+    GQLPasswordRequirementsQueryVariables
+  >(GQLPasswordRequirementsDocument, options);
+}
+// @ts-ignore
+export function useGQLPasswordRequirementsSuspenseQuery(
+  baseOptions?: Apollo.SuspenseQueryHookOptions<
+    GQLPasswordRequirementsQuery,
+    GQLPasswordRequirementsQueryVariables
+  >,
+): Apollo.UseSuspenseQueryResult<
+  GQLPasswordRequirementsQuery,
+  GQLPasswordRequirementsQueryVariables
+>;
+export function useGQLPasswordRequirementsSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GQLPasswordRequirementsQuery,
+        GQLPasswordRequirementsQueryVariables
+      >,
+): Apollo.UseSuspenseQueryResult<
+  GQLPasswordRequirementsQuery | undefined,
+  GQLPasswordRequirementsQueryVariables
+>;
+export function useGQLPasswordRequirementsSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GQLPasswordRequirementsQuery,
+        GQLPasswordRequirementsQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GQLPasswordRequirementsQuery,
+    GQLPasswordRequirementsQueryVariables
+  >(GQLPasswordRequirementsDocument, options);
+}
+export type GQLPasswordRequirementsQueryHookResult = ReturnType<
+  typeof useGQLPasswordRequirementsQuery
+>;
+export type GQLPasswordRequirementsLazyQueryHookResult = ReturnType<
+  typeof useGQLPasswordRequirementsLazyQuery
+>;
+export type GQLPasswordRequirementsSuspenseQueryHookResult = ReturnType<
+  typeof useGQLPasswordRequirementsSuspenseQuery
+>;
+export type GQLPasswordRequirementsQueryResult = Apollo.QueryResult<
+  GQLPasswordRequirementsQuery,
+  GQLPasswordRequirementsQueryVariables
+>;
 export const GQLUserAndOrgDocument = gql`
   query UserAndOrg {
     me {
@@ -45343,6 +45459,7 @@ export const namedOperations = {
     HashBankById: 'HashBankById',
     ExchangeApis: 'ExchangeApis',
     ExchangeApiSchema: 'ExchangeApiSchema',
+    PasswordRequirements: 'PasswordRequirements',
     UserAndOrg: 'UserAndOrg',
     LoggedInUserForRoute: 'LoggedInUserForRoute',
     PermissionGatedRouteLoggedInUser: 'PermissionGatedRouteLoggedInUser',

--- a/client/src/graphql/passwordRequirementsQuery.ts
+++ b/client/src/graphql/passwordRequirementsQuery.ts
@@ -1,0 +1,9 @@
+import { gql } from '@apollo/client';
+
+export const PASSWORD_REQUIREMENTS_QUERY = gql`
+  query PasswordRequirements {
+    passwordRequirements {
+      minLength
+    }
+  }
+`;

--- a/client/src/utils/password.ts
+++ b/client/src/utils/password.ts
@@ -1,0 +1,7 @@
+/**
+ * Fallback used while `passwordRequirements` is loading or if the query
+ * fails, so forms don't briefly accept a password shorter than the server
+ * will actually allow. Kept in sync with the server default in
+ * `server/services/userManagementService/constants.ts`.
+ */
+export const DEFAULT_MIN_PASSWORD_LENGTH = 8;

--- a/client/src/webpages/auth/SignUp.tsx
+++ b/client/src/webpages/auth/SignUp.tsx
@@ -10,9 +10,11 @@ import CoopButton from '../dashboard/components/CoopButton';
 import {
   namedOperations,
   useGQLInviteUserTokenQuery,
+  useGQLPasswordRequirementsQuery,
   useGQLSignUpMutation,
 } from '../../graphql/generated';
 import LogoBlack from '../../images/LogoBlack.png';
+import { DEFAULT_MIN_PASSWORD_LENGTH } from '../../utils/password';
 
 gql`
   query InviteUserToken($token: String!) {
@@ -73,6 +75,11 @@ export default function SignUp() {
     variables: { token: token ?? '' },
     skip: !token,
   });
+
+  const { data: passwordRequirementsData } = useGQLPasswordRequirementsQuery();
+  const minPasswordLength =
+    passwordRequirementsData?.passwordRequirements.minLength ??
+    DEFAULT_MIN_PASSWORD_LENGTH;
 
   const [signUp, { loading: signUpLoading }] = useGQLSignUpMutation({
     refetchQueries: [namedOperations.Query.LoggedInUserForRoute],
@@ -135,8 +142,10 @@ export default function SignUp() {
       });
     } else {
       // Password-based signup
-      if (!password || password.length < 8) {
-        setErrorMessage('Password must be at least 8 characters long.');
+      if (!password || password.length < minPasswordLength) {
+        setErrorMessage(
+          `Password must be at least ${minPasswordLength} characters long.`,
+        );
         return;
       }
 
@@ -246,7 +255,7 @@ export default function SignUp() {
                 Password
               </label>
               <Input.Password
-                placeholder="Password (min 8 characters)"
+                placeholder={`Password (min ${minPasswordLength} characters)`}
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 size="large"
@@ -262,7 +271,8 @@ export default function SignUp() {
               disabled={
                 !firstName ||
                 !lastName ||
-                (!tokenInfo.samlEnabled && (!password || password.length < 8))
+                (!tokenInfo.samlEnabled &&
+                  (!password || password.length < minPasswordLength))
               }
               size="large"
             />

--- a/client/src/webpages/auth/forgot_password/ResetPassword.tsx
+++ b/client/src/webpages/auth/forgot_password/ResetPassword.tsx
@@ -6,8 +6,12 @@ import { Link, Navigate, useNavigate, useParams } from 'react-router-dom';
 
 import CoopModal from '@/webpages/dashboard/components/CoopModal';
 
-import { useGQLResetPasswordMutation } from '../../../graphql/generated';
+import {
+  useGQLPasswordRequirementsQuery,
+  useGQLResetPasswordMutation,
+} from '../../../graphql/generated';
 import LogoBlack from '../../../images/LogoBlack.png';
+import { DEFAULT_MIN_PASSWORD_LENGTH } from '../../../utils/password';
 
 gql`
   mutation ResetPassword($input: ResetPasswordInput!) {
@@ -22,11 +26,19 @@ export default function ResetPassword() {
   const [confirmPassword, setConfirmPassword] = useState<string | undefined>(
     undefined,
   );
+  const [errorMessage, setErrorMessage] = useState<string | undefined>(
+    undefined,
+  );
   const [showErrorModal, setShowErrorModal] = useState(false);
   const showError = () => setShowErrorModal(true);
 
   const { token } = useParams<{ token: string | undefined }>();
   const navigate = useNavigate();
+
+  const { data: passwordRequirementsData } = useGQLPasswordRequirementsQuery();
+  const minPasswordLength =
+    passwordRequirementsData?.passwordRequirements.minLength ??
+    DEFAULT_MIN_PASSWORD_LENGTH;
 
   const [resetPassword, { loading: resetPasswordLoading }] =
     useGQLResetPasswordMutation({
@@ -47,7 +59,7 @@ export default function ResetPassword() {
   const newPasswordInput = (
     <Input.Password
       className="rounded-lg"
-      placeholder="Enter new password"
+      placeholder={`Enter new password (min ${minPasswordLength} characters)`}
       value={newPassword}
       onChange={(event) => {
         setNewPassword(event.target.value);
@@ -70,18 +82,27 @@ export default function ResetPassword() {
       type="primary"
       htmlType="submit"
       loading={resetPasswordLoading}
-      onClick={async () =>
-        resetPassword({
+      onClick={async () => {
+        if (newPassword !== confirmPassword) {
+          setErrorMessage('Passwords do not match.');
+          return;
+        }
+        if (!newPassword || newPassword.length < minPasswordLength) {
+          setErrorMessage(
+            `Password must be at least ${minPasswordLength} characters long.`,
+          );
+          return;
+        }
+        setErrorMessage(undefined);
+        await resetPassword({
           variables: {
             input: {
-              // Safe to assert non-null since onSetNewPassword is used
-              // in a component that's only rendered if data is non-null
               token,
-              newPassword: newPassword!,
+              newPassword,
             },
           },
-        })
-      }
+        });
+      }}
     >
       Update Password
     </Button>
@@ -108,6 +129,15 @@ export default function ResetPassword() {
             <img src={LogoBlack} alt="Coop Logo" className="h-12" />
           </Link>
           <div className="py-5 text-2xl font-bold">Reset Password</div>
+          {errorMessage && (
+            <div
+              role="alert"
+              aria-live="assertive"
+              className="mb-4 p-3 w-full bg-red-50 border border-red-200 rounded text-red-700 text-sm"
+            >
+              {errorMessage}
+            </div>
+          )}
           <div className="flex flex-col items-center justify-center w-full gap-4">
             {newPasswordInput}
             {confirmPasswordInput}

--- a/client/src/webpages/settings/AccountSettings.tsx
+++ b/client/src/webpages/settings/AccountSettings.tsx
@@ -33,6 +33,7 @@ import {
   useGQLAccountSettingsQuery,
   useGQLChangePasswordMutation,
   useGQLDeleteUserMutation,
+  useGQLPasswordRequirementsQuery,
   useGQLPersonalSafetySettingsQuery,
   useGQLSetModeratorSafetySettingsMutation,
   useGQLUpdateAccountInfoMutation,
@@ -46,6 +47,7 @@ import {
   preferencesFromColorScheme,
   type ModeratorSafetyColorScheme,
 } from '../../models/safetySettings';
+import { DEFAULT_MIN_PASSWORD_LENGTH } from '../../utils/password';
 import {
   BLUR_LEVELS,
   type BlurStrength,
@@ -222,6 +224,11 @@ export default function AccountSettings() {
     error: accountSettingsError,
   } = useGQLAccountSettingsQuery();
 
+  const { data: passwordRequirementsData } = useGQLPasswordRequirementsQuery();
+  const minPasswordLength =
+    passwordRequirementsData?.passwordRequirements.minLength ??
+    DEFAULT_MIN_PASSWORD_LENGTH;
+
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [currentPassword, setCurrentPassword] = useState('');
@@ -378,9 +385,9 @@ export default function AccountSettings() {
       return;
     }
 
-    if (newPassword.length < 8) {
+    if (newPassword.length < minPasswordLength) {
       toast.error('Password Too Short', {
-        description: 'Password must be at least 8 characters long.',
+        description: `Password must be at least ${minPasswordLength} characters long.`,
       });
       return;
     }
@@ -393,7 +400,13 @@ export default function AccountSettings() {
         },
       },
     });
-  }, [currentPassword, newPassword, confirmNewPassword, changePassword]);
+  }, [
+    currentPassword,
+    newPassword,
+    confirmNewPassword,
+    changePassword,
+    minPasswordLength,
+  ]);
 
   const moderatorSafetyBlurValue = useMemo(
     () => [safetySettings.moderatorSafetyBlurLevel],
@@ -478,7 +491,7 @@ export default function AccountSettings() {
           </DialogHeader>
           <DialogDescription>
             Enter your current password and choose a new password. Your new
-            password must be at least 8 characters long.
+            password must be at least {minPasswordLength} characters long.
           </DialogDescription>
           <div className="flex flex-col gap-4 p-4">
             <div>

--- a/server/graphql/generated.ts
+++ b/server/graphql/generated.ts
@@ -3396,6 +3396,11 @@ export type GQLPartialItemsSuccessResponse = {
   readonly items: ReadonlyArray<GQLItem>;
 };
 
+export type GQLPasswordRequirements = {
+  readonly __typename?: 'PasswordRequirements';
+  readonly minLength: Scalars['Int']['output'];
+};
+
 export type GQLPendingInvite = {
   readonly __typename?: 'PendingInvite';
   readonly createdAt: Scalars['DateTime']['output'];
@@ -3551,6 +3556,7 @@ export type GQLQuery = {
   readonly ncmecThreads: ReadonlyArray<GQLThreadWithMessagesAndIpAddress>;
   readonly org?: Maybe<GQLOrg>;
   readonly partialItems: GQLPartialItemsResponse;
+  readonly passwordRequirements: GQLPasswordRequirements;
   /** Server-owned grouping + ordering for the role-editor UI. Gated on MANAGE_ROLES. */
   readonly permissionGroups: ReadonlyArray<GQLPermissionGroup>;
   readonly policy?: Maybe<GQLPolicy>;
@@ -6309,6 +6315,7 @@ export type GQLResolversTypes = {
       items: ReadonlyArray<GQLResolversTypes['Item']>;
     }
   >;
+  PasswordRequirements: ResolverTypeWrapper<GQLPasswordRequirements>;
   PendingInvite: ResolverTypeWrapper<GQLPendingInvite>;
   PermissionGroup: ResolverTypeWrapper<GQLPermissionGroup>;
   PermissionGroupItem: ResolverTypeWrapper<GQLPermissionGroupItem>;
@@ -7015,6 +7022,7 @@ export type GQLResolversParentTypes = {
   PartialItemsSuccessResponse: Omit<GQLPartialItemsSuccessResponse, 'items'> & {
     items: ReadonlyArray<GQLResolversParentTypes['Item']>;
   };
+  PasswordRequirements: GQLPasswordRequirements;
   PendingInvite: GQLPendingInvite;
   PermissionGroup: GQLPermissionGroup;
   PermissionGroupItem: GQLPermissionGroupItem;
@@ -12250,6 +12258,14 @@ export type GQLPartialItemsSuccessResponseResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type GQLPasswordRequirementsResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['PasswordRequirements'] =
+    GQLResolversParentTypes['PasswordRequirements'],
+> = {
+  minLength?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
+};
+
 export type GQLPendingInviteResolvers<
   ContextType = Context,
   ParentType extends GQLResolversParentTypes['PendingInvite'] =
@@ -12724,6 +12740,11 @@ export type GQLQueryResolvers<
     ParentType,
     ContextType,
     RequireFields<GQLQueryPartialItemsArgs, 'input'>
+  >;
+  passwordRequirements?: Resolver<
+    GQLResolversTypes['PasswordRequirements'],
+    ParentType,
+    ContextType
   >;
   permissionGroups?: Resolver<
     ReadonlyArray<GQLResolversTypes['PermissionGroup']>,
@@ -15287,6 +15308,7 @@ export type GQLResolvers<ContextType = Context> = {
   PartialItemsMissingEndpointError?: GQLPartialItemsMissingEndpointErrorResolvers<ContextType>;
   PartialItemsResponse?: GQLPartialItemsResponseResolvers<ContextType>;
   PartialItemsSuccessResponse?: GQLPartialItemsSuccessResponseResolvers<ContextType>;
+  PasswordRequirements?: GQLPasswordRequirementsResolvers<ContextType>;
   PendingInvite?: GQLPendingInviteResolvers<ContextType>;
   PermissionGroup?: GQLPermissionGroupResolvers<ContextType>;
   PermissionGroupItem?: GQLPermissionGroupItemResolvers<ContextType>;

--- a/server/graphql/resolvers.ts
+++ b/server/graphql/resolvers.ts
@@ -3,7 +3,10 @@ import { type GraphQLFieldResolver } from 'graphql';
 
 import { type GQLServices } from '../api.js';
 import { type DataSources } from '../iocContainer/index.js';
-import { UserPermission } from '../services/userManagementService/index.js';
+import {
+  MIN_PASSWORD_LENGTH,
+  UserPermission,
+} from '../services/userManagementService/index.js';
 import { CoopError, isCoopErrorOfType } from '../utils/errors.js';
 import { type GraphQLUserParent } from './datasources/userKyselyPersistence.js';
 import {
@@ -130,6 +133,9 @@ const Query: GQLQueryResolvers = {
       );
       return false;
     }
+  },
+  passwordRequirements() {
+    return { minLength: MIN_PASSWORD_LENGTH };
   },
 };
 

--- a/server/graphql/schema.ts
+++ b/server/graphql/schema.ts
@@ -457,12 +457,17 @@ const typeDefs = /* GraphQL */ `
 
   directive @publicResolver on FIELD_DEFINITION
 
+  type PasswordRequirements {
+    minLength: Int!
+  }
+
   type Query {
     myOrg: Org
     userFromToken(token: String!): ID
     inviteUserToken(token: String!): InviteUserTokenResponse! @publicResolver
     allRuleInsights: AllRuleInsights
     isWarehouseAvailable: Boolean!
+    passwordRequirements: PasswordRequirements! @publicResolver
   }
 
   type Mutation {

--- a/server/services/userManagementService/constants.ts
+++ b/server/services/userManagementService/constants.ts
@@ -1,0 +1,1 @@
+export const MIN_PASSWORD_LENGTH = 8;

--- a/server/services/userManagementService/index.ts
+++ b/server/services/userManagementService/index.ts
@@ -1,4 +1,5 @@
 export { UserManagementPg } from './dbTypes.js';
+export { MIN_PASSWORD_LENGTH } from './constants.js';
 export {
   default as makeUserManagementService,
   type UserManagementService,

--- a/server/services/userManagementService/userManagementService.test.ts
+++ b/server/services/userManagementService/userManagementService.test.ts
@@ -1,6 +1,7 @@
 import { type Kysely } from 'kysely';
 
 import { makeTestWithFixture } from '../../test/utils.js';
+import { MIN_PASSWORD_LENGTH } from './constants.js';
 import type { UserManagementPg } from './index.js';
 import UserManagementService from './userManagementService.js';
 
@@ -255,6 +256,41 @@ describe('UserManagementService', () => {
         // ...and the user's sessions are deleted so a phished session can't
         // outlive the reset.
         expect(mockDb.deleteFrom).toHaveBeenCalledWith('public.session');
+      },
+    );
+
+    testWithFixtures(
+      'rejects a password shorter than the minimum length',
+      async ({ sut }) => {
+        const mockSelect = {
+          selectAll: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          executeTakeFirst: jest.fn().mockResolvedValue({
+            hashed_token: 'hashed',
+            user_id: 'user-123',
+            org_id: 'org-456',
+            created_at: new Date(),
+          }),
+        };
+
+        (mockDb.selectFrom as jest.Mock).mockReturnValue(mockSelect);
+
+        const tooShortPassword = 'a'.repeat(MIN_PASSWORD_LENGTH - 1);
+
+        await expect(
+          sut.resetPasswordForToken({
+            token: 'plaintext-token',
+            newPassword: tooShortPassword,
+          }),
+        ).rejects.toThrow(
+          expect.objectContaining({
+            message: expect.stringContaining(
+              `at least ${MIN_PASSWORD_LENGTH} characters`,
+            ),
+          }),
+        );
+
+        expect(mockDb.updateTable).not.toHaveBeenCalled();
       },
     );
   });

--- a/server/services/userManagementService/userManagementService.ts
+++ b/server/services/userManagementService/userManagementService.ts
@@ -5,6 +5,7 @@ import { type Kysely } from 'kysely';
 import type { Dependencies } from '../../iocContainer/index.js';
 import { inject } from '../../iocContainer/utils.js';
 import {
+  makeBadRequestError,
   makeNotFoundError,
   makeUnauthorizedError,
 } from '../../utils/errors.js';
@@ -12,6 +13,7 @@ import { makeKyselyTransactionWithRetry } from '../../utils/kyselyTransactionWit
 import { asyncRandomBytes } from '../../utils/misc.js';
 import { HOUR_MS } from '../../utils/time.js';
 import { CoopEmailAddress } from '../sendEmailService/sendEmailService.js';
+import { MIN_PASSWORD_LENGTH } from './constants.js';
 import type { MrtChartConfig } from './dbTypes.js';
 import type { UserManagementPg } from './index.js';
 import {
@@ -472,6 +474,13 @@ class UserManagementService {
     // NB: Tokens expire one hour after creation
     if (Date.now() - new Date(fetchedToken.created_at).getTime() > HOUR_MS) {
       return;
+    }
+
+    if (newPassword.length < MIN_PASSWORD_LENGTH) {
+      throw makeBadRequestError(
+        `Password must be at least ${MIN_PASSWORD_LENGTH} characters long.`,
+        { shouldErrorSpan: false, pointer: '/input/newPassword' },
+      );
     }
 
     const hashedPassword = await hashPassword(newPassword);


### PR DESCRIPTION
## Context & Requests for Reviewers
fixes #1062 

Added `MIN_PASSWORD_LENGTH` constant = 8 in server which is fetched via graphql query. Also, added a fallback in client in case the query is still loading or errors.

## Tests

<!-- Describe how you tested your changes, including any manual steps or automated tests performed. -->
<!-- Provide screenshots if available -->
tested locally
<img width="524" height="454" alt="image" src="https://github.com/user-attachments/assets/c702bc89-460b-4e3e-8243-f845b5b31723" />
<img width="524" height="454" alt="image" src="https://github.com/user-attachments/assets/759719a5-e3b0-4bc0-bfb3-f3549da538ab" />

## (Optional) Rollout Plan

<!--
Are there any special things that have to be done before this can be deployed
to prod (e.g., other blocking PRs; manual load testing/validation that needs to
be done on staging; etc.)? If so, please note them here.
 -->

## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] **If you changed anything user-facing** (i.e. user interface or APIs):
  Did you update the CHANGELOG.md and related docs?

- [ ] **If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**
  Did you update the corresponding history tables and their triggers?

- [ ] **If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?

- [ ] **If you added a new signal in `server/services/signalsService/signals/**`:**
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Password requirements are now configurable and shared across sign-up, password reset, and account settings.
  * Password fields display the current minimum length requirement.
* **Bug Fixes**
  * Added consistent client- and server-side validation for minimum password length.
  * Password reset requests with passwords below the required length are rejected with clear inline feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->