### PR TITLE
chore: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # Format: path-pattern @username @org/team-name
 
 # Maintainers: Default owners for all files
-* @roostorg/community @julietshen
+* @roostorg/community
 
 # Docs contributors
 docs/ @roostorg/roosters


### PR DESCRIPTION
Removed @julietshen explicitly since she's on the @roostorg/community team now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership settings so the community team is the sole default code owner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->