### PR TITLE
fix(client): unique DOM ids for Item Type field Required/Hidden checkboxes

### DIFF
--- a/client/src/webpages/dashboard/item_types/ItemTypeForm.test.tsx
+++ b/client/src/webpages/dashboard/item_types/ItemTypeForm.test.tsx
@@ -1,0 +1,33 @@
+import { GQLScalarType } from '../../../graphql/generated';
+import { nextFieldIndex } from './ItemTypeForm';
+import type { FieldState } from './ItemTypeFormCustomField';
+
+function field(index: number): FieldState {
+  return {
+    index,
+    name: `field${index}`,
+    type: GQLScalarType.String,
+    required: false,
+    hidden: false,
+  };
+}
+
+describe('nextFieldIndex', () => {
+  it('is 0 for an empty field list', () => {
+    expect(nextFieldIndex([])).toBe(0);
+  });
+
+  it('is length when indices are contiguous from 0', () => {
+    expect(nextFieldIndex([field(0), field(1), field(2)])).toBe(3);
+  });
+
+  it('does not reuse an existing index after a middle field was removed', () => {
+    // Simulates: add 3 (0,1,2) -> delete the middle -> add again.
+    // `customFields.length` would have returned 2, colliding with field(2).
+    const afterDelete = [field(0), field(2)];
+    const next = nextFieldIndex(afterDelete);
+
+    expect(next).toBe(3);
+    expect(afterDelete.map((f) => f.index)).not.toContain(next);
+  });
+});

