### PR TITLE
fix(client): redirect back after creating a Location Bank

### DIFF
--- a/client/src/webpages/dashboard/banks/location/LocationBankForm.tsx
+++ b/client/src/webpages/dashboard/banks/location/LocationBankForm.tsx
@@ -3,7 +3,7 @@ import { Button } from 'antd';
 import { Plus } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import FullScreenLoading from '../../../../components/common/FullScreenLoading';
 import CoopButton from '../../components/CoopButton';
@@ -181,6 +181,19 @@ export default function LocationBankForm() {
     });
 
   const { id } = useParams<{ id?: string }>();
+  const navigate = useNavigate();
+
+  const onCloseModal = () => {
+    const succeeded =
+      createMutationParams.data?.createLocationBank.__typename ===
+        'MutateLocationBankSuccessResponse' ||
+      updateMutationParams.data?.updateLocationBank.__typename ===
+        'MutateLocationBankSuccessResponse';
+    setModalInfo(undefined);
+    if (succeeded) {
+      navigate(-1);
+    }
+  };
 
   const bankQueryParams = useGQLLocationBankQuery({
     // not-null assertion is safe b/c, per skip below, id is defined
@@ -324,11 +337,11 @@ export default function LocationBankForm() {
     <CoopModal
       title={modalInfo?.title}
       visible={modalInfo != null}
-      onClose={() => setModalInfo(undefined)}
+      onClose={onCloseModal}
       footer={[
         {
           title: modalInfo?.buttonText ?? '',
-          onClick: () => setModalInfo(undefined),
+          onClick: onCloseModal,
           type: 'primary',
         },
       ]}


### PR DESCRIPTION
## Context & Requests for Reviewers

The Location Bank form left the user on the form after a successful create/update. The Text and Hash bank forms both `navigate(-1)` when the success modal is dismissed

## Tests

https://github.com/user-attachments/assets/9ac9dbf1-9db0-41ba-94ef-a9328f12fa87


https://github.com/user-attachments/assets/88be119c-511d-4e87-bf5d-608ecdbd555c



## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] **If you changed anything user-facing** (i.e. user interface or APIs):
  Did you update related docs?

- [ ] **If the change is notable** (refer to [Keep a Changelog](https://keepachangelog.com/en/2.0.0/) conventions):
  Did you update CHANGELOG.md?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- After successfully creating or updating a location bank, the form now returns to the location bank rules page.
- Location bank listings now load the latest server data whenever opened, ensuring recent additions and updates are displayed.
- Closing the location bank form after a successful change now follows consistent navigation behavior and returns to the rules view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->