### PR TITLE
ci: track the github-actions ecosystem in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 #
-# Major version updates are disabled for now across every ecosystem/directory.
+# Major version updates are disabled for now across every ecosystem/directory,
+# except `github-actions` (see the note on that block below).
 # Security updates are unaffected (Dependabot ignores `ignore` rules for
 # security advisories), so majors still land when they fix a vulnerability.
 
@@ -215,5 +216,30 @@ updates:
       nodejs-instrumentation-dev:
         dependency-type: 'development'
         applies-to: 'version-updates'
+        patterns:
+          - '*'
+
+  # Enable version updates for GitHub Actions
+  #
+  # Deliberately *not* ignoring `version-update:semver-major` here, unlike the
+  # ecosystems above. Actions majors are mostly runner-runtime bumps (e.g.
+  # node20 -> node24) that GitHub eventually forces anyway; blocking them means
+  # the pins rot until someone does a manual pass. Actions are also SHA-pinned
+  # and reviewed here, so a bad major cannot land silently.
+  #
+  # Note: Dependabot bumps the action SHA only. Tool versions passed *into* an
+  # action (e.g. the `version:` input of zizmorcore/zizmor-action, or the image
+  # digest inside boostsecurityio/poutine-action) still need a manual bump.
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 7
+    labels:
+      - 'dependencies'
+      - 'dependabot'
+    groups:
+      github-actions:
         patterns:
           - '*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ For more information about each release including git tags and artifacts, see [R
 - Passwords are hashed with Argon2id instead of bcrypt at cost factor 5 ([#901](https://github.com/roostorg/coop/pull/901) by [@serendipty01](https://github.com/serendipty01), closes [#900](https://github.com/roostorg/coop/issues/900))
 - Minimum password length raised to 15 and enforced server-side ([#1065](https://github.com/roostorg/coop/pull/1065), [#1094](https://github.com/roostorg/coop/pull/1094) by [@serendipty01](https://github.com/serendipty01))
 
+### CI & infrastructure
+
+- Dependabot now tracks the `github-actions` ecosystem, and every action pin was bumped to its current release
+
 ## [1.0.2] - 2026-06-30
 
 This release addresses reported security advisories, improves NCMEC CyberTipline reporting, and includes front-end quality-of-life improvements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ For more information about each release including git tags and artifacts, see [R
 
 ### CI & infrastructure
 
-- Dependabot now tracks the `github-actions` ecosystem, and every action pin was bumped to its current release
+- Dependabot now tracks the `github-actions` ecosystem, and every action pin was bumped to its current release ([#1157](https://github.com/roostorg/coop/pull/1157)–[#1168](https://github.com/roostorg/coop/pull/1168) by [@reitblatt](https://github.com/reitblatt))
 
 ## [1.0.2] - 2026-06-30
 


### PR DESCRIPTION
Adds a `github-actions` ecosystem to `.github/dependabot.yml`, mirroring `roostorg/osprey`, so action pins are maintained automatically instead of by periodic manual passes. All updates land in one grouped weekly PR with a 7-day cooldown.

### The semver-major decision (please read)

Every other ecosystem in this file ignores `version-update:semver-major`. **This block deliberately does not.**

Reasoning: action majors are overwhelmingly runner-runtime bumps — `actions/upload-artifact` v5 -> v6 and `actions/cache` v4 -> v5 exist almost entirely to move from Node 20 to Node 24, which GitHub's runners force on us anyway. If majors were ignored here, the exact situation this stack of PRs is fixing (a `node20` pin sitting on `main` emitting a deprecation annotation on every run) would silently recur, and the config would be self-defeating. Actions are also SHA-pinned and every bump is reviewed in a PR, so a bad major cannot land silently.

The trade-off is accepted noise: an occasional major that needs a call-site change (e.g. `actions/checkout` v7 blocking fork-PR checkouts) will show up as a red Dependabot PR rather than never being offered. That is the cheaper failure mode.

I updated the file's header comment so "majors are disabled across every ecosystem" is no longer inaccurate.

### Also documented

A note that Dependabot bumps the action SHA only: tool versions passed *into* an action still need a human — the `version:` input of `zizmorcore/zizmor-action`, and the image digest baked into `boostsecurityio/poutine-action` (arriving in #1156).

### CHANGELOG

This PR carries the single `### CI & infrastructure` entry for the whole pin-bump stack; the individual bump PRs are CI-only and do not touch `CHANGELOG.md`. It will conflict trivially with #1156, which introduces the same heading.

### Verification

- SHA re-derived from the release tag via `git/ref/tags` -> `git/tags` (annotated tags dereferenced), not copied from the tag ref.
- `zizmor` 1.25.2 (the version this repo pins): no findings.

Split out of a single pin-bump pass; sibling PRs cover the other actions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added weekly automated monitoring for GitHub Actions dependencies.
  * Enabled major-version updates for GitHub Actions dependencies.
  * Grouped GitHub Actions dependency updates and applied consistent labeling.

* **Documentation**
  * Updated the unreleased changelog with the new dependency monitoring and action version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->