### PR TITLE
ci: bump actions/cache to v6.1.0 and converge the two pins

### DIFF
--- a/.github/workflows/agentscan.yml
+++ b/.github/workflows/agentscan.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Cache AgentScan analysis
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .agentscan-cache
           key: agentscan-cache-${{ github.event.pull_request.user.login }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('server/package-lock.json') }}


### PR DESCRIPTION
`actions/cache` -> v6.1.0 (`55cc8345863c7cc4c66a329aec7e433d2d1c52a9`) in both places, converging two divergent pins:

| workflow | old | new |
| --- | --- | --- |
| `agentscan.yml` | v5.0.5 (`27d5ce7`) | v6.1.0 |
| `e2e.yaml` | v4.3.0 (`0057852`) | v6.1.0 |

### Why this bump matters

`e2e.yaml` was pinned to v4.3.0, which declares `runs.using: node20` and therefore emits a Node 20 deprecation annotation on every run. The repo also had no reason to run two different majors of the same action.

### Why this is safe (semver-major)

- **v5.0.0**: `node24` runtime (requires runner >= 2.327.1; GitHub-hosted runners are fine). No input changes.
- **v6.0.0**: ESM migration and dependency updates. No input changes.
- **v6.1.0**: `@actions/cache` 6.1.0, handles read-only cache access.
- Inputs used here — `path`, `key`, `restore-keys` — and the `cache-hit` output (consumed by the Playwright install step) are unchanged. No call-site changes.

### Verification

- SHA re-derived from the release tag via `git/ref/tags` -> `git/tags` (annotated tags dereferenced), not copied from the tag ref.
- `zizmor` 1.25.2 (the version this repo pins): no findings.
- `poutine` 1.1.6 local scan: 0 results at `warning` level or above.

Split out of a single pin-bump pass; sibling PRs cover the other actions. Draft until CI is green.

Fixes #894 