### PR TITLE
Fix `check_generated_graphql` and move to Debian 12 as 11 is EOL.

### DIFF
--- a/.github/workflows/apply_pr_checks.yaml
+++ b/.github/workflows/apply_pr_checks.yaml
@@ -76,7 +76,7 @@ jobs:
         run: npm run check:node-version
 
   check_generated_graphql:
-    timeout-minutes: 4
+    timeout-minutes: 5
     needs: [changes]
     if: needs.changes.outputs.server == 'true' || needs.changes.outputs.client == 'true'
     runs-on: ubuntu-latest
@@ -84,12 +84,25 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - name: Prepare Docker images
-        uses: ./.github/actions/prepare-docker-images
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          build: codegen-check
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Check generated GraphQL is up to date
-        run: docker compose run --rm --quiet-pull codegen-check
+        run: |
+          npm run generate
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "Generated GraphQL files are out of date. Run npm run generate and commit the result."
+            git status
+            git diff
+            exit 1
+          fi
 
   check_migration_order:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,29 +111,29 @@ If tests fail with database errors, check migration logs via `docker compose log
 
 ## CI
 
-CI runs entirely via GitHub Actions (`.github/workflows/apply_pr_checks.yaml`). Most PR checks are defined as `docker compose` services so you can reproduce any CI job locally; the formatting check runs directly via `actions/setup-node`. Run them in your shell (paste-as-is — each command's exit code matches the corresponding CI step's exit code):
+CI runs entirely via GitHub Actions (`.github/workflows/apply_pr_checks.yaml`). Most PR checks are defined as `docker compose` services so you can reproduce any CI job locally; formatting and GraphQL codegen run directly via `actions/setup-node`. Run them in your shell (paste-as-is — each command's exit code matches the corresponding CI step's exit code):
 
 ```bash
-docker compose run --rm codegen-check
+npm ci && npm run prettier
+npm ci && npm run generate && test -z "$(git status --porcelain)"
 docker compose run --rm backend npm run lint
 docker compose run --rm backend npm run build
 docker compose run --rm client npm run lint
 docker compose run --rm client npm run build
 docker compose run --rm test
