### PR TITLE
fix: seed system roles

### DIFF
--- a/db/src/scripts/api-server-pg/2026.08.25T15.56.24.seed_missing_system_roles.sql
+++ b/db/src/scripts/api-server-pg/2026.08.25T15.56.24.seed_missing_system_roles.sql
@@ -1,0 +1,110 @@
+BEGIN;
+
+WITH role_defaults(key, display_name, description) AS (
+    VALUES
+        ('ADMIN', 'Admin', 'Manages all users in the org and has every permission.'),
+        ('RULES_MANAGER', 'Rules Manager', 'Can modify and run rules and actions, but cannot manage users.'),
+        ('MODERATOR_MANAGER', 'Moderator Manager', 'Can view MRT, edit queues, and manage moderators.'),
+        ('MODERATOR', 'Moderator', 'Reviews queues they have been granted access to.'),
+        ('CHILD_SAFETY_MODERATOR', 'Child Safety Moderator', 'Reviews child safety jobs, including NCMEC.'),
+        ('ANALYST', 'Analyst', 'Reads rules and insights; can run backtests and edit non-live rules.'),
+        ('EXTERNAL_MODERATOR', 'External Moderator', 'Read-only MRT access for external moderation partners.')
+),
+inserted_roles AS (
+    INSERT INTO public.roles (org_id, key, display_name, description, is_system)
+    SELECT
+        o.id,
+        r.key,
+        r.display_name,
+        r.description,
+        true
+    FROM public.orgs AS o
+    CROSS JOIN role_defaults AS r
+    ON CONFLICT (org_id, key) DO NOTHING
+    RETURNING id, key
+),
+role_permission_seed(role_key, permission) AS (
+    VALUES
+        ('ADMIN', 'MANAGE_ORG'),
+        ('ADMIN', 'MUTATE_LIVE_RULES'),
+        ('ADMIN', 'MUTATE_NON_LIVE_RULES'),
+        ('ADMIN', 'RUN_RETROACTION'),
+        ('ADMIN', 'RUN_BACKTEST'),
+        ('ADMIN', 'VIEW_INSIGHTS'),
+        ('ADMIN', 'MANUALLY_ACTION_CONTENT'),
+        ('ADMIN', 'VIEW_MRT'),
+        ('ADMIN', 'VIEW_MRT_DATA'),
+        ('ADMIN', 'VIEW_CHILD_SAFETY_DATA'),
+        ('ADMIN', 'EDIT_MRT_QUEUES'),
+        ('ADMIN', 'MANAGE_POLICIES'),
+        ('ADMIN', 'VIEW_INVESTIGATION'),
+        ('ADMIN', 'VIEW_RULES_DASHBOARD'),
+        ('ADMIN', 'MANAGE_ROLES'),
+        ('ADMIN', 'MANAGE_USERS'),
+        ('ADMIN', 'MANAGE_ROUTING_RULES'),
+
+        ('RULES_MANAGER', 'MUTATE_LIVE_RULES'),
+        ('RULES_MANAGER', 'MUTATE_NON_LIVE_RULES'),
+        ('RULES_MANAGER', 'RUN_RETROACTION'),
+        ('RULES_MANAGER', 'RUN_BACKTEST'),
+        ('RULES_MANAGER', 'VIEW_INSIGHTS'),
+        ('RULES_MANAGER', 'MANUALLY_ACTION_CONTENT'),
+        ('RULES_MANAGER', 'MANAGE_POLICIES'),
+        ('RULES_MANAGER', 'VIEW_INVESTIGATION'),
+        ('RULES_MANAGER', 'VIEW_RULES_DASHBOARD'),
+
+        ('ANALYST', 'MUTATE_NON_LIVE_RULES'),
+        ('ANALYST', 'RUN_BACKTEST'),
+        ('ANALYST', 'VIEW_INSIGHTS'),
+        ('ANALYST', 'VIEW_INVESTIGATION'),
+        ('ANALYST', 'VIEW_RULES_DASHBOARD'),
+
+        ('MODERATOR_MANAGER', 'VIEW_MRT'),
+        ('MODERATOR_MANAGER', 'VIEW_MRT_DATA'),
+        ('MODERATOR_MANAGER', 'EDIT_MRT_QUEUES'),
+        ('MODERATOR_MANAGER', 'MANAGE_ROUTING_RULES'),
+        ('MODERATOR_MANAGER', 'MANAGE_POLICIES'),
+        ('MODERATOR_MANAGER', 'VIEW_INVESTIGATION'),
+        ('MODERATOR_MANAGER', 'VIEW_RULES_DASHBOARD'),
+        ('MODERATOR_MANAGER', 'VIEW_CHILD_SAFETY_DATA'),
+        ('MODERATOR_MANAGER', 'MANUALLY_ACTION_CONTENT'),
+
+        ('MODERATOR', 'VIEW_MRT'),
+        ('MODERATOR', 'VIEW_MRT_DATA'),
+        ('MODERATOR', 'MANAGE_POLICIES'),
+        ('MODERATOR', 'MANUALLY_ACTION_CONTENT'),
+        ('MODERATOR', 'VIEW_INVESTIGATION'),
+        ('MODERATOR', 'VIEW_RULES_DASHBOARD'),
+
+        ('CHILD_SAFETY_MODERATOR', 'VIEW_MRT'),
+        ('CHILD_SAFETY_MODERATOR', 'VIEW_MRT_DATA'),
+        ('CHILD_SAFETY_MODERATOR', 'VIEW_CHILD_SAFETY_DATA'),
+        ('CHILD_SAFETY_MODERATOR', 'MANAGE_POLICIES'),
+        ('CHILD_SAFETY_MODERATOR', 'MANUALLY_ACTION_CONTENT'),
+        ('CHILD_SAFETY_MODERATOR', 'VIEW_INVESTIGATION'),
+        ('CHILD_SAFETY_MODERATOR', 'VIEW_RULES_DASHBOARD'),
+
+        ('EXTERNAL_MODERATOR', 'VIEW_MRT')
+)
+INSERT INTO public.role_permissions (role_id, permission)
+SELECT r.id, p.permission
+FROM inserted_roles AS r
+JOIN role_permission_seed AS p ON p.role_key = r.key;
+
+UPDATE public.users AS u
+SET role_id = r.id
+FROM public.roles AS r
+WHERE u.role_id IS NULL
+    AND r.org_id = u.org_id
+    AND r.key = u.role
+    AND r.is_system = true;
+
+UPDATE public.invite_user_tokens AS t
+SET role_id = r.id
+FROM public.roles AS r
+WHERE t.role_id IS NULL
+    AND r.org_id = t.org_id
+    AND r.key = t.role
+    AND r.is_system = true;
+
+COMMIT;

