### PR TITLE
fix(client): make the Rules dashboard table fill the available width

### DIFF
--- a/client/src/webpages/dashboard/actions/ActionsDashboard.tsx
+++ b/client/src/webpages/dashboard/actions/ActionsDashboard.tsx
@@ -301,7 +301,7 @@ export default function ActionsDashboard() {
   const table = (
     <div className="rounded-2xl">
       {/* @ts-ignore */}
-      <Table columns={columns} data={tableData} />
+      <Table columns={columns} data={tableData} containerClassName="w-full" />
     </div>
   );
 

--- a/client/src/webpages/dashboard/banks/hash/HashBanksDashboard.tsx
+++ b/client/src/webpages/dashboard/banks/hash/HashBanksDashboard.tsx
@@ -202,9 +202,9 @@ export default function HashBanksDashboard() {
 
   const table = (
     <div className="rounded-2xl">
-      {/* @ts-ignore */}
       <CustomTable
         columns={columns}
+        // @ts-ignore -- tableData is possibly undefined before `banks` loads
         data={tableData}
         containerClassName="w-full"
       />

--- a/client/src/webpages/dashboard/banks/hash/HashBanksDashboard.tsx
+++ b/client/src/webpages/dashboard/banks/hash/HashBanksDashboard.tsx
@@ -203,7 +203,11 @@ export default function HashBanksDashboard() {
   const table = (
     <div className="rounded-2xl">
       {/* @ts-ignore */}
-      <CustomTable columns={columns} data={tableData} />
+      <CustomTable
+        columns={columns}
+        data={tableData}
+        containerClassName="w-full"
+      />
     </div>
   );
 

--- a/client/src/webpages/dashboard/banks/location/LocationBanksDashboard.tsx
+++ b/client/src/webpages/dashboard/banks/location/LocationBanksDashboard.tsx
@@ -211,7 +211,7 @@ export default function LocationBanksDashboard() {
   const table = (
     <div className="rounded-[15px]">
       {/* @ts-ignore */}
-      <Table columns={columns} data={tableData} />
+      <Table columns={columns} data={tableData} containerClassName="w-full" />
     </div>
   );
 

--- a/client/src/webpages/dashboard/banks/text/TextBanksDashboard.tsx
+++ b/client/src/webpages/dashboard/banks/text/TextBanksDashboard.tsx
@@ -231,7 +231,7 @@ export default function TextBanksDashboard() {
   const table = (
     <div className="rounded-2xl">
       {/* @ts-ignore */}
-      <Table columns={columns} data={tableData} />
+      <Table columns={columns} data={tableData} containerClassName="w-full" />
     </div>
   );
 

--- a/client/src/webpages/dashboard/item_types/ItemTypesDashboard.tsx
+++ b/client/src/webpages/dashboard/item_types/ItemTypesDashboard.tsx
@@ -496,7 +496,7 @@ export default function ItemTypesDashboard() {
         emptyDashboard
       ) : (
         /* @ts-ignore */
-        <Table columns={columns} data={tableData} />
+        <Table columns={columns} data={tableData} containerClassName="w-full" />
       )}
       {deleteModal}
       {errorModal}

--- a/client/src/webpages/dashboard/rules/dashboard/ReportingRulesDashboard.tsx
+++ b/client/src/webpages/dashboard/rules/dashboard/ReportingRulesDashboard.tsx
@@ -381,7 +381,12 @@ export default function ReportingRulesDashboard() {
     <CoopButton title="Create Report Rule" destination="form" />
   );
   const table = (
-    <Table columns={columns} data={tableData} rowLinkTo={rowLinkTo} />
+    <Table
+      columns={columns}
+      data={tableData}
+      rowLinkTo={rowLinkTo}
+      containerClassName="w-full"
+    />
   );
 
   const emptyDashboard = (

--- a/client/src/webpages/dashboard/rules/dashboard/RulesDashboard.tsx
+++ b/client/src/webpages/dashboard/rules/dashboard/RulesDashboard.tsx
@@ -525,6 +525,12 @@ export default function RulesDashboard() {
       columns={columns}
       data={tableData}
       rowLinkTo={rowLinkTo}
+      // Table.tsx defaults its container to `w-fit` when this isn't set, so
+      // the table only ever took its columns' intrinsic width, leaving a
+      // growing gutter on wide screens. Match the other dashboards (MRT
+      // queues, recent decisions, NCMEC reports, ...) that already opt into
+      // `w-full`.
+      containerClassName="w-full"
       topLeftComponent={
         rulesByStatus.archived?.length ? (
           <TabBar<RuleTableMode>

--- a/client/src/webpages/settings/ManageUsers.tsx
+++ b/client/src/webpages/settings/ManageUsers.tsx
@@ -710,7 +710,11 @@ export default function ManageUsers() {
       {effectiveTab === 'users' && (
         <>
           {/* @ts-ignore */}
-          <Table columns={columns} data={tableData} />
+          <Table
+            columns={columns}
+            data={tableData}
+            containerClassName="w-full"
+          />
           <div className="divider my-9" />
           <ManageUsersInviteUserSection />
         </>


### PR DESCRIPTION
## Context & Requests for Reviewers
fixes #1228 
`Table.tsx` defaults its container to `w-fit` when `containerClassName` isn't set, so several dashboard tables only ever took their columns' intrinsic width, leaving a growing gutter on wide screens. Opts the Rules dashboard, and (second commit) Item Types, Actions, Reporting Rules, Text/Location/Hash Banks, and Manage Users into `w-full`, matching the dashboards that already had it (MRT queues, recent decisions, NCMEC reports, ...).

## Tests


<img width="1386" height="741" alt="rules-table-width-repro-01" src="https://github.com/user-attachments/assets/3a882eca-c2d4-4848-ab2a-81f74d8e6412" />

https://github.com/user-attachments/assets/11e284be-e0ce-4942-b2ef-f2b970e41f9c



## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] **If you changed anything user-facing** (i.e. user interface or APIs):
  Did you update related docs?

- [ ] **If the change is notable** (refer to [Keep a Changelog](https://keepachangelog.com/en/2.0.0/) conventions):
  Did you update CHANGELOG.md?