### PR TITLE
fix(client): stop recent-decisions pagination past the last page

### DIFF
--- a/client/src/webpages/dashboard/mrt/ManualReviewRecentDecisions.tsx
+++ b/client/src/webpages/dashboard/mrt/ManualReviewRecentDecisions.tsx
@@ -149,6 +149,11 @@ gql`
 type RecentDecision =
   GQLGetRecentDecisionsQuery['getRecentDecisions'][number]['decisions'][number];
 
+// Mirrors the server-side `limit` in
+// server/services/manualReviewToolService/modules/DecisionAnalytics.ts. A page
+// with fewer rows than this is the last page.
+const RECENT_DECISIONS_PAGE_SIZE = 100;
+
 // Column visibility configuration
 type ColumnId =
   | 'decisionTime'
@@ -313,24 +318,37 @@ export default function ManualReviewRecentDecisions() {
   const navigate = useNavigate();
 
   const [page, setPage] = useState(0);
+  // A full page means there may be more; a short (or empty) page is the last one.
+  const hasNextPage =
+    (allDecisionsData?.getRecentDecisions.length ?? 0) >=
+    RECENT_DECISIONS_PAGE_SIZE;
+
   // Handle clicking the page left icon
   const handlePrevious = () => {
-    setPage((prevOffset) => Math.max(0, prevOffset - 1));
+    // Fetch the page we're moving to, not the stale `page` from this render's
+    // closure — `setPage` is async, so reading `page` here would refetch the
+    // page we're leaving.
+    const nextPage = Math.max(0, page - 1);
+    setPage(nextPage);
     getRecentDecisions({
       fetchPolicy: 'network-only',
       variables: {
-        input: getRecentDecisionsInput(unsavedFilterValue ?? {}, page),
+        input: getRecentDecisionsInput(unsavedFilterValue ?? {}, nextPage),
       },
     });
   };
 
   // Handle clicking the page right icon
   const handleNext = () => {
-    setPage((prevOffset) => prevOffset + 1);
+    if (!hasNextPage) {
+      return;
+    }
+    const nextPage = page + 1;
+    setPage(nextPage);
     getRecentDecisions({
       fetchPolicy: 'network-only',
       variables: {
-        input: getRecentDecisionsInput(unsavedFilterValue ?? {}, page),
+        input: getRecentDecisionsInput(unsavedFilterValue ?? {}, nextPage),
       },
     });
   };
@@ -1109,7 +1127,12 @@ export default function ManualReviewRecentDecisions() {
                 />
                 <span>Page {page + 1}</span>
                 <ChevronRight
-                  className="font-bold cursor-pointer w-7 text-slate-500"
+                  className={
+                    hasNextPage
+                      ? 'font-bold cursor-pointer w-7 text-slate-500'
+                      : 'w-7 text-slate-300 cursor-not-allowed pointer-events-none'
+                  }
+                  aria-disabled={!hasNextPage}
                   onClick={() => handleNext()}
                 />
               </div>


### PR DESCRIPTION
## Context & Requests for Reviewers
fixes #1222 
The next-page chevron on `/dashboard/manual_review/recent` had no bounds check and could page indefinitely into empty results. Disable it once the current page returns fewer rows than the server page size.

## Tests

manually tested

https://github.com/user-attachments/assets/d756d3f2-dcb7-406b-9003-46868874a821




## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] **If you changed anything user-facing** (i.e. user interface or APIs):
  Did you update related docs?

- [ ] **If the change is notable** (refer to [Keep a Changelog](https://keepachangelog.com/en/2.0.0/) conventions):
  Did you update CHANGELOG.md?