-npm ci && npm run prettier
 ```
 
 Individual checks:
 
-| CI job                                   | Local command                                   |
-| ---------------------------------------- | ----------------------------------------------- |
-| `check_formatting`                       | `npm ci && npm run prettier`                    |
-| `check_generated_graphql`                | `docker compose run --rm codegen-check`         |
-| `check_api_server` (lint)                | `docker compose run --rm backend npm run lint`  |
-| `check_api_server` (build)               | `docker compose run --rm backend npm run build` |
-| `run_frontend_checks_if_changed` (lint)  | `docker compose run --rm client npm run lint`   |
-| `run_frontend_checks_if_changed` (build) | `docker compose run --rm client npm run build`  |
-| `check_api_server` (test)                | `docker compose run --rm test`                  |
+| CI job                                   | Local command                                                       |
+| ---------------------------------------- | ------------------------------------------------------------------- |
+| `check_formatting`                       | `npm ci && npm run prettier`                                        |
+| `check_generated_graphql`                | `npm ci && npm run generate && test -z "$(git status --porcelain)"` |
+| `check_api_server` (lint)                | `docker compose run --rm backend npm run lint`                      |
+| `check_api_server` (build)               | `docker compose run --rm backend npm run build`                     |
+| `run_frontend_checks_if_changed` (lint)  | `docker compose run --rm client npm run lint`                       |
+| `run_frontend_checks_if_changed` (build) | `docker compose run --rm client npm run build`                      |
+| `check_api_server` (test)                | `docker compose run --rm test`                                      |
 
 Tear down:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ For more information about each release including git tags and artifacts, see [R
 - Settings "Other" tab renamed to "Partial Items" and its settings relocated ([#965](https://github.com/roostorg/coop/pull/965) by [@golden-fox07](https://github.com/golden-fox07))
 - Queue deletion is refused while routing rules still reference the queue ([#808](https://github.com/roostorg/coop/pull/808) by [@reitblatt](https://github.com/reitblatt))
 - Long text fields in the review console collapse behind a "Read more" control ([#903](https://github.com/roostorg/coop/pull/903) by [@taobojlen](https://github.com/taobojlen))
-- Production Node images moved from Debian 11 (bullseye) to Debian 12 (bookworm)
+- Production Node images moved from Debian 11 (bullseye) to Debian 12 (bookworm) ([#1138](https://github.com/roostorg/coop/pull/1138) by [@juanmrad](https://github.com/juanmrad))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For more information about each release including git tags and artifacts, see [R
 - Settings "Other" tab renamed to "Partial Items" and its settings relocated ([#965](https://github.com/roostorg/coop/pull/965) by [@golden-fox07](https://github.com/golden-fox07))
 - Queue deletion is refused while routing rules still reference the queue ([#808](https://github.com/roostorg/coop/pull/808) by [@reitblatt](https://github.com/reitblatt))
 - Long text fields in the review console collapse behind a "Read more" control ([#903](https://github.com/roostorg/coop/pull/903) by [@taobojlen](https://github.com/taobojlen))
+- Production Node images moved from Debian 11 (bullseye) to Debian 12 (bookworm)
 
 ### Removed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN npm run build
 # make a shared layer that can be the base for worker and api images.
 FROM node:24.20.0-bookworm-slim AS backend_base
 WORKDIR /app
-RUN apt-get update && apt-get install dumb-init
+RUN apt-get update && apt-get install -y --no-install-recommends dumb-init && rm -rf /var/lib/apt/lists/*
 COPY --from=build_backend ["/app/package.json", "/app/package-lock.json", "./"]
 RUN npm ci --omit=dev
 COPY --from=build_backend /app/transpiled ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,8 @@
 # Docker's cache will let us skip installs when the dependencies haven't changed.
 # We build on debian because it has fewer dependency issues than Alpine for our
 # native modules, and we don't really care about the larger image size.
-FROM node:24.20.0-bullseye-slim AS server_base
+FROM node:24.20.0-bookworm-slim AS server_base
 WORKDIR /app
-RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
 
 COPY ["server/package.json", "server/package-lock.json", "./"]
 RUN npm ci
@@ -19,7 +18,7 @@ FROM server_base AS build_backend
 RUN npm run build
 
 # make a shared layer that can be the base for worker and api images.
-FROM node:24.20.0-bullseye-slim AS backend_base
+FROM node:24.20.0-bookworm-slim AS backend_base
 WORKDIR /app
 RUN apt-get update && apt-get install dumb-init
 COPY --from=build_backend ["/app/package.json", "/app/package-lock.json", "./"]

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.20.0-bullseye-slim AS client_base
+FROM node:24.20.0-bookworm-slim AS client_base
 WORKDIR /app
 
 # ARG is used to get the release id into the ENV from the command line, and then

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.20.0-bullseye-slim AS builder
+FROM node:24.20.0-bookworm-slim AS builder
 
 WORKDIR /app
 
@@ -13,7 +13,7 @@ RUN npm run build
 
 RUN npm prune --omit=dev
 
-FROM node:24.20.0-bullseye-slim AS base
+FROM node:24.20.0-bookworm-slim AS base
 
 WORKDIR /app
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
 
   # Runs all migrations from scratch, after clearing the database(s).
   migrations:
-    image: node:24.20.0-bullseye-slim
+    image: node:24.20.0-bookworm-slim
     command: bash -c 'set -e
       npm i && ( [ "$CI" = "true" ] && npm run db:clean -- --env staging || true )
       && for db in api-server-pg scylla clickhouse; do npm run db:create -- --db "$$db" --env staging; npm run db:update -- --db "$$db" --env staging; done'
@@ -41,7 +41,7 @@ services:
         condition: service_healthy
 
   drop_dbs:
-    image: node:24.20.0-bullseye-slim
+    image: node:24.20.0-bookworm-slim
     command: bash -c 'npm i && npm run db:drop -- --env staging'
     working_dir: /src
     env_file: ./.env.githubci
@@ -125,24 +125,6 @@ services:
       redis:
         condition: service_started
 
-  # Regenerate GraphQL types and fail if the working tree drifts.
-  # Mirrors the `check_generated_graphql` CI job.
-  # node_modules is in a dedicated volume so the install doesn't clobber the host's node_modules.
-  codegen-check:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: server_base
-    working_dir: /src
-    command: bash -c 'set -e
-      && git config --global --add safe.directory /src
-      && npm ci
-      && npm run generate
-      && [[ -z "$(git status --porcelain)" ]]'
-    volumes:
-      - .:/src
-      - codegen_node_modules:/src/node_modules
-
   backend:
     build:
       context: .
@@ -206,4 +188,3 @@ volumes:
   scylla_data:
   redis_data:
   clickhouse_data:
-  codegen_node_modules:

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -79,12 +79,12 @@ docker compose -f docker-compose.images.yaml down -v
 
 ## Image details
 
-| Image             | Dockerfile          | Build target          | Base                              |
-| ----------------- | ------------------- | --------------------- | --------------------------------- |
-| `coop-server`     | `Dockerfile`        | `build_server`        | node:24-bullseye-slim + dumb-init |
-| `coop-worker`     | `Dockerfile`        | `build_worker_runner` | node:24-bullseye-slim + dumb-init |
-| `coop-client`     | `client/Dockerfile` | `serve`               | nginx:1.27-bookworm               |
-| `coop-migrations` | `db/Dockerfile`     | _(final stage)_       | node:24-bullseye-slim             |
+| Image             | Dockerfile          | Build target          | Base                                   |
+| ----------------- | ------------------- | --------------------- | -------------------------------------- |
+| `coop-server`     | `Dockerfile`        | `build_server`        | node:24.20.0-bookworm-slim + dumb-init |
+| `coop-worker`     | `Dockerfile`        | `build_worker_runner` | node:24.20.0-bookworm-slim + dumb-init |
+| `coop-client`     | `client/Dockerfile` | `serve`               | nginx:1.29.1-bookworm                  |
+| `coop-migrations` | `db/Dockerfile`     | _(final stage)_       | node:24.20.0-bookworm-slim             |
 
 The client image serves the Vite-built SPA via nginx and proxies `/api/` requests (including `/api/v1/graphql`) to a backend service named `server` on port 8080.
 

--- a/docs/development/local.md
+++ b/docs/development/local.md
@@ -213,21 +213,23 @@ npm run check:prepush
 
 ## Running CI locally
 
-All PR checks are defined as `docker compose` services to reproduce any CI job locally.
+Most PR checks are defined as `docker compose` services so you can reproduce them locally; formatting and GraphQL codegen run on the host Node install.
 
-| CI job                                   | Local command                                   |
-| ---------------------------------------- | ----------------------------------------------- |
-| `check_generated_graphql`                | `docker compose run --rm codegen-check`         |
-| `check_api_server` (lint)                | `docker compose run --rm backend npm run lint`  |
-| `check_api_server` (build)               | `docker compose run --rm backend npm run build` |
-| `run_frontend_checks_if_changed` (lint)  | `docker compose run --rm client npm run lint`   |
-| `run_frontend_checks_if_changed` (build) | `docker compose run --rm client npm run build`  |
-| `check_api_server` (test)                | `docker compose run --rm test`                  |
+| CI job                                   | Local command                                                       |
+| ---------------------------------------- | ------------------------------------------------------------------- |
+| `check_formatting`                       | `npm ci && npm run prettier`                                        |
+| `check_generated_graphql`                | `npm ci && npm run generate && test -z "$(git status --porcelain)"` |
+| `check_api_server` (lint)                | `docker compose run --rm backend npm run lint`                      |
+| `check_api_server` (build)               | `docker compose run --rm backend npm run build`                     |
+| `run_frontend_checks_if_changed` (lint)  | `docker compose run --rm client npm run lint`                       |
+| `run_frontend_checks_if_changed` (build) | `docker compose run --rm client npm run build`                      |
+| `check_api_server` (test)                | `docker compose run --rm test`                                      |
 
 Run the full suite (stops at first failure):
 
 ```sh
