### PR TITLE
ci: bump docker/setup-qemu-action from v4.1.0 to v4.3.0

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -100,7 +100,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+      - uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
 
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
@@ -146,7 +146,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+      - uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
 
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
@@ -192,7 +192,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+      - uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
 
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 


### PR DESCRIPTION
`docker/setup-qemu-action` v4.1.0 -> v4.3.0 (`0611638` -> `1f40c72289eff860ee54a304f1438e3cff362e0a`), 3 call sites in `publish-docker.yaml`.

Minor releases: `@docker/actions-toolkit` 0.91 -> 0.96, esbuild bundle name preservation, and transitive dependency bumps. No input, output, or behaviour changes; these steps take no inputs.

### Verification

- SHA re-derived from the release tag via `git/ref/tags` -> `git/tags` (annotated tags dereferenced), not copied from the tag ref.
- `zizmor` 1.25.2 (the version this repo pins): no findings.
- `poutine` 1.1.6 local scan: 0 results at `warning` level or above.

Split out of a single pin-bump pass; sibling PRs cover the other actions. Draft until CI is green.
