### PR TITLE
ci: bump actions/upload-artifact from v5.0.0 to v7.0.1 (Node 20 deprecation)

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -149,7 +149,7 @@ jobs:
 
       - name: Upload Playwright report
         if: ${{ failure() }}
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-report
           path: server/e2e/playwright-report/


### PR DESCRIPTION
`actions/upload-artifact` v5.0.0 -> v7.0.1 (`330a01c` -> `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`), 1 call site (`e2e.yaml`, Playwright report).

### Why this bump matters

v5.0.0 declares `runs.using: node20`. GitHub's runners now force it onto Node 24 and emit a deprecation annotation on **every** run ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). This was one of only two Node 20 actions left in the repo (the other is `actions/cache@v4.3.0`, handled in a sibling PR).

### Why this is safe (two majors)

- **v6.0.0**: runtime moves to `node24` (requires runner >= 2.327.1; we use GitHub-hosted runners). No input changes.
- **v7.0.0**: ESM migration plus a new optional `archive` input for unzipped single-file uploads. Purely additive.
- **v7.0.1**: docs and a dependency fix.
- Inputs used here — `name`, `path`, `retention-days` — are unchanged. No call-site changes.

### Verification

- SHA re-derived from the release tag via `git/ref/tags` -> `git/tags` (annotated tags dereferenced), not copied from the tag ref.
- `zizmor` 1.25.2 (the version this repo pins): no findings.
- `poutine` 1.1.6 local scan: 0 results at `warning` level or above.

Split out of a single pin-bump pass; sibling PRs cover the other actions. Draft until CI is green.
