### PR TITLE
[803] Provide item ids for additional items with clipboard copy

### DIFF
--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ContentRelatedItemComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ContentRelatedItemComponent.tsx
@@ -1,6 +1,8 @@
 import { GQLContentItem } from '@/graphql/generated';
 import { ItemTypeFieldFieldData } from '@/webpages/dashboard/item_types/itemTypeUtils';
 
+import CopyTextComponent from '@/components/common/CopyTextComponent';
+
 import FieldsComponent from './ManualReviewJobFieldsComponent';
 
 type LoadedContentItem = Pick<GQLContentItem, 'data'> & {
@@ -9,10 +11,11 @@ type LoadedContentItem = Pick<GQLContentItem, 'data'> & {
 
 export default function ContentRelatedItemComponent(props: {
   item: LoadedContentItem;
+  itemId?: string;
   unblurAllMedia: boolean;
   title: string;
 }) {
-  const { item, unblurAllMedia } = props;
+  const { item, itemId, unblurAllMedia } = props;
 
   const fieldData = item.type.baseFields.map(
     (
@@ -25,11 +28,24 @@ export default function ContentRelatedItemComponent(props: {
   );
   return (
     <div className="flex flex-col items-start justify-start w-full py-4 mt-8 space-y-2 bg-white border border-gray-200 border-solid rounded-lg">
-      <div className="flex flex-col w-full mx-4">
+      <div className="flex flex-row items-center justify-between w-full px-4">
         <div className="text-lg font-semibold text-start">
           {/* TODO: make this title org-agnostic  */}
           {props.title}
         </div>
+        {itemId ? (
+          <div className="min-w-0 shrink text-slate-400">
+            <CopyTextComponent
+              displayValue={
+                'ID: ' +
+                (itemId.length > 20
+                  ? itemId.slice(0, 10) + '…' + itemId.slice(-10)
+                  : itemId)
+              }
+              value={itemId}
+            />
+          </div>
+        ) : null}
       </div>
 
       <div className="max-w-full min-w-[50%] grow mx-4">

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/ContentRelatedItemComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/ContentRelatedItemComponent.tsx
@@ -28,13 +28,13 @@ export default function ContentRelatedItemComponent(props: {
   );
   return (
     <div className="flex flex-col items-start justify-start w-full py-4 mt-8 space-y-2 bg-white border border-gray-200 border-solid rounded-lg">
-      <div className="flex flex-row items-center justify-between w-full px-4">
-        <div className="text-lg font-semibold text-start">
+      <div className="flex flex-wrap items-center justify-between gap-1 w-full px-4">
+        <div className="text-lg font-semibold text-start truncate min-w-0">
           {/* TODO: make this title org-agnostic  */}
           {props.title}
         </div>
         {itemId ? (
-          <div className="min-w-0 shrink text-slate-400">
+          <div className="shrink-0 text-slate-400">
             <CopyTextComponent
               displayValue={
                 'ID: ' +

--- a/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobLatestSubmissionsWithThreadComponent.tsx
+++ b/client/src/webpages/dashboard/mrt/manual_review_job/v2/user/ManualReviewJobLatestSubmissionsWithThreadComponent.tsx
@@ -262,6 +262,7 @@ export default function ManualReviewJobLatestSubmissionsWithThreadComponent(prop
               baseFields: item.itemTypeFields,
             },
           }}
+          itemId={item.itemId}
           unblurAllMedia={unblurAllMedia}
           title={`${item.itemTypeName}`}
           key={item.itemId}


### PR DESCRIPTION
## Context & Requests for Reviewers

Fixes #803

<img width="1040" height="336" alt="Screenshot 2026-09-08 at 10 12 46 PM" src="https://github.com/user-attachments/assets/c655ea2f-b883-47cd-92ba-c22a11dc8217" />

Provide Item ids on additional items as well as way to copy the item ids. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Item IDs are now displayed alongside related content titles when available.
  - Item IDs can be copied directly from the interface.
  - IDs are truncated visually to preserve layout while remaining copyable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->