### PR TITLE
PR template: split CHANGELOG from docs, clarify

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,10 @@ be done on staging; etc.)? If so, please note them here.
 _Only check items that apply to this PR; leave the rest unchecked._
 
 - [ ] **If you changed anything user-facing** (i.e. user interface or APIs):
-  Did you update the CHANGELOG.md and related docs?
+  Did you update related docs?
+
+- [ ] **If the change is notable** (refer to [Keep a Changelog](https://keepachangelog.com/en/2.0.0/) conventions):
+  Did you update CHANGELOG.md?
 
 - [ ] **If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**
   Did you update the corresponding history tables and their triggers?


### PR DESCRIPTION
Split the CHANGELOG.md update checklist item from the user-facing changes to docs item, explicitly using the "notable" term used by Keep a Changelog and [Osprey's PR template](https://github.com/roostorg/osprey/blob/83162046855467b5329bedb98bca89873d3bbd92/.github/PULL_REQUEST_TEMPLATE.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified pull request checklist requirements for updating user-facing or API documentation.
  * Added a separate requirement to update the changelog for notable changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->