### PR TITLE
Enforce password minimum length server-side and raise it to 15

### DIFF
--- a/client/src/utils/password.ts
+++ b/client/src/utils/password.ts
@@ -2,6 +2,7 @@
  * Fallback used while `passwordRequirements` is loading or if the query
  * fails, so forms don't briefly accept a password shorter than the server
  * will actually allow. Kept in sync with the server default in
- * `server/services/userManagementService/constants.ts`.
+ * `server/services/userManagementService/constants.ts` (15 per NIST SP
+ * 800-63-4 §3.1.1).
  */
-export const DEFAULT_MIN_PASSWORD_LENGTH = 8;
+export const DEFAULT_MIN_PASSWORD_LENGTH = 15;

--- a/client/src/webpages/auth/forgot_password/ResetPassword.tsx
+++ b/client/src/webpages/auth/forgot_password/ResetPassword.tsx
@@ -56,24 +56,56 @@ export default function ResetPassword() {
     return <Navigate to="/login" />;
   }
 
+  const isPasswordTooShort =
+    newPassword != null &&
+    newPassword.length > 0 &&
+    newPassword.length < minPasswordLength;
+
   const newPasswordInput = (
-    <Input.Password
-      className="rounded-lg"
-      placeholder={`Enter new password (min ${minPasswordLength} characters)`}
-      value={newPassword}
-      onChange={(event) => {
-        setNewPassword(event.target.value);
-      }}
-    />
+    <>
+      <Input.Password
+        className="rounded-lg"
+        placeholder={`Enter new password (min ${minPasswordLength} characters)`}
+        value={newPassword}
+        status={isPasswordTooShort ? 'error' : undefined}
+        aria-invalid={isPasswordTooShort}
+        aria-describedby={isPasswordTooShort ? 'newPassword-error' : undefined}
+        onChange={(event) => {
+          setNewPassword(event.target.value);
+        }}
+      />
+      {isPasswordTooShort && (
+        <div id="newPassword-error" className="w-full text-xs text-red-600">
+          Password must be at least {minPasswordLength} characters long.
+        </div>
+      )}
+    </>
   );
 