--- a/server/bin/create-org-and-user.ts
+++ b/server/bin/create-org-and-user.ts
@@ -17,6 +17,7 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
 import { kyselyOrgInsert } from '../graphql/datasources/orgKyselyPersistence.js';
+import { seedSystemRolesForOrg } from '../graphql/datasources/rolePersistence.js';
 import { kyselyUserInsert } from '../graphql/datasources/userKyselyPersistence.js';
 import getBottle from '../iocContainer/index.js';
 import {
@@ -82,6 +83,8 @@ async function createOrgAndUser() {
       name: argv.name,
       websiteUrl: argv.website,
     });
+
+    await seedSystemRolesForOrg(container.KyselyPg, orgId);
 
     // Create signing keys and API key (both reference org via FK)
     await container.SigningKeyPairService.createAndStoreSigningKeys(orgId);

--- a/server/graphql/datasources/rolePersistence.test.ts
+++ b/server/graphql/datasources/rolePersistence.test.ts
@@ -8,6 +8,7 @@ import {
 import createOrg from '../../test/fixtureHelpers/createOrg.js';
 import { makeTransactionalTestWithFixture } from '../../test/harness/transactionalTest.js';
 import { seedSystemRolesForOrg } from './rolePersistence.js';
+import { kyselyUserInsert } from './userKyselyPersistence.js';
 
 describe('seedSystemRolesForOrg', () => {
   const testWithFixture = makeTransactionalTestWithFixture(async ({ deps }) => {
@@ -39,6 +40,39 @@ describe('seedSystemRolesForOrg', () => {
       expect(roles.map(({ key }) => key).sort()).toEqual(
         Object.values(UserRole).sort(),
       );
+    },
+  );
+
+  testWithFixture(
+    'links a subsequently inserted admin user to the persisted admin role',
+    async ({ deps, org }) => {
+      await seedSystemRolesForOrg(deps.KyselyPg, org.id);
+      const userId = uid();
+      await kyselyUserInsert({
+        db: deps.KyselyPg,
+        id: userId,
+        orgId: org.id,
+        email: `${uid()}@example.com`,
+        firstName: 'Org',
+        lastName: 'Admin',
+        role: UserRole.ADMIN,
+        password: null,
+        loginMethods: ['saml'],
+        approvedByAdmin: true,
+      });
+
+      const user = await deps.KyselyPg.selectFrom('public.users')
+        .select('role_id')
+        .where('id', '=', userId)
+        .executeTakeFirstOrThrow();
+      const adminRole = await deps.KyselyPg.selectFrom('public.roles')
+        .select('id')
+        .where('org_id', '=', org.id)
+        .where('key', '=', UserRole.ADMIN)
+        .executeTakeFirstOrThrow();
+
+      expect(user.role_id).not.toBeNull();
+      expect(user.role_id).toBe(adminRole.id);
     },
   );
 

--- a/server/graphql/datasources/rolePersistence.test.ts
+++ b/server/graphql/datasources/rolePersistence.test.ts
@@ -1,0 +1,151 @@
+import { uid } from 'uid';
+
+import {
+  getPermissionsForRole,
+  SystemRoleDefaults,
+  UserRole,
+} from '../../services/userManagementService/index.js';
+import createOrg from '../../test/fixtureHelpers/createOrg.js';
+import { makeTransactionalTestWithFixture } from '../../test/harness/transactionalTest.js';
+import { seedSystemRolesForOrg } from './rolePersistence.js';
+
+describe('seedSystemRolesForOrg', () => {
+  const testWithFixture = makeTransactionalTestWithFixture(async ({ deps }) => {
+    const { org } = await createOrg(
+      {
+        KyselyPg: deps.KyselyPg,
+        ModerationConfigService: deps.ModerationConfigService,
+        ApiKeyService: deps.ApiKeyService,
+      },
+      uid(),
+    );
+    const roles = await deps.KyselyPg.selectFrom('public.roles')
+      .select('id')
+      .where('org_id', '=', org.id)
+      .execute();
+    expect(roles).toEqual([]);
+    return { org };
+  });
+
+  testWithFixture(
+    'persists every system role for a fresh organization',
+    async ({ deps, org }) => {
+      await seedSystemRolesForOrg(deps.KyselyPg, org.id);
+
+      const roles = await deps.KyselyPg.selectFrom('public.roles')
+        .select('key')
+        .where('org_id', '=', org.id)
+        .execute();
+      expect(roles.map(({ key }) => key).sort()).toEqual(
+        Object.values(UserRole).sort(),
+      );
+    },
+  );
+
+  testWithFixture(
+    'persists default metadata and permissions for each role',
+    async ({ deps, org }) => {
+      await seedSystemRolesForOrg(deps.KyselyPg, org.id);
+
+      const roles = await deps.KyselyPg.selectFrom('public.roles')
+        .select(['id', 'key', 'display_name', 'description', 'is_system'])
+        .where('org_id', '=', org.id)
+        .execute();
+      for (const roleKey of Object.values(UserRole)) {
+        const role = roles.find(({ key }) => key === roleKey);
+        expect(role).toMatchObject({
+          key: roleKey,
+          display_name: SystemRoleDefaults[roleKey].displayName,
+          description: SystemRoleDefaults[roleKey].description,
+          is_system: true,
+        });
+        const permissions = await deps.KyselyPg.selectFrom(
+          'public.role_permissions',
+        )
+          .select('permission')
+          .where('role_id', '=', role!.id)
+          .execute();
+        expect(permissions.map(({ permission }) => permission).sort()).toEqual(
+          [...getPermissionsForRole(roleKey)].sort(),
+        );
+      }
+    },
+  );
+
+  testWithFixture(
+    'preserves an existing role while inserting missing roles',
+    async ({ deps, org }) => {
+      const admin = await deps.KyselyPg.insertInto('public.roles')
+        .values({
+          org_id: org.id,
+          key: UserRole.ADMIN,
+          display_name: 'Edited admin',
+          description: 'Custom description',
+          is_system: true,
+        })
+        .returning('id')
+        .executeTakeFirstOrThrow();
+      await deps.KyselyPg.insertInto('public.role_permissions')
+        .values({ role_id: admin.id, permission: 'MANAGE_ORG' })
+        .execute();
+
+      await seedSystemRolesForOrg(deps.KyselyPg, org.id);
+
+      const roles = await deps.KyselyPg.selectFrom('public.roles')
+        .select(['id', 'key', 'display_name', 'description'])
+        .where('org_id', '=', org.id)
+        .execute();
+      expect(roles).toHaveLength(Object.values(UserRole).length);
+      expect(roles.find(({ key }) => key === UserRole.ADMIN)).toEqual({
+        id: admin.id,
+        key: UserRole.ADMIN,
+        display_name: 'Edited admin',
+        description: 'Custom description',
+      });
+      const adminPermissions = await deps.KyselyPg.selectFrom(
+        'public.role_permissions',
+      )
+        .select('permission')
+        .where('role_id', '=', admin.id)
+        .execute();
+      expect(adminPermissions).toEqual([{ permission: 'MANAGE_ORG' }]);
+      for (const roleKey of Object.values(UserRole).filter(
+        (key) => key !== UserRole.ADMIN,
+      )) {
+        const role = roles.find(({ key }) => key === roleKey)!;
+        const permissions = await deps.KyselyPg.selectFrom(
+          'public.role_permissions',
+        )
+          .select('permission')
+          .where('role_id', '=', role.id)
+          .execute();
+        expect(permissions.map(({ permission }) => permission).sort()).toEqual(
+          [...getPermissionsForRole(roleKey)].sort(),
+        );
+      }
+    },
+  );
+
+  testWithFixture('is a no-op when invoked again', async ({ deps, org }) => {
+    await seedSystemRolesForOrg(deps.KyselyPg, org.id);
+    const readState = async () => ({
+      roles: await deps.KyselyPg.selectFrom('public.roles')
+        .selectAll()
+        .where('org_id', '=', org.id)
+        .orderBy('key')
+        .execute(),
+      permissions: await deps.KyselyPg.selectFrom('public.role_permissions')
+        .innerJoin('public.roles', 'public.roles.id', 'role_id')
+        .select(['role_id', 'permission'])
+        .where('org_id', '=', org.id)
+        .orderBy('role_id')
+        .orderBy('permission')
+        .execute(),
+    });
+    const before = await readState();
+
+    await seedSystemRolesForOrg(deps.KyselyPg, org.id);
+
+    expect(await readState()).toEqual(before);
+  });
+});

--- a/server/graphql/datasources/rolePersistence.ts
+++ b/server/graphql/datasources/rolePersistence.ts
@@ -13,6 +13,42 @@ import { makeKyselyTransactionWithRetry } from '../../utils/kyselyTransactionWit
 
 type RolesKysely = Kysely<CombinedPg>;
 
+/** Inserts any missing system roles and their initial permissions for an org. */
+export async function seedSystemRolesForOrg(
+  kysely: RolesKysely,
+  orgId: string,
+): Promise<void> {
+  await makeKyselyTransactionWithRetry(kysely)(async (tx) => {
+    const insertedRoles = await tx
+      .insertInto('public.roles')
+      .values(
+        Object.values(UserRole).map((roleKey) => ({
+          org_id: orgId,
+          key: roleKey,
+          display_name: SystemRoleDefaults[roleKey].displayName,
+          description: SystemRoleDefaults[roleKey].description,
+          is_system: true,
+        })),
+      )
+      .onConflict((oc) => oc.columns(['org_id', 'key']).doNothing())
+      .returning(['id', 'key'])
+      .execute();
+
+    const permissions = insertedRoles.flatMap(({ id, key }) =>
+      getPermissionsForRole(key).map((permission) => ({
+        role_id: id,
+        permission,
+      })),
+    );
+    if (permissions.length > 0) {
+      await tx
+        .insertInto('public.role_permissions')
+        .values(permissions)
+        .execute();
+    }
+  });
+}
+
 /**
  * GraphQL `Role` parent shape returned to the role-editor UI. `id` is the
  * `public.roles.id` UUID when the org has a persisted row, otherwise `null`


### PR DESCRIPTION
## Context & Requests for Reviewers

Fixes #1061 

In https://github.com/roostorg/coop/pull/528, we started working on more granular permissions. Roles + permissions are now persisted in the database.

However, new orgs created since then did *not* get the new DB-backed roles and permissions. Instead, they rely on defaults in the code, and the permissions only get created on-demand when the defaults are edited. This means that there are really 2 different implementations of permissions!

We can clean this up by getting every org to use the DB-backed roles and permissions so there's just one way to do it. This PR:

- Adds a data migration that creates the default roles + permissions for all orgs
- Updates the new-org script so that new orgs are created with the default roles + permissions

Once this is merged, we no longer need the non-DB, code `isFallback` path for permissions.

## Tests

I tested this manually by creating an org on main, editing a default role, then checking out this branch and running the data migration, and verifying the permissions in the DB.

## (Optional) Rollout Plan

N/A

## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] ~~**If you changed anything user-facing** (i.e. user interface or APIs):~~
  Did you update the CHANGELOG.md and related docs?

- [ ] ~~**If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**~~
  Did you update the corresponding history tables and their triggers?

- [ ] ~~**If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**~~
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?

- [ ] ~~**If you added a new signal in `server/services/signalsService/signals/**`:**~~
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System roles and their default permissions are now automatically created for each organization.
  * Existing users and invitations are linked to their corresponding system roles.
  * New organizations receive role setup automatically during creation.
  * Role provisioning is safe to repeat and preserves existing role assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->