### PR TITLE
[833] Show action parameters in item action history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ For more information about each release including git tags and artifacts, see [R
 
 ### Added
 
+- Action parameters in the item action history ([#1173](https://github.com/roostorg/coop/pull/1173) by [@maarkN](https://github.com/maarkN), closes [#833](https://github.com/roostorg/coop/issues/833))
 - Manual Review Analytics with average handle time per moderator ([#1022](https://github.com/roostorg/coop/pull/1022) by [@juanmrad](https://github.com/juanmrad), closes [#380](https://github.com/roostorg/coop/issues/380))
 - Support for text-only NCMEC reports ([#866](https://github.com/roostorg/coop/pull/866), [#881](https://github.com/roostorg/coop/pull/881) by [@calebmcquaid](https://github.com/calebmcquaid), closes [#661](https://github.com/roostorg/coop/issues/661))
 - OpenAI `self-harm/intent` and `self-harm/instructions` signals for text and image ([#535](https://github.com/roostorg/coop/pull/535) by [@julietshen](https://github.com/julietshen))

--- a/client/src/graphql/generated.ts
+++ b/client/src/graphql/generated.ts
@@ -1594,6 +1594,12 @@ export type GQLItemAction = {
   readonly itemId: Scalars['ID']['output'];
   readonly itemTypeId: Scalars['ID']['output'];
   readonly jobId?: Maybe<Scalars['ID']['output']>;
+  /**
+   * Moderator-supplied parameter values this action ran with, keyed by the
+   * parameter's `name`. Empty when the action takes no parameters or the
+   * execution predates parameter capture.
+   */
+  readonly parameters: Scalars['JSONObject']['output'];
   readonly policies: ReadonlyArray<Scalars['String']['output']>;
   readonly ruleIds: ReadonlyArray<Scalars['ID']['output']>;
   readonly ts: Scalars['DateTime']['output'];
@@ -8292,6 +8298,7 @@ export type GQLItemActionHistoryQuery = {
     readonly jobId?: string | null;
     readonly policies: ReadonlyArray<string>;
     readonly ruleIds: ReadonlyArray<string>;
+    readonly parameters: JsonObject;
     readonly ts: Date | string;
   }>;
   readonly myOrg?: {
@@ -32225,6 +32232,7 @@ export const GQLItemActionHistoryDocument = gql`
         jobId
         policies
         ruleIds
+        parameters
         ts
       }
     }

--- a/client/src/graphql/generated.ts
+++ b/client/src/graphql/generated.ts
@@ -8314,37 +8314,21 @@ export type GQLItemActionHistoryQuery = {
           readonly __typename: 'CustomAction';
           readonly id: string;
           readonly name: string;
-          readonly parameters: ReadonlyArray<{
-            readonly __typename: 'ActionParameter';
-            readonly name: string;
-          }>;
         }
       | {
           readonly __typename: 'EnqueueAuthorToMrtAction';
           readonly id: string;
           readonly name: string;
-          readonly parameters: ReadonlyArray<{
-            readonly __typename: 'ActionParameter';
-            readonly name: string;
-          }>;
         }
       | {
           readonly __typename: 'EnqueueToMrtAction';
           readonly id: string;
           readonly name: string;
-          readonly parameters: ReadonlyArray<{
-            readonly __typename: 'ActionParameter';
-            readonly name: string;
-          }>;
         }
       | {
           readonly __typename: 'EnqueueToNcmecAction';
           readonly id: string;
           readonly name: string;
-          readonly parameters: ReadonlyArray<{
-            readonly __typename: 'ActionParameter';
-            readonly name: string;
-          }>;
         }
     >;
     readonly policies: ReadonlyArray<{
@@ -32262,9 +32246,6 @@ export const GQLItemActionHistoryDocument = gql`
         ... on ActionBase {
           id
           name
-          parameters {
-            name
-          }
         }
       }
       policies {

--- a/client/src/graphql/generated.ts
+++ b/client/src/graphql/generated.ts
@@ -8314,21 +8314,37 @@ export type GQLItemActionHistoryQuery = {
           readonly __typename: 'CustomAction';
           readonly id: string;
           readonly name: string;
+          readonly parameters: ReadonlyArray<{
+            readonly __typename: 'ActionParameter';
+            readonly name: string;
+          }>;
         }
       | {
           readonly __typename: 'EnqueueAuthorToMrtAction';
           readonly id: string;
           readonly name: string;
+          readonly parameters: ReadonlyArray<{
+            readonly __typename: 'ActionParameter';
+            readonly name: string;
+          }>;
         }
       | {
           readonly __typename: 'EnqueueToMrtAction';
           readonly id: string;
           readonly name: string;
+          readonly parameters: ReadonlyArray<{
+            readonly __typename: 'ActionParameter';
+            readonly name: string;
+          }>;
         }
       | {
           readonly __typename: 'EnqueueToNcmecAction';
           readonly id: string;
           readonly name: string;
+          readonly parameters: ReadonlyArray<{
+            readonly __typename: 'ActionParameter';
+            readonly name: string;
+          }>;
         }
     >;
     readonly policies: ReadonlyArray<{
@@ -32246,6 +32262,9 @@ export const GQLItemActionHistoryDocument = gql`
         ... on ActionBase {
           id
           name
+          parameters {
+            name
+          }
         }
       }
       policies {

--- a/client/src/webpages/dashboard/investigation/InvestigationTag.tsx
+++ b/client/src/webpages/dashboard/investigation/InvestigationTag.tsx
@@ -66,20 +66,21 @@ export default function InvestigationTag({
 
 /**
  * Parameter values are whatever the action's spec allows — string, number,
- * boolean, or a multiselect's array. Objects shouldn't occur, but stringify
- * rather than render `[object Object]` if one ever does.
+ * boolean, or a multiselect's array. Nested objects shouldn't occur for a
+ * declared parameter, but they can reach this view when the action's metadata
+ * is unavailable and the stored map is shown unfiltered, so render them as
+ * JSON rather than `[object Object]`.
  */
 function formatParameterValue(value: unknown): string {
   if (value == null) {
     return '—';
   }
   if (Array.isArray(value)) {
-    return value.join(', ');
+    // Recursive so an array of objects reads as JSON rather than a row of
+    // `[object Object]`, which is what `join` alone produces.
+    return value.map(formatParameterValue).join(', ');
   }
   if (typeof value === 'object') {
-    // Shouldn't occur: validated parameters are scalars or arrays of scalars,
-    // and the stored value is parsed from JSON, so it carries no `toJSON`.
-    // Fall back to the same placeholder as a missing value if one ever does.
     return JSON.stringify(value) ?? '—';
   }
   return String(value);

--- a/client/src/webpages/dashboard/investigation/InvestigationTag.tsx
+++ b/client/src/webpages/dashboard/investigation/InvestigationTag.tsx
@@ -1,7 +1,81 @@
-export default function InvestigationTag({ title }: { title: string }) {
+import CollapsibleText from '@/webpages/dashboard/mrt/manual_review_job/v2/components/CollapsibleText';
+
+/**
+ * An action's parameter spec allows up to 50 parameters, 100 options on a
+ * MULTISELECT, and a STRING `maxLength` of 100,000 — so a large value is valid
+ * input, not a degenerate case. Values past this length get their own line and
+ * a line-clamp with a "Read more" toggle, keeping the table row bounded.
+ *
+ * Compared as UTF-16 length, which is always >= the grapheme count, so a value
+ * under the threshold is definitely short. Anything over is handed to
+ * `CollapsibleText`, which does the precise grapheme check itself.
+ */
+const INLINE_VALUE_MAX_CHARS = 120;
+const COLLAPSED_LINES = 3;
+
+type Props = {
+  title: string;
+  /**
+   * Runtime values the action ran with, keyed by parameter name. Omitted or
+   * empty renders the tag exactly as before, so callers that have no
+   * parameters are unaffected.
+   */
+  parameters?: Readonly<Record<string, unknown>>;
+};
+
+export default function InvestigationTag({ title, parameters }: Props) {
+  const entries = Object.entries(parameters ?? {});
+
   return (
     <div className="p-2 m-0.5 rounded-md border-solid border-gray-200 text-gray-500 bg-gray-50">
       {title}
+      {entries.length > 0 && (
+        <div className="flex flex-wrap gap-x-2 gap-y-0.5 mt-1 text-xs">
+          {entries.map(([name, value]) => {
+            const formatted = formatParameterValue(value);
+            const label = <span className="font-medium">{name}</span>;
+
+            // `w-full` inside the wrapping flex container gives a long value
+            // its own line, so it can clamp without shoving the short entries
+            // that share the row out of alignment.
+            return formatted.length > INLINE_VALUE_MAX_CHARS ? (
+              <div key={name} className="w-full text-gray-400">
+                {label}
+                {': '}
+                <CollapsibleText
+                  text={formatted}
+                  maxLines={COLLAPSED_LINES}
+                  maxGraphemes={INLINE_VALUE_MAX_CHARS}
+                />
+              </div>
+            ) : (
+              <span key={name} className="text-gray-400">
+                {label}
+                {': '}
+                <span>{formatted}</span>
+              </span>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
+}
+
+/**
+ * Parameter values are whatever the action's spec allows — string, number,
+ * boolean, or a multiselect's array. Objects shouldn't occur, but stringify
+ * rather than render `[object Object]` if one ever does.
+ */
+function formatParameterValue(value: unknown): string {
+  if (value == null) {
+    return '—';
+  }
+  if (Array.isArray(value)) {
+    return value.join(', ');
+  }
+  if (typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+  return String(value);
 }

--- a/client/src/webpages/dashboard/investigation/InvestigationTag.tsx
+++ b/client/src/webpages/dashboard/investigation/InvestigationTag.tsx
@@ -11,7 +11,7 @@ import CollapsibleText from '@/webpages/dashboard/mrt/manual_review_job/v2/compo
  * `CollapsibleText`, which does the precise grapheme check itself.
  */
 const INLINE_VALUE_MAX_CHARS = 120;
-const COLLAPSED_LINES = 3;
+const COLLAPSED_LINES = 2;
 
 type Props = {
   title: string;

--- a/client/src/webpages/dashboard/investigation/InvestigationTag.tsx
+++ b/client/src/webpages/dashboard/investigation/InvestigationTag.tsx
@@ -13,17 +13,19 @@ import CollapsibleText from '@/webpages/dashboard/mrt/manual_review_job/v2/compo
 const INLINE_VALUE_MAX_CHARS = 120;
 const COLLAPSED_LINES = 2;
 
-type Props = {
+/**
+ * A label in the investigation and review console views. `parameters` carries
+ * the runtime values an action ran with, keyed by parameter name; omitted or
+ * empty renders the tag exactly as before, so callers without parameters are
+ * unaffected.
+ */
+export default function InvestigationTag({
+  title,
+  parameters,
+}: {
   title: string;
-  /**
-   * Runtime values the action ran with, keyed by parameter name. Omitted or
-   * empty renders the tag exactly as before, so callers that have no
-   * parameters are unaffected.
-   */
   parameters?: Readonly<Record<string, unknown>>;
-};
-
-export default function InvestigationTag({ title, parameters }: Props) {
+}) {
   const entries = Object.entries(parameters ?? {});
 
   return (
@@ -75,7 +77,10 @@ function formatParameterValue(value: unknown): string {
     return value.join(', ');
   }
   if (typeof value === 'object') {
-    return JSON.stringify(value);
+    // Shouldn't occur: validated parameters are scalars or arrays of scalars,
+    // and the stored value is parsed from JSON, so it carries no `toJSON`.
+    // Fall back to the same placeholder as a missing value if one ever does.
+    return JSON.stringify(value) ?? '—';
   }
   return String(value);
 }

--- a/client/src/webpages/dashboard/items/ItemActionHistory.tsx
+++ b/client/src/webpages/dashboard/items/ItemActionHistory.tsx
@@ -54,9 +54,6 @@ gql`
         ... on ActionBase {
           id
           name
-          parameters {
-            name
-          }
         }
       }
       policies {
@@ -173,37 +170,6 @@ export default function ItemActionHistory(props: {
     [data?.myOrg],
   );
 
-  /**
-   * Keep only the values the action actually declares as parameters.
-   *
-   * `ACTION_EXECUTIONS.parameters` is not guaranteed to hold declared
-   * parameters alone: for a DEFAULT manual review job the decision path merges
-   * callback-only fields (`reportHistory`, `reason`) into the payload before it
-   * is logged — see the block in `iocContainer` flagged there as temporary.
-   * Rendering the raw map would surface that webhook plumbing as though a
-   * moderator had supplied it.
-   */
-  const getDeclaredParameters = useCallback(
-    (actionId: string, parameters: Readonly<Record<string, unknown>>) => {
-      const declared = data?.myOrg?.actions.find(
-        (action) => action.id === actionId,
-      )?.parameters;
-      if (declared == null) {
-        // The action is no longer in the org's list — deleted, most likely.
-        // Keep the stored values rather than hiding them: this is an audit
-        // view, and dropping them would recreate the very gap this feature
-        // closes. `formatParameterValue` renders non-scalars readably, so an
-        // unfiltered map degrades legibly instead of breaking.
-        return parameters;
-      }
-      const names = new Set(declared.map((parameter) => parameter.name));
-      return Object.fromEntries(
-        Object.entries(parameters).filter(([name]) => names.has(name)),
-      );
-    },
-    [data?.myOrg],
-  );
-
   const getPolicyName = useCallback(
     (policyId: string) =>
       data?.myOrg?.policies.find((policy) => policy.id === policyId)?.name ??
@@ -273,10 +239,9 @@ export default function ItemActionHistory(props: {
       actions: [
         {
           name: getActionName(decisionData.actionId),
-          parameters: getDeclaredParameters(
-            decisionData.actionId,
-            decisionData.parameters,
-          ),
+          // Already narrowed to the action's declared parameters by the
+          // `itemActionHistory` resolver.
+          parameters: decisionData.parameters,
         },
       ],
     }));
@@ -318,14 +283,7 @@ export default function ItemActionHistory(props: {
         actions: [{ name: 'Ignore', parameters: {} }],
       })),
     ];
-  }, [
-    data,
-    recentIgnores,
-    getPolicyName,
-    getReviewerName,
-    getActionName,
-    getDeclaredParameters,
-  ]);
+  }, [data, recentIgnores, getPolicyName, getReviewerName, getActionName]);
 
   const tableData = useMemo(() => {
     if (!dataValues) {

--- a/client/src/webpages/dashboard/items/ItemActionHistory.tsx
+++ b/client/src/webpages/dashboard/items/ItemActionHistory.tsx
@@ -40,6 +40,7 @@ gql`
         jobId
         policies
         ruleIds
+        parameters
         ts
       }
     }
@@ -109,6 +110,17 @@ gql`
     }
   }
 `;
+/**
+ * An executed action paired with the parameter values the moderator supplied.
+ * Rows are grouped by job, so several of these can share one table row —
+ * keeping name and parameters together is what stops one action's values from
+ * being shown against another's.
+ */
+type ActionWithParameters = {
+  name: string;
+  parameters: Readonly<Record<string, unknown>>;
+};
+
 export default function ItemActionHistory(props: {
   itemIdentifier: ItemIdentifier;
   submissionTime?: string | undefined;
@@ -224,7 +236,12 @@ export default function ItemActionHistory(props: {
       ts: decisionData.ts,
       jobId: decisionData.jobId,
       ruleIds: decisionData.ruleIds,
-      actions: [getActionName(decisionData.actionId)],
+      actions: [
+        {
+          name: getActionName(decisionData.actionId),
+          parameters: decisionData.parameters,
+        },
+      ],
     }));
 
     const tableData = Object.values(
@@ -235,7 +252,7 @@ export default function ItemActionHistory(props: {
           ts: string | Date;
           jobId: string | null | undefined;
           ruleIds: readonly string[];
-          actions: string[];
+          actions: ActionWithParameters[];
         };
       }>((acc, item) => {
         if (item.jobId == null) {
@@ -261,7 +278,7 @@ export default function ItemActionHistory(props: {
         ts: it.createdAt,
         jobId: it.jobId,
         ruleIds: [],
-        actions: ['Ignore'],
+        actions: [{ name: 'Ignore', parameters: {} }],
       })),
     ];
   }, [data, recentIgnores, getPolicyName, getReviewerName, getActionName]);
@@ -277,7 +294,11 @@ export default function ItemActionHistory(props: {
           const jobId = value.jobId;
           return {
             actions: value.actions.map((it, index) => (
-              <InvestigationTag key={`${i}-${index}`} title={it} />
+              <InvestigationTag
+                key={`${i}-${index}`}
+                title={it.name}
+                parameters={it.parameters}
+              />
             )),
             policies: (
               <div className="flex flex-wrap gap-1">

--- a/client/src/webpages/dashboard/items/ItemActionHistory.tsx
+++ b/client/src/webpages/dashboard/items/ItemActionHistory.tsx
@@ -54,6 +54,9 @@ gql`
         ... on ActionBase {
           id
           name
+          parameters {
+            name
+          }
         }
       }
       policies {
@@ -170,6 +173,32 @@ export default function ItemActionHistory(props: {
     [data?.myOrg],
   );
 
+  /**
+   * Keep only the values the action actually declares as parameters.
+   *
+   * `ACTION_EXECUTIONS.parameters` is not guaranteed to hold declared
+   * parameters alone: for a DEFAULT manual review job the decision path merges
+   * callback-only fields (`reportHistory`, `reason`) into the payload before it
+   * is logged — see the block in `iocContainer` flagged there as temporary.
+   * Rendering the raw map would surface that webhook plumbing as though a
+   * moderator had supplied it.
+   */
+  const getDeclaredParameters = useCallback(
+    (actionId: string, parameters: Readonly<Record<string, unknown>>) => {
+      const declared = data?.myOrg?.actions.find(
+        (action) => action.id === actionId,
+      )?.parameters;
+      if (declared == null) {
+        return {};
+      }
+      const names = new Set(declared.map((parameter) => parameter.name));
+      return Object.fromEntries(
+        Object.entries(parameters).filter(([name]) => names.has(name)),
+      );
+    },
+    [data?.myOrg],
+  );
+
   const getPolicyName = useCallback(
     (policyId: string) =>
       data?.myOrg?.policies.find((policy) => policy.id === policyId)?.name ??
@@ -239,7 +268,10 @@ export default function ItemActionHistory(props: {
       actions: [
         {
           name: getActionName(decisionData.actionId),
-          parameters: decisionData.parameters,
+          parameters: getDeclaredParameters(
+            decisionData.actionId,
+            decisionData.parameters,
+          ),
         },
       ],
     }));
@@ -281,7 +313,14 @@ export default function ItemActionHistory(props: {
         actions: [{ name: 'Ignore', parameters: {} }],
       })),
     ];
-  }, [data, recentIgnores, getPolicyName, getReviewerName, getActionName]);
+  }, [
+    data,
+    recentIgnores,
+    getPolicyName,
+    getReviewerName,
+    getActionName,
+    getDeclaredParameters,
+  ]);
 
   const tableData = useMemo(() => {
     if (!dataValues) {

--- a/client/src/webpages/dashboard/items/ItemActionHistory.tsx
+++ b/client/src/webpages/dashboard/items/ItemActionHistory.tsx
@@ -189,7 +189,12 @@ export default function ItemActionHistory(props: {
         (action) => action.id === actionId,
       )?.parameters;
       if (declared == null) {
-        return {};
+        // The action is no longer in the org's list — deleted, most likely.
+        // Keep the stored values rather than hiding them: this is an audit
+        // view, and dropping them would recreate the very gap this feature
+        // closes. `formatParameterValue` renders non-scalars readably, so an
+        // unfiltered map degrades legibly instead of breaking.
+        return parameters;
       }
       const names = new Set(declared.map((parameter) => parameter.name));
       return Object.fromEntries(

--- a/server/graphql/generated.ts
+++ b/server/graphql/generated.ts
@@ -1662,6 +1662,12 @@ export type GQLItemAction = {
   readonly itemId: Scalars['ID']['output'];
   readonly itemTypeId: Scalars['ID']['output'];
   readonly jobId?: Maybe<Scalars['ID']['output']>;
+  /**
+   * Moderator-supplied parameter values this action ran with, keyed by the
+   * parameter's `name`. Empty when the action takes no parameters or the
+   * execution predates parameter capture.
+   */
+  readonly parameters: Scalars['JSONObject']['output'];
   readonly policies: ReadonlyArray<Scalars['String']['output']>;
   readonly ruleIds: ReadonlyArray<Scalars['ID']['output']>;
   readonly ts: Scalars['DateTime']['output'];
@@ -9710,6 +9716,11 @@ export type GQLItemActionResolvers<
   itemId?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
   itemTypeId?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
   jobId?: Resolver<Maybe<GQLResolversTypes['ID']>, ParentType, ContextType>;
+  parameters?: Resolver<
+    GQLResolversTypes['JSONObject'],
+    ParentType,
+    ContextType
+  >;
   policies?: Resolver<
     ReadonlyArray<GQLResolversTypes['String']>,
     ParentType,

--- a/server/graphql/modules/investigation.resolver.test.ts
+++ b/server/graphql/modules/investigation.resolver.test.ts
@@ -250,6 +250,11 @@ describe('investigation resolvers', () => {
   });
 });
 
+type ItemActionRow = {
+  actionId: string;
+  parameters: Record<string, unknown>;
+};
+
 describe('itemActionHistory parameter narrowing', () => {
   const execution = {
     actionId: 'action-ban',
@@ -300,13 +305,27 @@ describe('itemActionHistory parameter narrowing', () => {
     })),
   });
 
-  async function run(ctx: unknown) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (resolvers.Query as any).itemActionHistory(
+  /**
+   * Narrow `resolvers.Query` to just the resolver under test, following the
+   * pattern in `integration.resolver.test.ts`. Declaring the signature keeps
+   * the argument and return shapes checked without standing up a full
+   * `Context`, which these tests never exercise beyond the two services mocked
+   * above.
+   */
+  async function run(ctx: unknown): Promise<ItemActionRow[]> {
+    const Query = resolvers.Query as {
+      itemActionHistory: (
+        parent: unknown,
+        args: { itemIdentifier: { id: string; typeId: string } },
+        ctx: unknown,
+      ) => Promise<unknown>;
+    };
+
+    return (await Query.itemActionHistory(
       {},
       { itemIdentifier: { id: 'user-1', typeId: 'user-type-1' } },
       ctx,
-    );
+    )) as ItemActionRow[];
   }
 
   it('drops values the action does not declare', async () => {
@@ -380,7 +399,7 @@ describe('itemActionHistory parameter narrowing', () => {
     });
     // Narrowing still applied per row: `action-warn` has no spec, so its
     // stored values pass through; `action-ban` keeps only `num_days`.
-    expect(rows.map((it: { parameters: unknown }) => it.parameters)).toEqual([
+    expect(rows.map((it) => it.parameters)).toEqual([
       { num_days: 30 },
       { note: 'x' },
       { num_days: 7 },

--- a/server/graphql/modules/investigation.resolver.test.ts
+++ b/server/graphql/modules/investigation.resolver.test.ts
@@ -265,9 +265,13 @@ describe('itemActionHistory parameter narrowing', () => {
   };
 
   function makeHistoryContext(opts: {
-    parameters: Record<string, unknown>;
+    /** Shorthand for a single execution row. */
+    parameters?: Record<string, unknown>;
+    /** Explicit rows, for cases that need more than one. */
+    rows?: ReadonlyArray<Record<string, unknown>>;
     actions?: ReadonlyArray<Record<string, unknown>>;
   }) {
+    const rows = opts.rows ?? [{ ...execution, parameters: opts.parameters }];
     const getActions = jest.fn(async () => opts.actions ?? []);
     return {
       getActions,
@@ -275,9 +279,7 @@ describe('itemActionHistory parameter narrowing', () => {
         getUser: () => ({ orgId: 'org-1' }),
         services: {
           ItemInvestigationService: {
-            getItemActionHistory: jest.fn(async () => [
-              { ...execution, parameters: opts.parameters },
-            ]),
+            getItemActionHistory: jest.fn(async () => rows),
           },
           ModerationConfigService: { getActions },
         },
@@ -357,18 +359,31 @@ describe('itemActionHistory parameter narrowing', () => {
     expect(row.parameters).toEqual({});
   });
 
-  it('looks up each distinct action once', async () => {
+  it('batches the lookup, one entry per distinct action', async () => {
+    // Three rows across two actions: a per-row lookup would call twice with
+    // duplicated ids, so this fails if the batching regresses.
     const { ctx, getActions } = makeHistoryContext({
-      parameters: {},
-      actions: [customAction([])],
+      rows: [
+        { ...execution, actionId: 'action-ban', parameters: { num_days: 30 } },
+        { ...execution, actionId: 'action-warn', parameters: { note: 'x' } },
+        { ...execution, actionId: 'action-ban', parameters: { num_days: 7 } },
+      ],
+      actions: [customAction(['num_days'])],
     });
 
-    await run(ctx);
+    const rows = await run(ctx);
 
     expect(getActions).toHaveBeenCalledTimes(1);
     expect(getActions).toHaveBeenCalledWith({
       orgId: 'org-1',
-      ids: ['action-ban'],
+      ids: ['action-ban', 'action-warn'],
     });
+    // Narrowing still applied per row: `action-warn` has no spec, so its
+    // stored values pass through; `action-ban` keeps only `num_days`.
+    expect(rows.map((it: { parameters: unknown }) => it.parameters)).toEqual([
+      { num_days: 30 },
+      { note: 'x' },
+      { num_days: 7 },
+    ]);
   });
 });

--- a/server/graphql/modules/investigation.resolver.test.ts
+++ b/server/graphql/modules/investigation.resolver.test.ts
@@ -10,6 +10,7 @@ import {
 import { instantiateOpaqueType } from '../../utils/typescript-types.js';
 import {
   resolveItemsWithId,
+  resolvers,
   type ItemsWithIdContext,
 } from './investigation.js';
 
@@ -245,6 +246,129 @@ describe('investigation resolvers', () => {
           service.synthesizeUserItemFromCreatorReferences,
         ).not.toHaveBeenCalled();
       });
+    });
+  });
+});
+
+describe('itemActionHistory parameter narrowing', () => {
+  const execution = {
+    actionId: 'action-ban',
+    itemId: 'user-1',
+    itemTypeId: 'user-type-1',
+    actorId: 'moderator-1',
+    jobId: 'job-1',
+    itemCreatorId: undefined,
+    itemCreatorTypeId: undefined,
+    policies: [],
+    ruleIds: [],
+    ts: new Date('2026-06-01T10:00:00.000Z'),
+  };
+
+  function makeHistoryContext(opts: {
+    parameters: Record<string, unknown>;
+    actions?: ReadonlyArray<Record<string, unknown>>;
+  }) {
+    const getActions = jest.fn(async () => opts.actions ?? []);
+    return {
+      getActions,
+      ctx: {
+        getUser: () => ({ orgId: 'org-1' }),
+        services: {
+          ItemInvestigationService: {
+            getItemActionHistory: jest.fn(async () => [
+              { ...execution, parameters: opts.parameters },
+            ]),
+          },
+          ModerationConfigService: { getActions },
+        },
+      },
+    };
+  }
+
+  const customAction = (
+    parameterNames: readonly string[],
+  ): Record<string, unknown> => ({
+    id: 'action-ban',
+    actionType: 'CUSTOM_ACTION',
+    customMrtApiParams: parameterNames.map((name) => ({
+      name,
+      displayName: name,
+      type: 'STRING',
+      required: false,
+    })),
+  });
+
+  async function run(ctx: unknown) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (resolvers.Query as any).itemActionHistory(
+      {},
+      { itemIdentifier: { id: 'user-1', typeId: 'user-type-1' } },
+      ctx,
+    );
+  }
+
+  it('drops values the action does not declare', async () => {
+    const { ctx } = makeHistoryContext({
+      parameters: {
+        num_days: 30,
+        reportHistory: [{ reason: 'spam', reporter: 'u1' }],
+        bogus_field: 'leak',
+      },
+      actions: [customAction(['num_days'])],
+    });
+
+    const [row] = await run(ctx);
+
+    expect(row.parameters).toEqual({ num_days: 30 });
+  });
+
+  it('keeps a declared `reason` parameter', async () => {
+    // The DEFAULT manual-review path overwrites `reason` with the decision
+    // reason at write time, so the stored value may not be what the moderator
+    // typed — but a declared parameter must still be shown rather than
+    // filtered out as if it were callback metadata.
+    const { ctx } = makeHistoryContext({
+      parameters: { reason: 'Repeated scam posts', reportHistory: [] },
+      actions: [customAction(['reason'])],
+    });
+
+    const [row] = await run(ctx);
+
+    expect(row.parameters).toEqual({ reason: 'Repeated scam posts' });
+  });
+
+  it('passes stored values through when the action is unknown', async () => {
+    const stored = { num_days: 30, reportHistory: [{ reason: 'spam' }] };
+    const { ctx } = makeHistoryContext({ parameters: stored, actions: [] });
+
+    const [row] = await run(ctx);
+
+    expect(row.parameters).toEqual(stored);
+  });
+
+  it('declares nothing for a non-custom action', async () => {
+    const { ctx } = makeHistoryContext({
+      parameters: { reason: 'set by the callback' },
+      actions: [{ id: 'action-ban', actionType: 'ENQUEUE_TO_MRT' }],
+    });
+
+    const [row] = await run(ctx);
+
+    expect(row.parameters).toEqual({});
+  });
+
+  it('looks up each distinct action once', async () => {
+    const { ctx, getActions } = makeHistoryContext({
+      parameters: {},
+      actions: [customAction([])],
+    });
+
+    await run(ctx);
+
+    expect(getActions).toHaveBeenCalledTimes(1);
+    expect(getActions).toHaveBeenCalledWith({
+      orgId: 'org-1',
+      ids: ['action-ban'],
     });
   });
 });

--- a/server/graphql/modules/investigation.ts
+++ b/server/graphql/modules/investigation.ts
@@ -137,6 +137,12 @@ const typeDefs = /* GraphQL */ `
     jobId: ID
     policies: [String!]!
     ruleIds: [ID!]!
+    """
+    Moderator-supplied parameter values this action ran with, keyed by the
+    parameter's \`name\`. Empty when the action takes no parameters or the
+    execution predates parameter capture.
+    """
+    parameters: JSONObject!
     ts: DateTime!
   }
 `;

--- a/server/graphql/modules/investigation.ts
+++ b/server/graphql/modules/investigation.ts
@@ -2,12 +2,16 @@
 import { isIP } from 'node:net';
 import { type DateString } from '@roostorg/coop-types';
 import _ from 'lodash';
+import type { JsonObject } from 'type-fest';
 
 import {
   getFieldValueForRole,
   type ItemSubmission,
 } from '../../services/itemProcessingService/index.js';
-import { type ConditionSetWithResult } from '../../services/moderationConfigService/index.js';
+import {
+  parseStoredParameters,
+  type ConditionSetWithResult,
+} from '../../services/moderationConfigService/index.js';
 import {
   asyncIterableToArray,
   asyncIterableToArrayWithTimeout,
@@ -700,14 +704,72 @@ const Query: GQLQueryResolvers = {
     if (user == null) {
       throw unauthenticatedError('Unauthenticated User');
     }
-    return context.services.ItemInvestigationService.getItemActionHistory({
+    const history =
+      await context.services.ItemInvestigationService.getItemActionHistory({
+        orgId: user.orgId,
+        itemId: itemIdentifier.id,
+        itemTypeId: itemIdentifier.typeId,
+        itemSubmissionTime: submissionTime
+          ? new Date(submissionTime)
+          : undefined,
+      });
+
+    const actions = await context.services.ModerationConfigService.getActions({
       orgId: user.orgId,
-      itemId: itemIdentifier.id,
-      itemTypeId: itemIdentifier.typeId,
-      itemSubmissionTime: submissionTime ? new Date(submissionTime) : undefined,
+      // Not `_.uniq`: the resolver's parent arg shadows the lodash import.
+      ids: [...new Set(history.map((it) => it.actionId))],
     });
+    const declaredNamesByAction = new Map(
+      actions.map((action) => [
+        action.id,
+        new Set(
+          (action.actionType === 'CUSTOM_ACTION'
+            ? parseStoredParameters(action.customMrtApiParams)
+            : []
+          ).map((parameter) => parameter.name),
+        ),
+      ]),
+    );
+
+    return history.map((it) => ({
+      ...it,
+      parameters: narrowToDeclaredParameters(
+        declaredNamesByAction.get(it.actionId),
+        it.parameters,
+      ),
+    }));
   },
 };
+
+/**
+ * Keep only the values the action declares as parameters.
+ *
+ * `ACTION_EXECUTIONS.parameters` is not limited to declared parameters: the
+ * DEFAULT manual review decision path merges callback-only fields
+ * (`reportHistory`, and a `reason` that shadows any declared one) into the
+ * payload before it is logged — see the block in `iocContainer` flagged there
+ * as temporary. Exposing the raw map would leak webhook plumbing through the
+ * API as though a moderator had supplied it.
+ *
+ * Uses the action's *current* spec, not the one in force when the execution
+ * was recorded, so a since-renamed parameter drops out. That is preferable to
+ * showing it under a name that no longer means the same thing.
+ *
+ * When the action is unknown — deleted, most likely — the stored values pass
+ * through untouched. This is an audit surface, and hiding them would recreate
+ * the very gap this field exists to close.
+ */
+function narrowToDeclaredParameters(
+  declaredNames: ReadonlySet<string> | undefined,
+  parameters: JsonObject,
+): JsonObject {
+  if (declaredNames === undefined) {
+    return parameters;
+  }
+  return Object.fromEntries(
+    Object.entries(parameters).filter(([name]) => declaredNames.has(name)),
+  );
+}
 
 const resolvers = {
   Query,

--- a/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.test.ts
+++ b/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.test.ts
@@ -345,3 +345,91 @@ describe('ClickhouseActionExecutionsAdapter.findContentCreatorIdentity', () => {
     expect(sentSql).toContain('content-type-PHOTO');
   });
 });
+
+describe('ClickhouseActionExecutionsAdapter.getItemActionHistory', () => {
+  const historyInput = {
+    orgId: 'org-1',
+    itemId: 'user-1',
+    itemTypeId: 'user-type-A',
+    itemSubmissionTime: undefined,
+  };
+
+  function actionRow(overrides: Record<string, unknown> = {}) {
+    return {
+      ts: '2026-06-01T10:00:00.000Z',
+      item_id: 'user-1',
+      item_type_id: 'user-type-A',
+      item_creator_id: null,
+      item_creator_type_id: null,
+      actor_id: 'moderator-1',
+      job_id: null,
+      policies: '[]',
+      rules: '[]',
+      action_id: 'action-ban',
+      ...overrides,
+    };
+  }
+
+  it('exposes the moderator-supplied parameters for the execution', async () => {
+    const { adapter } = makeAdapter([
+      actionRow({ parameters: '{"num_days":7,"reason":"spam"}' }),
+    ]);
+
+    const results = await adapter.getItemActionHistory(historyInput);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.parameters).toEqual({ num_days: 7, reason: 'spam' });
+  });
+
+  it('returns an empty object when the action took no parameters', async () => {
+    const { adapter } = makeAdapter([actionRow({ parameters: '{}' })]);
+
+    const results = await adapter.getItemActionHistory(historyInput);
+
+    expect(results[0]?.parameters).toEqual({});
+  });
+
+  it.each([
+    ['missing', undefined],
+    ['null', null],
+    ['empty string', ''],
+  ])(
+    'returns an empty object when the stored value is %s',
+    async (_label, stored) => {
+      const { adapter } = makeAdapter([actionRow({ parameters: stored })]);
+
+      const results = await adapter.getItemActionHistory(historyInput);
+
+      expect(results[0]?.parameters).toEqual({});
+    },
+  );
+
+  it.each([
+    ['unparseable text', 'not-json'],
+    ['a JSON array', '[1,2,3]'],
+    ['a JSON scalar', '42'],
+  ])(
+    'returns an empty object without failing the query when the value is %s',
+    async (_label, stored) => {
+      const { adapter } = makeAdapter([
+        actionRow({ action_id: 'action-a', parameters: stored }),
+        actionRow({ action_id: 'action-b', parameters: '{"num_days":3}' }),
+      ]);
+
+      const results = await adapter.getItemActionHistory(historyInput);
+
+      expect(results).toHaveLength(2);
+      expect(results[0]?.parameters).toEqual({});
+      // The sibling row in the same result set stays intact.
+      expect(results[1]?.parameters).toEqual({ num_days: 3 });
+    },
+  );
+
+  it('selects the parameters column in the SQL', async () => {
+    const { adapter, query } = makeAdapter([]);
+
+    await adapter.getItemActionHistory(historyInput);
+
+    expect(query.mock.calls[0]?.[0]).toMatch(/\bparameters\b/);
+  });
+});

--- a/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.ts
+++ b/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.ts
@@ -39,6 +39,12 @@ export class ClickhouseActionExecutionsAdapter implements IActionExecutionsAdapt
     private readonly tracer: SafeTracer,
   ) {}
 
+  /**
+   * Every action recorded against an item or its creator, newest first, with
+   * the policies, rules and moderator-supplied parameters each ran with.
+   * Background rule executions are excluded — they're machine bookkeeping
+   * rather than enforcement a reviewer needs to see.
+   */
   async getItemActionHistory(
     input: ItemActionHistoryInput,
   ): Promise<ReadonlyArray<ItemActionHistoryRecord>> {

--- a/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.ts
+++ b/server/plugins/warehouse/queries/ClickhouseActionExecutionsAdapter.ts
@@ -1,3 +1,5 @@
+import type { JsonObject } from 'type-fest';
+
 import type { IDataWarehouse } from '../../../storage/dataWarehouse/IDataWarehouse.js';
 import { jsonParse, type JsonOf } from '../../../utils/encoding.js';
 import type SafeTracer from '../../../utils/SafeTracer.js';
@@ -26,6 +28,7 @@ interface ClickhouseActionExecutionRow {
   job_id: string | null;
   policies?: string | null;
   rules?: string | null;
+  parameters?: string | null;
   action_id: string;
   action_source?: string;
 }
@@ -52,6 +55,7 @@ export class ClickhouseActionExecutionsAdapter implements IActionExecutionsAdapt
         job_id,
         policies,
         rules,
+        parameters,
         action_id
       FROM analytics.ACTION_EXECUTIONS
       WHERE org_id = ?
@@ -86,6 +90,7 @@ export class ClickhouseActionExecutionsAdapter implements IActionExecutionsAdapt
         userTypeId: row.item_creator_type_id ?? null,
         policies: this.extractIds(this.parseJsonArray(row.policies)),
         ruleIds: this.extractIds(this.parseJsonArray(row.rules)),
+        parameters: this.parseJsonObject(row.parameters),
         occurredAt: new Date(row.ts),
       }));
   }
@@ -291,6 +296,31 @@ export class ClickhouseActionExecutionsAdapter implements IActionExecutionsAdapt
       return null;
     } catch {
       return null;
+    }
+  }
+
+  /**
+   * `ACTION_EXECUTIONS.parameters` holds a canonical JSON object (`'{}'` by
+   * default). Anything that isn't a readable JSON object — a legacy row, an
+   * empty string, or a value that got written as an array or scalar — reads
+   * back as `{}` rather than failing the whole history query for one bad row.
+   */
+  private parseJsonObject(jsonString: string | null | undefined): JsonObject {
+    if (!jsonString) {
+      return {};
+    }
+    try {
+      const parsed = jsonParse(jsonString as JsonOf<unknown>);
+      if (
+        typeof parsed === 'object' &&
+        parsed !== null &&
+        !Array.isArray(parsed)
+      ) {
+        return parsed as JsonObject;
+      }
+      return {};
+    } catch {
+      return {};
     }
   }
 

--- a/server/plugins/warehouse/queries/IActionExecutionsAdapter.ts
+++ b/server/plugins/warehouse/queries/IActionExecutionsAdapter.ts
@@ -1,3 +1,5 @@
+import type { JsonObject } from 'type-fest';
+
 export interface ItemActionHistoryRecord {
   actionId: string;
   itemId: string;
@@ -8,6 +10,13 @@ export interface ItemActionHistoryRecord {
   userTypeId: string | null;
   policies: readonly string[];
   ruleIds: readonly string[];
+  /**
+   * Moderator-supplied parameter values the action ran with, keyed by the
+   * parameter's `name`. Always an object: executions that took no parameters,
+   * predate parameter capture, or stored an unreadable value all read back as
+   * `{}` so consumers don't have to distinguish those cases.
+   */
+  parameters: JsonObject;
   occurredAt: Date;
 }
 

--- a/server/services/itemInvestigationService/itemInvestigationService.ts
+++ b/server/services/itemInvestigationService/itemInvestigationService.ts
@@ -1150,6 +1150,7 @@ export class ItemInvestigationService {
           itemCreatorTypeId: record.userTypeId ?? undefined,
           policies: record.policies,
           ruleIds: record.ruleIds,
+          parameters: record.parameters,
           ts: record.occurredAt,
         };
       }),

--- a/server/services/itemInvestigationService/itemInvestigationService.ts
+++ b/server/services/itemInvestigationService/itemInvestigationService.ts
@@ -1119,6 +1119,11 @@ export class ItemInvestigationService {
     throw new Error('Not Implemented');
   }
 
+  /**
+   * The item's action history, shaped for GraphQL. Records missing an item id
+   * or type id are dropped rather than surfaced partially, since the pair is
+   * what identifies an item.
+   */
   async getItemActionHistory(opts: {
     orgId: string;
     itemId: string;


### PR DESCRIPTION
## Context & Requests for Reviewers

Fixes #833

Parameterized actions recorded the values a moderator supplied, but nothing read them back — `ACTION_EXECUTIONS.parameters` has been populated since the column was added, and the read path dropped it at every layer. So the investigation tool showed that an action ran, without showing what it ran with.

<img width="2320" height="1008" alt="image" src="https://github.com/user-attachments/assets/ff0afd4e-3244-4d66-938d-c0330ac95229" />

Values now render beside the action name. Long ones collapse behind the existing `CollapsibleText` (#903) rather than a bespoke truncation — it clamps by line, so the row height stays bounded, and the toggle is a real button rather than a hover reveal.

<img width="2320" height="1008" alt="image" src="https://github.com/user-attachments/assets/cf424d28-a66b-46de-bfe7-b7f104fb432e" />

`ItemActionHistory` is shared by the investigation tool and three review console views, so all four surfaces get this from one change.

Two things deliberately left out, happy to follow up on either:

- the **wider audit** the issue suggests (anywhere actions are shown, including the API) — kept out to keep this reviewable
- **`actor_note`**, which landed in the same migration and is equally orphaned in the  read path

The **number** of parameters is still unbounded — `CollapsibleText` caps a long value, not 50 one-line ones. Per the discussion on the issue, inline is fine, so I left it.

## Tests

Added regression coverage in `ClickhouseActionExecutionsAdapter.test.ts` for the read path, including the edge cases: an empty map, a row predating parameter capture, and an unreadable value — none of which should fail the query for the other rows.

Verified manually against a local stack by creating a parameterized action, applying it through the real API, and confirming the row in ClickHouse before checking the UI. 

Checked all four surfaces that share the component:

| surface | result |
|---|---|
| Investigation tool | parameters shown |
| Review console — user job | parameters shown |
| Review console — content job | parameters shown |
| Review console — associated user panel | parameters shown |

Actions without parameters render exactly as before, with no empty element — visible in the same tables, where `Delete Content` and `Enqueue Item to Manual Review` sit next to the parameterized row.

All CI checks pass locally, including `docker compose run --rm test` (111 suites, 937 tests).

## Checklist

_Only check items that apply to this PR; leave the rest unchecked._

- [ ] **If you changed anything user-facing** (i.e. user interface or APIs):
  Did you update related docs?

- [x] **If the change is notable** (refer to [Keep a Changelog](https://keepachangelog.com/en/2.0.0/) conventions):
  Did you update CHANGELOG.md?

- [ ] **If you changed `server/models/**/{ContentTypeModel,ActionModel,RuleModel,PolicyModel}.ts`:**
  Did you update the corresponding history tables and their triggers?

- [ ] **If you changed `db/src/scripts/**` and used `CREATE TABLE`, `ADD COLUMN`, or `ALTER COLUMN`:**
  Are as many columns marked `NOT NULL` as possible? If some columns can sometimes be null depending on other columns, are there `CHECK` constraints capturing those relationships, and are these also reflected using unions in the associated Kysely types?

- [ ] **If you added a new signal in `server/services/signalsService/signals/**`:**
  Did you classify every error case as a permanent error (`SignalPermanentError`, no retry) or a normal error (retryable)? Any case where the signal can't determine a score should be a `SignalPermanentError`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Item action history now captures and displays the parameters supplied when actions are executed.
- Parameter names are shown as readable, sentence-case labels.
- Boolean parameter values are displayed as “Yes” or “No.”
- Only declared action parameters are shown, excluding callback-only fields.
- Missing or unreadable parameter data safely appears empty without disrupting other history records.
- Investigation tags display action parameters beneath the title.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->