### PR TITLE
ci: bump zizmorcore/zizmor-action from v0.5.6 to v0.6.4

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -29,8 +29,10 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        uses: zizmorcore/zizmor-action@cc914d7f3750a2d13d75c7f184a1060aa0e9d482 # v0.6.4
         with:
+          # Pinned deliberately: the action SHA is Dependabot-managed, but the
+          # zizmor version it installs is not, so this needs a manual bump.
           version: '1.25.2'
           # only upload to github advanced security on `main`.
           # on PRs from forks (which do not have permission to push SARIF results)


### PR DESCRIPTION
`zizmorcore/zizmor-action` v0.5.6 -> v0.6.4 (`5f14fd0` -> `cc914d7f3750a2d13d75c7f184a1060aa0e9d482`), 1 call site (`zizmor.yml`).

### Why this is safe

- The 0.6.x line is additive: a new `collect` input, log grouping for the image pull, and a rolling default `version` (now zizmor 1.30.1). The `version`, `advanced-security` and `annotations` inputs we pass all still exist with the same semantics.
- **The zizmor tool version stays pinned at `1.25.2`**, as agreed in review on #721, so this bump changes the action wrapper only — the analysis itself is byte-identical.

### The tool version is deliberately not bumped here

Dependabot bumps the action SHA but cannot see the `version:` input, so that pin needs a human. I checked what a bump would cost today: zizmor 1.30.1 exits 12 on this repo with 2 new `low` [`self-repository`](https://docs.zizmor.sh/audits/#self-repository) findings, both asking for `uses: $/.github/actions/prepare-docker-images` instead of `./...` in `apply_pr_checks.yaml`. That is a workflow change unrelated to pin hygiene, so it belongs in its own PR rather than being smuggled into a SHA bump.

I added a comment at the call site so the next person knows the input is manually maintained.

### Verification

- SHA re-derived from the release tag via `git/ref/tags` -> `git/tags` (annotated tags dereferenced), not copied from the tag ref.
- `zizmor` 1.25.2 (the version this repo pins): no findings.
- `poutine` 1.1.6 local scan: 0 results at `warning` level or above.

Split out of a single pin-bump pass; sibling PRs cover the other actions. Draft until CI is green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated security scanning workflow to use a newer zizmor action version.
  * Added maintenance guidance for keeping the action version current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->