### PR TITLE
ci: bump dorny/paths-filter from v4.0.1 to v4.0.3

### DIFF
--- a/.github/workflows/apply_pr_checks.yaml
+++ b/.github/workflows/apply_pr_checks.yaml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
           filters: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
           filters: |

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -65,7 +65,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         if: github.event_name == 'push'
         with:


### PR DESCRIPTION
`dorny/paths-filter` v4.0.1 -> v4.0.3 (`fbd0ab8` -> `ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d`), 3 call sites.

Patch-level, no input or output changes; `filters` and the `changes`/named outputs behave the same.

Notable content:

- **Security**: escapes multi-line filenames in `list-files` shell/CSV output ([GHSA-7hc6-8hq5-9q2m](https://github.com/advisories/GHSA-7hc6-8hq5-9q2m)). This repo does not use `list-files`, so it was not exposed, but the fixed version is strictly better.
- Fixes for older `git` compatibility and dubious-ownership errors in container jobs; a warning-message scoping fix.

### Verification

- SHA re-derived from the release tag via `git/ref/tags` -> `git/tags` (annotated tags dereferenced), not copied from the tag ref.
- `zizmor` 1.25.2 (the version this repo pins): no findings.
- `poutine` 1.1.6 local scan: 0 results at `warning` level or above.

Split out of a single pin-bump pass; sibling PRs cover the other actions. Draft until CI is green.
