### PR TITLE
docs: Update Partial Items settings note

### DIFF
--- a/docs/api/partial-items.md
+++ b/docs/api/partial-items.md
@@ -8,10 +8,7 @@ To use this API, your platform must provide a Partial Items API endpoint that ca
 
 To verify that an incoming request actually came from Coop, check the `Coop-Signature` header. See [API Keys & Authentication](../development/api-auth.md#verifying-incoming-requests-from-coop) for the signature verification algorithm and a code example.
 
-> [!IMPORTANT]
-> **It is not yet possible to configure this from the Coop UI**, so you'll have to manage it in code. See [roostorg/coop#378](https://github.com/roostorg/coop/issues/378) for details.
-
-You'll need to update your Coop instance's code with the endpoint URL and any required headers (including any additional authentication, such as an API key) so it can make the HTTP requests.
+You can configure the Partial Items API endpoint URL and any required headers (including any additional authentication, such as an API key) under [Settings](../user/administration.md#partial-items).
 
 ## REST API example
 


### PR DESCRIPTION
## Context & Requests for Reviewers

<!-- Briefly describe the changes introduced in this pull request. Link GitHub Issue if available for context on your change. -->

Documentation for [Partial Items](https://roostorg.github.io/coop/latest/api/partial-items.html) currently states that it's not possible to configure the API details from the UI and points to issue #378 for additional context. 

This note is now outdated as PR #709 introduced a section on the UI to configure the Partial Items API, and #378 is now closed.

PR removes the note from the docs and adds a link to the Settings section where the Partial Items setup screenshot is currently shown.

## Tests

Docs build successfully with `mdbook build docs`

Current docs:
<img width="786" height="528" alt="Screenshot 2026-08-31 at 7 51 43 PM" src="https://github.com/user-attachments/assets/63761806-dda8-4588-89f5-1dc996887407" />

Updated docs:
<img width="929" height="516" alt="Screenshot 2026-08-31 at 7 52 28 PM" src="https://github.com/user-attachments/assets/1ffed6e6-07d0-46bc-9583-8f9d96abfc6b" />


## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [x] **If you changed anything user-facing** (i.e. user interface or APIs):
  Did you update related docs?: Yes, PR is a documentation change.

- [ ] **If the change is notable** (refer to [Keep a Changelog](https://keepachangelog.com/en/2.0.0/) conventions):
  Did you update CHANGELOG.md?

- [ ] **If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**
  Did you update the corresponding history tables and their triggers?

- [ ] **If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?

- [ ] **If you added a new signal in `server/services/signalsService/signals/**`:**
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Partial Items API setup instructions to explain that the API URL and required headers can be configured in Coop Settings.
  * Removed outdated limitations and code-management guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->