### PR TITLE
Defer incompatible dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -128,6 +128,10 @@ updates:
     ignore:
       - dependency-name: '*'
         update-types: ['version-update:semver-major']
+      - dependency-name: 'jest-light-runner'
+        versions: ['>=0.6.0 <1.0.0']
+      - dependency-name: 'typescript'
+        versions: ['>=5.0.0 <6.0.0']
     groups:
       server-prod-security:
         dependency-type: 'production'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -130,6 +130,8 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: 'jest-light-runner'
         versions: ['>=0.6.0 <1.0.0']
+      - dependency-name: 'type-fest'
+        versions: ['>4.3.2 <5.0.0']
       - dependency-name: 'typescript'
         versions: ['>=5.0.0 <6.0.0']
     groups:


### PR DESCRIPTION
This is following up from https://github.com/roostorg/coop/pull/1082.

Dependabot tries to update three things that break:
- typescript to a later 5.x. this is redundant since @serendipty01 is working on updating us to 6.x anyway: https://github.com/roostorg/coop/pull/910
- type-fest. this update breaks a lot of our types. probably worth updating after we get to typescript 6.
- jest-light-runner to 0.8.1. this breaks because it pulls in jest 30 code, and we're on jest 29. these will need to be updated together, but if we do move to a unified framework like adonis, also redundant.

so let's pause these dependabot updates for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings to exclude selected version ranges for testing and TypeScript tooling.
  * Continued blocking major-version dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->