### PR TITLE
docs: Document content proxy service

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -33,9 +33,13 @@ VITE_DOCS_URL=https://roostorg.github.io/coop/latest
 # Cloud Console rather than relying on it being secret.
 VITE_GOOGLE_PLACES_API_KEY=
 
-# URL of the content proxy service to use for content display in iframes.
-# This is used to proxy the content URL to the content proxy service.
-VITE_CONTENT_PROXY_URL=http://localhost:4000
-
-# Comma-separated list of patterns to match content URLs that should be displayed in iframes
+# Comma-separated list of patterns to match content URLs that should be
+# displayed in iframes (rather than just as links) in review jobs. Domains (e.g.
+# `example.com`) match exact domains and subdomains; substrings (e.g. `foo`)
+# are substring-matched against hostnames. Leave blank to disable iframes.
 VITE_CONTENT_URL_PATTERN=
+
+# URL of a content proxy service used to display item content in review jobs via
+# iframe. Implementing a proxy enables you to implement wellness features for
+# rich content. Leave unset to load matching content directly in an iframe.
+VITE_CONTENT_PROXY_URL=

--- a/docs/development/deployment.md
+++ b/docs/development/deployment.md
@@ -35,7 +35,7 @@ Many other settings are only required if you are enabling specific features or c
 
 - Child safety reporting is optional, but if you are using NCMEC reporting you must configure the org settings in Coop and set `NCMEC_ENV=production` on the server only when your deployment has been approved for live reporting. See [NCMEC CyberTipline](../integrations/ncmec.md#test-vs-production-submissions).
 
-- Client-side integrations such as Google Places and custom docs/content proxy URLs are optional and can be left unset if you do not use those capabilities.
+- Client-side integrations such as Google Places and custom docs URLs are optional and can be left unset if you do not use those capabilities. See [Content Proxy](#content-proxy) below for `VITE_CONTENT_PROXY_URL`.
 
 - Third-party integration keys in `server/.env.example` are generally optional unless you are enabling the corresponding integration.
 
@@ -79,6 +79,40 @@ To set it up:
 4. Copy the contents of the XML file. In Coop, go to **Settings** → **SSO** and paste the XML into the **Identity Provider Metadata** field.
 5. On the same page, enter `email` in the **Attributes** section.
 6. In your Okta app under **Assignments**, assign users or groups to your app.
+
+## Content Proxy
+
+Coop can optionally route item content URLs through a **content proxy**: a service you host that fetches a content URL and serves it back inside the review iframe, so it can control presentation and apply wellness features server-side (since the review UI cannot otherwise style or control content from a cross-origin iframe).
+
+Set `VITE_CONTENT_PROXY_URL` to your proxy's base URL to enable it. Left unset (the default), matching content just loads directly in the iframe.
+
+Coop does not ship a reference proxy implementation, so you'll need to deploy your own implementation.
+
+### Load content
+
+Coop loads your proxy at:
+
+```
+<VITE_CONTENT_PROXY_URL>/?contentUrl=<url-encoded content URL>
+```
+
+Your service should fetch and serve back the given `contentUrl`'s content.
+
+### Wellness features
+
+After the iframe loads, and whenever a reviewer changes their overlay settings, Coop posts a message to your proxy's page:
+
+```json
+{
+  "type": "customControl",
+  "blur": 0,
+  "grayscale": false,
+  "shouldTranslate": false,
+  "sepia": false
+}
+```
+
+`blur` ranges from `0` (none) to `6` (strongest); `grayscale` and `sepia` are simple on/off filters. Your proxy's page should listen for this message and apply the requested effects to the content it's displaying.
 
 ## Historical reference
 

--- a/docs/development/deployment.md
+++ b/docs/development/deployment.md
@@ -82,7 +82,7 @@ To set it up:
 
 ## Content Proxy
 
-Coop can optionally route item content URLs through a **content proxy**: a service you host that fetches a content URL and serves it back inside the review iframe, so it can control presentation and apply wellness features server-side (since the review UI cannot otherwise style or control content from a cross-origin iframe).
+Coop can optionally route item content URLs through a **content proxy**: a service you host that fetches a content URL and serves it back inside the review iframe, so it can control presentation and apply wellness features (since the review UI cannot otherwise style or control content from a cross-origin iframe).
 
 Set `VITE_CONTENT_PROXY_URL` to your proxy's base URL to enable it. Left unset (the default), matching content just loads directly in the iframe.
 

--- a/docs/development/local.md
+++ b/docs/development/local.md
@@ -47,7 +47,11 @@ Redis connection settings, external API keys for integrations, session secrets, 
 
 ### `client/.env`
 
-Settings for Vite, content proxying, and generating sourcemaps.
+Settings for Vite and generating sourcemaps.
+
+The content URL pattern (`VITE_CONTENT_URL_PATTERN`) determines which content URLs (if any) are rendered in an iframe versus just as links in review jobs. Domains in this list (e.g. `example.com`) match exact domains and subdomains, while substrings (e.g. `foo`) are substring-matched against content URL hostnames for backward compatibility.
+
+The content proxy URL (`VITE_CONTENT_PROXY_URL`) is optional and unset by default; without it, content matching the content URL pattern is loaded directly in an iframe. Implementing a content proxy enables you to implement wellness features that can't be applied to an iframe otherwise.
 
 ## Docker services
 


### PR DESCRIPTION
Fixes #374 by providing a bit more context in the .env comments and local development docs, plus a new section in the deployment docs covering how to implement a proxy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified iframe content loading and hostname pattern matching.
  - Documented optional content proxy configuration, URL format, and supported wellness controls.
  - Updated local development and deployment guidance for content URLs and proxy settings.

- **Configuration**
  - Added clearer environment variable defaults and descriptions.
  - Content now loads directly in an iframe by default when no proxy is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->