--- a/client/src/webpages/dashboard/item_types/ItemTypeForm.tsx
+++ b/client/src/webpages/dashboard/item_types/ItemTypeForm.tsx
@@ -590,7 +590,7 @@ export default function ItemTypeForm() {
             onClick={() =>
               setCustomFields([
                 ...customFields,
-                getDefaultEmptyField(customFields.length),
+                getDefaultEmptyField(nextFieldIndex(customFields)),
               ])
             }
           >
@@ -673,6 +673,18 @@ export default function ItemTypeForm() {
       {modal}
     </div>
   );
+}
+
+/**
+ * Next unused field index. Deliberately not `customFields.length`:
+ * `onClickDelete` removes a field by filtering on `index` without
+ * re-indexing the rest, so a new field taking `length` can collide with an
+ * existing index — producing duplicate React keys and duplicate
+ * Required/Hidden checkbox DOM ids (the bug this file's ids are meant to
+ * avoid).
+ */
+export function nextFieldIndex(fields: readonly FieldState[]): number {
+  return fields.reduce((max, field) => Math.max(max, field.index), -1) + 1;
 }
 
 function getDefaultEmptyField(index: number): FieldState {

--- a/client/src/webpages/dashboard/item_types/ItemTypeFormCustomField.test.tsx
+++ b/client/src/webpages/dashboard/item_types/ItemTypeFormCustomField.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import '@testing-library/jest-dom/extend-expect';
+
+import { ItemTypeKind } from '@roostorg/coop-types';
+import { vi } from 'vitest';
+
+import { GQLScalarType } from '../../../graphql/generated';
+import ItemTypeFormCustomField, {
+  type FieldState,
+} from './ItemTypeFormCustomField';
+
+function makeField(index: number): FieldState {
+  return {
+    index,
+    name: `field${index}`,
+    type: GQLScalarType.String,
+    required: false,
+    hidden: false,
+  };
+}
+
+function renderTwoFields(
+  updateFieldState: (prev: FieldState, next: FieldState) => void,
+) {
+  return render(
+    <>
+      <ItemTypeFormCustomField
+        field={makeField(0)}
+        availableRoles={[]}
+        itemTypeKind={ItemTypeKind.CONTENT}
+        updateFieldState={updateFieldState}
+        onClickDelete={vi.fn()}
+      />
+      <ItemTypeFormCustomField
+        field={makeField(1)}
+        availableRoles={[]}
+        itemTypeKind={ItemTypeKind.CONTENT}
+        updateFieldState={updateFieldState}
+        onClickDelete={vi.fn()}
+      />
+    </>,
+  );
+}
+
+describe('ItemTypeFormCustomField', () => {
+  it('gives each field row unique Required/Hidden checkbox ids', () => {
+    renderTwoFields(vi.fn());
+
+    const requiredFors = screen
+      .getAllByText('Required')
+      .map((label) => label.getAttribute('for'));
+    const hiddenFors = screen
+      .getAllByText('Hidden Field')
+      .map((label) => label.getAttribute('for'));
+
+    expect(new Set(requiredFors).size).toBe(2);
+    expect(new Set(hiddenFors).size).toBe(2);
+    expect(requiredFors.every(Boolean)).toBe(true);
+    expect(hiddenFors.every(Boolean)).toBe(true);
+  });
+
+  it("does not cross-trigger a different field's checkbox when clicking a label", () => {
+    const updateFieldState = vi.fn();
+    renderTwoFields(updateFieldState);
+
+    const secondRequiredLabel = screen.getAllByText('Required')[1];
+    fireEvent.click(secondRequiredLabel);
+
+    expect(updateFieldState).toHaveBeenCalledTimes(1);
+    const [prevField, newField] = updateFieldState.mock.calls[0];
+    expect(prevField.index).toBe(1);
+    expect(newField.required).toBe(true);
+  });
+});

--- a/client/src/webpages/dashboard/item_types/ItemTypeFormCustomField.tsx
+++ b/client/src/webpages/dashboard/item_types/ItemTypeFormCustomField.tsx
@@ -165,7 +165,7 @@ export default function ItemTypeFormCustomField<T extends ItemTypeKind>(props: {
 
         <div className="flex items-center mb-2 mr-2 space-x-2">
           <Checkbox
-            id="required-checkbox"
+            id={`required-checkbox-${field.index}`}
             checked={field.required}
             onCheckedChange={(isChecked) =>
               updateFieldState(field, {
@@ -174,12 +174,12 @@ export default function ItemTypeFormCustomField<T extends ItemTypeKind>(props: {
               })
             }
           />
-          <Label htmlFor="required-checkbox">Required</Label>
+          <Label htmlFor={`required-checkbox-${field.index}`}>Required</Label>
         </div>
 
         <div className="flex items-center mb-2 space-x-2">
           <Checkbox
-            id="hidden-checkbox"
+            id={`hidden-checkbox-${field.index}`}
             checked={field.hidden}
             onCheckedChange={(isChecked) =>
               updateFieldState(field, {
@@ -188,7 +188,7 @@ export default function ItemTypeFormCustomField<T extends ItemTypeKind>(props: {
               })
             }
           />
-          <Label htmlFor="hidden-checkbox">Hidden Field</Label>
+          <Label htmlFor={`hidden-checkbox-${field.index}`}>Hidden Field</Label>
         </div>
         <Button
           className="self-end ml-2 text-red-500 border-none"


### PR DESCRIPTION
## Context & Requests for Reviewers
fixes #1229
fixing bug while creating/editing an item type where clicking a later row's "Required" / "Hidden Field" label toggles the first row's checkbox.

## Tests

manually tested
fix: 

https://github.com/user-attachments/assets/b3f09203-6eef-4e08-bd03-c24126999aa5




issue: 


https://github.com/user-attachments/assets/66c0dee8-b850-4a2a-af6b-ea714867e639


## (Optional) Rollout Plan

<!--
Are there any special things that have to be done before this can be deployed
to prod (e.g., other blocking PRs; manual load testing/validation that needs to
be done on staging; etc.)? If so, please note them here.
 -->

## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] **If you changed anything user-facing** (i.e. user interface or APIs):
  Did you update related docs?

- [ ] **If the change is notable** (refer to [Keep a Changelog](https://keepachangelog.com/en/2.0.0/) conventions):
  Did you update CHANGELOG.md?

- [ ] **If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**
  Did you update the corresponding history tables and their triggers?

- [ ] **If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?

- [ ] **If you added a new signal in `server/services/signalsService/signals/**`:**
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed checkbox and label associations when multiple custom fields are displayed, ensuring each “Required” and “Hidden Field” control targets the correct field.
- **Tests**
  - Added coverage verifying unique checkbox identifiers and correct updates when interacting with individual field controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->