+  const doPasswordsMismatch =
+    confirmPassword != null &&
+    confirmPassword.length > 0 &&
+    newPassword !== confirmPassword;
+
   const confirmPasswordInput = (
-    <Input.Password
-      className="rounded-lg"
-      placeholder="Confirm new password"
-      value={confirmPassword}
-      onChange={(event) => setConfirmPassword(event.target.value)}
-    />
+    <>
+      <Input.Password
+        className="rounded-lg"
+        placeholder="Confirm new password"
+        value={confirmPassword}
+        status={doPasswordsMismatch ? 'error' : undefined}
+        aria-invalid={doPasswordsMismatch}
+        aria-describedby={
+          doPasswordsMismatch ? 'confirmPassword-error' : undefined
+        }
+        onChange={(event) => setConfirmPassword(event.target.value)}
+      />
+      {doPasswordsMismatch && (
+        <div id="confirmPassword-error" className="w-full text-xs text-red-600">
+          Passwords do not match.
+        </div>
+      )}
+    </>
   );
 
   const submitButton = (
@@ -82,6 +114,12 @@ export default function ResetPassword() {
       type="primary"
       htmlType="submit"
       loading={resetPasswordLoading}
+      disabled={
+        !newPassword ||
+        !confirmPassword ||
+        isPasswordTooShort ||
+        doPasswordsMismatch
+      }
       onClick={async () => {
         if (newPassword !== confirmPassword) {
           setErrorMessage('Passwords do not match.');

--- a/client/src/webpages/settings/AccountSettings.tsx
+++ b/client/src/webpages/settings/AccountSettings.tsx
@@ -463,8 +463,18 @@ export default function AccountSettings() {
   const hasPasswordLogin =
     accountSettingsData?.me?.loginMethods?.includes('password') ?? false;
 
+  const isNewPasswordTooShort =
+    Boolean(newPassword) && newPassword.length < minPasswordLength;
+
+  const doNewPasswordsMismatch =
+    Boolean(confirmNewPassword) && newPassword !== confirmNewPassword;
+
   const isChangePasswordButtonDisabled =
-    !currentPassword || !newPassword || !confirmNewPassword;
+    !currentPassword ||
+    !newPassword ||
+    !confirmNewPassword ||
+    isNewPasswordTooShort ||
+    doNewPasswordsMismatch;
 
   return (
     <>
@@ -512,7 +522,19 @@ export default function AccountSettings() {
                 value={newPassword}
                 onChange={handleNewPasswordChange}
                 placeholder="Enter your new password"
+                aria-invalid={isNewPasswordTooShort}
+                aria-describedby={
+                  isNewPasswordTooShort ? 'newPassword-error' : undefined
+                }
               />
+              {isNewPasswordTooShort && (
+                <div
+                  id="newPassword-error"
+                  className="text-xs text-red-600 mt-1"
+                >
+                  Password must be at least {minPasswordLength} characters long.
+                </div>
+              )}
             </div>
             <div>
               <Label htmlFor="confirmNewPassword">Confirm New Password</Label>
@@ -522,7 +544,21 @@ export default function AccountSettings() {
                 value={confirmNewPassword}
                 onChange={handleConfirmNewPasswordChange}
                 placeholder="Confirm your new password"
+                aria-invalid={doNewPasswordsMismatch}
+                aria-describedby={
+                  doNewPasswordsMismatch
+                    ? 'confirmNewPassword-error'
+                    : undefined
+                }
               />
+              {doNewPasswordsMismatch && (
+                <div
+                  id="confirmNewPassword-error"
+                  className="text-xs text-red-600 mt-1"
+                >
+                  Passwords do not match.
+                </div>
+              )}
             </div>
           </div>
           <DialogFooter>

--- a/server/bin/README.md
+++ b/server/bin/README.md
@@ -83,7 +83,7 @@ All parameters are required:
 - `--website`: Organization website URL (must be a valid URL)
 - `--firstName`: Admin user's first name
 - `--lastName`: Admin user's last name
-- `--password`: Admin user's password (minimum 8 characters recommended)
+- `--password`: Admin user's password (minimum 15 characters, required)
 
 ### Output
 
@@ -148,7 +148,7 @@ The script performs the following actions:
 
 - The API key is only displayed once. Make sure to copy and store it securely.
 - The organization name and email must be unique in the database.
-- The password should be strong and at least 8 characters long.
+- The password must be strong and at least 15 characters long.
 - All database connections are properly closed after the script completes.
 
 ### Troubleshooting

--- a/server/graphql/datasources/UserApi.test.ts
+++ b/server/graphql/datasources/UserApi.test.ts
@@ -1,9 +1,23 @@
 import { type Kysely } from 'kysely';
 
-import { hashPassword } from '../../services/userManagementService/index.js';
+import { type Dependencies } from '../../iocContainer/index.js';
+import {
+  hashPassword,
+  MIN_PASSWORD_LENGTH,
+} from '../../services/userManagementService/index.js';
 import { makeTestWithFixture } from '../../test/utils.js';
+import { type GQLMutationSignUpArgs } from '../generated.js';
 import UserAPI from './UserApi.js';
 import { type GraphQLUserParent } from './userKyselyPersistence.js';
+
+// UserAPI is constructed with five injected dependencies, but the
+// password-length guard paths exercised in this file only reach `kyselyPg`.
+// Stub the other four here with a single typed `never` so no call site needs
+// to repeat the cast (and none of them reach for `any`).
+function makeUserAPIForGuardTest(kyselyPg: Dependencies['KyselyPg']) {
+  const unusedDep = undefined as never;
+  return new UserAPI(kyselyPg, unusedDep, unusedDep, unusedDep, unusedDep);
+}
 
 // changePassword only touches the injected Kysely instance (for the user
 // update + session deletion); the other constructor deps are unused here.
@@ -75,18 +89,7 @@ describe('UserAPI', () => {
           updated_at: new Date(),
         });
 
-        // Remaining constructor deps are unused by changePassword.
-        const sut = new UserAPI(
-          kyselyPg,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- unused mock dep
-          {} as any,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- unused mock dep
-          {} as any,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- unused mock dep
-          {} as any,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- unused mock dep
-          {} as any,
-        );
+        const sut = makeUserAPIForGuardTest(kyselyPg);
 
         const user = {
           id: userId,
@@ -96,7 +99,7 @@ describe('UserAPI', () => {
 
         await sut.changePassword(
           user,
-          { currentPassword, newPassword: 'new-password' },
+          { currentPassword, newPassword: 'a'.repeat(MIN_PASSWORD_LENGTH) },
           currentSid,
         );
 
@@ -105,5 +108,67 @@ describe('UserAPI', () => {
         expect(deleteWhere).toHaveBeenCalledWith('sid', '!=', currentSid);
       },
     );
+
+    testWithFixtures(
+      'rejects a new password shorter than the minimum without writing',
+      async () => {
+        const currentPassword = 'current-password';
+        const passwordHash = await hashPassword(currentPassword);
+
+        const { kyselyPg, updateExecuteTakeFirst, deleteFrom } =
+          makeMockKyselyPg();
+
+        const sut = makeUserAPIForGuardTest(kyselyPg);
+
+        const user = {
+          id: 'user-123',
+          loginMethods: ['password'],
+          password: passwordHash,
+        } as unknown as GraphQLUserParent;
+
+        await expect(
+          sut.changePassword(
+            user,
+            {
+              currentPassword,
+              newPassword: 'a'.repeat(MIN_PASSWORD_LENGTH - 1),
+            },
+            'sid-abc',
+          ),
+        ).rejects.toThrow(`at least ${MIN_PASSWORD_LENGTH} characters`);
+
+        // No password write, no session purge.
+        expect(updateExecuteTakeFirst).not.toHaveBeenCalled();
+        expect(deleteFrom).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  describe('#signUp', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('rejects a password shorter than the minimum', async () => {
+      const { kyselyPg } = makeMockKyselyPg();
+
+      const sut = makeUserAPIForGuardTest(kyselyPg);
+
+      const args: GQLMutationSignUpArgs = {
+        input: {
+          email: 'new@example.com',
+          password: 'a'.repeat(MIN_PASSWORD_LENGTH - 1),
+          firstName: 'New',
+          lastName: 'User',
+          orgId: 'org-456',
+          role: 'ADMIN',
+          loginMethod: 'PASSWORD',
+        },
+      };
+
+      await expect(sut.signUp(args, undefined)).rejects.toThrow(
+        `at least ${MIN_PASSWORD_LENGTH} characters`,
+      );
+    });
   });
 });

--- a/server/graphql/datasources/UserApi.ts
+++ b/server/graphql/datasources/UserApi.ts
@@ -7,6 +7,7 @@ import { type LoginMethod } from '../../services/coreAppTables.js';
 import {
   deleteSessionsForUser,
   hashPassword,
+  MIN_PASSWORD_LENGTH,
   passwordMatchesHash,
 } from '../../services/userManagementService/index.js';
 import {
@@ -146,6 +147,14 @@ class UserAPI {
         { shouldErrorSpan: true },
       );
 
+    // `password != null` keeps SAML / invite-only signups (which carry no
+    // password) working — the length check only applies when one is set.
+    if (password != null && password.length < MIN_PASSWORD_LENGTH)
+      throw makeBadRequestError(
+        `Password must be at least ${MIN_PASSWORD_LENGTH} characters long.`,
+        { shouldErrorSpan: true, pointer: '/input/password' },
+      );
+
     const existingUser = await kyselyUserFindByEmail(this.kyselyPg, email);
     if (existingUser != null) {
       throw makeSignUpUserExistsError({ shouldErrorSpan: true });
@@ -264,6 +273,12 @@ class UserAPI {
         shouldErrorSpan: true,
       });
     }
+
+    if (newPassword.length < MIN_PASSWORD_LENGTH)
+      throw makeBadRequestError(
+        `Password must be at least ${MIN_PASSWORD_LENGTH} characters long.`,
+        { shouldErrorSpan: true, pointer: '/input/newPassword' },
+      );
 
     const hashedNewPassword = await hashPassword(newPassword);
     // Update the password and invalidate the user's other sessions atomically:

--- a/server/services/userManagementService/constants.ts
+++ b/server/services/userManagementService/constants.ts
@@ -1,1 +1,5 @@
-export const MIN_PASSWORD_LENGTH = 8;
+// 15-character minimum per NIST SP 800-63-4 §3.1.1, which requires verifiers to
+// permit (and recommends requiring) passwords of at least 15 characters:
+// https://pages.nist.gov/800-63-4/sp800-63b.html#passwordver
+// Hardcoded on purpose — not admin-configurable and not an env var.
+export const MIN_PASSWORD_LENGTH = 15;

--- a/server/services/userManagementService/userManagementService.test.ts
+++ b/server/services/userManagementService/userManagementService.test.ts
@@ -248,7 +248,7 @@ describe('UserManagementService', () => {
 
         await sut.resetPasswordForToken({
           token: 'plaintext-token',
-          newPassword: 'new-password',
+          newPassword: 'a'.repeat(MIN_PASSWORD_LENGTH),
         });
 
         // The password row is updated...


### PR DESCRIPTION
## Context & Requests for Reviewers
follow-up to PR #1065.
Update minimum password length to 15 according to [NIST guidelines](https://pages.nist.gov/800-63-4/sp800-63b.html#passwordver) and add missing password check in signup and change user password.

## Tests

<!-- Describe how you tested your changes, including any manual steps or automated tests performed. -->
<!-- Provide screenshots if available -->
Change password
<img width="423" height="182" alt="image" src="https://github.com/user-attachments/assets/1ed1b566-3700-4e9a-b8e8-b37a61f71cfb" />
<img width="958" height="718" alt="image" src="https://github.com/user-attachments/assets/4012c11d-e6c8-44c4-97e4-3c13d4683311" />
<img width="900" height="716" alt="image" src="https://github.com/user-attachments/assets/4c54e902-3d98-4552-bc89-5fbb2d4ce494" />

Forgot Password
<img width="564" height="471" alt="image" src="https://github.com/user-attachments/assets/0a071c49-ebc3-48c6-865b-204cc5d12dd5" />
<img width="536" height="442" alt="image" src="https://github.com/user-attachments/assets/0e22efdd-f023-4231-9a4b-c061f3e91942" />

Signup as a new user (button is disabled until minimum password length)
<img width="471" height="621" alt="image" src="https://github.com/user-attachments/assets/15ce27bc-7ba6-4ffb-ab61-aa410dbce003" />
<img width="471" height="614" alt="image" src="https://github.com/user-attachments/assets/1151ee81-0c51-4873-ac49-135ddf1b068a" />

## Open questions
1. We see 2 eyes for show password in some screenshots. First one is antd and second one is from browser. Should i resolve in this PR or raise a new one for the fix ?
2. Should i add the check that new password cannot be same as old password ?

## (Optional) Rollout Plan

<!--
Are there any special things that have to be done before this can be deployed
to prod (e.g., other blocking PRs; manual load testing/validation that needs to
be done on staging; etc.)? If so, please note them here.
 -->

## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] **If you changed anything user-facing** (i.e. user interface or APIs):
  Did you update related docs?

- [ ] **If the change is notable** (refer to [Keep a Changelog](https://keepachangelog.com/en/2.0.0/) conventions):
  Did you update CHANGELOG.md?

- [ ] **If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**
  Did you update the corresponding history tables and their triggers?

- [ ] **If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?

- [ ] **If you added a new signal in `server/services/signalsService/signals/**`:**
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline password validation during password resets and account password changes.
  * Password fields now clearly indicate short or mismatched entries.
  * Submission is disabled until passwords are complete, sufficiently long, and matching.

* **Bug Fixes**
  * Enforced a minimum password length of 15 characters for sign-up, password changes, and resets.
  * Updated password guidance and validation messages to reflect the stronger requirement.

* **Documentation**
  * Updated setup guidance to recommend passwords of at least 15 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->