### PR TITLE
fix(client): auto-close the sidebar Settings submenu when leaving Settings

### DIFF
--- a/client/src/components/Sidebar.test.tsx
+++ b/client/src/components/Sidebar.test.tsx
@@ -1,6 +1,10 @@
 import { TooltipProvider } from '@/coop-ui/Tooltip';
-import { fireEvent, render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import {
+  createMemoryRouter,
+  MemoryRouter,
+  RouterProvider,
+} from 'react-router-dom';
 
 import '@testing-library/jest-dom/extend-expect';
 
@@ -86,6 +90,12 @@ function getSettingsButton() {
   return screen.queryByRole('button', { name: 'Settings' });
 }
 
+// Non-null variant for the cases where the button is always present (i.e. every
+// test except the "not in the document" one).
+function getSettingsButtonEl() {
+  return screen.getByRole('button', { name: 'Settings' });
+}
+
 describe('Sidebar', () => {
   it('renders main menu items and footer links', () => {
     renderSidebar();
@@ -119,12 +129,116 @@ describe('Sidebar', () => {
 
   it('expands settings sub-items when gear icon is clicked', () => {
     renderSidebar('/dashboard/overview', 'Overview');
-    const settingsButton = getSettingsButton();
+    const settingsButton = getSettingsButtonEl();
     expect(settingsButton).toHaveAttribute('aria-expanded', 'false');
 
-    fireEvent.click(settingsButton!);
+    fireEvent.click(settingsButton);
 
     expect(settingsButton).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('collapses a gear-opened settings submenu when clicking outside the sidebar', () => {
+    renderSidebar('/dashboard/overview', 'Overview');
+    fireEvent.click(getSettingsButtonEl());
+    expect(getSettingsButton()).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.pointerDown(document.body);
+
+    expect(getSettingsButton()).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('keeps the submenu open when clicking the gear toggle or a sub-item', () => {
+    renderSidebar('/dashboard/overview', 'Overview');
+    fireEvent.click(getSettingsButtonEl());
+    expect(getSettingsButton()).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.pointerDown(getSettingsButtonEl());
+    expect(getSettingsButton()).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.pointerDown(screen.getByText('Item Types'));
+    expect(getSettingsButton()).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('collapses the submenu when clicking its own empty padding', () => {
+    renderSidebar('/dashboard/overview', 'Overview');
+    fireEvent.click(getSettingsButtonEl());
+    expect(getSettingsButton()).toHaveAttribute('aria-expanded', 'true');
+
+    // The panel that wraps the sub-item list, but outside the list itself.
+    const panel = screen
+      .getByText('Item Types')
+      .closest('[class*="overflow-hidden"]');
+    if (panel == null) {
+      throw new Error('settings submenu panel not found');
+    }
+    fireEvent.pointerDown(panel);
+
+    expect(getSettingsButton()).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('collapses a gear-opened settings submenu when navigating to another page', async () => {
+    const router = createMemoryRouter(
+      [
+        {
+          path: '*',
+          element: (
+            <Sidebar
+              menuItems={menuItems}
+              settingsMenuItems={settingsMenuItems}
+              selectedMenuItem="Overview"
+              setSelectedMenuItem={vi.fn()}
+              permissions={allPermissions}
+              logout={vi.fn()}
+            />
+          ),
+        },
+      ],
+      { initialEntries: ['/dashboard/overview'] },
+    );
+    render(
+      <TooltipProvider>
+        <RouterProvider router={router} />
+      </TooltipProvider>,
+    );
+
+    // Open via the gear button while on a non-settings route (no settings route
+    // was ever visited).
+    fireEvent.click(getSettingsButtonEl());
+    expect(getSettingsButton()).toHaveAttribute('aria-expanded', 'true');
+
+    await act(async () => {
+      await router.navigate('/dashboard/manual_review');
+    });
+
+    expect(getSettingsButton()).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('collapses settings sub-items after navigating away from Settings', () => {
+    const props = {
+      menuItems,
+      settingsMenuItems,
+      setSelectedMenuItem: vi.fn(),
+      permissions: allPermissions,
+      logout: vi.fn(),
+    };
+    let selectedMenuItem = 'Settings';
+    const tree = () => (
+      <TooltipProvider>
+        <MemoryRouter initialEntries={['/dashboard/settings']}>
+          <Sidebar {...props} selectedMenuItem={selectedMenuItem} />
+        </MemoryRouter>
+      </TooltipProvider>
+    );
+
+    const { rerender } = render(tree());
+    const subItemContainer = screen
+      .getByText('Item Types')
+      .closest('[class*="overflow-hidden"]');
+    expect(subItemContainer).not.toHaveClass('max-h-0');
+
+    selectedMenuItem = 'Overview';
+    rerender(tree());
+    expect(subItemContainer).toHaveClass('max-h-0');
   });
 
   describe('path-based menu selection', () => {

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -10,7 +10,13 @@ import {
   User as UserAlt3Filled,
   type LucideIcon,
 } from 'lucide-react';
-import React, { ReactElement, useEffect, useMemo, useState } from 'react';
+import React, {
+  ReactElement,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { Link, useLocation } from 'react-router-dom';
 
 import DashboardMenuButton from '@/webpages/dashboard/components/DashboardMenuButton';
@@ -247,12 +253,44 @@ export default function Sidebar(props: SidebarProps) {
 
   const [isSettingsMenuExpanded, setIsSettingsMenuExpanded] =
     useState(isSettingsSelected);
+  // Re-sync the submenu to the active route on every navigation: expand on a
+  // settings page, collapse on anything else. `pathname` is in the deps (not
+  // just `isSettingsSelected`) so a submenu that was opened with the gear
+  // button — without ever entering a settings route — still collapses when the
+  // user navigates to another top-level page.
   useEffect(() => {
-    if (isSettingsSelected) {
-      setIsSettingsMenuExpanded(true);
-    }
-  }, [isSettingsSelected]);
+    setIsSettingsMenuExpanded(isSettingsSelected);
+  }, [isSettingsSelected, pathname]);
   const isSettingsMenuVisible = isSettingsMenuExpanded && !collapsed;
+
+  // While the submenu is open, collapse it on any click that isn't a settings
+  // sub-item link or the gear toggle itself — the dashboard content, the
+  // submenu's own padding, other sidebar items, etc. (Clicking a sub-item
+  // navigates to a settings route, which the effect above re-expands, so no
+  // flicker.)
+  const settingsSubItemsRef = useRef<HTMLDivElement>(null);
+  const settingsToggleRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!isSettingsMenuExpanded) {
+      return;
+    }
+    const handlePointerDown = (event: Event) => {
+      const target = event.target;
+      if (!(target instanceof Node)) {
+        return;
+      }
+      if (
+        settingsSubItemsRef.current?.contains(target) ||
+        settingsToggleRef.current?.contains(target)
+      ) {
+        return;
+      }
+      setIsSettingsMenuExpanded(false);
+    };
+    // pointerdown covers mouse, touch, and pen uniformly.
+    document.addEventListener('pointerdown', handlePointerDown);
+    return () => document.removeEventListener('pointerdown', handlePointerDown);
+  }, [isSettingsMenuExpanded]);
 
   const settingsMenu = (
     <div
@@ -268,7 +306,10 @@ export default function Sidebar(props: SidebarProps) {
         transition: 'max-height 0.5s ease-in-out',
       }}
     >
-      <div className="flex flex-col gap-[4px] m-[16px]">
+      <div
+        ref={settingsSubItemsRef}
+        className="flex flex-col gap-[4px] m-[16px]"
+      >
         {accessibleSettingsSubItems.map((item) => (
           <Link
             key={item.title}
@@ -350,6 +391,7 @@ export default function Sidebar(props: SidebarProps) {
               <Tooltip>
                 <TooltipTrigger asChild>
                   <div
+                    ref={settingsToggleRef}
                     role="button"
                     aria-label="Settings"
                     aria-expanded={isSettingsMenuVisible}


### PR DESCRIPTION
## Context & Requests for Reviewers
fixes #1224 
The Settings accordion only ever expanded on navigation into a settings route and never collapsed, so it stayed open after navigating elsewhere. 

## Tests
manually tested
fix


https://github.com/user-attachments/assets/0952c526-d3ea-41d3-8946-45e7eb3e7d27



issue


https://github.com/user-attachments/assets/33f458aa-87b7-40ff-8fdc-f0fea921cfc8


## (Optional) Rollout Plan

<!--
Are there any special things that have to be done before this can be deployed
to prod (e.g., other blocking PRs; manual load testing/validation that needs to
be done on staging; etc.)? If so, please note them here.
 -->

## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] **If you changed anything user-facing** (i.e. user interface or APIs):
  Did you update related docs?

- [ ] **If the change is notable** (refer to [Keep a Changelog](https://keepachangelog.com/en/2.0.0/) conventions):
  Did you update CHANGELOG.md?

- [ ] **If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**
  Did you update the corresponding history tables and their triggers?

- [ ] **If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?

- [ ] **If you added a new signal in `server/services/signalsService/signals/**`:**
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Settings submenu now stays synchronized with the current page during navigation.
  * The submenu now closes when users click outside it or its toggle.
  * Sidebar selection and submenu behavior are more consistent when leaving Settings.
  * Improved handling of sidebar collapse, panel interactions, and route navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->