### PR TITLE
chore: Normalize line-endings with .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 server/graphql/generated.ts linguist-generated=true
 client/src/graphql/generated.ts linguist-generated=true
+
+# Normalize line-endings for text files
+* text=auto eol=lf


### PR DESCRIPTION
If someone uses Windows or has different defaults than Unix/Linux, we end up with mixed line-endings which causes issues with diffs (like in #1057). Git gives us a way to specify preferred line endings with `.gitattributes`, so let's do that and have Git automatically handle it for us.

This is the same as what we did in Osprey: https://github.com/roostorg/osprey/pull/451