### PR TITLE
docs: Flag that wellness settings don't apply to iframes by default

### DIFF
--- a/docs/user/administration.md
+++ b/docs/user/administration.md
@@ -38,6 +38,8 @@ Reviewer wellness controls for media displayed in the Review Console including b
 
 ![Wellness tab in Settings with Blur Media slider, Greyscale toggle, and Mute Videos toggle](../images/settings-wellness.png)
 
+Note that wellness settings apply to images and videos by default; they will not apply to embedded content unless your Coop deployment has implemented a [content proxy](../development/deployment.md#content-proxy).
+
 ### Partial Items
 
 Configuration for the [Partial Items](../api/partial-items.md) endpoint and the request headers Coop sends to it.


### PR DESCRIPTION
As raised in #768

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that wellness settings apply by default to images and videos.
  - Documented that embedded content is excluded unless the deployment implements a content proxy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->