### PR TITLE
docs: Add release information

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -25,6 +25,7 @@
   - [API Authentication](development/api-auth.md)
   - [Data Warehouse Abstraction](development/data-warehouse.md)
   - [Docker Images](development/docker.md)
+  - [Releases](development/releases.md)
   - [Deployment](development/deployment.md)
 
 ---

--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -1,0 +1,36 @@
+# Releases
+
+Coop follows a lightweight release process so downstream users can depend on version tags (e.g. `1.0.1`) instead of commit hashes. The process may evolve as project usage grows. There is currently no fixed release cadence; generally, releases are made when:
+
+- Downstream users need an updated stable version tag,
+- Meaningful changes have accumulated and CI is green, and/or
+- A [security advisory](https://github.com/roostorg/coop/security/) is addressed
+
+## Versioning
+
+Coop uses [Semantic Versioning (SemVer)](https://semver.org/) following the MAJOR.MINOR.PATCH version format. In brief:
+
+- **Patch releases** (x.y.**Z**): backward-compatible fixes or small improvements
+- **Minor releases** (x.**Y**.z): new functionality or substantial improvements; changes to public API are backward-compatible
+- **Major releases** (**X**.y.z): backward-incompatible changes to public API, or major feature or user interface overhauls
+
+## Creating a release
+
+Before cutting a release, ensure:
+
+- [ ] **CI is passing** for the `main` branch
+- [ ] **You understand the correct version** according to SemVer
+- [ ] **[CHANGELOG.md](https://github.com/roostorg/coop/blob/main/CHANGELOG.md) is up-to-date**
+
+Then:
+
+1. In GitHub: **Releases** → **Draft a new release**
+2. **Create a tag** in SemVer format `x.y.z` from the `main` branch
+3. **Draft the release notes**, starting from [CHANGELOG.md](https://github.com/roostorg/coop/blob/main/CHANGELOG.md)
+4. Check **Create a discussion for this release** for at least major and minor releases
+5. **Publish** the release
+
+Publishing a release triggers automations:
+
+- **Docker images**: builds and pushes version-tagged Docker images for `coop-server`, `coop-worker`, `coop-client`, and `coop-migrations`
+- **Docs**: adds a folder for the release to the [index](https://roostorg.github.io/coop/) with a snapshot of the docs

--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -6,6 +6,8 @@ Coop follows a lightweight release process so downstream users can depend on ver
 - Meaningful changes have accumulated and CI is green, and/or
 - A [security advisory](https://github.com/roostorg/coop/security/) is addressed
 
+We do not currently backport changes to or release patches for versions other than the latest.
+
 ## Versioning
 
 Coop uses [Semantic Versioning (SemVer)](https://semver.org/) following the MAJOR.MINOR.PATCH version format. In brief:


### PR DESCRIPTION
Addresses https://github.com/roostorg/community/issues/74, and reflects the changes in https://github.com/roostorg/osprey/pull/475.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a Development Guide section explaining the release process.
  - Documented release timing and Semantic Versioning conventions.
  - Added instructions for creating releases.
  - Described automated Docker image builds and documentation snapshots triggered when a release is published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->