### PR TITLE
fix(client): commit pending TextTokenInput text on blur

### DIFF
--- a/client/src/webpages/dashboard/rules/TextTokenInput.test.tsx
+++ b/client/src/webpages/dashboard/rules/TextTokenInput.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import '@testing-library/jest-dom/extend-expect';
+
+import { vi } from 'vitest';
+
+import TextTokenInput from './TextTokenInput';
+
+describe('TextTokenInput', () => {
+  it('commits pending text to a token on blur', () => {
+    const updateTokenValues = vi.fn();
+    render(
+      <TextTokenInput
+        uniqueKey="test"
+        updateTokenValues={updateTokenValues}
+        initialValues={[]}
+      />,
+    );
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'testword' } });
+    fireEvent.blur(input);
+
+    expect(updateTokenValues).toHaveBeenCalledWith(['testword']);
+    expect(screen.getByText('testword')).toBeInTheDocument();
+  });
+
+  it('does not create an empty token when blurring an empty field', () => {
+    const updateTokenValues = vi.fn();
+    render(
+      <TextTokenInput
+        uniqueKey="test"
+        updateTokenValues={updateTokenValues}
+        initialValues={[]}
+      />,
+    );
+
+    fireEvent.blur(screen.getByRole('textbox'));
+
+    expect(updateTokenValues).not.toHaveBeenCalled();
+  });
+
+  it('commits only once when an outside click also triggers blur', () => {
+    const updateTokenValues = vi.fn();
+    render(
+      <TextTokenInput
+        uniqueKey="test"
+        updateTokenValues={updateTokenValues}
+        initialValues={[]}
+      />,
+    );
+
+    const input = screen.getByRole('textbox');
+    input.focus();
+    fireEvent.change(input, { target: { value: 'testword' } });
+
+    // Clicking a focusable element outside the input: the browser fires blur
+    // (which commits) before the document click handler runs.
+    fireEvent.blur(input);
+    input.blur();
+    fireEvent.click(document.body);
+
+    expect(updateTokenValues).toHaveBeenCalledTimes(1);
+    expect(updateTokenValues).toHaveBeenCalledWith(['testword']);
+  });
+
+  it('still commits on a click outside that does not move focus (dead space)', () => {
+    const updateTokenValues = vi.fn();
+    render(
+      <TextTokenInput
+        uniqueKey="test"
+        updateTokenValues={updateTokenValues}
+        initialValues={[]}
+      />,
+    );
+
+    const input = screen.getByRole('textbox');
+    input.focus();
+    fireEvent.change(input, { target: { value: 'testword' } });
+
+    // A click on non-focusable page chrome leaves the input focused, so no
+    // blur fires — the document click handler is what commits here.
+    fireEvent.click(document.body);
+
+    expect(updateTokenValues).toHaveBeenCalledTimes(1);
+    expect(updateTokenValues).toHaveBeenCalledWith(['testword']);
+  });
+});

--- a/client/src/webpages/dashboard/rules/TextTokenInput.tsx
+++ b/client/src/webpages/dashboard/rules/TextTokenInput.tsx
@@ -33,6 +33,11 @@ export default function TextTokenInput(props: {
       if (
         inputEl.current &&
         !inputEl.current.contains(event.target as Node) &&
+        // If the click moved focus out of the input, `onBlur` already
+        // committed the pending text — bail so we don't call addToken (and
+        // updateTokenValues) a second time. This handler now only covers
+        // clicks on non-focusable "dead space", which don't fire a blur.
+        document.activeElement === inputEl.current &&
         tokenBuilder.length > 0
       ) {
         addToken();
@@ -113,6 +118,13 @@ export default function TextTokenInput(props: {
               }
             }}
             onChange={(event) => setTokenBuiler(event.target.value)}
+            onBlur={() => {
+              // Commit whatever is typed when focus leaves the field (e.g.
+              // clicking "Save Changes"), not just on Enter / outside click.
+              if (tokenBuilder.length > 0) {
+                addToken();
+              }
+            }}
             placeholder={
               tokens.length > 0 || placeholder == null ? '' : placeholder
             }


### PR DESCRIPTION
## Context & Requests for Reviewers
fixes #1225
The matching-strings input only turned pending text into a token on Enter or an outside click, so clicking Save Changes directly dropped the just-typed value. Flush it on blur as well.

## Tests

manually tested
issue:

https://github.com/user-attachments/assets/f2782cd9-aef3-43d9-bfd7-7733a8cdafd8


fix: 

https://github.com/user-attachments/assets/8a3af862-18a7-448c-971d-93de04d33c74



## (Optional) Rollout Plan

<!--
Are there any special things that have to be done before this can be deployed
to prod (e.g., other blocking PRs; manual load testing/validation that needs to
be done on staging; etc.)? If so, please note them here.
 -->

## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] **If you changed anything user-facing** (i.e. user interface or APIs):
  Did you update related docs?

- [ ] **If the change is notable** (refer to [Keep a Changelog](https://keepachangelog.com/en/2.0.0/) conventions):
  Did you update CHANGELOG.md?

- [ ] **If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**
  Did you update the corresponding history tables and their triggers?

- [ ] **If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?

- [ ] **If you added a new signal in `server/services/signalsService/signals/**`:**
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.
