### PR TITLE
fix: Regression on queue creation

### DIFF
--- a/client/src/webpages/dashboard/mrt/ManualReviewQueueForm.tsx
+++ b/client/src/webpages/dashboard/mrt/ManualReviewQueueForm.tsx
@@ -321,8 +321,11 @@ export default function ManualReviewQueueForm() {
   }, [queue, queue?.autoCloseJobs]);
 
   useEffect(() => {
+    if (!queue) {
+      return;
+    }
     setModeratorsWithAccess(sortedUsers.map((it) => it.id));
-  }, [sortedUsers]);
+  }, [queue, sortedUsers]);
 
   if (queueQueryError || error) {
     // eslint-disable-next-line @typescript-eslint/only-throw-error

--- a/server/graphql/modules/manualReviewTool.ts
+++ b/server/graphql/modules/manualReviewTool.ts
@@ -2353,12 +2353,15 @@ const Mutation: GQLMutationResolvers = {
       clearReportsScope,
       clearReportsTriggerActionIds,
     } = params.input;
+
+    // createManualReviewQueue expects userIds to be unique so as to not violate the DB primary key for users_and_accessible_queues
+    const userIdsWithCurrentUser = Array.from(new Set([...userIds, user.id]));
     try {
       const queue =
         await context.services.ManualReviewToolService.createManualReviewQueue({
           description: description ?? null,
           name,
-          userIds: [...userIds, user.id],
+          userIds: userIdsWithCurrentUser,
           hiddenActionIds,
           isAppealsQueue,
           autoCloseJobs,


### PR DESCRIPTION
Fixes #1074 

## Context & Requests for Reviewers

When moving `setModeratorsWithAccess` to its own effect, I didn't add the short-circuit behavior the original effect had when `queue` is undefined (i.e., queue creation).  This causes `moderatorsWithAccess` to be populated with admins whereas previously it was initially empty.  

While this may be a bit of a UX-win since it more correctly shows the future state of access to the queue, it causes a regression due an existing bug with createManualReviewQueue when one or more of the userIds is also the currently logged in user (or really any case where userIds is duplicated).

The following PR fixes the UI regression and patches createManualReviewQueue so that it always de-duplicates userIds before attempting to insert into users_and_accessible_queues

Note, semi-related: admins/mod-managers don't appear to need to be added to users_and_accessible_queues in order to view/update/delete queues.  Ideally, we should probably strip admins/mod-managers from moderatorsWithAccess before sending to the server.  That way we never populate people who have implicit access into users_and_accessible_queues which will make explicitlyAssignedReviewers more accurate to its naming/intention.  I avoided this approach since it would constitutes a change in behavior and data model which could have unintended side-effects.

## Tests

Manually tested creating queue.  

Before e6aa07fad9dd324fd2d1c58276dafde3fe8e8181:
- Admins are **not** auto-populated in the form
- Creating a new queue succeeds

After e6aa07fad9dd324fd2d1c58276dafde3fe8e8181
- Admins are auto-populated in form
- creating a new queue fails

After patch
- Admins are **not** auto-populated in the form
- Creating a new queue succeeds.

## (Optional) Rollout Plan

<!--
Are there any special things that have to be done before this can be deployed
to prod (e.g., other blocking PRs; manual load testing/validation that needs to
be done on staging; etc.)? If so, please note them here.
 -->

## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] **If you changed anything user-facing** (i.e. user interface or APIs):
  Did you update the CHANGELOG.md and related docs?
N/A, fixing a regression

- [ ] **If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**
  Did you update the corresponding history tables and their triggers?
N/A

- [ ] **If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?
N/A

- [ ] **If you added a new signal in `server/services/signalsService/signals/**`:**
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added handle-time reporting, with filtering by date range, queue, and reviewer.
  * Handle-time results can be grouped by queue or reviewer.
  * Added assignment and job creation timestamps to manual review decisions.
* **Bug Fixes**
  * Improved manual review queue setup when queue data is unavailable.
  * Prevented duplicate users, including the current user, from being added to queues.
  * Added validation to prevent invalid date ranges in handle-time reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->