### PR TITLE
fix: allMediaItems throws when a thread item is included

### DIFF
--- a/server/graphql/modules/manualReviewTool.ts
+++ b/server/graphql/modules/manualReviewTool.ts
@@ -1687,10 +1687,7 @@ const NcmecManualReviewJobPayload: GQLNcmecManualReviewJobPayloadResolvers = {
           typeSelector:
             ncmecContentItemSubmission.contentItem.itemTypeIdentifier,
         });
-        if (
-          type === undefined ||
-          (type.kind !== 'CONTENT' && type.kind !== 'USER')
-        ) {
+        if (type === undefined) {
           throw new Error(
             `No Content Item Type found for id: ${ncmecContentItemSubmission.contentItem.itemTypeIdentifier.id}`,
           );

--- a/server/test/fixtureHelpers/createThreadItemTypes.ts
+++ b/server/test/fixtureHelpers/createThreadItemTypes.ts
@@ -1,0 +1,64 @@
+import { faker } from '@faker-js/faker';
+import { ScalarTypes, type Field } from '@roostorg/coop-types';
+
+import { type Dependencies } from '../../iocContainer/index.js';
+import { type NonEmptyArray } from '../../utils/typescript-types.js';
+
+export default async function (opts: {
+  moderationConfigService: Dependencies['ModerationConfigService'];
+  orgId: string;
+  numItemTypes?: number;
+  includeCreator?: boolean;
+  extra: { fields?: NonEmptyArray<Field> };
+}) {
+  const {
+    moderationConfigService,
+    orgId,
+    extra,
+    numItemTypes = 1,
+    includeCreator = false,
+  } = opts;
+
+  const itemTypes = await Promise.all(
+    Array.from({ length: numItemTypes }).map(async () =>
+      moderationConfigService.createThreadType(orgId, {
+        name: `${faker.lorem.words(2)}`,
+        description: faker.lorem.sentence(),
+        schema: extra.fields ?? [
+          {
+            name: 'field1',
+            type: ScalarTypes.STRING,
+            required: false,
+            container: null,
+          },
+          ...(includeCreator
+            ? [
+                {
+                  name: 'creatorId',
+                  type: ScalarTypes.RELATED_ITEM,
+                  required: false,
+                  container: null,
+                },
+              ]
+            : []),
+        ],
+        schemaFieldRoles: includeCreator
+          ? {
+              creatorId: 'creatorId',
+            }
+          : {},
+      }),
+    ),
+  );
+
+  return {
+    itemTypes,
+    cleanup: async () => {
+      await Promise.all(
+        itemTypes.map(async (it) =>
+          moderationConfigService.deleteItemType({ itemTypeId: it.id, orgId }),
+        ),
+      );
+    },
+  };
+}

--- a/server/test/fixtureHelpers/createUser.ts
+++ b/server/test/fixtureHelpers/createUser.ts
@@ -8,7 +8,10 @@ import {
 } from '../../graphql/datasources/userKyselyPersistence.js';
 import { type CombinedPg } from '../../services/combinedDbTypes.js';
 import { type LoginMethod } from '../../services/coreAppTables.js';
-import { UserRole, hashPassword } from '../../services/userManagementService/index.js';
+import {
+  hashPassword,
+  UserRole,
+} from '../../services/userManagementService/index.js';
 import { logErrorAndThrow } from '../utils.js';
 
 // SAML-only by default keeps the `password_null_when_not_present` CHECK

--- a/server/test/fixtureHelpers/createUser.ts
+++ b/server/test/fixtureHelpers/createUser.ts
@@ -8,7 +8,7 @@ import {
 } from '../../graphql/datasources/userKyselyPersistence.js';
 import { type CombinedPg } from '../../services/combinedDbTypes.js';
 import { type LoginMethod } from '../../services/coreAppTables.js';
-import { UserRole } from '../../services/userManagementService/index.js';
+import { UserRole, hashPassword } from '../../services/userManagementService/index.js';
 import { logErrorAndThrow } from '../utils.js';
 
 // SAML-only by default keeps the `password_null_when_not_present` CHECK
@@ -22,12 +22,17 @@ export default async function createUser(
     id?: string;
     role?: UserRole;
     loginMethods?: readonly LoginMethod[];
+    /** Plaintext; hashed before insert when provided. */
     password?: string | null;
+    approvedByAdmin?: boolean;
   } = {},
 ) {
   const userId = extra.id ?? uid();
   const loginMethods = extra.loginMethods ?? DEFAULT_LOGIN_METHODS;
-  const password = extra.password ?? null;
+  const password =
+    extra.password != null && extra.password !== ''
+      ? await hashPassword(extra.password)
+      : null;
 
   const user = await kyselyUserInsert({
     db,
@@ -39,6 +44,7 @@ export default async function createUser(
     lastName: faker.name.lastName(),
     role: extra.role ?? UserRole.ADMIN,
     loginMethods,
+    approvedByAdmin: extra.approvedByAdmin,
   }).catch(logErrorAndThrow);
 
   return {

--- a/server/test/fixtureHelpers/makeStubFetchHTTP.ts
+++ b/server/test/fixtureHelpers/makeStubFetchHTTP.ts
@@ -1,0 +1,88 @@
+import { Headers } from 'undici';
+
+import {
+  type CoopRequestQuery,
+  type CoopResponse,
+  type FetchHTTP,
+  type HandleResponseBody,
+} from '../../services/networkingService/index.js';
+
+/** Shape of one recorded outgoing fetchHTTP call. */
+export type RecordedFetchHTTPCall = {
+  url: string;
+  method: string;
+  body: unknown;
+  headers?: Record<string, string | ReadonlyArray<string>>;
+};
+
+/** Records every outgoing fetchHTTP call and returns canned CyberTip
+ * responses. */
+export function makeStubFetchHTTP(
+  reportId: string,
+  fileId: string,
+  opts: { preservationUrl?: string } = {},
+): {
+  fetchHTTP: FetchHTTP;
+  calls: RecordedFetchHTTPCall[];
+} {
+  const calls: RecordedFetchHTTPCall[] = [];
+  const preservationUrl = opts.preservationUrl;
+  const ok = <T extends HandleResponseBody>(body: unknown): CoopResponse<T> =>
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the stub returns a canned body through a slot typed by the caller's T.
+    ({
+      status: 200,
+      ok: true,
+      headers: new Headers(),
+      body,
+    }) as CoopResponse<T>;
+  const fetchHTTP: FetchHTTP = async <T extends HandleResponseBody>(
+    query: CoopRequestQuery<T>,
+  ): Promise<CoopResponse<T>> => {
+    const { url, method, body, headers } = query;
+    // eslint-disable-next-line functional/immutable-data -- request recorder mutates by design
+    calls.push({ url, method, body, headers });
+
+    // media download for #upload
+    if (method === 'get') {
+      const stream = new ReadableStream({
+        start(ctr) {
+          ctr.enqueue(new TextEncoder().encode('fake-media-bytes'));
+          ctr.close();
+        },
+      });
+      return ok<T>(stream);
+    }
+    // NCMEC CyberTip protocol — every XML endpoint returns responseCode=0.
+    // /submit, /upload, /fileinfo use `reportResponse`; /finish uses
+    // `reportDoneResponse`.
+    if (
+      url.endsWith('/ispws/submit') ||
+      url.endsWith('/ispws/upload') ||
+      url.endsWith('/ispws/fileinfo')
+    ) {
+      const isSubmit = url.endsWith('/ispws/submit');
+      const isUpload = url.endsWith('/ispws/upload');
+      return ok<T>({
+        reportResponse: {
+          responseCode: { _text: '0' },
+          ...(isSubmit ? { reportId: { _text: reportId } } : {}),
+          ...(isUpload ? { fileId: { _text: fileId } } : {}),
+        },
+      });
+    }
+    if (url.endsWith('/ispws/finish')) {
+      return ok<T>({
+        reportDoneResponse: {
+          responseCode: { _text: '0' },
+          reportId: { _text: reportId },
+          files: [{ fileId: { _text: fileId } }],
+        },
+      });
+    }
+    if (preservationUrl != null && url === preservationUrl) {
+      return ok<T>(undefined);
+    }
+    throw new Error(`stub fetchHTTP: unexpected request ${method} ${url}`);
+  };
+  return { fetchHTTP, calls };
+}

--- a/server/test/integ/ncmec-report-submission.integ.test.ts
+++ b/server/test/integ/ncmec-report-submission.integ.test.ts
@@ -1,0 +1,427 @@
+/**
+ * Integration test: e2e testing for NCMEC
+ *
+ * Tests the full NCMEC flow including reporting with csam: true
+ * to the moderator dequeueing and then finally submitting the decision.
+ *
+ * Asserts that all types of media are correctly submitted to Cybertips.
+ *
+ * Run with: npm run test:integration
+ * Requires: `npm run up && npm run db:update`
+ */
+import { ScalarTypes } from '@roostorg/coop-types';
+import { uid } from 'uid';
+
+import { jsonStringify } from '../../utils/encoding.js';
+import createContentItemTypes from '../fixtureHelpers/createContentItemTypes.js';
+import createMrtQueue from '../fixtureHelpers/createMrtQueue.js';
+import createOrg from '../fixtureHelpers/createOrg.js';
+import createThreadItemTypes from '../fixtureHelpers/createThreadItemTypes.js';
+import createUser from '../fixtureHelpers/createUser.js';
+import { makeStubFetchHTTP } from '../fixtureHelpers/makeStubFetchHTTP.js';
+import {
+  makeIntegrationServer,
+  type IntegrationServer,
+} from './setupIntegrationServer.js';
+import {
+  waitFor,
+  waitForItemInScylla,
+  waitForJobCreationInPostgres,
+} from './wait.js';
+
+const MEDIA_URL = 'https://example.com/ncmec-submit-decision.jpg';
+const REVIEWER_PASSWORD = 'integ-reviewer-password-1';
+
+describe('NCMEC report and submission (integration)', () => {
+  const orgId = uid();
+  const ncmecReportId = uid();
+  let harness: IntegrationServer | undefined;
+  let fetchStub: ReturnType<typeof makeStubFetchHTTP>;
+  let apiKey: string;
+  let userItemTypeId: string;
+  let queueId: string;
+  let reviewerEmail: string;
+  let reviewerId: string;
+  let orgCleanup: (() => Promise<unknown>) | undefined;
+  let reviewerCleanup: (() => Promise<unknown>) | undefined;
+  let queueCleanup: (() => Promise<unknown>) | undefined;
+
+  beforeAll(async () => {
+    fetchStub = makeStubFetchHTTP(ncmecReportId, 'f1');
+    harness = await makeIntegrationServer({
+      mockedDeps: { fetchHTTP: fetchStub.fetchHTTP },
+    });
+
+    const orgFixture = await createOrg(
+      {
+        KyselyPg: harness.deps.KyselyPg,
+        ModerationConfigService: harness.deps.ModerationConfigService,
+        ApiKeyService: harness.deps.ApiKeyService,
+      },
+      orgId,
+    );
+    apiKey = orgFixture.apiKey;
+    userItemTypeId = orgFixture.defaultUserItemType.id;
+    orgCleanup = orgFixture.cleanup;
+
+    const reviewerFixture = await createUser(harness.deps.KyselyPg, orgId, {
+      password: REVIEWER_PASSWORD,
+      loginMethods: ['password'],
+      approvedByAdmin: true,
+    });
+    reviewerEmail = reviewerFixture.user.email;
+    reviewerId = reviewerFixture.user.id;
+    reviewerCleanup = reviewerFixture.cleanup;
+
+    const queueFixture = await createMrtQueue({
+      orgId,
+      mrtService: harness.deps.ManualReviewToolService,
+      userId: reviewerId,
+    });
+    queueId = queueFixture.queue.id;
+    queueCleanup = queueFixture.cleanup;
+
+    await harness.deps.NcmecService.updateNcmecOrgSettings({
+      orgId,
+      username: 'espuser',
+      password: 'esppass',
+      contactEmail: 'reporter@example.com',
+      moreInfoUrl: null,
+      companyTemplate: 'AcmeESP',
+      legalUrl: 'https://acme.example/legal',
+      ncmecPreservationEndpoint: null,
+      ncmecAdditionalInfoEndpoint: null,
+      defaultNcmecQueueId: null,
+      defaultInternetDetailType: 'WEB_PAGE',
+      termsOfService: null,
+      contactPersonEmail: null,
+      contactPersonFirstName: null,
+      contactPersonLastName: null,
+      contactPersonPhone: null,
+      mediaReviewRequirement: 'ALL',
+      minMediaToReview: null,
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    try {
+      await queueCleanup?.();
+      await reviewerCleanup?.();
+      await orgCleanup?.();
+    } finally {
+      await harness?.shutdown();
+    }
+  }, 30_000);
+
+  test('submitManualReviewDecision SUBMIT_NCMEC_REPORT via GQL triggers CyberTip submit', async () => {
+    if (!harness) throw new Error('harness was not initialized');
+
+    const contentTypeFixture = await createContentItemTypes({
+      moderationConfigService: harness.deps.ModerationConfigService,
+      orgId,
+      includeCreator: true,
+      extra: {
+        fields: [
+          {
+            name: 'image',
+            type: ScalarTypes.IMAGE,
+            required: false,
+            container: null,
+          },
+          {
+            name: 'creatorId',
+            type: ScalarTypes.RELATED_ITEM,
+            required: true,
+            container: null,
+          },
+        ],
+      },
+    });
+    const contentTypeId = contentTypeFixture.itemTypes[0].id;
+
+    const threadTypeFixture = await createThreadItemTypes({
+      moderationConfigService: harness.deps.ModerationConfigService,
+      orgId,
+      includeCreator: true,
+      extra: {
+        fields: [
+          {
+            name: 'image',
+            type: ScalarTypes.IMAGE,
+            required: false,
+            container: null,
+          },
+          {
+            name: 'creatorId',
+            type: ScalarTypes.RELATED_ITEM,
+            required: true,
+            container: null,
+          },
+        ],
+      },
+    });
+    const threadTypeId = threadTypeFixture.itemTypes[0].id;
+
+    const contentItemId = uid();
+    const threadItemId = uid();
+    const creatorUserId = uid();
+    const reporterId = uid();
+    const creatorRef = { id: creatorUserId, typeId: userItemTypeId };
+    const THREAD_MEDIA_URL =
+      'https://example.com/ncmec-submit-decision-thread.jpg';
+
+    try {
+      await harness.request
+        .post('/api/v1/items/async')
+        .set('x-api-key', apiKey)
+        .send({
+          items: [
+            {
+              id: contentItemId,
+              typeId: contentTypeId,
+              data: { image: MEDIA_URL, creatorId: creatorRef },
+            },
+            {
+              id: threadItemId,
+              typeId: threadTypeId,
+              data: { image: THREAD_MEDIA_URL, creatorId: creatorRef },
+            },
+          ],
+        })
+        .expect(202);
+
+      await waitForItemInScylla(harness.deps, {
+        orgId,
+        itemIdentifier: { id: contentItemId, typeId: contentTypeId },
+      });
+      await waitForItemInScylla(harness.deps, {
+        orgId,
+        itemIdentifier: { id: threadItemId, typeId: threadTypeId },
+      });
+
+      await harness.request
+        .post('/api/v1/report')
+        .set('x-api-key', apiKey)
+        .send({
+          reporter: {
+            kind: 'user',
+            typeId: userItemTypeId,
+            id: reporterId,
+          },
+          reportedAt: new Date().toISOString(),
+          reportedForReason: { csam: true },
+          reportedItem: {
+            id: contentItemId,
+            typeId: contentTypeId,
+            data: { image: MEDIA_URL, creatorId: creatorRef },
+          },
+        })
+        .expect(201);
+
+      await waitForJobCreationInPostgres(harness.deps, {
+        orgId,
+        itemIdentifier: { id: creatorUserId, typeId: userItemTypeId },
+      });
+
+      // --- Submit decision via GraphQL API ---
+      const loginRes = await harness.request.post('/api/v1/graphql').send({
+        query: `mutation {
+          login(input: { email: ${jsonStringify(reviewerEmail)}, password: ${jsonStringify(REVIEWER_PASSWORD)} }) {
+            __typename
+          }
+        }`,
+      });
+      expect(loginRes.status).toBe(200);
+      expect(loginRes.body?.data?.login?.__typename).toBe(
+        'LoginSuccessResponse',
+      );
+
+      const dequeueRes = await harness.request.post('/api/v1/graphql').send({
+        query: `mutation {
+          dequeueManualReviewJob(queueId: ${jsonStringify(queueId)}) {
+            ... on DequeueManualReviewJobSuccessResponse {
+              job {
+                id
+                payload {
+                  ... on NcmecManualReviewJobPayload {
+                    allMediaItems {
+                      isReported
+                      contentItem {
+                        __typename
+                        ... on ItemBase {
+                          id
+                          type { id }
+                          data
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+              lockToken
+            }
+          }
+        }`,
+      });
+      if (dequeueRes.status !== 200) {
+        throw new Error(
+          `dequeueManualReviewJob failed: HTTP ${dequeueRes.status} — ${jsonStringify(dequeueRes.body)}`,
+        );
+      }
+      expect(dequeueRes.body.errors).toBeUndefined();
+      const dequeueData = dequeueRes.body.data?.dequeueManualReviewJob;
+      if (!dequeueData) {
+        throw new Error('expected a job to dequeue');
+      }
+
+      const {
+        job: { id: jobId, payload },
+        lockToken,
+      } = dequeueData;
+
+      type AllMediaItem = {
+        isReported: boolean;
+        contentItem: {
+          __typename: string;
+          id: string;
+          type: { id: string };
+          data: Record<string, unknown>;
+        };
+      };
+
+      const mediaByItemId = new Map<string, AllMediaItem>(
+        (payload.allMediaItems as AllMediaItem[]).map((m) => [
+          m.contentItem.id,
+          m,
+        ]),
+      );
+      expect(mediaByItemId.get(contentItemId)?.isReported).toBe(true);
+      expect(mediaByItemId.get(threadItemId)?.isReported).toBe(false);
+      expect(mediaByItemId.get(contentItemId)?.contentItem.__typename).toBe(
+        'ContentItem',
+      );
+      expect(mediaByItemId.get(threadItemId)?.contentItem.__typename).toBe(
+        'ThreadItem',
+      );
+
+      // Build reportedMedia from the items the server returned
+      const reportedMediaGql = payload.allMediaItems
+        .map((m: AllMediaItem) => {
+          const url =
+            (m.contentItem.data['image'] as { url?: string } | undefined)
+              ?.url ?? '';
+          return (
+            `{ id: ${jsonStringify(m.contentItem.id)} ` +
+            `typeId: ${jsonStringify(m.contentItem.type.id)} ` +
+            `url: ${jsonStringify(url)} ` +
+            `industryClassification: A1 ` +
+            `fileAnnotations: [] }`
+          );
+        })
+        .join('\n');
+
+      const submitRes = await harness.request.post('/api/v1/graphql').send({
+        query: `mutation {
+          submitManualReviewDecision(input: {
+            queueId: ${jsonStringify(queueId)}
+            jobId: ${jsonStringify(jobId)}
+            lockToken: ${jsonStringify(lockToken)}
+            reportHistory: []
+            relatedItemActions: []
+            reportedItemDecisionComponents: [
+              {
+                submitNcmecReport: {
+                  incidentType: CHILD_PORNOGRAPHY
+                  reportedMessages: []
+                  reportedMedia: [${reportedMediaGql}]
+                }
+              }
+            ]
+          }) {
+            ... on SubmitDecisionSuccessResponse {
+              success
+            }
+          }
+        }`,
+      });
+      if (submitRes.status !== 200) {
+        throw new Error(
+          `submitManualReviewDecision failed: HTTP ${submitRes.status} — ${jsonStringify(submitRes.body)}`,
+        );
+      }
+      expect(submitRes.body.errors).toBeUndefined();
+      expect(submitRes.body.data?.submitManualReviewDecision?.success).toBe(
+        true,
+      );
+
+      // The IoC onRecordDecision handler fires asynchronously after the GQL
+      // response, so we poll until the expected CyberTip calls appear.
+      await waitFor('CyberTip /finish call', async () => {
+        const calls = fetchStub.calls
+          .filter((c) => c.url.includes('cybertip.org'))
+          .map((c) => c.url.replace(/^.*\/ispws/, ''));
+        if (!calls.includes('/finish')) return undefined;
+        return calls;
+      });
+
+      const cybertipPaths = fetchStub.calls
+        .filter((c) => c.url.includes('cybertip.org'))
+        .map((c) => c.url.replace(/^.*\/ispws/, ''));
+      expect(cybertipPaths.filter((p) => p === '/submit')).toHaveLength(1);
+      expect(cybertipPaths.filter((p) => p === '/finish')).toHaveLength(1);
+
+      const newCalls = fetchStub.calls;
+
+      // Both media items were downloaded from storage before upload
+      const downloadedUrls = newCalls
+        .filter((c) => c.method === 'get')
+        .map((c) => c.url);
+      expect(downloadedUrls).toContain(MEDIA_URL);
+      expect(downloadedUrls).toContain(THREAD_MEDIA_URL);
+
+      const submitCall = newCalls.find(
+        (c) => c.url.endsWith('/ispws/submit') && typeof c.body === 'string',
+      );
+      expect(submitCall?.headers?.Authorization).toMatch(/^Basic /);
+      expect(String(submitCall?.body)).toContain('<incidentType>');
+
+      // Each /fileinfo XML includes the originalFileName derived from the
+      // media URL, confirming the correct per-item data was sent to NCMEC
+      const fileinfoXmls = newCalls
+        .filter((c) => c.url.endsWith('/ispws/fileinfo'))
+        .map((c) => String(c.body));
+      expect(
+        fileinfoXmls.some((xml) => xml.includes('ncmec-submit-decision.jpg')),
+      ).toBe(true);
+      expect(
+        fileinfoXmls.some((xml) =>
+          xml.includes('ncmec-submit-decision-thread.jpg'),
+        ),
+      ).toBe(true);
+
+      // Both media items are persisted in the ncmec_reports row
+      const reportRow = await waitFor(
+        `ncmec_reports row for user ${creatorUserId}`,
+        async () =>
+          harness!.deps.KyselyPg.selectFrom('ncmec_reporting.ncmec_reports')
+            .select(['report_id', 'is_test', 'reviewer_id', 'reported_media'])
+            .where('org_id', '=', orgId)
+            .where('user_id', '=', creatorUserId)
+            .executeTakeFirst(),
+      );
+
+      expect(reportRow.report_id).toBe(ncmecReportId);
+      expect(reportRow.reviewer_id).toBe(reviewerId);
+      expect(reportRow.is_test).toBe(process.env.NCMEC_ENV !== 'production');
+
+      const reportedMediaIds = (
+        reportRow.reported_media as Array<{ id: string; typeId: string }>
+      ).map((m) => m.id);
+      expect(reportedMediaIds).toContain(contentItemId);
+      expect(reportedMediaIds).toContain(threadItemId);
+    } finally {
+      await contentTypeFixture.cleanup();
+      await threadTypeFixture.cleanup();
+    }
+  }, 60_000);
+});

--- a/server/test/integ/ncmec-submission.integ.test.ts
+++ b/server/test/integ/ncmec-submission.integ.test.ts
@@ -1,5 +1,4 @@
 import { uid } from 'uid';
-import { Headers } from 'undici';
 
 import {
   NCMECFileAnnotation,
@@ -8,95 +7,12 @@ import {
   NcmecReporting,
   type NCMECReportParams,
 } from '../../services/ncmecService/index.js';
-import {
-  type CoopRequestQuery,
-  type CoopResponse,
-  type FetchHTTP,
-  type HandleResponseBody,
-} from '../../services/networkingService/index.js';
 import createOrg from '../fixtureHelpers/createOrg.js';
+import { makeStubFetchHTTP } from '../fixtureHelpers/makeStubFetchHTTP.js';
 import { makeTransactionalTestWithFixture } from '../harness/transactionalTest.js';
 
 const MEDIA_URL = 'https://cdn.example/sample.jpg';
 const PRESERVATION_URL = 'https://preserve.example/req';
-
-/** Shape of one recorded outgoing fetchHTTP call. */
-type RecordedCall = {
-  url: string;
-  method: string;
-  body: unknown;
-  headers?: Record<string, string | ReadonlyArray<string>>;
-};
-
-/** Records every outgoing fetchHTTP call and returns canned CyberTip
- * responses. */
-function makeStubFetchHTTP(
-  reportId: string,
-  fileId: string,
-): {
-  fetchHTTP: FetchHTTP;
-  calls: RecordedCall[];
-} {
-  const calls: RecordedCall[] = [];
-  const ok = <T extends HandleResponseBody>(body: unknown): CoopResponse<T> =>
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the stub returns a canned body through a slot typed by the caller's T.
-    ({
-      status: 200,
-      ok: true,
-      headers: new Headers(),
-      body,
-    }) as CoopResponse<T>;
-  const fetchHTTP: FetchHTTP = async <T extends HandleResponseBody>(
-    query: CoopRequestQuery<T>,
-  ): Promise<CoopResponse<T>> => {
-    const { url, method, body, headers } = query;
-    // eslint-disable-next-line functional/immutable-data -- request recorder mutates by design
-    calls.push({ url, method, body, headers });
-
-    // media download for #upload
-    if (method === 'get') {
-      const stream = new ReadableStream({
-        start(ctr) {
-          ctr.enqueue(new TextEncoder().encode('fake-media-bytes'));
-          ctr.close();
-        },
-      });
-      return ok<T>(stream);
-    }
-    // NCMEC CyberTip protocol — every XML endpoint returns responseCode=0.
-    // /submit, /upload, /fileinfo use `reportResponse`; /finish uses
-    // `reportDoneResponse`.
-    if (
-      url.endsWith('/ispws/submit') ||
-      url.endsWith('/ispws/upload') ||
-      url.endsWith('/ispws/fileinfo')
-    ) {
-      const isSubmit = url.endsWith('/ispws/submit');
-      const isUpload = url.endsWith('/ispws/upload');
-      return ok<T>({
-        reportResponse: {
-          responseCode: { _text: '0' },
-          ...(isSubmit ? { reportId: { _text: reportId } } : {}),
-          ...(isUpload ? { fileId: { _text: fileId } } : {}),
-        },
-      });
-    }
-    if (url.endsWith('/ispws/finish')) {
-      return ok<T>({
-        reportDoneResponse: {
-          responseCode: { _text: '0' },
-          reportId: { _text: reportId },
-          files: [{ fileId: { _text: fileId } }],
-        },
-      });
-    }
-    if (url === PRESERVATION_URL) {
-      return ok<T>(undefined);
-    }
-    throw new Error(`stub fetchHTTP: unexpected request ${method} ${url}`);
-  };
-  return { fetchHTTP, calls };
-}
 
 describe('NCMEC submitReport (integration)', () => {
   const testWithFixture = makeTransactionalTestWithFixture(async ({ deps }) => {
@@ -134,7 +50,9 @@ describe('NCMEC submitReport (integration)', () => {
       minMediaToReview: null,
     });
 
-    const stub = makeStubFetchHTTP(reportId, fileId);
+    const stub = makeStubFetchHTTP(reportId, fileId, {
+      preservationUrl: PRESERVATION_URL,
+    });
     const ncmecReporting = new NcmecReporting(
       deps.KyselyPg,
       deps.KyselyPgReadReplica,

--- a/server/test/integ/setupIntegrationServer.ts
+++ b/server/test/integ/setupIntegrationServer.ts
@@ -7,6 +7,7 @@
  * via `npm run db:update`.
  */
 
+import passport from 'passport';
 import * as superTest from 'supertest';
 
 import getBottle, { type Dependencies } from '../../iocContainer/index.js';
@@ -18,8 +19,38 @@ export type IntegrationServer = {
   shutdown: () => Promise<void>;
 };
 
-export async function makeIntegrationServer(): Promise<IntegrationServer> {
+export type MakeIntegrationServerOptions = {
+  /** A hash of mocked dependencies to replace in the bottle  */
+  mockedDeps?: Partial<Dependencies>;
+};
+
+export async function makeIntegrationServer(
+  opts: MakeIntegrationServerOptions = {},
+): Promise<IntegrationServer> {
+  // passport keeps its state globally so we need to reset it each time we make a new server
+  // there is no public API to reset serializers/deserializers so we resort to clearing them.
+  type PassportInternals = {
+    _serializers: Array<unknown>;
+    _deserializers: Array<unknown>;
+    _strategies: Record<string, unknown>;
+  };
+  const passportInternals = passport as unknown as PassportInternals;
+  // eslint-disable-next-line functional/immutable-data
+  passportInternals._serializers = [];
+  // eslint-disable-next-line functional/immutable-data
+  passportInternals._deserializers = [];
+  for (const key of Object.keys(passportInternals._strategies)) {
+    if (key !== 'session') {
+      passport.unuse(key);
+    }
+  }
+
   const bottle = await getBottle();
+  if (opts.mockedDeps != null) {
+    for (const [name, value] of Object.entries(opts.mockedDeps)) {
+      bottle.factory(name as keyof Dependencies, () => value);
+    }
+  }
   const deps = bottle.container as Dependencies;
 
   const { app, shutdown: shutdownServer } = await makeServer(deps);


### PR DESCRIPTION
## Context & Requests for Reviewers
Thread items are able to have a creator and are indexed in Scylla as such.  If a user is reported for csam, those thread items will be included in the report.  This causes the "allMediaItems" to throw an error.  I removed the check for type.kind and instead just check if there is **_a_** known type.  Downstream UI and endpoints all appear to handle the thread item correctly.

### Additional changes:
- Added e2e test coverage for full NCMEC flow (reporting + submission)
- add bottle mock support for `makeIntegrationServer`
- Add `createThreadItemType` test helper
- Factor `makeStubFetchHTTP` out of `ncmec-submission.integ.test.ts` to its own module
- hash password in `createUser` so we can use it to login, also mark user as approved by admin

## Tests
- I added an integration test for full NCMEC flow (reporting + submission)
- Locally I reported a user that had a thread item attributed to her.  I validated that the manual review queue loaded correctly, the thread item was present, and I could submit a report with just a thread item.

<img width="1200" height="822" alt="Screenshot 2026-08-27 at 11 43 27" src="https://github.com/user-attachments/assets/0af6c99e-0075-43eb-8513-eab6b6c84638" />
<img width="950" height="768" alt="Screenshot 2026-08-27 at 11 44 49" src="https://github.com/user-attachments/assets/18ab3504-e975-4327-9481-ed0505db09f5" />


## (Optional) Rollout Plan

<!--
Are there any special things that have to be done before this can be deployed
to prod (e.g., other blocking PRs; manual load testing/validation that needs to
be done on staging; etc.)? If so, please note them here.
 -->

## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] **If you changed anything user-facing** (i.e. user interface or APIs):
  Did you update related docs?

- [ ] **If the change is notable** (refer to [Keep a Changelog](https://keepachangelog.com/en/2.0.0/) conventions):
  Did you update CHANGELOG.md?

- [ ] **If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**
  Did you update the corresponding history tables and their triggers?

- [ ] **If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?

- [ ] **If you added a new signal in `server/services/signalsService/signals/**`:**
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Manual review jobs now support additional item types, including thread items, instead of rejecting them.
  - Supported items can now be formatted and returned for review without triggering an item-type validation error.
  - Manual review queue submissions no longer include duplicate user entries.

- **Tests**
  - Expanded automated coverage for NCMEC report submission workflows, including media handling, thread items, and report persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->