### PR TITLE
[Email] Add way to preview emails locally via local transport

### DIFF
--- a/docs/development/local.md
+++ b/docs/development/local.md
@@ -166,7 +166,9 @@ Without this running, submitted items will be enqueued in Redis but not processe
 
 To preview emails locally without configuring SES or SendGrid, add the
 following to `server/.env`. The recipient, subject, and rendered content will
-be printed in the server terminal:
+be printed in the server terminal. This transport requires
+`NODE_ENV=development` and must not be enabled in a shared environment because
+messages can contain user information:
 
 ```sh
 EMAIL_TRANSPORT=console

--- a/docs/development/local.md
+++ b/docs/development/local.md
@@ -164,6 +164,14 @@ npm run runWorkerOrJob ItemProcessingWorker
 
 Without this running, submitted items will be enqueued in Redis but not processed. Other available workers/jobs can be found in `server/iocContainer/services/workersAndJobs.ts`.
 
+To preview emails locally without configuring SES or SendGrid, add the
+following to `server/.env`. The recipient, subject, and rendered content will
+be printed in the server terminal:
+
+```sh
+EMAIL_TRANSPORT=console
+```
+
 ### With distributed tracing
 
 ```sh

--- a/server/.env.example
+++ b/server/.env.example
@@ -109,6 +109,9 @@ OTEL_SERVICE_NAME=COOP_TEST_SERVICE
 NOREPLY_EMAIL=noreply@example.com
 SUPPORT_EMAIL=support@example.com
 TEAM_EMAIL=team@example.com
+# Set to `console` only for local testing to print emails instead of sending
+# them through SES or SendGrid. Printed messages can contain user information.
+# EMAIL_TRANSPORT=console
 
 # Selects the NCMEC CyberTipline endpoint that "Submit to NCMEC" decisions are
 # routed to. Anything other than the literal string `production` (including

--- a/server/.env.example
+++ b/server/.env.example
@@ -109,8 +109,9 @@ OTEL_SERVICE_NAME=COOP_TEST_SERVICE
 NOREPLY_EMAIL=noreply@example.com
 SUPPORT_EMAIL=support@example.com
 TEAM_EMAIL=team@example.com
-# Set to `console` only for local testing to print emails instead of sending
-# them through SES or SendGrid. Printed messages can contain user information.
+# With NODE_ENV=development, set to `console` for local testing to print emails
+# instead of sending them. Never enable this in shared environments: printed
+# messages can contain user information.
 # EMAIL_TRANSPORT=console
 
 # Selects the NCMEC CyberTipline endpoint that "Submit to NCMEC" decisions are

--- a/server/services/sendEmailService/sendEmailService.test.ts
+++ b/server/services/sendEmailService/sendEmailService.test.ts
@@ -2,6 +2,7 @@ import { SendEmailCommand, type SESClient } from '@aws-sdk/client-ses';
 
 import makeSendEmail, {
   CoopEmailAddress,
+  makeSendEmailViaConsole,
   makeSendEmailViaSendGrid,
   type Message,
 } from './sendEmailService.js';
