### PR TITLE
ci: bump docker/build-push-action from v7.2.0 to v7.3.0

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -116,7 +116,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
           tags: ${{ env.TAGS }}
 
-      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile
@@ -162,7 +162,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/coop-client
           tags: ${{ env.TAGS }}
 
-      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: client
           file: client/Dockerfile
@@ -208,7 +208,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/coop-migrations
           tags: ${{ env.TAGS }}
 
-      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: db
           file: db/Dockerfile


### PR DESCRIPTION
`docker/build-push-action` v7.2.0 -> v7.3.0 (`f9f3042` -> `53b7df96c91f9c12dcc8a07bcb9ccacbed38856a`), 3 call sites in `publish-docker.yaml`.

Minor release: `@docker/actions-toolkit` 0.90 -> 0.92, esbuild bundle name preservation, transitive dependency bumps. Inputs used here — `context`, `file`, `push`, `tags`, `labels`, `build-args`, `cache-from`, `cache-to` — are unchanged.

### Verification

- SHA re-derived from the release tag via `git/ref/tags` -> `git/tags` (annotated tags dereferenced), not copied from the tag ref.
- `zizmor` 1.25.2 (the version this repo pins): no findings.
- `poutine` 1.1.6 local scan: 0 results at `warning` level or above.

Split out of a single pin-bump pass; sibling PRs cover the other actions. Draft until CI is green.
