### PR TITLE
Remove legacy user role implementation

### DIFF
--- a/client/src/graphql/generated.ts
+++ b/client/src/graphql/generated.ts
@@ -4047,10 +4047,8 @@ export type GQLRole = {
   readonly __typename: 'Role';
   readonly description?: Maybe<Scalars['String']['output']>;
   readonly displayName: Scalars['String']['output'];
-  /** Persisted public.roles.id, or null when the row is materialized lazily on first save. */
-  readonly id?: Maybe<Scalars['ID']['output']>;
-  /** True when permissions/metadata come from the static fallback rather than public.roles. */
-  readonly isFallback: Scalars['Boolean']['output'];
+  /** Persisted public.roles.id. */
+  readonly id: Scalars['ID']['output'];
   readonly isSystem: Scalars['Boolean']['output'];
   /** Stable role identifier (matches UserRole). */
   readonly key: GQLUserRole;
@@ -24909,12 +24907,11 @@ export type GQLRolesForOrgQuery = {
   readonly __typename: 'Query';
   readonly rolesForOrg: ReadonlyArray<{
     readonly __typename: 'Role';
-    readonly id?: string | null;
+    readonly id: string;
     readonly key: GQLUserRole;
     readonly displayName: string;
     readonly description?: string | null;
     readonly isSystem: boolean;
-    readonly isFallback: boolean;
     readonly permissions: ReadonlyArray<GQLUserPermission>;
     readonly userCount: number;
   }>;
@@ -25110,12 +25107,11 @@ export type GQLUpdateRolePermissionsMutation = {
   readonly __typename: 'Mutation';
   readonly updateRolePermissions: {
     readonly __typename: 'Role';
-    readonly id?: string | null;
+    readonly id: string;
     readonly key: GQLUserRole;
     readonly displayName: string;
     readonly description?: string | null;
     readonly isSystem: boolean;
-    readonly isFallback: boolean;
     readonly permissions: ReadonlyArray<GQLUserPermission>;
     readonly userCount: number;
   };
@@ -25129,12 +25125,11 @@ export type GQLRenameRoleMutation = {
   readonly __typename: 'Mutation';
   readonly renameRole: {
     readonly __typename: 'Role';
-    readonly id?: string | null;
+    readonly id: string;
     readonly key: GQLUserRole;
     readonly displayName: string;
     readonly description?: string | null;
     readonly isSystem: boolean;
-    readonly isFallback: boolean;
     readonly permissions: ReadonlyArray<GQLUserPermission>;
     readonly userCount: number;
   };
@@ -43636,7 +43631,6 @@ export const GQLRolesForOrgDocument = gql`
       displayName
       description
       isSystem
-      isFallback
       permissions
       userCount
     }
@@ -44579,7 +44573,6 @@ export const GQLUpdateRolePermissionsDocument = gql`
       displayName
       description
       isSystem
-      isFallback
       permissions
       userCount
     }
@@ -44637,7 +44630,6 @@ export const GQLRenameRoleDocument = gql`
       displayName
       description
       isSystem
-      isFallback
       permissions
       userCount
     }

--- a/client/src/webpages/settings/ManageRolesTab.tsx
+++ b/client/src/webpages/settings/ManageRolesTab.tsx
@@ -22,7 +22,6 @@ gql`
       displayName
       description
       isSystem
-      isFallback
       permissions
       userCount
     }
@@ -122,12 +121,6 @@ export default function ManageRolesTab() {
               {role.description && (
                 <div className="text-sm text-gray-600 line-clamp-4">
                   {role.description}
-                </div>
-              )}
-              {role.isFallback && (
-                <div className="text-xs text-gray-500 italic">
-                  Using default permissions. Save changes to customize for your
-                  organization.
                 </div>
               )}
               <div className="flex-1" />

--- a/client/src/webpages/settings/ManageUsersInviteUserSection.test.tsx
+++ b/client/src/webpages/settings/ManageUsersInviteUserSection.test.tsx
@@ -35,7 +35,6 @@ const rolesMock: MockedResponse = {
           displayName: 'Admin',
           description: '',
           isSystem: true,
-          isFallback: false,
           permissions: [],
           userCount: 1,
         },

--- a/client/src/webpages/settings/RoleEditDialog.tsx
+++ b/client/src/webpages/settings/RoleEditDialog.tsx
@@ -41,7 +41,6 @@ gql`
       displayName
       description
       isSystem
-      isFallback
       permissions
       userCount
     }
@@ -54,7 +53,6 @@ gql`
       displayName
       description
       isSystem
-      isFallback
       permissions
       userCount
     }
@@ -66,7 +64,6 @@ type EditableRole = {
   displayName: string;
   description?: string | null;
   permissions: readonly GQLUserPermission[];
-  isFallback: boolean;
   userCount: number;
 };
 
@@ -228,14 +225,6 @@ export default function RoleEditDialog(props: {
                 : 'Any changes to this role will retroactively apply to every user assigned to this role.'}
             </div>
           </div>
-
-          {role.isFallback && (
-            <div className="text-xs text-gray-600 bg-gray-50 border border-gray-200 rounded p-3">
-              This role is currently using default permissions for your
-              organization. Saving will create a custom configuration that
-              overrides the defaults.
-            </div>
-          )}
 
           <div className="flex flex-col gap-2">
             <label

--- a/db/src/scripts/api-server-pg/2026.08.25T15.56.25.remove_legacy_role_columns.sql
+++ b/db/src/scripts/api-server-pg/2026.08.25T15.56.25.remove_legacy_role_columns.sql
@@ -1,0 +1,76 @@
+BEGIN;
+
+-- Prevent role assignments from changing between preflight validation and DDL.
+LOCK TABLE public.roles, public.users, public.invite_user_tokens IN ACCESS EXCLUSIVE MODE;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM public.users AS u
+        LEFT JOIN public.roles AS r ON r.id = u.role_id
+        WHERE u.role_id IS NULL
+            OR r.id IS NULL
+            OR r.org_id IS DISTINCT FROM u.org_id
+            OR r.is_system IS DISTINCT FROM true
+            OR r.key IS NULL
+            OR r.key NOT IN (
+                'ADMIN',
+                'RULES_MANAGER',
+                'MODERATOR_MANAGER',
+                'MODERATOR',
+                'CHILD_SAFETY_MODERATOR',
+                'ANALYST',
+                'EXTERNAL_MODERATOR'
+            )
+    ) THEN
+        RAISE EXCEPTION 'public.users contains an invalid role_id: role_id must be non-null, reference public.roles(id), belong to the same org, and identify a system role with a recognized key';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM public.invite_user_tokens AS t
+        LEFT JOIN public.roles AS r ON r.id = t.role_id
+        WHERE t.role_id IS NULL
+            OR r.id IS NULL
+            OR r.org_id IS DISTINCT FROM t.org_id
+            OR r.is_system IS DISTINCT FROM true
+            OR r.key IS NULL
+            OR r.key NOT IN (
+                'ADMIN',
+                'RULES_MANAGER',
+                'MODERATOR_MANAGER',
+                'MODERATOR',
+                'CHILD_SAFETY_MODERATOR',
+                'ANALYST',
+                'EXTERNAL_MODERATOR'
+            )
+    ) THEN
+        RAISE EXCEPTION 'public.invite_user_tokens contains an invalid role_id: role_id must be non-null, reference public.roles(id), belong to the same org, and identify a system role with a recognized key';
+    END IF;
+END
+$$;
+
+ALTER TABLE public.users
+    ALTER COLUMN role_id SET NOT NULL;
+
+ALTER TABLE public.invite_user_tokens
+    ALTER COLUMN role_id SET NOT NULL;
+
+ALTER TABLE public.users
+    DROP CONSTRAINT users_role_id_fkey,
+    ADD CONSTRAINT users_role_id_fkey
+        FOREIGN KEY (role_id) REFERENCES public.roles(id) ON DELETE RESTRICT;
+
+ALTER TABLE public.invite_user_tokens
+    DROP CONSTRAINT invite_user_tokens_role_id_fkey,
+    ADD CONSTRAINT invite_user_tokens_role_id_fkey
+        FOREIGN KEY (role_id) REFERENCES public.roles(id) ON DELETE RESTRICT;
+
+ALTER TABLE public.users
+    DROP COLUMN role;
+
+ALTER TABLE public.invite_user_tokens
+    DROP COLUMN role;
+
+COMMIT;

--- a/db/src/scripts/api-server-pg/2026.08.25T15.56.25.remove_legacy_role_columns.sql
+++ b/db/src/scripts/api-server-pg/2026.08.25T15.56.25.remove_legacy_role_columns.sql
@@ -68,9 +68,10 @@ ALTER TABLE public.invite_user_tokens
         FOREIGN KEY (role_id) REFERENCES public.roles(id) ON DELETE RESTRICT;
 
 ALTER TABLE public.users
-    DROP COLUMN role;
+    ALTER COLUMN role DROP NOT NULL,
+    ALTER COLUMN role DROP DEFAULT;
 
 ALTER TABLE public.invite_user_tokens
-    DROP COLUMN role;
+    ALTER COLUMN role DROP NOT NULL;
 
 COMMIT;

--- a/server/e2e/fixtures/coop.ts
+++ b/server/e2e/fixtures/coop.ts
@@ -23,6 +23,7 @@ async function importSeedHelpers() {
     createOrg,
     ums,
     userPersistence,
+    rolePersistence,
     createRule,
     createMrtQueue,
     itemSubmissionQueue,
@@ -37,6 +38,9 @@ async function importSeedHelpers() {
       `${TRANSPILED}/graphql/datasources/userKyselyPersistence.js`
     ) as Promise<
       typeof import('../../graphql/datasources/userKyselyPersistence.js')
+    >,
+    import(`${TRANSPILED}/graphql/datasources/rolePersistence.js`) as Promise<
+      typeof import('../../graphql/datasources/rolePersistence.js')
     >,
     import(`${TRANSPILED}/test/fixtureHelpers/createRule.js`) as Promise<
       typeof import('../../test/fixtureHelpers/createRule.js')
@@ -53,6 +57,7 @@ async function importSeedHelpers() {
     hashPassword: ums.hashPassword,
     UserRole: ums.UserRole,
     kyselyUserInsert: userPersistence.kyselyUserInsert,
+    seedSystemRolesForOrg: rolePersistence.seedSystemRolesForOrg,
     createRule: createRule.default,
     createMrtQueue: createMrtQueue.default,
     ITEM_SUBMISSION_QUEUE_NAME: itemSubmissionQueue.ITEM_SUBMISSION_QUEUE_NAME,
@@ -88,10 +93,16 @@ class Seeder {
    */
   async orgWithAdmin(opts: { password?: string } = {}): Promise<SeededAdmin> {
     const password = opts.password ?? 'e2e-password';
-    const { createOrg, hashPassword, UserRole, kyselyUserInsert } =
-      await importSeedHelpers();
+    const {
+      createOrg,
+      hashPassword,
+      UserRole,
+      kyselyUserInsert,
+      seedSystemRolesForOrg,
+    } = await importSeedHelpers();
 
     const org = await createOrg(this.deps);
+    await seedSystemRolesForOrg(this.deps.KyselyPg, org.org.id);
 
     const userId = uid();
     const email = `e2e-${userId}@example.com`;

--- a/server/graphql/datasources/OrgApi.test.ts
+++ b/server/graphql/datasources/OrgApi.test.ts
@@ -6,6 +6,7 @@ import createContentItemTypes from '../../test/fixtureHelpers/createContentItemT
 import createOrg from '../../test/fixtureHelpers/createOrg.js';
 import { makeTransactionalTestWithFixture } from '../../test/harness/transactionalTest.js';
 import { CoopError } from '../../utils/errors.js';
+import { seedSystemRolesForOrg } from './rolePersistence.js';
 import { kyselyUserInsert } from './userKyselyPersistence.js';
 
 describe('OrgAPI', () => {
@@ -18,6 +19,7 @@ describe('OrgAPI', () => {
       },
       uid(),
     );
+    await seedSystemRolesForOrg(deps.KyselyPg, org.id);
     return { org };
   });
 
@@ -243,6 +245,7 @@ describe('OrgAPI', () => {
           },
           uid(),
         );
+        await seedSystemRolesForOrg(deps.KyselyPg, otherOrg.id);
         const otherUserId = uid();
         await kyselyUserInsert({
           db: deps.KyselyPg,

--- a/server/graphql/datasources/rolePersistence.test.ts
+++ b/server/graphql/datasources/rolePersistence.test.ts
@@ -204,6 +204,132 @@ describe('role persistence', () => {
   });
 
   testWithFixture(
+    'lists persisted roles in canonical order with authoritative metadata, permissions, and IDs',
+    async ({ deps, org }) => {
+      const admin = await deps.KyselyPg.selectFrom('public.roles')
+        .select('id')
+        .where('org_id', '=', org.id)
+        .where('key', '=', UserRole.ADMIN)
+        .executeTakeFirstOrThrow();
+      await deps.KyselyPg.updateTable('public.roles')
+        .set({
+          display_name: 'Persisted administrator',
+          description: 'Persisted description',
+        })
+        .where('id', '=', admin.id)
+        .execute();
+      await deps.KyselyPg.deleteFrom('public.role_permissions')
+        .where('role_id', '=', admin.id)
+        .execute();
+      await deps.KyselyPg.insertInto('public.role_permissions')
+        .values({ role_id: admin.id, permission: 'MANAGE_ORG' })
+        .execute();
+      await deps.KyselyPg.insertInto('public.roles')
+        .values({
+          org_id: org.id,
+          key: 'UNKNOWN_ROLE',
+          display_name: 'Unknown role',
+          description: null,
+          is_system: true,
+        })
+        .execute();
+
+      const roles = await kyselyListRolesForOrg(deps.KyselyPg, org.id);
+
+      expect(roles.map(({ key }) => key)).toEqual(Object.values(UserRole));
+      expect(roles.every(({ id }) => typeof id === 'string')).toBe(true);
+      expect(roles.find(({ key }) => key === UserRole.ADMIN)).toMatchObject({
+        id: admin.id,
+        displayName: 'Persisted administrator',
+        description: 'Persisted description',
+        permissions: ['MANAGE_ORG'],
+      });
+    },
+  );
+
+  testWithFixture(
+    'returns an empty persisted permission set instead of role defaults',
+    async ({ deps, org }) => {
+      const role = await deps.KyselyPg.selectFrom('public.roles')
+        .select('id')
+        .where('org_id', '=', org.id)
+        .where('key', '=', UserRole.ADMIN)
+        .executeTakeFirstOrThrow();
+      await deps.KyselyPg.deleteFrom('public.role_permissions')
+        .where('role_id', '=', role.id)
+        .execute();
+
+      const roles = await kyselyListRolesForOrg(deps.KyselyPg, org.id);
+
+      expect(
+        roles.find(({ key }) => key === UserRole.ADMIN)?.permissions,
+      ).toEqual([]);
+    },
+  );
+
+  testWithFixture(
+    'rejects listing when an expected persisted system role is missing',
+    async ({ deps, org }) => {
+      await deps.KyselyPg.deleteFrom('public.roles')
+        .where('org_id', '=', org.id)
+        .where('key', '=', UserRole.ADMIN)
+        .execute();
+
+      await expect(
+        kyselyListRolesForOrg(deps.KyselyPg, org.id),
+      ).rejects.toThrow();
+    },
+  );
+
+  testWithFixture(
+    'rename rejects a missing role without inserting it',
+    async ({ deps, org }) => {
+      await deps.KyselyPg.deleteFrom('public.roles')
+        .where('org_id', '=', org.id)
+        .where('key', '=', UserRole.ADMIN)
+        .execute();
+
+      await expect(
+        kyselyRenameRole(deps.KyselyPg, {
+          orgId: org.id,
+          roleKey: UserRole.ADMIN,
+          displayName: 'Renamed admin',
+        }),
+      ).rejects.toThrow();
+      const persisted = await deps.KyselyPg.selectFrom('public.roles')
+        .select('id')
+        .where('org_id', '=', org.id)
+        .where('key', '=', UserRole.ADMIN)
+        .execute();
+      expect(persisted).toEqual([]);
+    },
+  );
+
+  testWithFixture(
+    'permission update rejects a missing role without inserting it',
+    async ({ deps, org }) => {
+      await deps.KyselyPg.deleteFrom('public.roles')
+        .where('org_id', '=', org.id)
+        .where('key', '=', UserRole.ADMIN)
+        .execute();
+
+      await expect(
+        kyselyUpdateRolePermissions(deps.KyselyPg, {
+          orgId: org.id,
+          roleKey: UserRole.ADMIN,
+          permissions: [],
+        }),
+      ).rejects.toThrow();
+      const persisted = await deps.KyselyPg.selectFrom('public.roles')
+        .select('id')
+        .where('org_id', '=', org.id)
+        .where('key', '=', UserRole.ADMIN)
+        .execute();
+      expect(persisted).toEqual([]);
+    },
+  );
+
+  testWithFixture(
     'counts only approved, non-rejected users by their persisted role ID',
     async ({ deps, org }) => {
       const insertUser = async (
@@ -269,6 +395,7 @@ describe('role persistence', () => {
         .values({
           token: uid(),
           email: `${uid()}@example.com`,
+          role: UserRole.ADMIN,
           role_id: adminRole.id,
           org_id: org.id,
         })

--- a/server/graphql/datasources/rolePersistence.test.ts
+++ b/server/graphql/datasources/rolePersistence.test.ts
@@ -226,7 +226,7 @@ describe('role persistence', () => {
         });
       await insertUser(UserRole.ADMIN, true, false);
       await insertUser(UserRole.MODERATOR, false, false);
-      await insertUser(UserRole.VIEWER, true, true);
+      await insertUser(UserRole.EXTERNAL_MODERATOR, true, true);
 
       const roles = await kyselyListRolesForOrg(deps.KyselyPg, org.id);
 
@@ -236,9 +236,9 @@ describe('role persistence', () => {
       expect(
         roles.find(({ key }) => key === UserRole.MODERATOR)?.userCount,
       ).toBe(0);
-      expect(roles.find(({ key }) => key === UserRole.VIEWER)?.userCount).toBe(
-        0,
-      );
+      expect(
+        roles.find(({ key }) => key === UserRole.EXTERNAL_MODERATOR)?.userCount,
+      ).toBe(0);
     },
   );
 

--- a/server/graphql/datasources/rolePersistence.test.ts
+++ b/server/graphql/datasources/rolePersistence.test.ts
@@ -313,7 +313,6 @@ describe('role persistence', () => {
         .values({
           token: uid(),
           email: `${uid()}@example.com`,
-          role: UserRole.ADMIN,
           role_id: adminRole.id,
           org_id: org.id,
         })

--- a/server/graphql/datasources/rolePersistence.test.ts
+++ b/server/graphql/datasources/rolePersistence.test.ts
@@ -204,7 +204,7 @@ describe('role persistence', () => {
   });
 
   testWithFixture(
-    'lists persisted roles in canonical order with authoritative metadata, permissions, and IDs',
+    'lists roles in canonical order with their metadata and permissions',
     async ({ deps, org }) => {
       const admin = await deps.KyselyPg.selectFrom('public.roles')
         .select('id')
@@ -244,88 +244,6 @@ describe('role persistence', () => {
         description: 'Persisted description',
         permissions: ['MANAGE_ORG'],
       });
-    },
-  );
-
-  testWithFixture(
-    'returns an empty persisted permission set instead of role defaults',
-    async ({ deps, org }) => {
-      const role = await deps.KyselyPg.selectFrom('public.roles')
-        .select('id')
-        .where('org_id', '=', org.id)
-        .where('key', '=', UserRole.ADMIN)
-        .executeTakeFirstOrThrow();
-      await deps.KyselyPg.deleteFrom('public.role_permissions')
-        .where('role_id', '=', role.id)
-        .execute();
-
-      const roles = await kyselyListRolesForOrg(deps.KyselyPg, org.id);
-
-      expect(
-        roles.find(({ key }) => key === UserRole.ADMIN)?.permissions,
-      ).toEqual([]);
-    },
-  );
-
-  testWithFixture(
-    'rejects listing when an expected persisted system role is missing',
-    async ({ deps, org }) => {
-      await deps.KyselyPg.deleteFrom('public.roles')
-        .where('org_id', '=', org.id)
-        .where('key', '=', UserRole.ADMIN)
-        .execute();
-
-      await expect(
-        kyselyListRolesForOrg(deps.KyselyPg, org.id),
-      ).rejects.toThrow();
-    },
-  );
-
-  testWithFixture(
-    'rename rejects a missing role without inserting it',
-    async ({ deps, org }) => {
-      await deps.KyselyPg.deleteFrom('public.roles')
-        .where('org_id', '=', org.id)
-        .where('key', '=', UserRole.ADMIN)
-        .execute();
-
-      await expect(
-        kyselyRenameRole(deps.KyselyPg, {
-          orgId: org.id,
-          roleKey: UserRole.ADMIN,
-          displayName: 'Renamed admin',
-        }),
-      ).rejects.toThrow();
-      const persisted = await deps.KyselyPg.selectFrom('public.roles')
-        .select('id')
-        .where('org_id', '=', org.id)
-        .where('key', '=', UserRole.ADMIN)
-        .execute();
-      expect(persisted).toEqual([]);
-    },
-  );
-
-  testWithFixture(
-    'permission update rejects a missing role without inserting it',
-    async ({ deps, org }) => {
-      await deps.KyselyPg.deleteFrom('public.roles')
-        .where('org_id', '=', org.id)
-        .where('key', '=', UserRole.ADMIN)
-        .execute();
-
-      await expect(
-        kyselyUpdateRolePermissions(deps.KyselyPg, {
-          orgId: org.id,
-          roleKey: UserRole.ADMIN,
-          permissions: [],
-        }),
-      ).rejects.toThrow();
-      const persisted = await deps.KyselyPg.selectFrom('public.roles')
-        .select('id')
-        .where('org_id', '=', org.id)
-        .where('key', '=', UserRole.ADMIN)
-        .execute();
-      expect(persisted).toEqual([]);
     },
   );
 

--- a/server/graphql/datasources/rolePersistence.test.ts
+++ b/server/graphql/datasources/rolePersistence.test.ts
@@ -7,7 +7,12 @@ import {
 } from '../../services/userManagementService/index.js';
 import createOrg from '../../test/fixtureHelpers/createOrg.js';
 import { makeTransactionalTestWithFixture } from '../../test/harness/transactionalTest.js';
-import { seedSystemRolesForOrg } from './rolePersistence.js';
+import {
+  kyselyListRolesForOrg,
+  kyselyRenameRole,
+  kyselyUpdateRolePermissions,
+  seedSystemRolesForOrg,
+} from './rolePersistence.js';
 import { kyselyUserInsert } from './userKyselyPersistence.js';
 
 describe('seedSystemRolesForOrg', () => {
@@ -182,4 +187,120 @@ describe('seedSystemRolesForOrg', () => {
 
     expect(await readState()).toEqual(before);
   });
+});
+
+describe('role persistence', () => {
+  const testWithFixture = makeTransactionalTestWithFixture(async ({ deps }) => {
+    const { org } = await createOrg(
+      {
+        KyselyPg: deps.KyselyPg,
+        ModerationConfigService: deps.ModerationConfigService,
+        ApiKeyService: deps.ApiKeyService,
+      },
+      uid(),
+    );
+    await seedSystemRolesForOrg(deps.KyselyPg, org.id);
+    return { org };
+  });
+
+  testWithFixture(
+    'counts only approved, non-rejected users by their persisted role ID',
+    async ({ deps, org }) => {
+      const insertUser = async (
+        role: UserRole,
+        approvedByAdmin: boolean,
+        rejectedByAdmin: boolean,
+      ) =>
+        kyselyUserInsert({
+          db: deps.KyselyPg,
+          id: uid(),
+          orgId: org.id,
+          email: `${uid()}@example.com`,
+          firstName: 'Role',
+          lastName: 'Member',
+          role,
+          password: null,
+          loginMethods: ['saml'],
+          approvedByAdmin,
+          rejectedByAdmin,
+        });
+      await insertUser(UserRole.ADMIN, true, false);
+      await insertUser(UserRole.MODERATOR, false, false);
+      await insertUser(UserRole.VIEWER, true, true);
+
+      const roles = await kyselyListRolesForOrg(deps.KyselyPg, org.id);
+
+      expect(roles.find(({ key }) => key === UserRole.ADMIN)?.userCount).toBe(
+        1,
+      );
+      expect(
+        roles.find(({ key }) => key === UserRole.MODERATOR)?.userCount,
+      ).toBe(0);
+      expect(roles.find(({ key }) => key === UserRole.VIEWER)?.userCount).toBe(
+        0,
+      );
+    },
+  );
+
+  testWithFixture(
+    'retains assignments and role-ID counts across metadata and permission changes',
+    async ({ deps, org }) => {
+      const userId = uid();
+      await kyselyUserInsert({
+        db: deps.KyselyPg,
+        id: userId,
+        orgId: org.id,
+        email: `${uid()}@example.com`,
+        firstName: 'Role',
+        lastName: 'Member',
+        role: UserRole.ADMIN,
+        password: null,
+        loginMethods: ['saml'],
+        approvedByAdmin: true,
+      });
+      const adminRole = await deps.KyselyPg.selectFrom('public.roles')
+        .select('id')
+        .where('org_id', '=', org.id)
+        .where('key', '=', UserRole.ADMIN)
+        .executeTakeFirstOrThrow();
+      const inviteId = await deps.KyselyPg.insertInto(
+        'public.invite_user_tokens',
+      )
+        .values({
+          token: uid(),
+          email: `${uid()}@example.com`,
+          role_id: adminRole.id,
+          org_id: org.id,
+        })
+        .returning('id')
+        .executeTakeFirstOrThrow();
+
+      const renamed = await kyselyRenameRole(deps.KyselyPg, {
+        orgId: org.id,
+        roleKey: UserRole.ADMIN,
+        displayName: 'Organization owner',
+      });
+      const updated = await kyselyUpdateRolePermissions(deps.KyselyPg, {
+        orgId: org.id,
+        roleKey: UserRole.ADMIN,
+        permissions: [],
+      });
+
+      expect(renamed.userCount).toBe(1);
+      expect(updated.userCount).toBe(1);
+      expect(updated.permissions).toEqual([]);
+      expect(
+        await deps.KyselyPg.selectFrom('public.users')
+          .select('role_id')
+          .where('id', '=', userId)
+          .executeTakeFirstOrThrow(),
+      ).toEqual({ role_id: adminRole.id });
+      expect(
+        await deps.KyselyPg.selectFrom('public.invite_user_tokens')
+          .select('role_id')
+          .where('id', '=', inviteId.id)
+          .executeTakeFirstOrThrow(),
+      ).toEqual({ role_id: adminRole.id });
+    },
+  );
 });

--- a/server/graphql/datasources/rolePersistence.test.ts
+++ b/server/graphql/datasources/rolePersistence.test.ts
@@ -248,7 +248,7 @@ describe('role persistence', () => {
   );
 
   testWithFixture(
-    'counts only approved, non-rejected users by their persisted role ID',
+    'counts approved and pending non-rejected users by their persisted role ID',
     async ({ deps, org }) => {
       const insertUser = async (
         role: UserRole,
@@ -279,7 +279,7 @@ describe('role persistence', () => {
       );
       expect(
         roles.find(({ key }) => key === UserRole.MODERATOR)?.userCount,
-      ).toBe(0);
+      ).toBe(1);
       expect(
         roles.find(({ key }) => key === UserRole.EXTERNAL_MODERATOR)?.userCount,
       ).toBe(0);

--- a/server/graphql/datasources/rolePersistence.ts
+++ b/server/graphql/datasources/rolePersistence.ts
@@ -127,17 +127,16 @@ export async function kyselyListRolesForOrg(
     persistedByKey.set(row.key, row);
   }
 
-  // Count by legacy `role` string to cover users predating the role_id backfill.
   const userCountRows = await countApprovedUsersByRole(kysely, orgId);
   const userCountsByRole = new Map<string, number>();
   for (const r of userCountRows) {
-    userCountsByRole.set(r.role, r.count);
+    userCountsByRole.set(r.roleId, r.count);
   }
 
   return Object.values(UserRole).map((roleKey) => {
     const row = persistedByKey.get(roleKey);
     const defaults = SystemRoleDefaults[roleKey];
-    const userCount = userCountsByRole.get(roleKey) ?? 0;
+    const userCount = row ? (userCountsByRole.get(row.id) ?? 0) : 0;
     if (row !== undefined) {
       // Persisted rows are authoritative; an empty set is a valid saved state.
       return {
@@ -167,24 +166,30 @@ export async function kyselyListRolesForOrg(
 async function countApprovedUsersByRole(
   kysely: RolesKysely,
   orgId: string,
-): Promise<ReadonlyArray<{ role: string; count: number }>> {
+): Promise<ReadonlyArray<{ roleId: string; count: number }>> {
   const rows = await kysely
-    .selectFrom('public.users')
-    .select((eb) => ['role', eb.fn.countAll<string>().as('count')])
-    .where('org_id', '=', orgId)
-    .where('rejected_by_admin', '=', false)
-    .where('role', 'is not', null)
-    .groupBy('role')
+    .selectFrom('public.users as users')
+    .innerJoin('public.roles as roles', (join) =>
+      join
+        .onRef('roles.id', '=', 'users.role_id')
+        .onRef('roles.org_id', '=', 'users.org_id'),
+    )
+    .select((eb) => [
+      'roles.id as roleId',
+      eb.fn.countAll<string>().as('count'),
+    ])
+    .where('users.org_id', '=', orgId)
+    .where('roles.org_id', '=', orgId)
+    .where('users.approved_by_admin', '=', true)
+    .where('users.rejected_by_admin', '=', false)
+    .groupBy('roles.id')
     .execute();
-  return rows
-    .filter((r): r is { role: string; count: string } => r.role != null)
-    .map((r) => ({ role: r.role, count: Number(r.count) }));
+  return rows.map((r) => ({ roleId: r.roleId, count: Number(r.count) }));
 }
 
 /**
  * Atomically replaces the permission set for `(orgId, roleKey)`. Materializes
- * the `public.roles` row on first save and backfills `role_id` on existing
- * users/invites so the next load picks up the persisted permissions.
+ * the `public.roles` row on first save.
  */
 export async function kyselyUpdateRolePermissions(
   kysely: RolesKysely,
@@ -297,22 +302,6 @@ async function ensureSystemRoleRow(
       .execute();
   }
 
-  // Backfill role_id on rows where it's NULL; don't stomp existing links.
-  await tx
-    .updateTable('public.users')
-    .set({ role_id: inserted.id })
-    .where('org_id', '=', opts.orgId)
-    .where('role', '=', opts.roleKey)
-    .where('role_id', 'is', null)
-    .execute();
-  await tx
-    .updateTable('public.invite_user_tokens')
-    .set({ role_id: inserted.id })
-    .where('org_id', '=', opts.orgId)
-    .where('role', '=', opts.roleKey)
-    .where('role_id', 'is', null)
-    .execute();
-
   return inserted.id;
 }
 
@@ -334,7 +323,7 @@ async function readRoleAfterWrite(
     .map((p) => p.permission)
     .filter(isUserPermission);
   const counts = await countApprovedUsersByRole(tx, opts.orgId);
-  const userCount = counts.find((c) => c.role === opts.roleKey)?.count ?? 0;
+  const userCount = counts.find((c) => c.roleId === opts.roleId)?.count ?? 0;
   return {
     id: row.id,
     key: opts.roleKey,

--- a/server/graphql/datasources/rolePersistence.ts
+++ b/server/graphql/datasources/rolePersistence.ts
@@ -49,23 +49,14 @@ export async function seedSystemRolesForOrg(
   });
 }
 
-/**
- * GraphQL `Role` parent shape returned to the role-editor UI. `id` is the
- * `public.roles.id` UUID when the org has a persisted row, otherwise `null`
- * (the row is materialized lazily on first save). `key` matches a
- * {@link UserRole} value and is the stable identifier the client sends back
- * on mutations.
- */
+/** GraphQL `Role` parent shape returned to the role-editor UI. */
 export type RoleParent = {
-  id: string | null;
+  id: string;
   key: UserRole;
   displayName: string;
   description: string | null;
   isSystem: boolean;
   permissions: UserPermission[];
-  /** True when this role is materialized from {@link SystemRoleDefaults} */
-  /** plus {@link UserPermissionsForRole} rather than `public.roles`. */
-  isFallback: boolean;
   /** Approved (non-rejected) users in the org assigned to this role. */
   userCount: number;
 };
@@ -78,13 +69,7 @@ type RoleRow = {
   is_system: boolean;
 };
 
-/**
- * Lists every system role for an org, merging persisted rows with the
- * static defaults so freshly created orgs (which haven't been seeded by
- * the role migration) still surface a complete role list. Permissions for
- * persisted rows come from `public.role_permissions`; missing rows fall
- * back to {@link UserPermissionsForRole}.
- */
+/** Lists every persisted system role for an org. */
 export async function kyselyListRolesForOrg(
   kysely: RolesKysely,
   orgId: string,
@@ -96,9 +81,7 @@ export async function kyselyListRolesForOrg(
     .where('is_system', '=', true)
     .execute();
 
-  const persistedIds = persistedRows
-    .filter((r): r is RoleRow & { id: string } => Boolean(r.id))
-    .map((r) => r.id);
+  const persistedIds = persistedRows.map((r) => r.id);
 
   const permissionRows: ReadonlyArray<{
     role_id: string;
@@ -127,6 +110,12 @@ export async function kyselyListRolesForOrg(
     persistedByKey.set(row.key, row);
   }
 
+  for (const roleKey of Object.values(UserRole)) {
+    if (!persistedByKey.has(roleKey)) {
+      throw new Error(`Missing persisted system role: ${roleKey}`);
+    }
+  }
+
   const userCountRows = await countApprovedUsersByRole(kysely, orgId);
   const userCountsByRole = new Map<string, number>();
   for (const r of userCountRows) {
@@ -134,31 +123,15 @@ export async function kyselyListRolesForOrg(
   }
 
   return Object.values(UserRole).map((roleKey) => {
-    const row = persistedByKey.get(roleKey);
-    const defaults = SystemRoleDefaults[roleKey];
-    const userCount = row ? (userCountsByRole.get(row.id) ?? 0) : 0;
-    if (row !== undefined) {
-      // Persisted rows are authoritative; an empty set is a valid saved state.
-      return {
-        id: row.id,
-        key: roleKey,
-        displayName: row.display_name,
-        description: row.description,
-        isSystem: row.is_system,
-        permissions: permissionsByRoleId.get(row.id) ?? [],
-        isFallback: false,
-        userCount,
-      };
-    }
+    const row = persistedByKey.get(roleKey)!;
     return {
-      id: null,
+      id: row.id,
       key: roleKey,
-      displayName: defaults.displayName,
-      description: defaults.description,
-      isSystem: true,
-      permissions: getPermissionsForRole(roleKey),
-      isFallback: true,
-      userCount,
+      displayName: row.display_name,
+      description: row.description,
+      isSystem: row.is_system,
+      permissions: permissionsByRoleId.get(row.id) ?? [],
+      userCount: userCountsByRole.get(row.id) ?? 0,
     };
   });
 }
@@ -188,8 +161,7 @@ async function countApprovedUsersByRole(
 }
 
 /**
- * Atomically replaces the permission set for `(orgId, roleKey)`. Materializes
- * the `public.roles` row on first save.
+ * Atomically replaces the permission set for `(orgId, roleKey)`.
  */
 export async function kyselyUpdateRolePermissions(
   kysely: RolesKysely,
@@ -201,7 +173,7 @@ export async function kyselyUpdateRolePermissions(
 ): Promise<RoleParent> {
   const { orgId, roleKey, permissions } = opts;
   return makeKyselyTransactionWithRetry(kysely)(async (tx) => {
-    const roleId = await ensureSystemRoleRow(tx, { orgId, roleKey });
+    const roleId = await getSystemRoleId(tx, { orgId, roleKey });
     await tx
       .deleteFrom('public.role_permissions')
       .where('role_id', '=', roleId)
@@ -224,7 +196,6 @@ export async function kyselyUpdateRolePermissions(
 
 /**
  * Renames a role's display name and optionally its description.
- * Materializes the `public.roles` row on first save.
  */
 export async function kyselyRenameRole(
   kysely: RolesKysely,
@@ -237,7 +208,7 @@ export async function kyselyRenameRole(
 ): Promise<RoleParent> {
   const { orgId, roleKey, displayName, description } = opts;
   return makeKyselyTransactionWithRetry(kysely)(async (tx) => {
-    const roleId = await ensureSystemRoleRow(tx, { orgId, roleKey });
+    const roleId = await getSystemRoleId(tx, { orgId, roleKey });
     await tx
       .updateTable('public.roles')
       .set({
@@ -255,7 +226,7 @@ export function kyselyGetPermissionGroups(): readonly PermissionGroup[] {
   return getPermissionGroups();
 }
 
-async function ensureSystemRoleRow(
+async function getSystemRoleId(
   tx: RolesKysely,
   opts: { orgId: string; roleKey: UserRole },
 ): Promise<string> {
@@ -265,44 +236,8 @@ async function ensureSystemRoleRow(
     .where('org_id', '=', opts.orgId)
     .where('key', '=', opts.roleKey)
     .where('is_system', '=', true)
-    .executeTakeFirst();
-  if (existing !== undefined) {
-    return existing.id;
-  }
-
-  const defaults = SystemRoleDefaults[opts.roleKey];
-  const inserted = await tx
-    .insertInto('public.roles')
-    .values({
-      org_id: opts.orgId,
-      key: opts.roleKey,
-      display_name: defaults.displayName,
-      description: defaults.description,
-      is_system: true,
-    })
-    .returning('id')
     .executeTakeFirstOrThrow();
-
-  // Seed permissions from the static defaults so a freshly materialized
-  // row never looks like an "explicitly empty" set to readers. Callers that
-  // overwrite permissions (e.g. kyselyUpdateRolePermissions) delete these
-  // before inserting their own.
-  const seededPermissions = Array.from(
-    new Set(getPermissionsForRole(opts.roleKey)),
-  );
-  if (seededPermissions.length > 0) {
-    await tx
-      .insertInto('public.role_permissions')
-      .values(
-        seededPermissions.map((permission) => ({
-          role_id: inserted.id,
-          permission,
-        })),
-      )
-      .execute();
-  }
-
-  return inserted.id;
+  return existing.id;
 }
 
 async function readRoleAfterWrite(
@@ -331,7 +266,6 @@ async function readRoleAfterWrite(
     description: row.description,
     isSystem: row.is_system,
     permissions,
-    isFallback: false,
     userCount,
   };
 }

--- a/server/graphql/datasources/rolePersistence.ts
+++ b/server/graphql/datasources/rolePersistence.ts
@@ -153,7 +153,6 @@ async function countApprovedUsersByRole(
     ])
     .where('users.org_id', '=', orgId)
     .where('roles.org_id', '=', orgId)
-    .where('users.approved_by_admin', '=', true)
     .where('users.rejected_by_admin', '=', false)
     .groupBy('roles.id')
     .execute();

--- a/server/graphql/datasources/userKyselyPersistence.test.ts
+++ b/server/graphql/datasources/userKyselyPersistence.test.ts
@@ -5,6 +5,7 @@ import { UserRole } from '../../services/userManagementService/index.js';
 import createOrg from '../../test/fixtureHelpers/createOrg.js';
 import createRule from '../../test/fixtureHelpers/createRule.js';
 import { makeTransactionalTestWithFixture } from '../../test/harness/transactionalTest.js';
+import { seedSystemRolesForOrg } from './rolePersistence.js';
 import {
   kyselyUserAddFavoriteRule,
   kyselyUserFindByEmail,
@@ -32,12 +33,6 @@ function samlUserInput(orgId: string) {
   };
 }
 
-const adminRoleSeed = {
-  key: UserRole.ADMIN,
-  display_name: 'Admin',
-  is_system: true,
-} as const;
-
 describe('userKyselyPersistence', () => {
   const testWithFixture = makeTransactionalTestWithFixture(async ({ deps }) => {
     const { org } = await createOrg(
@@ -48,6 +43,7 @@ describe('userKyselyPersistence', () => {
       },
       uid(),
     );
+    await seedSystemRolesForOrg(deps.KyselyPg, org.id);
     return { org };
   });
 
@@ -72,7 +68,16 @@ describe('userKyselyPersistence', () => {
           approvedByAdmin: false,
           rejectedByAdmin: false,
         });
-        // Fixture orgs lack `public.roles` rows, so this hits the fallback.
+        const persisted = await deps.KyselyPg.selectFrom('public.users')
+          .select('role_id')
+          .where('id', '=', input.id)
+          .executeTakeFirstOrThrow();
+        const adminRole = await deps.KyselyPg.selectFrom('public.roles')
+          .select('id')
+          .where('org_id', '=', org.id)
+          .where('key', '=', UserRole.ADMIN)
+          .executeTakeFirstOrThrow();
+        expect(persisted.role_id).toBe(adminRole.id);
         const permissions = inserted.getPermissions();
         expect(permissions).toContain('MANAGE_ORG');
         expect(permissions).toContain('MANAGE_ROLES');
@@ -88,6 +93,12 @@ describe('userKyselyPersistence', () => {
           role: UserRole.ANALYST,
         });
         expect(updated!.role).toBe(UserRole.ANALYST);
+        const persisted = await deps.KyselyPg.selectFrom('public.users')
+          .innerJoin('public.roles', 'public.roles.id', 'public.users.role_id')
+          .select(['public.users.role_id', 'public.roles.key'])
+          .where('public.users.id', '=', input.id)
+          .executeTakeFirstOrThrow();
+        expect(persisted.key).toBe(UserRole.ANALYST);
         const permissions = updated!.getPermissions();
         expect(permissions).toContain('VIEW_INSIGHTS');
         expect(permissions).not.toContain('MANAGE_ORG');
@@ -98,10 +109,14 @@ describe('userKyselyPersistence', () => {
       'getPermissions() reads from public.role_permissions when the org has saved them',
       async ({ deps, org }) => {
         // Reduced ADMIN set distinguishes DB result from the static fallback.
-        const roleRow = await deps.KyselyPg.insertInto('public.roles')
-          .values({ ...adminRoleSeed, org_id: org.id })
-          .returning('id')
+        const roleRow = await deps.KyselyPg.selectFrom('public.roles')
+          .select('id')
+          .where('org_id', '=', org.id)
+          .where('key', '=', UserRole.ADMIN)
           .executeTakeFirstOrThrow();
+        await deps.KyselyPg.deleteFrom('public.role_permissions')
+          .where('role_id', '=', roleRow.id)
+          .execute();
         await deps.KyselyPg.insertInto('public.role_permissions')
           .values({ role_id: roleRow.id, permission: 'MANAGE_ORG' })
           .execute();
@@ -119,8 +134,13 @@ describe('userKyselyPersistence', () => {
       'getPermissions() returns [] (no static fallback) when the role has zero saved permissions',
       async ({ deps, org }) => {
         // Regression: empty `role_permissions` is least-privilege; defaults would over-grant.
-        await deps.KyselyPg.insertInto('public.roles')
-          .values({ ...adminRoleSeed, org_id: org.id })
+        const adminRole = await deps.KyselyPg.selectFrom('public.roles')
+          .select('id')
+          .where('org_id', '=', org.id)
+          .where('key', '=', UserRole.ADMIN)
+          .executeTakeFirstOrThrow();
+        await deps.KyselyPg.deleteFrom('public.role_permissions')
+          .where('role_id', '=', adminRole.id)
           .execute();
 
         const input = samlUserInput(org.id);
@@ -129,6 +149,23 @@ describe('userKyselyPersistence', () => {
           ...input,
         });
         expect(inserted.getPermissions()).toEqual([]);
+      },
+    );
+
+    testWithFixture(
+      'throws when the requested org-scoped role is missing',
+      async ({ deps, org }) => {
+        await deps.KyselyPg.deleteFrom('public.roles')
+          .where('org_id', '=', org.id)
+          .where('key', '=', UserRole.ADMIN)
+          .execute();
+
+        await expect(
+          kyselyUserInsert({
+            db: deps.KyselyPg,
+            ...samlUserInput(org.id),
+          }),
+        ).rejects.toThrow();
       },
     );
 
@@ -274,9 +311,53 @@ describe('userKyselyPersistence', () => {
         expect(rows.every((r) => r.orgId === org.id)).toBe(true);
       },
     );
+
+    testWithFixture(
+      'find and list helpers derive role from the linked role row',
+      async ({ deps, org }) => {
+        const input = samlUserInput(org.id);
+        await kyselyUserInsert({ db: deps.KyselyPg, ...input });
+        const analyst = await deps.KyselyPg.selectFrom('public.roles')
+          .select('id')
+          .where('org_id', '=', org.id)
+          .where('key', '=', UserRole.ANALYST)
+          .executeTakeFirstOrThrow();
+        await deps.KyselyPg.updateTable('public.users')
+          .set({ role_id: analyst.id })
+          .where('id', '=', input.id)
+          .execute();
+
+        expect((await kyselyUserFindById(deps.KyselyPg, input.id))!.role).toBe(
+          UserRole.ANALYST,
+        );
+        expect(
+          (await kyselyUserListByOrg(deps.KyselyPg, org.id)).find(
+            ({ id }) => id === input.id,
+          )!.role,
+        ).toBe(UserRole.ANALYST);
+      },
+    );
   });
 
   describe('kyselyUserUpdate', () => {
+    testWithFixture(
+      'throws when updating to a missing org-scoped role',
+      async ({ deps, org }) => {
+        const input = samlUserInput(org.id);
+        await kyselyUserInsert({ db: deps.KyselyPg, ...input });
+        await deps.KyselyPg.deleteFrom('public.roles')
+          .where('org_id', '=', org.id)
+          .where('key', '=', UserRole.ANALYST)
+          .execute();
+
+        await expect(
+          kyselyUserUpdate(deps.KyselyPg, input.id, {
+            role: UserRole.ANALYST,
+          }),
+        ).rejects.toThrow();
+      },
+    );
+
     testWithFixture(
       'throws an invariant error for a malformed patch',
       async ({ deps, org }) => {

--- a/server/graphql/datasources/userKyselyPersistence.ts
+++ b/server/graphql/datasources/userKyselyPersistence.ts
@@ -3,7 +3,6 @@ import { sql, type Kysely } from 'kysely';
 import { type CombinedPg } from '../../services/combinedDbTypes.js';
 import { type LoginMethod } from '../../services/coreAppTables.js';
 import {
-  getPermissionsForRole,
   type UserPermission,
   type UserRole,
 } from '../../services/userManagementService/index.js';
@@ -12,22 +11,20 @@ import {
   validateUserUpdatePatch,
 } from './userValidation.js';
 
-// Resolves `(orgId, role)` to the matching `public.roles.id` so writes to
-// `public.users` / `public.invite_user_tokens` keep `role_id` in sync with
-// the legacy `role` varchar. Returns `null` for orgs without seeded role
-// rows; the read fallback handles them.
+// Resolves `(orgId, role)` to the matching `public.roles.id` for the
+// authoritative `public.users.role_id` assignment.
 async function lookupSystemRoleIdForUserRow(
   db: UsersDb,
   opts: { orgId: string; role: UserRole },
-): Promise<string | null> {
+): Promise<string> {
   const row = await db
     .selectFrom('public.roles')
     .select('id')
     .where('org_id', '=', opts.orgId)
     .where('key', '=', opts.role)
     .where('is_system', '=', true)
-    .executeTakeFirst();
-  return row?.id ?? null;
+    .executeTakeFirstOrThrow();
+  return row.id;
 }
 
 /**
@@ -73,7 +70,7 @@ type UserRow = {
   created_at: Date;
   updated_at: Date;
   org_id: string;
-  permissions: UserPermission[] | null;
+  permissions: UserPermission[];
 };
 
 // `public.users.login_methods` is a `login_method_enum[]`. Node-postgres ships
@@ -91,21 +88,16 @@ const loginMethodsAsTextArray = sql<LoginMethod[]>`login_methods::text[]`.as(
 // to avoid a follow-up round-trip. Correlated subquery (rather than LEFT
 // JOIN) preserves the existing INSERT/UPDATE...RETURNING shape, which a
 // JOIN would break by forcing GROUP BY across every selected column.
-//
-// NULL when `role_id` is unset (orgs not yet migrated to DB-backed roles
-// fall back to `UserPermissionsForRole` defaults). An explicitly empty
-// array means the role exists but has no permissions, which is a valid
-// least-privilege state we MUST honor — falling back to defaults there
-// would silently over-grant permissions.
-const permissionsArray = sql<UserPermission[] | null>`(
-  CASE
-    WHEN public.users.role_id IS NULL THEN NULL
-    ELSE (
-      SELECT COALESCE(array_agg(rp.permission), ARRAY[]::varchar[])
-      FROM public.role_permissions rp
-      WHERE rp.role_id = public.users.role_id
-    )
-  END
+const roleKey = sql<UserRole>`(
+  SELECT public.roles.key
+  FROM public.roles
+  WHERE public.roles.id = public.users.role_id
+)`.as('role');
+
+const permissionsArray = sql<UserPermission[]>`(
+  SELECT COALESCE(array_agg(rp.permission), ARRAY[]::varchar[])
+  FROM public.role_permissions rp
+  WHERE rp.role_id = public.users.role_id
 )`.as('permissions');
 
 const USER_COLUMNS = [
@@ -114,7 +106,6 @@ const USER_COLUMNS = [
   'password',
   'first_name',
   'last_name',
-  'role',
   'approved_by_admin',
   'rejected_by_admin',
   'created_at',
@@ -123,10 +114,7 @@ const USER_COLUMNS = [
 ] as const;
 
 function rowToGraphQLUserParent(row: UserRow): GraphQLUserParent {
-  // DB-backed permissions when the org has them (including an explicit
-  // empty set, which means "least privilege" and must NOT escalate to
-  // defaults). Only fall back when there's no role_id at all.
-  const permissions = row.permissions ?? getPermissionsForRole(row.role);
+  const permissions = row.permissions;
   return {
     id: row.id,
     email: row.email,
@@ -153,6 +141,7 @@ export async function kyselyUserFindById(
   const row = await db
     .selectFrom('public.users')
     .select(USER_COLUMNS)
+    .select(roleKey)
     .select(loginMethodsAsTextArray)
     .select(permissionsArray)
     .where('id', '=', id)
@@ -167,6 +156,7 @@ export async function kyselyUserFindByIdAndOrg(
   const row = await db
     .selectFrom('public.users')
     .select(USER_COLUMNS)
+    .select(roleKey)
     .select(loginMethodsAsTextArray)
     .select(permissionsArray)
     .where('id', '=', opts.id)
@@ -182,6 +172,7 @@ export async function kyselyUserFindByEmail(
   const row = await db
     .selectFrom('public.users')
     .select(USER_COLUMNS)
+    .select(roleKey)
     .select(loginMethodsAsTextArray)
     .select(permissionsArray)
     .where('email', '=', email)
@@ -196,6 +187,7 @@ export async function kyselyUserFindByEmailAndOrg(
   const row = await db
     .selectFrom('public.users')
     .select(USER_COLUMNS)
+    .select(roleKey)
     .select(loginMethodsAsTextArray)
     .select(permissionsArray)
     .where('email', '=', opts.email)
@@ -214,6 +206,7 @@ export async function kyselyUserFindByIds(
   const rows = await db
     .selectFrom('public.users')
     .select(USER_COLUMNS)
+    .select(roleKey)
     .select(loginMethodsAsTextArray)
     .select(permissionsArray)
     .where('id', 'in', ids)
@@ -228,6 +221,7 @@ export async function kyselyUserListByOrg(
   const rows = await db
     .selectFrom('public.users')
     .select(USER_COLUMNS)
+    .select(roleKey)
     .select(loginMethodsAsTextArray)
     .select(permissionsArray)
     .where('org_id', '=', orgId)
@@ -279,7 +273,6 @@ export async function kyselyUserInsert(opts: {
       password: opts.password,
       first_name: opts.firstName,
       last_name: opts.lastName,
-      role: opts.role,
       role_id: roleId,
       approved_by_admin: opts.approvedByAdmin ?? false,
       rejected_by_admin: opts.rejectedByAdmin ?? false,
@@ -288,6 +281,7 @@ export async function kyselyUserInsert(opts: {
       updated_at: now,
     })
     .returning(USER_COLUMNS)
+    .returning(roleKey)
     .returning(loginMethodsAsTextArray)
     .returning(permissionsArray)
     .executeTakeFirstOrThrow();
@@ -320,8 +314,7 @@ export async function kyselyUserUpdate(
     email?: string;
     first_name?: string;
     last_name?: string;
-    role?: UserRole;
-    role_id?: string | null;
+    role_id?: string;
     password?: string | null;
     approved_by_admin?: boolean;
     rejected_by_admin?: boolean;
@@ -338,7 +331,6 @@ export async function kyselyUserUpdate(
     update.last_name = patch.lastName;
   }
   if (patch.role != null) {
-    update.role = patch.role;
     // Resolve the role's org via the user row first; the patch doesn't
     // carry orgId, and roles are scoped per org.
     const userOrg = await db
@@ -369,6 +361,7 @@ export async function kyselyUserUpdate(
     .set(update)
     .where('id', '=', userId)
     .returning(USER_COLUMNS)
+    .returning(roleKey)
     .returning(loginMethodsAsTextArray)
     .returning(permissionsArray)
     .executeTakeFirst();

--- a/server/graphql/datasources/userKyselyPersistenceFindByEmailAndOrg.test.ts
+++ b/server/graphql/datasources/userKyselyPersistenceFindByEmailAndOrg.test.ts
@@ -4,6 +4,7 @@ import { uid } from 'uid';
 import { UserRole } from '../../services/userManagementService/index.js';
 import createOrg from '../../test/fixtureHelpers/createOrg.js';
 import { makeTransactionalTestWithFixture } from '../../test/harness/transactionalTest.js';
+import { seedSystemRolesForOrg } from './rolePersistence.js';
 import {
   kyselyUserFindByEmailAndOrg,
   kyselyUserInsert,
@@ -32,6 +33,7 @@ describe('kyselyUserFindByEmailAndOrg', () => {
       },
       uid(),
     );
+    await seedSystemRolesForOrg(deps.KyselyPg, org.id);
     return { org };
   });
 

--- a/server/graphql/generated.ts
+++ b/server/graphql/generated.ts
@@ -4115,10 +4115,8 @@ export type GQLRole = {
   readonly __typename?: 'Role';
   readonly description?: Maybe<Scalars['String']['output']>;
   readonly displayName: Scalars['String']['output'];
-  /** Persisted public.roles.id, or null when the row is materialized lazily on first save. */
-  readonly id?: Maybe<Scalars['ID']['output']>;
-  /** True when permissions/metadata come from the static fallback rather than public.roles. */
-  readonly isFallback: Scalars['Boolean']['output'];
+  /** Persisted public.roles.id. */
+  readonly id: Scalars['ID']['output'];
   readonly isSystem: Scalars['Boolean']['output'];
   /** Stable role identifier (matches UserRole). */
   readonly key: GQLUserRole;
@@ -13364,8 +13362,7 @@ export type GQLRoleResolvers<
     ContextType
   >;
   displayName?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  id?: Resolver<Maybe<GQLResolversTypes['ID']>, ParentType, ContextType>;
-  isFallback?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
   isSystem?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
   key?: Resolver<GQLResolversTypes['UserRole'], ParentType, ContextType>;
   permissions?: Resolver<

--- a/server/graphql/modules/roles.resolver.test.ts
+++ b/server/graphql/modules/roles.resolver.test.ts
@@ -43,7 +43,6 @@ function stubRoleParent() {
     description: 'desc',
     isSystem: true,
     permissions: [UserPermission.MANAGE_ORG],
-    isFallback: false,
     userCount: 1,
   };
 }

--- a/server/graphql/modules/roles.ts
+++ b/server/graphql/modules/roles.ts
@@ -15,16 +15,14 @@ import {
 
 const typeDefs = /* GraphQL */ `
   type Role {
-    "Persisted public.roles.id, or null when the row is materialized lazily on first save."
-    id: ID
+    "Persisted public.roles.id."
+    id: ID!
     "Stable role identifier (matches UserRole)."
     key: UserRole!
     displayName: String!
     description: String
     isSystem: Boolean!
     permissions: [UserPermission!]!
-    "True when permissions/metadata come from the static fallback rather than public.roles."
-    isFallback: Boolean!
     "Number of approved (non-rejected) users in the org assigned to this role."
     userCount: Int!
   }

--- a/server/graphql/utils/resolveSamlUser.test.ts
+++ b/server/graphql/utils/resolveSamlUser.test.ts
@@ -7,6 +7,7 @@ import { UserRole } from '../../services/userManagementService/index.js';
 import createOrg from '../../test/fixtureHelpers/createOrg.js';
 import { makeTransactionalTestWithFixture } from '../../test/harness/transactionalTest.js';
 import { type default as SafeTracer } from '../../utils/SafeTracer.js';
+import { seedSystemRolesForOrg } from '../datasources/rolePersistence.js';
 import {
   kyselyUserInsert,
   type UsersDb,
@@ -40,6 +41,7 @@ describe('resolveSamlUser', () => {
       },
       uid(),
     );
+    await seedSystemRolesForOrg(deps.KyselyPg, org.id);
     return { org };
   });
 

--- a/server/services/coreAppTables.ts
+++ b/server/services/coreAppTables.ts
@@ -1,7 +1,5 @@
 import { type Generated, type GeneratedAlways } from 'kysely';
 
-import { type UserRole } from './userManagementService/index.js';
-
 /** Postgres enum for backtests.status (generated column — read-only in app). */
 export type BacktestStatusDb = 'RUNNING' | 'COMPLETE' | 'CANCELED';
 
@@ -30,8 +28,7 @@ export type CoreAppTablesPg = {
     password: string | null;
     first_name: string;
     last_name: string;
-    role: UserRole;
-    role_id: string | null;
+    role_id: string;
     approved_by_admin: boolean;
     rejected_by_admin: boolean;
     created_at: Date;

--- a/server/services/userManagementService/dbTypes.ts
+++ b/server/services/userManagementService/dbTypes.ts
@@ -6,7 +6,6 @@ import type {
   JobCreationsInput,
 } from '../manualReviewToolService/modules/DecisionAnalytics.js';
 import { type OrgSettingsPg } from '../orgSettingsService/index.js';
-import type { UserRole } from './permissioning.js';
 
 export type MrtChartConfig = {
   title: string;
@@ -72,8 +71,7 @@ export type UserManagementPg = {
     id: GeneratedAlways<string>;
     token: string;
     email: string;
-    role: UserRole;
-    role_id: string | null;
+    role_id: string;
     created_at: GeneratedAlways<Date>;
     updated_at: GeneratedAlways<Date>;
     org_id: string;

--- a/server/services/userManagementService/rolePersistence.test.ts
+++ b/server/services/userManagementService/rolePersistence.test.ts
@@ -60,34 +60,6 @@ describe('UserManagementService role persistence', () => {
   );
 
   testWithFixture(
-    'rejects invite creation when the organization system role is missing',
-    async ({ deps, org }) => {
-      await deps.KyselyPg.deleteFrom('public.role_permissions')
-        .where(
-          'role_id',
-          'in',
-          deps.KyselyPg.selectFrom('public.roles')
-            .select('id')
-            .where('org_id', '=', org.id)
-            .where('key', '=', UserRole.ANALYST),
-        )
-        .execute();
-      await deps.KyselyPg.deleteFrom('public.roles')
-        .where('org_id', '=', org.id)
-        .where('key', '=', UserRole.ANALYST)
-        .execute();
-
-      await expect(
-        deps.UserManagementService.createInviteUserToken({
-          email: faker.internet.email(),
-          role: UserRole.ANALYST,
-          orgId: org.id,
-        }),
-      ).rejects.toThrow();
-    },
-  );
-
-  testWithFixture(
     'signs up with a role-ID-backed invite and consumes its token',
     async ({ deps, org }) => {
       const email = faker.internet.email();
@@ -182,68 +154,6 @@ describe('UserManagementService role persistence', () => {
       ).resolves.toEqual([
         expect.objectContaining({ id: userId, role: UserRole.ANALYST }),
       ]);
-    },
-  );
-
-  testWithFixture(
-    'rejects role updates when the organization system role is missing',
-    async ({ deps, org }) => {
-      const userId = uid();
-      const adminRole = await deps.KyselyPg.selectFrom('public.roles')
-        .select('id')
-        .where('org_id', '=', org.id)
-        .where('key', '=', UserRole.ADMIN)
-        .executeTakeFirstOrThrow();
-      const now = new Date();
-      await deps.KyselyPg.insertInto('public.users')
-        .values({
-          id: userId,
-          org_id: org.id,
-          email: faker.internet.email(),
-          first_name: 'Existing',
-          last_name: 'User',
-          role_id: adminRole.id,
-          login_methods: ['saml'],
-          password: null,
-          approved_by_admin: true,
-          rejected_by_admin: false,
-          created_at: now,
-          updated_at: now,
-        })
-        .execute();
-      await deps.KyselyPg.deleteFrom('public.role_permissions')
-        .where(
-          'role_id',
-          'in',
-          deps.KyselyPg.selectFrom('public.roles')
-            .select('id')
-            .where('org_id', '=', org.id)
-            .where('key', '=', UserRole.ANALYST),
-        )
-        .execute();
-      await deps.KyselyPg.deleteFrom('public.roles')
-        .where('org_id', '=', org.id)
-        .where('key', '=', UserRole.ANALYST)
-        .execute();
-
-      await expect(
-        deps.UserManagementService.updateUserRole({
-          userId,
-          newRole: UserRole.ANALYST,
-          orgId: org.id,
-          invoker: {
-            userId: uid(),
-            orgId: org.id,
-            permissions: [UserPermission.MANAGE_USERS],
-          },
-        }),
-      ).rejects.toThrow();
-
-      const persistedUser = await deps.KyselyPg.selectFrom('public.users')
-        .select('role_id')
-        .where('id', '=', userId)
-        .executeTakeFirstOrThrow();
-      expect(persistedUser.role_id).toBe(adminRole.id);
     },
   );
 });

--- a/server/services/userManagementService/rolePersistence.test.ts
+++ b/server/services/userManagementService/rolePersistence.test.ts
@@ -137,6 +137,7 @@ describe('UserManagementService role persistence', () => {
         .where('org_id', '=', org.id)
         .where('key', '=', UserRole.ADMIN)
         .executeTakeFirstOrThrow();
+      const now = new Date();
       await deps.KyselyPg.insertInto('public.users')
         .values({
           id: userId,
@@ -149,6 +150,8 @@ describe('UserManagementService role persistence', () => {
           password: null,
           approved_by_admin: true,
           rejected_by_admin: false,
+          created_at: now,
+          updated_at: now,
         })
         .execute();
 
@@ -191,6 +194,7 @@ describe('UserManagementService role persistence', () => {
         .where('org_id', '=', org.id)
         .where('key', '=', UserRole.ADMIN)
         .executeTakeFirstOrThrow();
+      const now = new Date();
       await deps.KyselyPg.insertInto('public.users')
         .values({
           id: userId,
@@ -203,6 +207,8 @@ describe('UserManagementService role persistence', () => {
           password: null,
           approved_by_admin: true,
           rejected_by_admin: false,
+          created_at: now,
+          updated_at: now,
         })
         .execute();
       await deps.KyselyPg.deleteFrom('public.role_permissions')

--- a/server/services/userManagementService/rolePersistence.test.ts
+++ b/server/services/userManagementService/rolePersistence.test.ts
@@ -1,0 +1,243 @@
+import { faker } from '@faker-js/faker';
+import { uid } from 'uid';
+
+// This integration fixture intentionally exercises the production role seeder.
+// eslint-disable-next-line import/no-restricted-paths
+import { seedSystemRolesForOrg } from '../../graphql/datasources/rolePersistence.js';
+// This integration fixture calls the GraphQL datasource with its generated enum.
+// eslint-disable-next-line no-restricted-syntax, import/no-restricted-paths
+import { GQLUserRole } from '../../graphql/generated.js';
+import createOrg from '../../test/fixtureHelpers/createOrg.js';
+import { makeTransactionalTestWithFixture } from '../../test/harness/transactionalTest.js';
+import { UserPermission, UserRole } from './permissioning.js';
+
+describe('UserManagementService role persistence', () => {
+  const testWithFixture = makeTransactionalTestWithFixture(async ({ deps }) => {
+    const { org } = await createOrg(
+      {
+        KyselyPg: deps.KyselyPg,
+        ModerationConfigService: deps.ModerationConfigService,
+        ApiKeyService: deps.ApiKeyService,
+      },
+      uid(),
+    );
+    await seedSystemRolesForOrg(deps.KyselyPg, org.id);
+    return { org };
+  });
+
+  testWithFixture(
+    'creates and reads invites through their organization role ID',
+    async ({ deps, org }) => {
+      const email = faker.internet.email();
+      const token = await deps.UserManagementService.createInviteUserToken({
+        email,
+        role: UserRole.ANALYST,
+        orgId: org.id,
+      });
+
+      const persisted = await deps.KyselyPg.selectFrom(
+        'public.invite_user_tokens',
+      )
+        .innerJoin('public.roles', 'public.roles.id', 'role_id')
+        .select(['role_id', 'public.roles.key'])
+        .where('token', '=', token)
+        .executeTakeFirstOrThrow();
+      expect(persisted.role_id).not.toBeNull();
+      expect(persisted.key).toBe(UserRole.ANALYST);
+      await expect(
+        deps.UserManagementService.getInviteUserToken({ token }),
+      ).resolves.toMatchObject({
+        email,
+        orgId: org.id,
+        role: UserRole.ANALYST,
+      });
+      await expect(
+        deps.UserManagementService.getPendingInvites(org.id),
+      ).resolves.toEqual([
+        expect.objectContaining({ email, role: UserRole.ANALYST }),
+      ]);
+    },
+  );
+
+  testWithFixture(
+    'rejects invite creation when the organization system role is missing',
+    async ({ deps, org }) => {
+      await deps.KyselyPg.deleteFrom('public.role_permissions')
+        .where(
+          'role_id',
+          'in',
+          deps.KyselyPg.selectFrom('public.roles')
+            .select('id')
+            .where('org_id', '=', org.id)
+            .where('key', '=', UserRole.ANALYST),
+        )
+        .execute();
+      await deps.KyselyPg.deleteFrom('public.roles')
+        .where('org_id', '=', org.id)
+        .where('key', '=', UserRole.ANALYST)
+        .execute();
+
+      await expect(
+        deps.UserManagementService.createInviteUserToken({
+          email: faker.internet.email(),
+          role: UserRole.ANALYST,
+          orgId: org.id,
+        }),
+      ).rejects.toThrow();
+    },
+  );
+
+  testWithFixture(
+    'signs up with a role-ID-backed invite and consumes its token',
+    async ({ deps, org }) => {
+      const email = faker.internet.email();
+      const token = await deps.UserManagementService.createInviteUserToken({
+        email,
+        role: UserRole.ANALYST,
+        orgId: org.id,
+      });
+      const input = {
+        email,
+        firstName: 'Invited',
+        lastName: 'User',
+        inviteUserToken: token,
+        loginMethod: 'SAML' as const,
+        orgId: org.id,
+      };
+
+      await expect(
+        deps.UserAPIDataSource.signUp(
+          { input: { ...input, role: GQLUserRole.Admin } },
+          undefined,
+        ),
+      ).rejects.toThrow('Invalid invite token');
+
+      const user = await deps.UserAPIDataSource.signUp(
+        { input: { ...input, role: GQLUserRole.Analyst } },
+        undefined,
+      );
+      expect(user).toMatchObject({
+        email,
+        orgId: org.id,
+        role: UserRole.ANALYST,
+      });
+      expect(user.id).toEqual(expect.any(String));
+      await expect(
+        deps.UserManagementService.getInviteUserToken({ token }),
+      ).resolves.toBeNull();
+    },
+  );
+
+  testWithFixture(
+    'updates a user through the organization role ID and round-trips its key',
+    async ({ deps, org }) => {
+      const userId = uid();
+      const adminRole = await deps.KyselyPg.selectFrom('public.roles')
+        .select('id')
+        .where('org_id', '=', org.id)
+        .where('key', '=', UserRole.ADMIN)
+        .executeTakeFirstOrThrow();
+      await deps.KyselyPg.insertInto('public.users')
+        .values({
+          id: userId,
+          org_id: org.id,
+          email: faker.internet.email(),
+          first_name: 'Role',
+          last_name: 'User',
+          role_id: adminRole.id,
+          login_methods: ['saml'],
+          password: null,
+          approved_by_admin: true,
+          rejected_by_admin: false,
+        })
+        .execute();
+
+      await deps.UserManagementService.updateUserRole({
+        userId,
+        newRole: UserRole.ANALYST,
+        orgId: org.id,
+        invoker: {
+          userId: uid(),
+          orgId: org.id,
+          permissions: [UserPermission.MANAGE_USERS],
+        },
+      });
+
+      const analystRole = await deps.KyselyPg.selectFrom('public.roles')
+        .select('id')
+        .where('org_id', '=', org.id)
+        .where('key', '=', UserRole.ANALYST)
+        .executeTakeFirstOrThrow();
+      const persistedUser = await deps.KyselyPg.selectFrom('public.users')
+        .select('role_id')
+        .where('id', '=', userId)
+        .executeTakeFirstOrThrow();
+      expect(persistedUser.role_id).toBe(analystRole.id);
+
+      await expect(
+        deps.UserManagementService.getUsersForOrg(org.id),
+      ).resolves.toEqual([
+        expect.objectContaining({ id: userId, role: UserRole.ANALYST }),
+      ]);
+    },
+  );
+
+  testWithFixture(
+    'rejects role updates when the organization system role is missing',
+    async ({ deps, org }) => {
+      const userId = uid();
+      const adminRole = await deps.KyselyPg.selectFrom('public.roles')
+        .select('id')
+        .where('org_id', '=', org.id)
+        .where('key', '=', UserRole.ADMIN)
+        .executeTakeFirstOrThrow();
+      await deps.KyselyPg.insertInto('public.users')
+        .values({
+          id: userId,
+          org_id: org.id,
+          email: faker.internet.email(),
+          first_name: 'Existing',
+          last_name: 'User',
+          role_id: adminRole.id,
+          login_methods: ['saml'],
+          password: null,
+          approved_by_admin: true,
+          rejected_by_admin: false,
+        })
+        .execute();
+      await deps.KyselyPg.deleteFrom('public.role_permissions')
+        .where(
+          'role_id',
+          'in',
+          deps.KyselyPg.selectFrom('public.roles')
+            .select('id')
+            .where('org_id', '=', org.id)
+            .where('key', '=', UserRole.ANALYST),
+        )
+        .execute();
+      await deps.KyselyPg.deleteFrom('public.roles')
+        .where('org_id', '=', org.id)
+        .where('key', '=', UserRole.ANALYST)
+        .execute();
+
+      await expect(
+        deps.UserManagementService.updateUserRole({
+          userId,
+          newRole: UserRole.ANALYST,
+          orgId: org.id,
+          invoker: {
+            userId: uid(),
+            orgId: org.id,
+            permissions: [UserPermission.MANAGE_USERS],
+          },
+        }),
+      ).rejects.toThrow();
+
+      const persistedUser = await deps.KyselyPg.selectFrom('public.users')
+        .select('role_id')
+        .where('id', '=', userId)
+        .executeTakeFirstOrThrow();
+      expect(persistedUser.role_id).toBe(adminRole.id);
+    },
+  );
+});

--- a/server/services/userManagementService/userManagementService.ts
+++ b/server/services/userManagementService/userManagementService.ts
@@ -31,20 +31,18 @@ class UserManagementService {
     private readonly configService: Dependencies['ConfigService'],
   ) {}
 
-  // Returns null for orgs without seeded role rows; the read path falls
-  // back to UserPermissionsForRole defaults.
   async #lookupSystemRoleId(opts: {
     orgId: string;
     role: UserRole;
-  }): Promise<string | null> {
+  }): Promise<string> {
     const row = await this.pgQuery
       .selectFrom('public.roles')
       .select('id')
       .where('org_id', '=', opts.orgId)
       .where('key', '=', opts.role)
       .where('is_system', '=', true)
-      .executeTakeFirst();
-    return row?.id ?? null;
+      .executeTakeFirstOrThrow();
+    return row.id;
   }
 
   async getUserInterfaceSettings(opts: { userId: string; orgId: string }) {
@@ -94,8 +92,18 @@ class UserManagementService {
     const { token } = opts;
     const tokenRow = await this.pgQuery
       .selectFrom('public.invite_user_tokens')
-      .selectAll()
-      .where('token', '=', token)
+      .innerJoin('public.roles', (join) =>
+        join
+          .onRef('public.roles.id', '=', 'public.invite_user_tokens.role_id')
+          .onRef(
+            'public.roles.org_id',
+            '=',
+            'public.invite_user_tokens.org_id',
+          ),
+      )
+      .selectAll('public.invite_user_tokens')
+      .select('public.roles.key as role')
+      .where('public.invite_user_tokens.token', '=', token)
       .executeTakeFirst();
 
     if (tokenRow == null) {
@@ -128,7 +136,7 @@ class UserManagementService {
     const token = (await asyncRandomBytes(32)).toString('hex');
     await this.pgQuery
       .insertInto('public.invite_user_tokens')
-      .values({ token, email, role, role_id: roleId, org_id: orgId })
+      .values({ token, email, role_id: roleId, org_id: orgId })
       .execute();
     return token;
   }
@@ -140,9 +148,19 @@ class UserManagementService {
   > {
     const result = await this.pgQuery
       .selectFrom('public.invite_user_tokens')
-      .selectAll()
-      .where('org_id', '=', orgId)
-      .orderBy('created_at', 'desc')
+      .innerJoin('public.roles', (join) =>
+        join
+          .onRef('public.roles.id', '=', 'public.invite_user_tokens.role_id')
+          .onRef(
+            'public.roles.org_id',
+            '=',
+            'public.invite_user_tokens.org_id',
+          ),
+      )
+      .selectAll('public.invite_user_tokens')
+      .select('public.roles.key as role')
+      .where('public.invite_user_tokens.org_id', '=', orgId)
+      .orderBy('public.invite_user_tokens.created_at', 'desc')
       .execute();
 
     return result.map((row) => ({
@@ -323,7 +341,7 @@ class UserManagementService {
 
     const result = await this.pgQuery
       .updateTable('public.users')
-      .set({ role: newRole, role_id: newRoleId })
+      .set({ role_id: newRoleId })
       .where('id', '=', userId)
       .where('org_id', '=', invoker.orgId)
       .executeTakeFirst();
@@ -503,16 +521,21 @@ class UserManagementService {
   async getUsersForOrg(orgId: string) {
     return this.pgQuery
       .selectFrom('public.users')
+      .innerJoin('public.roles', (join) =>
+        join
+          .onRef('public.roles.id', '=', 'public.users.role_id')
+          .onRef('public.roles.org_id', '=', 'public.users.org_id'),
+      )
       .select([
-        'id',
-        'email',
-        'first_name as firstName',
-        'last_name as lastName',
-        'role',
+        'public.users.id',
+        'public.users.email',
+        'public.users.first_name as firstName',
+        'public.users.last_name as lastName',
+        'public.roles.key as role',
       ])
-      .where('org_id', '=', orgId)
-      .where('rejected_by_admin', '=', false)
-      .where('approved_by_admin', '=', true)
+      .where('public.users.org_id', '=', orgId)
+      .where('public.users.rejected_by_admin', '=', false)
+      .where('public.users.approved_by_admin', '=', true)
       .execute();
   }
 }

--- a/server/test/fixtureHelpers/createUser.ts
+++ b/server/test/fixtureHelpers/createUser.ts
@@ -2,6 +2,8 @@ import { faker } from '@faker-js/faker';
 import { type Kysely } from 'kysely';
 import { uid } from 'uid';
 
+// Test fixtures may create intentionally minimal organizations without roles.
+import { seedSystemRolesForOrg } from '../../graphql/datasources/rolePersistence.js';
 import {
   kyselyUserDeleteById,
   kyselyUserInsert,
@@ -37,6 +39,7 @@ export default async function createUser(
       ? await hashPassword(extra.password)
       : null;
 
+  await seedSystemRolesForOrg(db, orgId);
   const user = await kyselyUserInsert({
     db,
     id: userId,


### PR DESCRIPTION
## Context & Requests for Reviewers

Follow-up from #1061. Now that all orgs have DB-backed roles and permissions, we don't need the fallback code, and we don't need the legacy `role` column in the database. Instead, we can always use `role_id` -- an actual foreign key that refers to the role in the database.

## Tests

I ran this locally, using an org first created on `main`, and tested that I can click around (+ edit permissions) without issues.

## (Optional) Rollout Plan

Because this removes a GraphQL field, any live users may get some errors in their browsers until they refresh their page. I think this is acceptable for this self-hosted software. The alternative is to deprecate the field and stop using it, and then only later (when everyone has updated to that version), *then* fully remove it. I don't think the juice is worth the squeeze there.

## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] ~~**If you changed anything user-facing** (i.e. user interface or APIs):~~
  Did you update the CHANGELOG.md and related docs?

- [ ] ~~**If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**~~
  Did you update the corresponding history tables and their triggers?

- [ ] ~~**If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**~~
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?

- [ ] ~~**If you added a new signal in `server/services/signalsService/signals/**`:**~~
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Role Management**
  * Roles now use persisted organization-specific records for consistent permissions and assignments.
  * Role identifiers are always available when viewing or editing roles.
  * The “Using default permissions” notice is no longer displayed.

* **Data Reliability**
  * User and invitation role assignments remain preserved when roles are renamed or permissions change.
  * Invalid or missing role assignments are rejected instead of being silently replaced with defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->