### PR TITLE
Fix flaky E2E tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -103,11 +103,16 @@ jobs:
           npm run db:update -- --env staging --db scylla
           npm run db:update -- --env staging --db clickhouse
 
+      - name: Build server
+        # Playwright writes artifacts under server/e2e. A compiler watcher
+        # restarts the API during tests when those directories change.
+        run: npm --prefix server run build
+
       - name: Start server and client
         # Redirect output to files so the backgrounded processes don't hold this
         # step's stdout pipe open (which would hang the step).
         run: |
-          npm run server:start > /tmp/server.log 2>&1 &
+          (cd server && node --env-file=.env transpiled/bin/www.js) > /tmp/server.log 2>&1 &
           (cd client && npm start) > /tmp/client.log 2>&1 &
           # Wait (up to 120s) for the API (tcp 8080) and client (http 3000) to be
           # ready. A built-in shell loop avoids fetching an undeclared dependency

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -104,8 +104,6 @@ jobs:
           npm run db:update -- --env staging --db clickhouse
 
       - name: Build server
-        # Playwright writes artifacts under server/e2e. A compiler watcher
-        # restarts the API during tests when those directories change.
         run: npm --prefix server run build
 
       - name: Start server and client


### PR DESCRIPTION
## Context & Requests for Reviewers

This fixes an occassional flake in our E2E tests in CI: we now build the server up front.

Before, we were running a live-reloading watcher, which means that changes on the filesystem (like Playwright writing an artifact) could trigger restarts and thus break network requests.

May be related to #1110 

## Tests

See CI passing!

## (Optional) Rollout Plan

N/A



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated end-to-end test setup to build the server before launching it.
  * Server startup now uses the transpiled production output during end-to-end testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->