@@ -120,7 +121,7 @@ describe('sendEmailService', () => {
         text: 'Hello',
       };
 
-      await expect(sendEmail(msg)).resolves.not.toThrow();
+      await expect(sendEmail(msg)).resolves.toBe(false);
     });
 
     it('should log the error when SES fails', async () => {
@@ -152,6 +153,56 @@ describe('sendEmailService', () => {
     it('should create a function when given an API key', () => {
       const sendEmail = makeSendEmailViaSendGrid('SG.test-key');
       expect(typeof sendEmail).toBe('function');
+    });
+  });
+
+  describe('console backend', () => {
+    it('prints the email and reports successful delivery', async () => {
+      const consoleSpy = jest
+        .spyOn(console, 'log')
+        .mockImplementation(() => {});
+      const sendEmail = makeSendEmailViaConsole();
+      const msg: Message = {
+        to: 'test_user@example.com',
+        from: CoopEmailAddress.NoReply,
+        subject: 'Test Subject',
+        text: 'Test body',
+      };
+
+      await expect(sendEmail(msg)).resolves.toBe(true);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Email sent via console transport:',
+        msg,
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it('is selected explicitly through EMAIL_TRANSPORT', async () => {
+      const previousTransport = process.env.EMAIL_TRANSPORT;
+      process.env.EMAIL_TRANSPORT = 'console';
+      const consoleSpy = jest
+        .spyOn(console, 'log')
+        .mockImplementation(() => {});
+
+      try {
+        const sendEmail = makeSendEmail();
+        await expect(
+          sendEmail({
+            to: 'test_user@example.com',
+            from: CoopEmailAddress.NoReply,
+            subject: 'Test Subject',
+            text: 'Test body',
+          }),
+        ).resolves.toBe(true);
+        expect(consoleSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        if (previousTransport === undefined) {
+          delete process.env.EMAIL_TRANSPORT;
+        } else {
+          process.env.EMAIL_TRANSPORT = previousTransport;
+        }
+        consoleSpy.mockRestore();
+      }
     });
   });
 

--- a/server/services/sendEmailService/sendEmailService.test.ts
+++ b/server/services/sendEmailService/sendEmailService.test.ts
@@ -161,21 +161,24 @@ describe('sendEmailService', () => {
       const consoleSpy = jest
         .spyOn(console, 'log')
         .mockImplementation(() => {});
-      const sendEmail = makeSendEmailViaConsole();
-      const msg: Message = {
-        to: 'test_user@example.com',
-        from: CoopEmailAddress.NoReply,
-        subject: 'Test Subject',
-        text: 'Test body',
-      };
 
-      await expect(sendEmail(msg)).resolves.toBe(true);
-      expect(consoleSpy).toHaveBeenCalledWith(
-        'Email sent via console transport:',
-        msg,
-      );
-      consoleSpy.mockRestore();
-    });
+      try {
+        const sendEmail = makeSendEmailViaConsole();
+        const msg: Message = {
+          to: 'test_user@example.com',
+          from: CoopEmailAddress.NoReply,
+          subject: 'Test Subject',
+          text: 'Test body',
+        };
+
+        await expect(sendEmail(msg)).resolves.toBe(true);
+        expect(consoleSpy).toHaveBeenCalledWith(
+          'Email sent via console transport:',
+          msg,
+        );
+      } finally {
+        consoleSpy.mockRestore();
+      }
 
     it('is selected explicitly through EMAIL_TRANSPORT', async () => {
       const previousTransport = process.env.EMAIL_TRANSPORT;

--- a/server/services/sendEmailService/sendEmailService.test.ts
+++ b/server/services/sendEmailService/sendEmailService.test.ts
@@ -179,6 +179,8 @@ describe('sendEmailService', () => {
 
   describe('console backend', () => {
     it('prints the email and reports successful delivery', async () => {
+      const previousNodeEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'development';
       const consoleSpy = jest
         .spyOn(console, 'log')
         .mockImplementation(() => {});
@@ -198,6 +200,11 @@ describe('sendEmailService', () => {
           msg,
         );
       } finally {
+        if (previousNodeEnv === undefined) {
+          delete process.env.NODE_ENV;
+        } else {
+          process.env.NODE_ENV = previousNodeEnv;
+        }
         consoleSpy.mockRestore();
       }
     });
@@ -244,9 +251,14 @@ describe('sendEmailService', () => {
       process.env.NODE_ENV = 'production';
 
       try {
-        expect(() => makeSendEmail()).toThrow(
-          'EMAIL_TRANSPORT=console is only available when NODE_ENV=development',
-        );
+        for (const makeTransport of [
+          () => makeSendEmail(),
+          () => makeSendEmailViaConsole(),
+        ]) {
+          expect(makeTransport).toThrow(
+            'EMAIL_TRANSPORT=console is only available when NODE_ENV=development',
+          );
+        }
       } finally {
         if (previousTransport === undefined) {
           delete process.env.EMAIL_TRANSPORT;

--- a/server/services/sendEmailService/sendEmailService.test.ts
+++ b/server/services/sendEmailService/sendEmailService.test.ts
@@ -1,4 +1,5 @@
 import { SendEmailCommand, type SESClient } from '@aws-sdk/client-ses';
+import sgMail from '@sendgrid/mail';
 
 import makeSendEmail, {
   CoopEmailAddress,
@@ -34,7 +35,7 @@ describe('sendEmailService', () => {
         html: '<p>Hello</p>',
       };
 
-      await sendEmail(msg);
+      await expect(sendEmail(msg)).resolves.toBe(true);
 
       expect(mockSend).toHaveBeenCalledTimes(1);
       const command = mockSend.mock.calls[0][0];
@@ -150,9 +151,29 @@ describe('sendEmailService', () => {
   });
 
   describe('SendGrid backend', () => {
-    it('should create a function when given an API key', () => {
+    it('reports successful and failed delivery attempts', async () => {
+      const sendSpy = jest.spyOn(sgMail, 'send');
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
       const sendEmail = makeSendEmailViaSendGrid('SG.test-key');
-      expect(typeof sendEmail).toBe('function');
+      const msg: Message = {
+        to: 'test_user@example.com',
+        from: CoopEmailAddress.NoReply,
+        subject: 'Test Subject',
+        text: 'Test body',
+      };
+
+      try {
+        sendSpy.mockResolvedValueOnce([] as never);
+        await expect(sendEmail(msg)).resolves.toBe(true);
+
+        sendSpy.mockRejectedValueOnce(new Error('SendGrid error'));
+        await expect(sendEmail(msg)).resolves.toBe(false);
+      } finally {
+        sendSpy.mockRestore();
+        consoleSpy.mockRestore();
+      }
     });
   });
 
@@ -179,10 +200,13 @@ describe('sendEmailService', () => {
       } finally {
         consoleSpy.mockRestore();
       }
+    });
 
     it('is selected explicitly through EMAIL_TRANSPORT', async () => {
       const previousTransport = process.env.EMAIL_TRANSPORT;
+      const previousNodeEnv = process.env.NODE_ENV;
       process.env.EMAIL_TRANSPORT = 'console';
+      process.env.NODE_ENV = 'development';
       const consoleSpy = jest
         .spyOn(console, 'log')
         .mockImplementation(() => {});
@@ -204,7 +228,36 @@ describe('sendEmailService', () => {
         } else {
           process.env.EMAIL_TRANSPORT = previousTransport;
         }
+        if (previousNodeEnv === undefined) {
+          delete process.env.NODE_ENV;
+        } else {
+          process.env.NODE_ENV = previousNodeEnv;
+        }
         consoleSpy.mockRestore();
+      }
+    });
+
+    it('rejects console transport outside development', () => {
+      const previousTransport = process.env.EMAIL_TRANSPORT;
+      const previousNodeEnv = process.env.NODE_ENV;
+      process.env.EMAIL_TRANSPORT = 'console';
+      process.env.NODE_ENV = 'production';
+
+      try {
+        expect(() => makeSendEmail()).toThrow(
+          'EMAIL_TRANSPORT=console is only available when NODE_ENV=development',
+        );
+      } finally {
+        if (previousTransport === undefined) {
+          delete process.env.EMAIL_TRANSPORT;
+        } else {
+          process.env.EMAIL_TRANSPORT = previousTransport;
+        }
+        if (previousNodeEnv === undefined) {
+          delete process.env.NODE_ENV;
+        } else {
+          process.env.NODE_ENV = previousNodeEnv;
+        }
       }
     });
   });

--- a/server/services/sendEmailService/sendEmailService.ts
+++ b/server/services/sendEmailService/sendEmailService.ts
@@ -95,9 +95,15 @@ const makeSendEmail = (clientOrContainer?: SESClient | unknown) => {
   }
 
   if (process.env.EMAIL_TRANSPORT === 'console') {
-    return makeSendEmailViaConsole();
+    if (process.env.NODE_ENV === 'production') {
+      // eslint-disable-next-line no-console
+      console.error(
+        'EMAIL_TRANSPORT=console is disabled when NODE_ENV=production',
+      );
+    } else {
+      return makeSendEmailViaConsole();
+    }
   }
-
   const sendGridApiKey = process.env.SENDGRID_API_KEY;
   if (sendGridApiKey) {
     return makeSendEmailViaSendGrid(sendGridApiKey);

--- a/server/services/sendEmailService/sendEmailService.ts
+++ b/server/services/sendEmailService/sendEmailService.ts
@@ -52,11 +52,13 @@ export function makeSendEmailViaSES(client: SESClient) {
 
     try {
       await client.send(command);
+      return true;
     } catch (error) {
       if (error instanceof Error) {
         // eslint-disable-next-line no-console
         console.error('Failed to send email:', error.message);
       }
+      return false;
     }
   };
 }
@@ -66,25 +68,42 @@ export function makeSendEmailViaSendGrid(apiKey: string) {
   return async (msg: Message) => {
     try {
       await sgMail.send(msg);
+      return true;
     } catch (error) {
       if (error instanceof Error) {
         // eslint-disable-next-line no-console
         console.error('Failed to send email:', error.message);
       }
+      return false;
     }
   };
 }
 
+export function makeSendEmailViaConsole() {
+  return async (msg: Message) => {
+    // This transport is explicitly enabled for local testing and may include
+    // recipient information and rendered notification content.
+    // eslint-disable-next-line no-console
+    console.log('Email sent via console transport:', msg);
+    return true;
+  };
+}
+
 const makeSendEmail = (clientOrContainer?: SESClient | unknown) => {
+  if (isSESClient(clientOrContainer)) {
+    return makeSendEmailViaSES(clientOrContainer);
+  }
+
+  if (process.env.EMAIL_TRANSPORT === 'console') {
+    return makeSendEmailViaConsole();
+  }
+
   const sendGridApiKey = process.env.SENDGRID_API_KEY;
   if (sendGridApiKey) {
     return makeSendEmailViaSendGrid(sendGridApiKey);
   }
 
-  const sesClient = isSESClient(clientOrContainer)
-    ? clientOrContainer
-    : new SESClient({});
-  return makeSendEmailViaSES(sesClient);
+  return makeSendEmailViaSES(new SESClient({}));
 };
 
 export default makeSendEmail;

--- a/server/services/sendEmailService/sendEmailService.ts
+++ b/server/services/sendEmailService/sendEmailService.ts
@@ -95,15 +95,14 @@ const makeSendEmail = (clientOrContainer?: SESClient | unknown) => {
   }
 
   if (process.env.EMAIL_TRANSPORT === 'console') {
-    if (process.env.NODE_ENV === 'production') {
-      // eslint-disable-next-line no-console
-      console.error(
-        'EMAIL_TRANSPORT=console is disabled when NODE_ENV=production',
+    if (process.env.NODE_ENV !== 'development') {
+      throw new Error(
+        'EMAIL_TRANSPORT=console is only available when NODE_ENV=development',
       );
-    } else {
-      return makeSendEmailViaConsole();
     }
+    return makeSendEmailViaConsole();
   }
+
   const sendGridApiKey = process.env.SENDGRID_API_KEY;
   if (sendGridApiKey) {
     return makeSendEmailViaSendGrid(sendGridApiKey);

--- a/server/services/sendEmailService/sendEmailService.ts
+++ b/server/services/sendEmailService/sendEmailService.ts
@@ -80,6 +80,12 @@ export function makeSendEmailViaSendGrid(apiKey: string) {
 }
 
 export function makeSendEmailViaConsole() {
+  if (process.env.NODE_ENV !== 'development') {
+    throw new Error(
+      'EMAIL_TRANSPORT=console is only available when NODE_ENV=development',
+    );
+  }
+
   return async (msg: Message) => {
     // This transport is explicitly enabled for local testing and may include
     // recipient information and rendered notification content.
@@ -95,11 +101,6 @@ const makeSendEmail = (clientOrContainer?: SESClient | unknown) => {
   }
 
   if (process.env.EMAIL_TRANSPORT === 'console') {
-    if (process.env.NODE_ENV !== 'development') {
-      throw new Error(
-        'EMAIL_TRANSPORT=console is only available when NODE_ENV=development',
-      );
-    }
     return makeSendEmailViaConsole();
   }
 


### PR DESCRIPTION
## Context & Requests for Reviewers

Adds very simple email transport to allow preview of emails via console log. 

This is meant for local development and testing of how emails would be sent and rendered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added instructions for previewing emails locally in the server terminal without configuring an external email provider.
  - Clarified that the console email transport requires development mode and must not be enabled in shared environments because messages may contain user information.
  - Updated the example environment configuration with the same safety guidance.

- **Bug Fixes**
  - Prevented the console email transport from being used outside development mode.
  - Improved email transport checks and success/failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->