-docker compose run --rm codegen-check \
+npm ci && npm run prettier \
+  && npm run generate && test -z "$(git status --porcelain)" \
   && docker compose run --rm backend npm run lint \
   && docker compose run --rm backend npm run build \
   && docker compose run --rm client npm run lint \


### PR DESCRIPTION
## Context & Requests for Reviewers

Debian 11 LTS ended 31 August 2026. `check_generated_graphql` (and any other job that `apt-get`s inside `node:24.20.0-bullseye-slim`) started failing on `apt-get install git` with exit 100. Frontend CI stayed green because that Dockerfile never calls apt.

This PR retags every Coop Node image from `node:24.20.0-bullseye-slim` to `node:24.20.0-bookworm-slim` (same Node 24.20.0). `nodejs-instrumentation` already used `node:24.20.0`, which is Bookworm.

GraphQL codegen CI used to build the server Docker image just to run `npm run generate`. It now runs on the GitHub runner the same way formatting does: `install Node`, `npm ci`, `regenerate types`, and fail if those files changed.

`git` was in the production server image only so that Docker job could run git status. That install is removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated production and development container images to Debian 12 (Bookworm), including Node.js and NGINX-based images.
  - Streamlined automated GraphQL generation and formatting checks by running them directly in the Node.js environment.
  - Removed the dedicated Docker-based GraphQL code generation service.

- **Documentation**
  - Updated the changelog and development guides with the new container images and revised local CI commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->