### PR TITLE
Fix Redis readiness checks for CI

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -75,7 +75,7 @@ jobs:
           echo "::error::image prep failed after 3 attempts"; exit 1
 
       - name: Start backing services
-        run: docker compose up --detach --quiet-pull postgres clickhouse scylla redis
+        run: docker compose up --detach --wait --quiet-pull postgres clickhouse scylla redis
 
       - name: Configure env
         run: |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,12 @@ services:
       - '127.0.0.1:6379:6379'
     volumes:
       - redis_data:/data
+    healthcheck:
+      test: ['CMD-SHELL', 'redis-cli ping | grep -qx PONG']
+      interval: 2s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
     deploy:
       resources:
         limits:
@@ -123,7 +129,7 @@ services:
       migrations:
         condition: service_completed_successfully
       redis:
-        condition: service_started
+        condition: service_healthy
 
   backend:
     build:


### PR DESCRIPTION
## Context & Requests for Reviewers

This PR adds a Redis health check, and tells Docker to wait for healthy backing services before running tests.

Fixes #1110

## Tests

See passing CI :)

## (Optional) Rollout Plan

N/A



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved end-to-end test startup reliability by waiting for PostgreSQL, ClickHouse, Scylla, and Redis services to pass health checks.
  - Tests now wait for Redis to be ready before running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->