### PR TITLE
Add AgentScan PR labeling workflow

### DIFF
--- a/.github/workflows/agentscan.yml
+++ b/.github/workflows/agentscan.yml
@@ -14,8 +14,6 @@ jobs:
     if: github.repository == 'roostorg/coop'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      issues: write
       pull-requests: write
     steps:
       - name: Cache AgentScan analysis

--- a/.github/workflows/agentscan.yml
+++ b/.github/workflows/agentscan.yml
@@ -14,6 +14,7 @@ jobs:
     if: github.repository == 'roostorg/coop'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - name: Cache AgentScan analysis

--- a/.github/workflows/agentscan.yml
+++ b/.github/workflows/agentscan.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   agentscan:
-    if: github.repository == 'roostorg/coop' && github.event.pull_request.user.login != 'dependabot[bot]'
+    if: github.repository == 'roostorg/coop'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/agentscan.yml
+++ b/.github/workflows/agentscan.yml
@@ -1,0 +1,24 @@
+name: AgentScan
+
+on:
+  # Write access is required to label fork PRs. This workflow never checks out
+  # or executes contributor-controlled code.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
+    branches: [main]
+    types: [opened, reopened]
+
+permissions: {}
+
+jobs:
+  agentscan:
+    if: github.repository == 'roostorg/coop' && github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Scan pull request author
+        uses: MatteoGabriele/agentscan-action@8112fb79b33fafb8506159df20129a34209ac410 # v2.5.0
+        with:
+          mode: labels

--- a/.github/workflows/agentscan.yml
+++ b/.github/workflows/agentscan.yml
@@ -18,7 +18,15 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      - name: Cache AgentScan analysis
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .agentscan-cache
+          key: agentscan-cache-${{ github.event.pull_request.user.login }}
+          restore-keys: agentscan-cache-
+
       - name: Scan pull request author
         uses: MatteoGabriele/agentscan-action@8112fb79b33fafb8506159df20129a34209ac410 # v2.5.0
         with:
+          cache-path: .agentscan-cache
           mode: labels


### PR DESCRIPTION
This is a small proposal: add a GitHub Action to run [AgentScan](https://agentscan.tools/) on PRs. This tool checks a contributor's GitHub history, and if it detects signs of the user being an AI agent, it adds a small label to the PR. So it's purely informational, but it'd be a nice additional data point when we get PRs from new contributors.

The reason is that PRs from AI agents are largely not worth reviewing, IMO! Reviewing PRs is a decent workload, and if there isn't a human on the other end, there's very little benefit -- it's much simpler for us to prompt an agent ourselves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated security scanning for pull requests targeting the main branch.
  * Scan results can now be applied as pull request labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->