### PR TITLE
client: declare google.maps types explicitly

### DIFF
--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "target": "ESNext",
-    "types": ["vite/client", "vite-plugin-svgr/client"],
+    "types": ["vite/client", "vite-plugin-svgr/client", "google.maps"],
     "module": "esnext",
     "strict": true,
     "esModuleInterop": true,

--- a/client/tsconfig.test.json
+++ b/client/tsconfig.test.json
@@ -5,7 +5,8 @@
       "vite/client",
       "vite-plugin-svgr/client",
       "vitest/globals",
-      "node"
+      "node",
+      "google.maps"
     ]
   },
   "include": [


### PR DESCRIPTION
The client tsconfig has an explicit `types` allowlist, but didn't include google.maps. It _was_ being included via the `/// <reference types="google.maps" />` directive from @googlemaps/js-api-loader's type declarations, but v1.16 drops the directive. Let's explicitly declare it since we depend on it!

This should fix CI for #1086

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated TypeScript configuration to recognize Google Maps type definitions alongside existing tooling types.
  - Applied the same type support to test configuration for consistent development and test environments.

- **User Impact**
  - No visible changes to the application’s functionality or interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->